### PR TITLE
feat: support multiple simultaneous TCP interfaces

### DIFF
--- a/Sources/ColumbaApp/App/ColumbaApp.swift
+++ b/Sources/ColumbaApp/App/ColumbaApp.swift
@@ -398,20 +398,12 @@ struct RootView: View {
             let enabledInterfaces = interfaceRepo.getEnabledInterfaces()
             DiagLog.log("[STARTUP] Step 4: \(enabledInterfaces.count) enabled interfaces")
 
-            let serverAddress: String
-            if let tcpEntity = enabledInterfaces.first(where: { $0.type == .tcpClient }),
-               case .tcpClient(let config) = tcpEntity.config {
-                serverAddress = "\(config.targetHost):\(config.targetPort)"
-            } else {
-                serverAddress = ""
-            }
-
-            // 5. Initialize AppServices with identity
+            // 5. Initialize AppServices with identity (TCP connected separately below)
             DiagLog.log("[STARTUP] Step 5: initialize AppServices")
             try await appServices.initialize(
                 identity: identity,
                 identityHash: active.identityHash,
-                tcpServerAddress: serverAddress
+                tcpServerAddress: ""
             )
             DiagLog.log("[STARTUP] Step 5: AppServices initialized OK")
 
@@ -444,8 +436,18 @@ struct RootView: View {
                 DiagLog.log("[STARTUP] Starting interface: \(iface.type) name=\(iface.name)")
                 switch iface.type {
                 case .tcpClient:
-                    // Already connected via appServices.initialize() above
-                    break
+                    if case .tcpClient(let config) = iface.config {
+                        let entityId = iface.id
+                        Task {
+                            DiagLog.log("[STARTUP] TCP connecting: \(config.targetHost):\(config.targetPort)")
+                            do {
+                                try await services.connectTCPInterface(entityId: entityId, host: config.targetHost, port: config.targetPort)
+                                DiagLog.log("[STARTUP] TCP connected: \(entityId)")
+                            } catch {
+                                DiagLog.log("[STARTUP] TCP connect FAILED [\(entityId)]: \(error.localizedDescription)")
+                            }
+                        }
+                    }
                 case .tcpServer:
                     break
                 case .autoInterface:

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -90,8 +90,11 @@ public final class AppServices {
     /// Path table for route lookups.
     public private(set) var pathTable: PathTable?
 
-    /// TCP interface to server.
-    public private(set) var tcpInterface: TCPInterface?
+    /// TCP interfaces keyed by entity ID. Multiple concurrent connections are supported.
+    public private(set) var tcpInterfaces: [String: TCPInterface] = [:]
+
+    /// Convenience accessor for the first TCP interface (backward compat).
+    public var tcpInterface: TCPInterface? { tcpInterfaces.values.first }
 
     /// RNode BLE interface for LoRa radio communication.
     public var rnodeInterface: RNodeInterface?
@@ -421,7 +424,7 @@ public final class AppServices {
             )
             do {
                 let newInterface = try TCPInterface(config: config)
-                self.tcpInterface = newInterface
+                tcpInterfaces["tcp-server"] = newInterface
                 try await newTransport.addInterface(newInterface)
             } catch {
                 logger.warning("TCP interface failed (non-fatal): \(error.localizedDescription, privacy: .public)")
@@ -536,7 +539,7 @@ public final class AppServices {
             )
             do {
                 let newInterface = try TCPInterface(config: config)
-                self.tcpInterface = newInterface
+                tcpInterfaces["tcp-server"] = newInterface
                 try await newTransport.addInterface(newInterface)
             } catch {
                 logger.warning("TCP interface failed (non-fatal): \(error.localizedDescription, privacy: .public)")
@@ -645,15 +648,22 @@ public final class AppServices {
                 guard let self = self else { return }
 
                 // Read actor-isolated properties OFF the main thread
-                let interface = await MainActor.run { self.tcpInterface }
+                let allTCPInterfaces = await MainActor.run { Array(self.tcpInterfaces.values) }
                 let autoIface = await MainActor.run { self.autoInterface }
                 let rnodeIface = await MainActor.run { self.rnodeInterface }
                 let bleIface = await MainActor.run { self.bleInterface }
 
-                // Check TCP state
-                let tcpState: InterfaceState = await interface?.state ?? .disconnected
-                let errorDesc = await interface?.lastErrorDescription
-                let tcpConnected = tcpState == .connected
+                // Aggregate TCP state across all interfaces
+                var anyTCPConnected = false
+                var anyTCPReconnecting = false
+                var errorDesc: String? = nil
+                for iface in allTCPInterfaces {
+                    let s = await iface.state
+                    if s == .connected { anyTCPConnected = true }
+                    if case .reconnecting = s { anyTCPReconnecting = true }
+                    if let err = await iface.lastErrorDescription { errorDesc = err }
+                }
+                let tcpConnected = anyTCPConnected
 
                 // Check non-TCP interfaces
                 let autoConnected: Bool
@@ -676,10 +686,7 @@ public final class AppServices {
                 }
 
                 let anyConnected = tcpConnected || autoConnected || rnodeConnected || bleConnected
-                let tcpReconnecting = {
-                    if case .reconnecting = tcpState { return true }
-                    return false
-                }()
+                let tcpReconnecting = anyTCPReconnecting && !anyTCPConnected
 
                 // Batch all UI mutations into a single MainActor.run
                 let shouldAnnounce: Bool = await MainActor.run {
@@ -1123,8 +1130,8 @@ public final class AppServices {
         // Shutdown router first (stops processing loop)
         await router?.shutdown()
 
-        // Disconnect TCP interface
-        await tcpInterface?.disconnect()
+        // Disconnect all TCP interfaces
+        await stopTCPInterface()
 
         // Stop RNode interface
         await stopRNodeInterface()
@@ -1137,29 +1144,20 @@ public final class AppServices {
         // Stop auto interface
         await stopAutoInterface()
 
-        // Remove interface from transport
-        if let transport = transport {
-            await transport.removeInterface(id: "tcp-server")
-        }
-
         isConnected = false
         logger.info("AppServices shutdown complete")
     }
 
-    /// Stop only the TCP interface without affecting other interfaces.
-    public func stopTCPInterface() async {
-        await tcpInterface?.disconnect()
-        if let transport = transport {
-            await transport.removeInterface(id: "tcp-server")
+    /// Connect a TCP interface by entity ID, replacing any existing one with the same ID.
+    ///
+    /// Multiple concurrent TCP interfaces are supported — each entity ID is independent.
+    public func connectTCPInterface(entityId: String, host: String, port: UInt16) async throws {
+        // Stop any existing interface with this entity ID
+        if let existing = tcpInterfaces[entityId] {
+            await existing.disconnect()
+            await transport?.removeInterface(id: entityId)
+            tcpInterfaces.removeValue(forKey: entityId)
         }
-        tcpInterface = nil
-        isConnected = false
-    }
-
-    /// Reconnect only the TCP interface without tearing down BLE/Auto/RNode.
-    public func reconnectTCPOnly(host: String, port: UInt16) async throws {
-        // Stop existing TCP
-        await stopTCPInterface()
 
         // Ensure base stack exists
         if transport == nil {
@@ -1169,9 +1167,8 @@ public final class AppServices {
             throw AppServicesError.transportNotConnected
         }
 
-        // Create and connect new TCP interface
         let config = InterfaceConfig(
-            id: "tcp-server",
+            id: entityId,
             name: "TCP Server",
             type: .tcp,
             enabled: true,
@@ -1180,15 +1177,13 @@ public final class AppServices {
             port: port
         )
         let newInterface = try TCPInterface(config: config)
-        self.tcpInterface = newInterface
+        tcpInterfaces[entityId] = newInterface
         try await transport.addInterface(newInterface)
 
-        // Re-register delivery destination
         if let dest = deliveryDestination {
             await transport.registerDestination(dest)
         }
 
-        // Restart router if it was shut down
         if let router = router {
             await router.setTransport(transport)
             await router.restart()
@@ -1197,12 +1192,35 @@ public final class AppServices {
             }
         }
 
-        // Apply transport mode
         if let identity = identity, SharedDefaults.suite.bool(forKey: "transport_enabled") {
             await transport.setTransportEnabled(true, identity: identity)
         }
 
         startStateObserver()
+    }
+
+    /// Stop a specific TCP interface by entity ID.
+    public func stopTCPInterface(entityId: String) async {
+        guard let interface = tcpInterfaces[entityId] else { return }
+        await interface.disconnect()
+        await transport?.removeInterface(id: entityId)
+        tcpInterfaces.removeValue(forKey: entityId)
+    }
+
+    /// Stop all TCP interfaces.
+    public func stopTCPInterface() async {
+        for (entityId, interface) in tcpInterfaces {
+            await interface.disconnect()
+            await transport?.removeInterface(id: entityId)
+        }
+        tcpInterfaces.removeAll()
+        isConnected = false
+    }
+
+    /// Reconnect only the TCP interface without tearing down BLE/Auto/RNode.
+    /// Uses the legacy "tcp-server" entity ID for backward compatibility.
+    public func reconnectTCPOnly(host: String, port: UInt16) async throws {
+        try await connectTCPInterface(entityId: "tcp-server", host: host, port: port)
     }
 
     // MARK: - Reconnection
@@ -1278,7 +1296,7 @@ public final class AppServices {
             port: port
         )
         let newInterface = try TCPInterface(config: config)
-        self.tcpInterface = newInterface
+        tcpInterfaces["tcp-server"] = newInterface
 
         // Add interface to transport (connects it)
         try await newTransport.addInterface(newInterface)

--- a/Sources/ColumbaApp/ViewModels/InterfaceManagementViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/InterfaceManagementViewModel.swift
@@ -124,9 +124,6 @@ public final class InterfaceManagementViewModel {
     /// Status observation task
     private var statusObserverTask: Task<Void, Never>?
 
-    /// The interface ID currently being monitored for connection
-    private var activeInterfaceId: String?
-
     // MARK: - Computed Properties
 
     /// Whether we're in edit mode (vs add mode)
@@ -297,26 +294,31 @@ public final class InterfaceManagementViewModel {
 
         let enabledInterfaces = repository.getEnabledInterfaces()
 
-        // --- TCP ---
-        let tcpEntity = enabledInterfaces.first(where: { $0.type == .tcpClient })
-        if let tcpIf = tcpEntity,
-           case .tcpClient(let config) = tcpIf.config {
-            let serverAddress = "\(config.targetHost):\(config.targetPort)"
-            logger.info("Applying TCP: \(serverAddress)")
-            activeInterfaceId = tcpIf.id
-            interfaceStatus[tcpIf.id] = .connecting
-            do {
-                try await appServices.reconnectTCPOnly(host: config.targetHost, port: config.targetPort)
-                showSuccess("Connecting to \(config.targetHost):\(config.targetPort)...")
-            } catch {
-                logger.error("TCP failed: \(error)")
-                interfaceStatus[tcpIf.id] = .error
-                showError("TCP failed: \(error.localizedDescription)")
+        // --- TCP (supports multiple simultaneous connections) ---
+        let enabledTCPs = enabledInterfaces.filter { $0.type == .tcpClient }
+        let enabledTCPIds = Set(enabledTCPs.map { $0.id })
+
+        // Connect/reconnect each enabled TCP interface
+        for tcpIf in enabledTCPs {
+            if case .tcpClient(let config) = tcpIf.config {
+                logger.info("Applying TCP[\(tcpIf.id)]: \(config.targetHost):\(config.targetPort)")
+                interfaceStatus[tcpIf.id] = .connecting
+                do {
+                    try await appServices.connectTCPInterface(entityId: tcpIf.id, host: config.targetHost, port: config.targetPort)
+                    showSuccess("Connecting to \(config.targetHost):\(config.targetPort)...")
+                } catch {
+                    logger.error("TCP failed [\(tcpIf.id)]: \(error)")
+                    interfaceStatus[tcpIf.id] = .error
+                    showError("TCP failed: \(error.localizedDescription)")
+                }
             }
-        } else if tcpEntity == nil && appServices.tcpInterface != nil {
-            logger.info("Stopping TCP")
-            await appServices.stopTCPInterface()
-            activeInterfaceId = nil
+        }
+
+        // Stop TCP interfaces that are no longer in the enabled set
+        let currentTCPIds = Set(appServices.tcpInterfaces.keys)
+        for oldId in currentTCPIds where !enabledTCPIds.contains(oldId) {
+            logger.info("Stopping TCP[\(oldId)]")
+            await appServices.stopTCPInterface(entityId: oldId)
         }
 
         // --- AutoInterface ---
@@ -407,39 +409,42 @@ public final class InterfaceManagementViewModel {
     // MARK: - Status Observation
 
     /// Start polling AppServices connection state to update interface status.
-    ///
-    /// On the first iteration, this also performs initial sync — detecting
-    /// interfaces that are already running (from app startup) and reflecting
-    /// their true state in the UI.
     private func startStatusObserver() {
         statusObserverTask?.cancel()
         statusObserverTask = Task.detached { [weak self] in
-            // Initial sync: detect already-running TCP interface
-            await MainActor.run {
-                guard let self = self else { return }
-                let enabledInterfaces = self.repository.getEnabledInterfaces()
-                if let tcpEntity = enabledInterfaces.first(where: { $0.type == .tcpClient }),
-                   self.appServices.tcpInterface != nil {
-                    self.activeInterfaceId = tcpEntity.id
-                }
-            }
-
             while !Task.isCancelled {
                 guard let self = self else { break }
 
                 // Read @MainActor properties we need for actor lookups
-                let (activeId, isConn, isReconn, connErr, autoIf, bleIf, rnodeIf, mpcIf, enabledIfs) = await MainActor.run {
+                let (tcpEntities, tcpIfaces, autoIf, bleIf, rnodeIf, mpcIf, enabledIfs) = await MainActor.run {
                     (
-                        self.activeInterfaceId,
-                        self.appServices.isConnected,
-                        self.appServices.isReconnecting,
-                        self.appServices.connectionError,
+                        self.repository.getEnabledInterfaces().filter { $0.type == .tcpClient },
+                        self.appServices.tcpInterfaces,
                         self.appServices.autoInterface,
                         self.appServices.bleInterface,
                         self.appServices.rnodeInterface,
                         self.appServices.mpcInterface,
                         self.repository.getEnabledInterfaces()
                     )
+                }
+
+                // Read TCP interface states off main thread
+                var tcpUpdates: [(String, InterfaceStatus, String?)] = []
+                for entity in tcpEntities {
+                    if let iface = tcpIfaces[entity.id] {
+                        let state = await iface.state
+                        let err = await iface.lastErrorDescription
+                        let status: InterfaceStatus
+                        switch state {
+                        case .connected: status = .connected
+                        case .connecting: status = .connecting
+                        case .reconnecting: status = .reconnecting
+                        case .disconnected: status = .disconnected
+                        }
+                        tcpUpdates.append((entity.id, status, err))
+                    } else {
+                        tcpUpdates.append((entity.id, .disconnected, nil))
+                    }
                 }
 
                 // Read actor-isolated state OFF main thread
@@ -471,25 +476,15 @@ public final class InterfaceManagementViewModel {
 
                 // Batch all UI mutations into single MainActor.run
                 await MainActor.run {
-                    // Track TCP interface status
-                    if let interfaceId = activeId {
-                        if isConn {
-                            if self.interfaceStatus[interfaceId] != .connected {
-                                self.interfaceStatus[interfaceId] = .connected
-                                self.errorMessage = nil
-                            }
-                        } else if isReconn {
-                            self.interfaceStatus[interfaceId] = .reconnecting
-                            if let error = connErr,
-                               self.errorMessage != error {
-                                self.showError(error)
-                            }
-                        } else if connErr != nil {
-                            self.interfaceStatus[interfaceId] = .error
-                            if let error = connErr,
-                               self.errorMessage != error {
-                                self.showError(error)
-                            }
+                    // Update TCP interface statuses
+                    for (id, status, err) in tcpUpdates {
+                        self.interfaceStatus[id] = status
+                        if (status == .reconnecting || status == .error),
+                           let e = err, self.errorMessage != e {
+                            self.showError(e)
+                        }
+                        if status == .connected {
+                            self.errorMessage = nil
                         }
                     }
 


### PR DESCRIPTION
## Summary

- Previously only the first enabled TCP client was used; additional entries were silently ignored. This caused custom local servers (added after onboarding) to be shadowed by the community server.
- `AppServices.tcpInterfaces` is now a `[String: TCPInterface]` dict keyed by entity ID, supporting N concurrent TCP connections.
- Startup and the interface management UI both connect every enabled TCP client independently.

## Changes

**`AppServices`**
- `tcpInterface: TCPInterface?` (stored) → `tcpInterfaces: [String: TCPInterface]`; `tcpInterface` kept as computed `values.first` for backward compat
- New `connectTCPInterface(entityId:host:port:)` — connects or replaces a specific TCP interface by entity ID
- New `stopTCPInterface(entityId:)` — stops one; existing `stopTCPInterface()` now stops all
- `startStateObserver` aggregates `.connected`/`.reconnecting` across all TCP interfaces

**`ColumbaApp._initializeServicesOnce`**
- Passes `""` to `initialize()` (skips built-in TCP setup)
- Loops all enabled TCP entities and calls `connectTCPInterface(entityId: iface.id, ...)`

**`InterfaceManagementViewModel.applyChanges`**
- Loops all enabled TCP clients instead of taking only `first`
- Stops interfaces whose entity IDs are no longer in the enabled set
- Status observer tracks each TCP entity's state independently (removed `activeInterfaceId`)

## Test plan

- [ ] Add two TCP client interfaces (e.g., community server + local `10.x.x.x` server) — both should show Connected
- [ ] Disable one TCP interface — only that one disconnects, the other stays up
- [ ] Delete a TCP interface — it stops and is removed from the transport
- [ ] Fresh install with no TCP interfaces — app starts offline cleanly
- [ ] Identity switch — all TCP interfaces reconnect correctly on the new identity

🤖 Generated with [Claude Code](https://claude.com/claude-code)