### PR TITLE
fix: resolve peer display names from LXMF announces

### DIFF
--- a/Sources/ColumbaApp/App/ColumbaApp.swift
+++ b/Sources/ColumbaApp/App/ColumbaApp.swift
@@ -424,6 +424,7 @@ struct RootView: View {
             #else
             let handler = IncomingMessageHandler(messageRepository: repo, database: db)
             #endif
+            handler.pathTable = appServices.pathTable
             self.incomingMessageHandler = handler
             if let router = appServices.router {
                 await router.setDelegate(handler)

--- a/Sources/ColumbaApp/Services/IncomingMessageHandler.swift
+++ b/Sources/ColumbaApp/Services/IncomingMessageHandler.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import LXMFSwift
+import ReticulumSwift
 import UserNotifications
 import os.log
 
@@ -34,6 +35,9 @@ public final class IncomingMessageHandler: LXMRouterDelegate {
 
     /// Database for notification sender name lookups.
     private let database: LXMFDatabase?
+
+    /// Path table for looking up sender display names from announces.
+    public var pathTable: PathTable?
 
     #if os(iOS)
     /// Location sharing manager for incoming telemetry extraction.
@@ -149,6 +153,14 @@ public final class IncomingMessageHandler: LXMRouterDelegate {
                 }
             } catch {
                 self.logger.error("[LXMF_INBOUND] Failed to update peer icon for \(messageHashHex): \(error.localizedDescription)")
+            }
+
+            // Look up sender display name from path table (announce data) and update conversation
+            if let pathTable = self.pathTable {
+                if let entry = await pathTable.lookup(destinationHash: sourceHash),
+                   let name = entry.displayName, !name.isEmpty {
+                    try? await self.messageRepository.ensureConversation(sourceHash, displayName: name)
+                }
             }
 
             // Check for FIELD_COLUMBA_META (0x70) cease signal (Android Columba format)

--- a/Sources/ColumbaApp/ViewModels/ChatsViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/ChatsViewModel.swift
@@ -9,6 +9,7 @@
 import Foundation
 import Observation
 import LXMFSwift
+import ReticulumSwift
 
 // MARK: - Conversation Model
 
@@ -147,13 +148,15 @@ public final class ChatsViewModel {
 
     private let repository: MessageRepository
     private let notificationObserver: NotificationObserver
+    private let pathTable: PathTable?
     private var inProcessObserver: NSObjectProtocol?
 
     // MARK: - Initialization
 
-    public init(repository: MessageRepository, notificationObserver: NotificationObserver) {
+    public init(repository: MessageRepository, notificationObserver: NotificationObserver, pathTable: PathTable? = nil) {
         self.repository = repository
         self.notificationObserver = notificationObserver
+        self.pathTable = pathTable
 
         // Register for Darwin notifications (cross-process, fires before DB save)
         notificationObserver.onNewMessage { [weak self] in
@@ -190,9 +193,23 @@ public final class ChatsViewModel {
 
         do {
             let records = try await repository.fetchConversations()
-            conversations = records
+            var convos = records
                 .filter { $0.lastMessagePreview != nil }
                 .map { Conversation(from: $0) }
+
+            // Backfill display names from path table for conversations that have none
+            if let pathTable {
+                for i in convos.indices where convos[i].displayName == nil {
+                    if let entry = await pathTable.lookup(destinationHash: convos[i].destinationHash),
+                       let name = entry.displayName, !name.isEmpty {
+                        convos[i].displayName = name
+                        // Persist so we don't need to look up again
+                        try? await repository.ensureConversation(convos[i].destinationHash, displayName: name)
+                    }
+                }
+            }
+
+            conversations = convos
             errorMessage = nil
         } catch {
             errorMessage = error.localizedDescription
@@ -207,9 +224,22 @@ public final class ChatsViewModel {
 
         do {
             let records = try await repository.fetchConversations()
-            conversations = records
+            var convos = records
                 .filter { $0.lastMessagePreview != nil }
                 .map { Conversation(from: $0) }
+
+            // Backfill display names from path table for conversations that have none
+            if let pathTable {
+                for i in convos.indices where convos[i].displayName == nil {
+                    if let entry = await pathTable.lookup(destinationHash: convos[i].destinationHash),
+                       let name = entry.displayName, !name.isEmpty {
+                        convos[i].displayName = name
+                        try? await repository.ensureConversation(convos[i].destinationHash, displayName: name)
+                    }
+                }
+            }
+
+            conversations = convos
             errorMessage = nil
         } catch {
             errorMessage = error.localizedDescription

--- a/Sources/ColumbaApp/Views/Chats/ChatsView.swift
+++ b/Sources/ColumbaApp/Views/Chats/ChatsView.swift
@@ -141,7 +141,8 @@ struct ChatsView: View {
             if viewModel == nil {
                 viewModel = ChatsViewModel(
                     repository: messageRepository,
-                    notificationObserver: notificationObserver
+                    notificationObserver: notificationObserver,
+                    pathTable: appServices.pathTable
                 )
             }
             await viewModel?.loadConversations()


### PR DESCRIPTION
## Summary
- **Bug**: Chat list showed "Peer DB3FFD25" instead of the actual display name from LXMF announces
- **Root cause**: `LXMFDatabase.updateConversationForMessage()` always sets `displayName: nil` when creating conversations from incoming messages, since `LXMessage` doesn't carry announce data
- **Fix**: `IncomingMessageHandler` now cross-references the `PathTable` to resolve sender display names on each incoming message; `ChatsViewModel` backfills existing conversations on load

## Test plan
- [ ] Send a message from a peer who has announced with a display name
- [ ] Verify the chat list shows the announce display name, not "Peer XXXXXXXX"
- [ ] Verify existing conversations with missing names get backfilled on app launch
- [ ] Verify user-set nicknames are not overwritten (ensureConversation only sets name if currently nil)

🤖 Generated with [Claude Code](https://claude.com/claude-code)