### PR TITLE
fix: break up identicon view expression for Swift type-checker

### DIFF
--- a/Sources/ColumbaApp/Views/Settings/MyIdentityView.swift
+++ b/Sources/ColumbaApp/Views/Settings/MyIdentityView.swift
@@ -635,13 +635,12 @@ struct SettingsIdenticonView: View {
                 ForEach(0..<5, id: \.self) { row in
                     ForEach(0..<5, id: \.self) { col in
                         if pattern[row][col] {
+                            let xPos: CGFloat = CGFloat(col) * cellSize + cellSize / 2
+                            let yPos: CGFloat = CGFloat(row) * cellSize + cellSize / 2
                             Circle()
                                 .fill(colors[row % colors.count])
                                 .frame(width: cellSize * 0.8, height: cellSize * 0.8)
-                                .position(
-                                    x: CGFloat(col) * cellSize + cellSize / 2,
-                                    y: CGFloat(row) * cellSize + cellSize / 2
-                                )
+                                .position(x: xPos, y: yPos)
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- Extract inline position arithmetic in `SettingsIdenticonView` into `let` bindings to fix "unable to type-check this expression in reasonable time" compiler error on some machines

## Test plan
- [x] Verified identity pattern grid renders correctly on device
- Build succeeds without type-checker timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)