### PR TITLE
fix: resolve trivial compiler warnings

### DIFF
--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -728,7 +728,7 @@ public final class AppServices {
                 // Auto-announce on connect (outside the MainActor.run to avoid blocking UI)
                 if shouldAnnounce {
                     try? await Task.sleep(for: .seconds(1))
-                    await MainActor.run {
+                    _ = await MainActor.run {
                         Task {
                             await self.autoAnnounce()
                             self.autoAnnounceManager?.resetTimer()

--- a/Sources/ColumbaApp/Services/CallManager.swift
+++ b/Sources/ColumbaApp/Services/CallManager.swift
@@ -402,7 +402,7 @@ public final class CallManager {
     /// (CXEndCallAction). Performs the actual Telephone hangup without
     /// re-entering CallKit.
     func hangupFromCallKit() {
-        guard let telephone else { return }
+        guard telephone != nil else { return }
         DiagLog.log("[CALL] hangupFromCallKit() triggered")
         isHangingUpFromCallKit = true
         hangup()

--- a/Sources/ColumbaApp/Services/MigrationImporter.swift
+++ b/Sources/ColumbaApp/Services/MigrationImporter.swift
@@ -193,7 +193,7 @@ actor MigrationImporter {
                         lxMessage.incoming = msg.isIncoming
 
                         // Pack and save through normal path
-                        try lxMessage.pack()
+                        _ = try lxMessage.pack()
                         try await db.saveMessage(lxMessage)
                         messagesImported += 1
                     } catch {

--- a/Sources/ColumbaApp/Services/OfflineMapManager.swift
+++ b/Sources/ColumbaApp/Services/OfflineMapManager.swift
@@ -103,7 +103,7 @@ final class OfflineMapManager {
         let context = regionId.data(using: .utf8)!
 
         // Create metadata
-        var region = OfflineMapRegion(
+        let region = OfflineMapRegion(
             id: regionId,
             name: name,
             centerLatitude: center.latitude,

--- a/Sources/ColumbaApp/ViewModels/ContactsViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/ContactsViewModel.swift
@@ -421,7 +421,7 @@ public final class ContactsViewModel {
         updateTask = Task {
             for await entry in pathTable.pathUpdates {
                 guard !Task.isCancelled else { break }
-                await handleNewPathEntry(entry)
+                handleNewPathEntry(entry)
             }
         }
     }

--- a/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
@@ -395,7 +395,7 @@ public final class MessagingViewModel {
         }
 
         // Remove from UI
-        withAnimation {
+        _ = withAnimation {
             messages.remove(at: index)
         }
 

--- a/Sources/ColumbaApp/Views/Contacts/ContactsView.swift
+++ b/Sources/ColumbaApp/Views/Contacts/ContactsView.swift
@@ -138,7 +138,7 @@ public struct ContactsView: View {
         }
         #if os(iOS)
         .fullScreenCover(isPresented: $showQRScanner) {
-            if let vm = viewModel {
+            if viewModel != nil {
                 QRScannerView(
                     onScanned: { hash, pubKey in
                         showQRScanner = false


### PR DESCRIPTION
## Summary
- `var` → `let` for never-mutated variable in OfflineMapManager
- Replace unused bindings with boolean tests in ContactsView and CallManager
- Remove unnecessary `await` on non-async `handleNewPathEntry`
- Suppress unused result warnings with `_ =` for `pack()`, `withAnimation`, `MainActor.run`

Eliminates 7 warnings. Only Swift 6 concurrency warnings remain (separate effort).

## Test plan
- [x] Builds clean with no new warnings
- Functional behavior unchanged (all changes are cosmetic to the compiler)

🤖 Generated with [Claude Code](https://claude.com/claude-code)