### PR TITLE
ci: add unit test workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,6 +46,8 @@ jobs:
             -destination "id=$DEVICE_ID" \
             -only-testing:ColumbaAppTests \
             -resultBundlePath TestResults.xcresult \
-            CODE_SIGN_IDENTITY="" \
+            CODE_SIGN_IDENTITY=- \
             CODE_SIGNING_REQUIRED=NO \
-            CODE_SIGNING_ALLOWED=NO
+            CODE_SIGNING_ALLOWED=YES \
+            DEVELOPMENT_TEAM="" \
+            PROVISIONING_PROFILE_SPECIFIER=""

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,39 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Clone sibling packages
+        run: |
+          git clone https://github.com/torlando-tech/reticulum-swift.git ../reticulum-swift
+          git clone https://github.com/torlando-tech/LXMF-swift.git ../LXMF-swift
+          git clone https://github.com/torlando-tech/LXST-swift.git ../LXST-swift
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_16.2.app
+
+      - name: Resolve packages
+        run: xcodebuild -resolvePackageDependencies -project ColumbaApp.xcodeproj -scheme ColumbaApp
+
+      - name: Run tests
+        run: |
+          xcodebuild test \
+            -project ColumbaApp.xcodeproj \
+            -scheme ColumbaApp \
+            -sdk iphonesimulator \
+            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            -only-testing:ColumbaAppTests \
+            -resultBundlePath TestResults.xcresult

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,4 +36,7 @@ jobs:
             -sdk iphonesimulator \
             -destination 'platform=iOS Simulator,name=iPhone 16' \
             -only-testing:ColumbaAppTests \
-            -resultBundlePath TestResults.xcresult
+            -resultBundlePath TestResults.xcresult \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,10 +28,6 @@ jobs:
           echo "Using $XCODE"
           sudo xcode-select -s "$XCODE"
           xcodebuild -version
-          xcrun simctl list devices available | grep iPhone | head -5
-
-      - name: Resolve packages
-        run: xcodebuild -resolvePackageDependencies -project ColumbaApp.xcodeproj -scheme ColumbaApp
 
       - name: Find simulator
         id: sim
@@ -41,14 +37,13 @@ jobs:
           echo "device_id=$DEVICE_ID" >> "$GITHUB_OUTPUT"
           echo "Using simulator: $DEVICE_ID"
 
-      - name: Build app target
+      - name: Build
         run: |
           xcodebuild build \
             -project ColumbaApp.xcodeproj \
-            -target ColumbaApp \
+            -scheme ColumbaApp \
             -sdk iphonesimulator \
             -destination "id=${{ steps.sim.outputs.device_id }}" \
-            ENABLE_TESTABILITY=YES \
             CODE_SIGN_IDENTITY=- \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=YES \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,26 +27,23 @@ jobs:
           XCODE=$(ls -d /Applications/Xcode_16*.app 2>/dev/null | sort -V | tail -1)
           echo "Using $XCODE"
           sudo xcode-select -s "$XCODE"
-
-      - name: Find simulator destination
-        id: dest
-        run: |
-          DEST=$(xcodebuild -showdestinations -project ColumbaApp.xcodeproj -scheme ColumbaApp 2>/dev/null \
-            | grep 'iOS Simulator' | grep 'iPhone' | head -1 \
-            | sed 's/.*{ //' | sed 's/ }$//')
-          echo "destination=$DEST" >> "$GITHUB_OUTPUT"
-          echo "Using destination: $DEST"
+          xcodebuild -version
+          xcrun simctl list devices available | grep iPhone | head -5
 
       - name: Resolve packages
         run: xcodebuild -resolvePackageDependencies -project ColumbaApp.xcodeproj -scheme ColumbaApp
 
       - name: Run tests
         run: |
+          # Find first available iPhone simulator
+          DEVICE_ID=$(xcrun simctl list devices available -j \
+            | python3 -c "import sys,json; devs=json.load(sys.stdin)['devices']; print(next(d['udid'] for rt in devs for d in devs[rt] if 'iPhone' in d['name']))")
+          echo "Using simulator: $DEVICE_ID"
           xcodebuild test \
             -project ColumbaApp.xcodeproj \
             -scheme ColumbaApp \
             -sdk iphonesimulator \
-            -destination '${{ steps.dest.outputs.destination }}' \
+            -destination "id=$DEVICE_ID" \
             -only-testing:ColumbaAppTests \
             -resultBundlePath TestResults.xcresult \
             CODE_SIGN_IDENTITY="" \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,21 +33,33 @@ jobs:
       - name: Resolve packages
         run: xcodebuild -resolvePackageDependencies -project ColumbaApp.xcodeproj -scheme ColumbaApp
 
-      - name: Run tests
+      - name: Find simulator
+        id: sim
         run: |
-          # Find first available iPhone simulator
           DEVICE_ID=$(xcrun simctl list devices available -j \
             | python3 -c "import sys,json; devs=json.load(sys.stdin)['devices']; print(next(d['udid'] for rt in devs for d in devs[rt] if 'iPhone' in d['name']))")
+          echo "device_id=$DEVICE_ID" >> "$GITHUB_OUTPUT"
           echo "Using simulator: $DEVICE_ID"
-          xcodebuild test \
+
+      - name: Build for testing
+        run: |
+          xcodebuild build-for-testing \
             -project ColumbaApp.xcodeproj \
             -scheme ColumbaApp \
             -sdk iphonesimulator \
-            -destination "id=$DEVICE_ID" \
-            -only-testing:ColumbaAppTests \
-            -resultBundlePath TestResults.xcresult \
+            -destination "id=${{ steps.sim.outputs.device_id }}" \
             CODE_SIGN_IDENTITY=- \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=YES \
             DEVELOPMENT_TEAM="" \
             PROVISIONING_PROFILE_SPECIFIER=""
+
+      - name: Run tests
+        run: |
+          xcodebuild test-without-building \
+            -project ColumbaApp.xcodeproj \
+            -scheme ColumbaApp \
+            -sdk iphonesimulator \
+            -destination "id=${{ steps.sim.outputs.device_id }}" \
+            -only-testing:ColumbaAppTests \
+            -resultBundlePath TestResults.xcresult

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,19 @@ jobs:
           git clone https://github.com/torlando-tech/LXST-swift.git ../LXST-swift
 
       - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_16.2.app
+        run: |
+          XCODE=$(ls -d /Applications/Xcode_16*.app 2>/dev/null | sort -V | tail -1)
+          echo "Using $XCODE"
+          sudo xcode-select -s "$XCODE"
+
+      - name: Find simulator destination
+        id: dest
+        run: |
+          DEST=$(xcodebuild -showdestinations -project ColumbaApp.xcodeproj -scheme ColumbaApp 2>/dev/null \
+            | grep 'iOS Simulator' | grep 'iPhone' | head -1 \
+            | sed 's/.*{ //' | sed 's/ }$//')
+          echo "destination=$DEST" >> "$GITHUB_OUTPUT"
+          echo "Using destination: $DEST"
 
       - name: Resolve packages
         run: xcodebuild -resolvePackageDependencies -project ColumbaApp.xcodeproj -scheme ColumbaApp
@@ -34,7 +46,7 @@ jobs:
             -project ColumbaApp.xcodeproj \
             -scheme ColumbaApp \
             -sdk iphonesimulator \
-            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            -destination '${{ steps.dest.outputs.destination }}' \
             -only-testing:ColumbaAppTests \
             -resultBundlePath TestResults.xcresult \
             CODE_SIGN_IDENTITY="" \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,28 +41,32 @@ jobs:
           echo "device_id=$DEVICE_ID" >> "$GITHUB_OUTPUT"
           echo "Using simulator: $DEVICE_ID"
 
-      - name: Build for testing
+      - name: Build app target
         run: |
-          set -o pipefail
-          xcodebuild build-for-testing \
+          xcodebuild build \
             -project ColumbaApp.xcodeproj \
             -scheme ColumbaApp \
             -sdk iphonesimulator \
             -destination "id=${{ steps.sim.outputs.device_id }}" \
+            -target ColumbaApp \
+            ENABLE_TESTABILITY=YES \
             CODE_SIGN_IDENTITY=- \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=YES \
             DEVELOPMENT_TEAM="" \
-            PROVISIONING_PROFILE_SPECIFIER="" 2>&1 | tee /tmp/build.log
-          echo "=== Build errors ==="
-          grep 'error:' /tmp/build.log || echo "No errors found"
+            PROVISIONING_PROFILE_SPECIFIER=""
 
-      - name: Run tests
+      - name: Build and run tests
         run: |
-          xcodebuild test-without-building \
+          xcodebuild test \
             -project ColumbaApp.xcodeproj \
             -scheme ColumbaApp \
             -sdk iphonesimulator \
             -destination "id=${{ steps.sim.outputs.device_id }}" \
             -only-testing:ColumbaAppTests \
-            -resultBundlePath TestResults.xcresult
+            -resultBundlePath TestResults.xcresult \
+            CODE_SIGN_IDENTITY=- \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=YES \
+            DEVELOPMENT_TEAM="" \
+            PROVISIONING_PROFILE_SPECIFIER=""

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,10 +45,9 @@ jobs:
         run: |
           xcodebuild build \
             -project ColumbaApp.xcodeproj \
-            -scheme ColumbaApp \
+            -target ColumbaApp \
             -sdk iphonesimulator \
             -destination "id=${{ steps.sim.outputs.device_id }}" \
-            -target ColumbaApp \
             ENABLE_TESTABILITY=YES \
             CODE_SIGN_IDENTITY=- \
             CODE_SIGNING_REQUIRED=NO \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,6 +43,7 @@ jobs:
 
       - name: Build for testing
         run: |
+          set -o pipefail
           xcodebuild build-for-testing \
             -project ColumbaApp.xcodeproj \
             -scheme ColumbaApp \
@@ -52,7 +53,9 @@ jobs:
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=YES \
             DEVELOPMENT_TEAM="" \
-            PROVISIONING_PROFILE_SPECIFIER=""
+            PROVISIONING_PROFILE_SPECIFIER="" 2>&1 | tee /tmp/build.log
+          echo "=== Build errors ==="
+          grep 'error:' /tmp/build.log || echo "No errors found"
 
       - name: Run tests
         run: |


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow that runs ColumbaAppTests (17 tests) on PRs and pushes to main
- Clones sibling local packages (reticulum-swift, LXMF-swift, LXST-swift) for the build
- Runs on macOS 15 with Xcode 16.2, targeting iPhone 16 simulator

## Test plan
- [ ] Verify the workflow runs successfully on this PR
- All 17 tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)