### PR TITLE
Route to RNode wizard after onboarding when user opted in

### DIFF
--- a/Sources/ColumbaApp/ViewModels/OnboardingViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/OnboardingViewModel.swift
@@ -132,6 +132,12 @@ final class OnboardingViewModel {
         // 5. Mark onboarding and settings as initialized
         UserDefaults.standard.set(true, forKey: "has_completed_onboarding")
         UserDefaults.standard.set(true, forKey: "settings_initialized")
+
+        // 6. If user opted into RNode, flag the shell to open the configuration
+        // wizard once MainTabView is on screen.
+        if selectedInterfaces.contains(.rnode) {
+            UserDefaults.standard.set(true, forKey: "pendingRNodeSetup")
+        }
     }
 
     /// Skip onboarding with safe defaults.

--- a/Sources/ColumbaApp/ViewModels/OnboardingViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/OnboardingViewModel.swift
@@ -134,11 +134,18 @@ final class OnboardingViewModel {
         UserDefaults.standard.set(true, forKey: "settings_initialized")
 
         // 6. If user opted into RNode, flag the shell to open the configuration
-        // wizard once MainTabView is on screen.
+        // wizard once MainTabView is on screen. Only meaningful on iOS — the
+        // RNode wizard's fullScreenCover is iOS-only.
+        #if os(iOS)
         if selectedInterfaces.contains(.rnode) {
-            UserDefaults.standard.set(true, forKey: "pendingRNodeSetup")
+            UserDefaults.standard.set(true, forKey: Self.pendingRNodeSetupKey)
         }
+        #endif
     }
+
+    /// UserDefaults key for signalling that onboarding requested the RNode
+    /// configuration wizard. Consumed by MainTabView on first appearance.
+    static let pendingRNodeSetupKey = "pendingRNodeSetup"
 
     /// Skip onboarding with safe defaults.
     func skipOnboarding(

--- a/Sources/ColumbaApp/Views/MainTabView.swift
+++ b/Sources/ColumbaApp/Views/MainTabView.swift
@@ -32,6 +32,7 @@ struct MainTabView: View {
 
     @State private var selectedTab: Tab = .chats
     @AppStorage("map_http_enabled") private var mapHttpEnabled: Bool = true
+    @AppStorage("pendingRNodeSetup") private var pendingRNodeSetup: Bool = false
 
     // MARK: - Body
 
@@ -84,6 +85,11 @@ struct MainTabView: View {
             .tag(Tab.settings)
         }
         .tint(Theme.accentColor)
+        .onAppear {
+            if pendingRNodeSetup {
+                selectedTab = .settings
+            }
+        }
         .onChange(of: pendingDeepLink) { _, newValue in
             if newValue != nil {
                 selectedTab = .contacts

--- a/Sources/ColumbaApp/Views/MainTabView.swift
+++ b/Sources/ColumbaApp/Views/MainTabView.swift
@@ -32,7 +32,11 @@ struct MainTabView: View {
 
     @State private var selectedTab: Tab = .chats
     @AppStorage("map_http_enabled") private var mapHttpEnabled: Bool = true
-    @AppStorage("pendingRNodeSetup") private var pendingRNodeSetup: Bool = false
+    @AppStorage(OnboardingViewModel.pendingRNodeSetupKey) private var pendingRNodeSetup: Bool = false
+    /// Session-scoped copy of `pendingRNodeSetup` consumed by `SettingsView` to
+    /// trigger the wizard. Set once by `onAppear` so the persisted flag can be
+    /// cleared atomically and subsequent re-appearances don't re-route the user.
+    @State private var shouldOpenRNodeWizard: Bool = false
 
     // MARK: - Body
 
@@ -77,7 +81,8 @@ struct MainTabView: View {
                 appServices: appServices,
                 settingsRepository: settingsRepository,
                 identityManager: identityManager,
-                onIdentitySwitch: onIdentitySwitch
+                onIdentitySwitch: onIdentitySwitch,
+                shouldOpenRNodeWizard: $shouldOpenRNodeWizard
             )
             .tabItem {
                 Label(Tab.settings.title, systemImage: Tab.settings.icon)
@@ -86,8 +91,12 @@ struct MainTabView: View {
         }
         .tint(Theme.accentColor)
         .onAppear {
+            // Consume the persisted flag atomically so a cancelled SettingsView
+            // task can't leave the user re-snapped to Settings on every appearance.
             if pendingRNodeSetup {
                 selectedTab = .settings
+                shouldOpenRNodeWizard = true
+                pendingRNodeSetup = false
             }
         }
         .onChange(of: pendingDeepLink) { _, newValue in

--- a/Sources/ColumbaApp/Views/Settings/SettingsView.swift
+++ b/Sources/ColumbaApp/Views/Settings/SettingsView.swift
@@ -162,6 +162,8 @@ struct SettingsView: View {
             await viewModel?.loadSettings()
 
             // If onboarding requested RNode configuration, launch the wizard now.
+            // Use selectInterfaceType so configType is set before validation runs
+            // when the user taps "Configure RNode" at the end of the wizard.
             if pendingRNodeSetup {
                 if interfaceRepository == nil {
                     let repo = InterfaceRepository()
@@ -171,7 +173,7 @@ struct SettingsView: View {
                         appServices: appServices
                     )
                 }
-                interfaceViewModel?.showRNodeWizard = true
+                interfaceViewModel?.selectInterfaceType(.rnode)
                 pendingRNodeSetup = false
             }
 

--- a/Sources/ColumbaApp/Views/Settings/SettingsView.swift
+++ b/Sources/ColumbaApp/Views/Settings/SettingsView.swift
@@ -27,6 +27,9 @@ struct SettingsView: View {
     let settingsRepository: SettingsRepository
     let identityManager: IdentityManager
     var onIdentitySwitch: (() -> Void)?
+    /// Session-scoped flag from MainTabView requesting the RNode wizard.
+    /// Cleared by SettingsView only after the wizard has actually been triggered.
+    @Binding var shouldOpenRNodeWizard: Bool
 
     // MARK: - State
 
@@ -41,7 +44,6 @@ struct SettingsView: View {
     /// Persisted across body re-evaluations so showRNodeWizard=true is not lost
     /// when SettingsView re-renders due to connection status polling changes.
     @State private var interfaceViewModel: InterfaceManagementViewModel?
-    @AppStorage("pendingRNodeSetup") private var pendingRNodeSetup: Bool = false
 
     // MARK: - Body
 
@@ -161,20 +163,24 @@ struct SettingsView: View {
             }
             await viewModel?.loadSettings()
 
-            // If onboarding requested RNode configuration, launch the wizard now.
+            // If MainTabView handed off an RNode wizard request, launch it now.
             // Use selectInterfaceType so configType is set before validation runs
             // when the user taps "Configure RNode" at the end of the wizard.
-            if pendingRNodeSetup {
-                if interfaceRepository == nil {
-                    let repo = InterfaceRepository()
+            // Only clear the flag after the VM is guaranteed non-nil, so a nil
+            // VM can't silently drop the request and permanently lose the flag.
+            if shouldOpenRNodeWizard {
+                if interfaceViewModel == nil {
+                    let repo = interfaceRepository ?? InterfaceRepository()
                     interfaceRepository = repo
                     interfaceViewModel = InterfaceManagementViewModel(
                         repository: repo,
                         appServices: appServices
                     )
                 }
-                interfaceViewModel?.selectInterfaceType(.rnode)
-                pendingRNodeSetup = false
+                if let vm = interfaceViewModel {
+                    vm.selectInterfaceType(.rnode)
+                    shouldOpenRNodeWizard = false
+                }
             }
 
             // Poll connection state every 2s so the card stays live

--- a/Sources/ColumbaApp/Views/Settings/SettingsView.swift
+++ b/Sources/ColumbaApp/Views/Settings/SettingsView.swift
@@ -41,6 +41,7 @@ struct SettingsView: View {
     /// Persisted across body re-evaluations so showRNodeWizard=true is not lost
     /// when SettingsView re-renders due to connection status polling changes.
     @State private var interfaceViewModel: InterfaceManagementViewModel?
+    @AppStorage("pendingRNodeSetup") private var pendingRNodeSetup: Bool = false
 
     // MARK: - Body
 
@@ -159,6 +160,20 @@ struct SettingsView: View {
                 )
             }
             await viewModel?.loadSettings()
+
+            // If onboarding requested RNode configuration, launch the wizard now.
+            if pendingRNodeSetup {
+                if interfaceRepository == nil {
+                    let repo = InterfaceRepository()
+                    interfaceRepository = repo
+                    interfaceViewModel = InterfaceManagementViewModel(
+                        repository: repo,
+                        appServices: appServices
+                    )
+                }
+                interfaceViewModel?.showRNodeWizard = true
+                pendingRNodeSetup = false
+            }
 
             // Poll connection state every 2s so the card stays live
             while !Task.isCancelled {


### PR DESCRIPTION
## Summary
- Onboarding's "Configure LoRa Radio" button previously dumped users on the Chats tab, even when they'd selected the RNode interface. `onFinish` only called `completeOnboarding` + `onComplete`, so the RNode-setup intent was silently dropped.
- Propagate the intent via a one-shot `@AppStorage("pendingRNodeSetup")` flag:
  - `OnboardingViewModel.completeOnboarding` sets the flag when `.rnode ∈ selectedInterfaces`.
  - `MainTabView.onAppear` reads the flag and switches `selectedTab` to `.settings`.
  - `SettingsView.task` (after the settings VM loads) lazily creates `InterfaceManagementViewModel`, sets `showRNodeWizard = true`, then clears the flag.

27 insertions, 3 files — no removals, no behavior change for users who didn't select RNode.

## Test plan
- [ ] Onboard with Auto-only selected → lands on Chats tab (unchanged)
- [ ] Onboard with RNode selected → lands on Settings tab with the RNode wizard's fullScreenCover visible
- [ ] Complete or cancel the wizard → flag is cleared (not re-triggered on next launch)
- [ ] Existing onboarded users → no change (flag defaults to false, `migrateExistingUsers` unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)