### PR TITLE
chore: switch SPM dependencies to remote URLs (fixes #10)

### DIFF
--- a/ColumbaApp.xcodeproj/project.pbxproj
+++ b/ColumbaApp.xcodeproj/project.pbxproj
@@ -674,10 +674,10 @@
 			);
 			mainGroup = ROOT;
 			packageReferences = (
-				PKGREF /* XCLocalSwiftPackageReference "../LXMF-swift" */,
-				PKGREF3 /* XCLocalSwiftPackageReference "../LXST-swift" */,
+				PKGREF /* XCRemoteSwiftPackageReference "LXMF-swift" */,
+				PKGREF3 /* XCRemoteSwiftPackageReference "LXST-swift" */,
 				PKGREF2 /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */,
-				PKGREF4 /* XCLocalSwiftPackageReference "../reticulum-swift" */,
+				PKGREF4 /* XCRemoteSwiftPackageReference "reticulum-swift" */,
 			);
 			productRefGroup = PRODS /* Products */;
 			projectDirPath = "";
@@ -1173,10 +1173,14 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCLocalSwiftPackageReference section */
-		PKGREF /* XCLocalSwiftPackageReference "../LXMF-swift" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = "../LXMF-swift";
+/* Begin XCRemoteSwiftPackageReference section */
+		PKGREF /* XCRemoteSwiftPackageReference "LXMF-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/torlando-tech/LXMF-swift.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.2.0;
+			};
 		};
 		PKGREF2 /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -1186,20 +1190,28 @@
 				minimumVersion = 6.9.0;
 			};
 		};
-		PKGREF3 /* XCLocalSwiftPackageReference "../LXST-swift" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = "../LXST-swift";
+		PKGREF3 /* XCRemoteSwiftPackageReference "LXST-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/torlando-tech/LXST-swift.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.1.0;
+			};
 		};
-		PKGREF4 /* XCLocalSwiftPackageReference "../reticulum-swift" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = "../reticulum-swift";
+		PKGREF4 /* XCRemoteSwiftPackageReference "reticulum-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/torlando-tech/reticulum-swift.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.1.0;
+			};
 		};
-/* End XCLocalSwiftPackageReference section */
+/* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
 		P001 /* LXMFSwift */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = PKGREF /* XCLocalSwiftPackageReference "../LXMF-swift" */;
+			package = PKGREF /* XCRemoteSwiftPackageReference "LXMF-swift" */;
 			productName = LXMFSwift;
 		};
 		P002 /* MapLibre */ = {
@@ -1209,12 +1221,12 @@
 		};
 		P003 /* LXSTSwift */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = PKGREF3 /* XCLocalSwiftPackageReference "../LXST-swift" */;
+			package = PKGREF3 /* XCRemoteSwiftPackageReference "LXST-swift" */;
 			productName = LXSTSwift;
 		};
 		P004 /* ReticulumSwift */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = PKGREF4 /* XCLocalSwiftPackageReference "../reticulum-swift" */;
+			package = PKGREF4 /* XCRemoteSwiftPackageReference "reticulum-swift" */;
 			productName = ReticulumSwift;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/ColumbaApp.xcodeproj/project.pbxproj
+++ b/ColumbaApp.xcodeproj/project.pbxproj
@@ -1179,7 +1179,7 @@
 			repositoryURL = "https://github.com/torlando-tech/LXMF-swift.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.2.0;
+				minimumVersion = 0.3.0;
 			};
 		};
 		PKGREF2 /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */ = {
@@ -1195,7 +1195,7 @@
 			repositoryURL = "https://github.com/torlando-tech/LXST-swift.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.1.0;
+				minimumVersion = 0.2.0;
 			};
 		};
 		PKGREF4 /* XCRemoteSwiftPackageReference "reticulum-swift" */ = {
@@ -1203,7 +1203,7 @@
 			repositoryURL = "https://github.com/torlando-tech/reticulum-swift.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.1.0;
+				minimumVersion = 0.2.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ColumbaApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ColumbaApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "aee17071b1fd80df4f24fdbd47dee2bc05fcecc9e8818c9b3b5c14a650d52c6e",
+  "originHash" : "ab8e26f753ec08ec6924cbf6fd931cf46454ee4b8b8fe509d5eb37eec3ff45e0",
   "pins" : [
     {
       "identity" : "bitbytedata",
@@ -29,6 +29,24 @@
       }
     },
     {
+      "identity" : "lxmf-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/torlando-tech/LXMF-swift.git",
+      "state" : {
+        "revision" : "97c4871bae3dcf392c0a2e10a7c1eb56639270ec",
+        "version" : "0.3.0"
+      }
+    },
+    {
+      "identity" : "lxst-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/torlando-tech/LXST-swift.git",
+      "state" : {
+        "revision" : "f84bd720ea602ed5a1983a0f058d90b6a4174c35",
+        "version" : "0.2.0"
+      }
+    },
+    {
       "identity" : "maplibre-gl-native-distribution",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/maplibre/maplibre-gl-native-distribution",
@@ -42,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/torlando-tech/reticulum-swift.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "689f5f701b665ac3aa28b7da11ba814480b711e3"
+        "revision" : "254410a83b287f78f21ae2a0234813abff3e4305",
+        "version" : "0.2.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -20,9 +20,9 @@ let package = Package(
         // `.swiftpm/configuration/mirrors.json` mapping the URL to a local
         // directory — see README "Local development against unreleased
         // library changes" for the exact recipe.
-        .package(url: "https://github.com/torlando-tech/LXMF-swift.git", from: "0.2.0"),
-        .package(url: "https://github.com/torlando-tech/LXST-swift.git", from: "0.1.0"),
-        .package(url: "https://github.com/torlando-tech/reticulum-swift.git", from: "0.1.0"),
+        .package(url: "https://github.com/torlando-tech/LXMF-swift.git", from: "0.3.0"),
+        .package(url: "https://github.com/torlando-tech/LXST-swift.git", from: "0.2.0"),
+        .package(url: "https://github.com/torlando-tech/reticulum-swift.git", from: "0.2.0"),
         .package(url: "https://github.com/maplibre/maplibre-gl-native-distribution", from: "6.9.0"),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -14,8 +14,15 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(path: "../LXMF-swift"),
-        .package(path: "../LXST-swift"),
+        // SPM resolves these from GitHub on every fresh checkout. To work
+        // against an in-progress local clone of any of these libraries
+        // without committing a path-override, drop a per-machine
+        // `.swiftpm/configuration/mirrors.json` mapping the URL to a local
+        // directory — see README "Local development against unreleased
+        // library changes" for the exact recipe.
+        .package(url: "https://github.com/torlando-tech/LXMF-swift.git", from: "0.2.0"),
+        .package(url: "https://github.com/torlando-tech/LXST-swift.git", from: "0.1.0"),
+        .package(url: "https://github.com/torlando-tech/reticulum-swift.git", from: "0.1.0"),
         .package(url: "https://github.com/maplibre/maplibre-gl-native-distribution", from: "6.9.0"),
     ],
     targets: [
@@ -24,6 +31,12 @@ let package = Package(
             dependencies: [
                 .product(name: "LXMFSwift", package: "LXMF-swift"),
                 .product(name: "LXSTSwift", package: "LXST-swift"),
+                // ReticulumSwift is imported directly by several view
+                // models (e.g. NomadNetBrowserViewModel,
+                // MessagingViewModel) — listed here as a direct product
+                // dep so the version constraint on the package above is
+                // actually exercised by SPM at resolution time.
+                .product(name: "ReticulumSwift", package: "reticulum-swift"),
                 .product(name: "MapLibre", package: "maplibre-gl-native-distribution"),
             ],
             path: "Sources/ColumbaApp"

--- a/README.md
+++ b/README.md
@@ -6,9 +6,33 @@ An iOS messaging app built on [Reticulum](https://reticulum.network) for encrypt
 
 Requires Xcode 15+ and iOS 17+.
 
-Open `ColumbaApp.xcodeproj` in Xcode, select a signing team, and build for your device.
+Open `ColumbaApp.xcodeproj` in Xcode, select a signing team, and build for
+your device. SPM resolves all dependencies (LXMFSwift, LXSTSwift,
+ReticulumSwift, MapLibre) automatically from their public GitHub
+repositories on first open — no sibling clones required.
 
-Dependencies are resolved automatically via Swift Package Manager.
+### Local development against unreleased library changes
+
+To work against an in-progress local clone of any of the Reticulum-stack
+libraries without committing a path-override, drop a per-machine SPM
+mirror file at `.swiftpm/configuration/mirrors.json` (already gitignored
+via `.swiftpm/`):
+
+```json
+{
+  "version": 1,
+  "mirrors": [
+    { "original": "https://github.com/torlando-tech/reticulum-swift.git", "mirror": "/Users/you/repos/reticulum-swift" },
+    { "original": "https://github.com/torlando-tech/LXMF-swift.git",      "mirror": "/Users/you/repos/LXMF-swift"      },
+    { "original": "https://github.com/torlando-tech/LXST-swift.git",      "mirror": "/Users/you/repos/LXST-swift"      }
+  ]
+}
+```
+
+SPM transparently resolves the listed URLs to your local checkouts, so
+you can iterate on a library and the iOS build picks up the changes
+without modifying `Package.swift` or the Xcode project. Remove the file
+to go back to the published versions.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -21,13 +21,18 @@ via `.swiftpm/`):
 ```json
 {
   "version": 1,
-  "mirrors": [
+  "object": [
     { "original": "https://github.com/torlando-tech/reticulum-swift.git", "mirror": "/Users/you/repos/reticulum-swift" },
     { "original": "https://github.com/torlando-tech/LXMF-swift.git",      "mirror": "/Users/you/repos/LXMF-swift"      },
     { "original": "https://github.com/torlando-tech/LXST-swift.git",      "mirror": "/Users/you/repos/LXST-swift"      }
   ]
 }
 ```
+
+The top-level key is `object`, not `mirrors`. That's the on-disk
+format SPM's `MirrorsStorage` reads, the same shape that
+`swift package config set-mirror` writes — using `mirrors` results
+in a no-op load with no warning.
 
 SPM transparently resolves the listed URLs to your local checkouts, so
 you can iterate on a library and the iOS build picks up the changes


### PR DESCRIPTION
Closes #10.

## Problem

`Package.swift` and `ColumbaApp.xcodeproj` both committed
`XCLocalSwiftPackageReference` / `.package(path:)` entries pointing at
sibling clones via `../LXMF-swift`, `../LXST-swift`, and
`../reticulum-swift`. Anyone cloning Columba-iOS hits:

```
the package manifest at '../LXMF-swift/Package.swift' cannot be accessed
(../LXMF-swift/Package.swift doesn't exist in file system).
```

The README claimed dependencies were resolved automatically — they
weren't. Only MapLibre was a real remote ref.

## What changes

- **`ColumbaApp.xcodeproj/project.pbxproj`**: PKGREF (LXMF), PKGREF3
  (LXST), PKGREF4 (reticulum) flipped from `XCLocalSwiftPackageReference`
  to `XCRemoteSwiftPackageReference` with `upToNextMajorVersion` pins
  at LXMF 0.3.0 / LXST 0.2.0 / reticulum-swift 0.2.0.
- **`Package.swift`**: same shape — three GitHub URLs with `from:` pins
  at the same versions, plus an explicit `ReticulumSwift` product dep
  on the executable target (five view models import it directly so SPM
  should know about it).
- **`README.md`**: drops the inaccurate "resolved automatically" line in
  favour of an honest description, and adds a "Local development
  against unreleased library changes" section documenting the
  `.swiftpm/configuration/mirrors.json` per-machine override
  (already covered by the existing `.swiftpm/` gitignore rule).

## Why these specific tags

- **reticulum-swift 0.2.0** ships the conformance wire bridge plus
  six Transport library bug fixes (PR #10).
- **LXMF-swift 0.3.0** is the first cut to pin reticulum-swift to a
  tagged semver constraint via the new repository URL. Earlier tags
  (0.1.0 / 0.2.0) referenced the old `reticulum-swift-lib` URL.
- **LXST-swift 0.2.0** is the same — first cut on the new URL with
  a tagged reticulum-swift pin.

## Test plan

- [x] `swift package resolve` — LXMF 0.3.0 / LXST 0.2.0 /
  reticulum-swift 0.2.0 resolve cleanly from the new repo URLs.
- [ ] Re-resolve and full Xcode build (this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)