### PR TITLE
chore: align bundle IDs and team for org account migration

### DIFF
--- a/ColumbaApp.xcodeproj/project.pbxproj
+++ b/ColumbaApp.xcodeproj/project.pbxproj
@@ -924,7 +924,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.columba.app.tunnel;
+				PRODUCT_BUNDLE_IDENTIFIER = network.columba.Columba.tunnel;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -950,7 +950,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.columba.app.tunnel;
+				PRODUCT_BUNDLE_IDENTIFIER = network.columba.Columba.tunnel;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -1044,7 +1044,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = network.columba.app;
+				PRODUCT_BUNDLE_IDENTIFIER = network.columba.Columba;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SUPPORTS_MACCATALYST = NO;
@@ -1082,7 +1082,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = network.columba.app;
+				PRODUCT_BUNDLE_IDENTIFIER = network.columba.Columba;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SUPPORTS_MACCATALYST = NO;
@@ -1101,7 +1101,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				PRODUCT_BUNDLE_IDENTIFIER = network.columba.app.tests;
+				PRODUCT_BUNDLE_IDENTIFIER = network.columba.Columba.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SUPPORTS_MACCATALYST = NO;
@@ -1121,7 +1121,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				PRODUCT_BUNDLE_IDENTIFIER = network.columba.app.tests;
+				PRODUCT_BUNDLE_IDENTIFIER = network.columba.Columba.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SUPPORTS_MACCATALYST = NO;

--- a/Config/Signing.xcconfig
+++ b/Config/Signing.xcconfig
@@ -1,2 +1,2 @@
-DEVELOPMENT_TEAM =
+DEVELOPMENT_TEAM = M2977H5PM5
 #include? "LocalSigning.xcconfig"

--- a/Sources/ColumbaApp/App/ColumbaApp.swift
+++ b/Sources/ColumbaApp/App/ColumbaApp.swift
@@ -12,9 +12,6 @@ import UserNotifications
 import BackgroundTasks
 import os
 
-/// App Group identifier for shared data between app and extensions.
-public let appGroupIdentifier = "group.network.columba.Columba"
-
 /// Main SwiftUI App entry point.
 ///
 /// Creates MainTabView as the root navigation container.

--- a/Sources/ColumbaApp/App/ColumbaApp.swift
+++ b/Sources/ColumbaApp/App/ColumbaApp.swift
@@ -38,7 +38,7 @@ struct ColumbaApp: App {
     init() {
         #if os(iOS)
         BGTaskScheduler.shared.register(
-            forTaskWithIdentifier: "network.columba.app.sync",
+            forTaskWithIdentifier: "network.columba.Columba.sync",
             using: nil
         ) { task in
             NotificationCenter.default.post(name: .columbaBackgroundSync, object: task)
@@ -330,7 +330,7 @@ struct RootView: View {
     // MARK: - Background Sync
 
     private func scheduleBackgroundSync() {
-        let request = BGAppRefreshTaskRequest(identifier: "network.columba.app.sync")
+        let request = BGAppRefreshTaskRequest(identifier: "network.columba.Columba.sync")
         request.earliestBeginDate = Date(timeIntervalSinceNow: 15 * 60)
         try? BGTaskScheduler.shared.submit(request)
     }
@@ -522,7 +522,7 @@ struct RootView: View {
 // MARK: - Notification Names
 
 extension Notification.Name {
-    static let columbaBackgroundSync = Notification.Name("com.columba.app.backgroundSync")
+    static let columbaBackgroundSync = Notification.Name("network.columba.Columba.backgroundSync")
 }
 
 // MARK: - Tab Enum

--- a/Sources/ColumbaApp/App/ColumbaApp.swift
+++ b/Sources/ColumbaApp/App/ColumbaApp.swift
@@ -13,7 +13,7 @@ import BackgroundTasks
 import os
 
 /// App Group identifier for shared data between app and extensions.
-public let appGroupIdentifier = "group.network.columba.app"
+public let appGroupIdentifier = "group.network.columba.Columba"
 
 /// Main SwiftUI App entry point.
 ///

--- a/Sources/ColumbaApp/Resources/ColumbaApp.entitlements
+++ b/Sources/ColumbaApp/Resources/ColumbaApp.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.network.columba.app</string>
+		<string>group.network.columba.Columba</string>
 	</array>
 	<key>com.apple.developer.networking.networkextension</key>
 	<array>

--- a/Sources/ColumbaApp/Resources/Info.plist
+++ b/Sources/ColumbaApp/Resources/Info.plist
@@ -4,13 +4,13 @@
 <dict>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
-		<string>network.columba.app.sync</string>
+		<string>network.columba.Columba.sync</string>
 	</array>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
 			<key>CFBundleURLName</key>
-			<string>network.columba.app.lxma</string>
+			<string>network.columba.Columba.lxma</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>lxma</string>

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -183,10 +183,10 @@ public final class AppServices {
     // MARK: - Internal State
 
     /// Logger for debugging service initialization.
-    private let logger = Logger(subsystem: "com.columba.app", category: "AppServices")
+    private let logger = Logger(subsystem: "network.columba.Columba", category: "AppServices")
 
     /// Static logger for use in static methods (identity loading).
-    private static let sLogger = Logger(subsystem: "com.columba.app", category: "AppServices")
+    private static let sLogger = Logger(subsystem: "network.columba.Columba", category: "AppServices")
 
 
     /// Interface state observer task (cancelled on deinit).

--- a/Sources/ColumbaApp/Services/AudioManager.swift
+++ b/Sources/ColumbaApp/Services/AudioManager.swift
@@ -84,7 +84,7 @@ public final class AudioManager {
     /// Set in start() from the engine's output node. Used to downmix decoded
     /// stereo frames to mono when the hardware can't play stereo.
     private var hwOutputChannels: Int = 1
-    private let logger = Logger(subsystem: "com.columba.app", category: "AudioManager")
+    private let logger = Logger(subsystem: "network.columba.Columba", category: "AudioManager")
 
     /// Notification observers for audio session events.
     private var interruptionObserver: NSObjectProtocol?

--- a/Sources/ColumbaApp/Services/AutoAnnounceManager.swift
+++ b/Sources/ColumbaApp/Services/AutoAnnounceManager.swift
@@ -32,7 +32,7 @@ public final class AutoAnnounceManager {
 
     private weak var appServices: AppServices?
     private var announceTask: Task<Void, Never>?
-    private let logger = Logger(subsystem: "com.columba.app", category: "AutoAnnounceManager")
+    private let logger = Logger(subsystem: "network.columba.Columba", category: "AutoAnnounceManager")
 
     // MARK: - Initialization
 

--- a/Sources/ColumbaApp/Services/CallKitManager.swift
+++ b/Sources/ColumbaApp/Services/CallKitManager.swift
@@ -34,7 +34,7 @@ public final class CallKitManager: NSObject, CXProviderDelegate {
 
     private let provider: CXProvider
     private let callController: CXCallController
-    private let logger = Logger(subsystem: "com.columba.app", category: "CallKitManager")
+    private let logger = Logger(subsystem: "network.columba.Columba", category: "CallKitManager")
 
     /// Weak reference back to CallManager for delegate callbacks.
     /// Set after initialization since CallManager creates CallKitManager.

--- a/Sources/ColumbaApp/Services/CallManager.swift
+++ b/Sources/ColumbaApp/Services/CallManager.swift
@@ -92,7 +92,7 @@ public final class CallManager {
     private var database: LXMFDatabase?
     private var durationTask: Task<Void, Never>?
     private var endedDismissTask: Task<Void, Never>?
-    private let logger = Logger(subsystem: "com.columba.app", category: "CallManager")
+    private let logger = Logger(subsystem: "network.columba.Columba", category: "CallManager")
 
     // MARK: - Initialization
 

--- a/Sources/ColumbaApp/Services/ExtensionFrameReader.swift
+++ b/Sources/ColumbaApp/Services/ExtensionFrameReader.swift
@@ -25,7 +25,7 @@ public final class ExtensionFrameReader: @unchecked Sendable {
     // MARK: - Properties
 
     private let frameQueue: SharedFrameQueue
-    private let logger = Logger(subsystem: "com.columba.app", category: "ExtensionFrameReader")
+    private let logger = Logger(subsystem: "network.columba.Columba", category: "ExtensionFrameReader")
 
     /// Callback to inject a TCP frame into transport
     public var onTCPFrameReceived: ((Data) -> Void)?

--- a/Sources/ColumbaApp/Services/IdentityManager.swift
+++ b/Sources/ColumbaApp/Services/IdentityManager.swift
@@ -19,7 +19,7 @@ actor IdentityManager {
     private static let storageKey = "localIdentities"
     static let keychainService = "com.columba.identity"
 
-    private let logger = Logger(subsystem: "com.columba.app", category: "IdentityManager")
+    private let logger = Logger(subsystem: "network.columba.Columba", category: "IdentityManager")
 
     // MARK: - State
 

--- a/Sources/ColumbaApp/Services/IncomingMessageHandler.swift
+++ b/Sources/ColumbaApp/Services/IncomingMessageHandler.swift
@@ -49,7 +49,7 @@ public final class IncomingMessageHandler: LXMRouterDelegate {
     private let createdAt = Date()
 
     /// Logger for debugging message receipt.
-    private let logger = Logger(subsystem: "com.columba.app", category: "IncomingMessageHandler")
+    private let logger = Logger(subsystem: "network.columba.Columba", category: "IncomingMessageHandler")
 
     // MARK: - Initialization
 

--- a/Sources/ColumbaApp/Services/InterfaceRepository.swift
+++ b/Sources/ColumbaApp/Services/InterfaceRepository.swift
@@ -10,7 +10,7 @@ import Foundation
 import ReticulumSwift
 import os.log
 
-private let logger = Logger(subsystem: "com.columba.app", category: "InterfaceRepository")
+private let logger = Logger(subsystem: "network.columba.Columba", category: "InterfaceRepository")
 
 // MARK: - Interface Entity
 

--- a/Sources/ColumbaApp/Services/LocationSharingManager.swift
+++ b/Sources/ColumbaApp/Services/LocationSharingManager.swift
@@ -128,7 +128,7 @@ public final class LocationSharingManager: NSObject {
 
     // MARK: - Private State
 
-    private let logger = Logger(subsystem: "com.columba.app", category: "LocationSharing")
+    private let logger = Logger(subsystem: "network.columba.Columba", category: "LocationSharing")
     private let locationManager = CLLocationManager()
     private var sendTimer: Timer?
     private var expirationTimer: Timer?

--- a/Sources/ColumbaApp/Services/MigrationExporter.swift
+++ b/Sources/ColumbaApp/Services/MigrationExporter.swift
@@ -16,7 +16,7 @@ import os.log
 actor MigrationExporter {
     private let identityManager: IdentityManager
     private let settingsRepository: SettingsRepository
-    private let logger = Logger(subsystem: "com.columba.app", category: "MigrationExporter")
+    private let logger = Logger(subsystem: "network.columba.Columba", category: "MigrationExporter")
 
     init(identityManager: IdentityManager, settingsRepository: SettingsRepository) {
         self.identityManager = identityManager

--- a/Sources/ColumbaApp/Services/MigrationImporter.swift
+++ b/Sources/ColumbaApp/Services/MigrationImporter.swift
@@ -16,7 +16,7 @@ import os.log
 actor MigrationImporter {
     private let identityManager: IdentityManager
     private let settingsRepository: SettingsRepository
-    private let logger = Logger(subsystem: "com.columba.app", category: "MigrationImporter")
+    private let logger = Logger(subsystem: "network.columba.Columba", category: "MigrationImporter")
 
     init(identityManager: IdentityManager, settingsRepository: SettingsRepository) {
         self.identityManager = identityManager

--- a/Sources/ColumbaApp/Services/NomadNetBrowserService.swift
+++ b/Sources/ColumbaApp/Services/NomadNetBrowserService.swift
@@ -2,7 +2,7 @@ import Foundation
 import ReticulumSwift
 import os.log
 
-private let logger = Logger(subsystem: "com.columba.app", category: "NomadNetBrowser")
+private let logger = Logger(subsystem: "network.columba.Columba", category: "NomadNetBrowser")
 
 /// Manages Link establishment and page fetching for NomadNet node browsing.
 public actor NomadNetBrowserService {

--- a/Sources/ColumbaApp/Services/OfflineMapManager.swift
+++ b/Sources/ColumbaApp/Services/OfflineMapManager.swift
@@ -62,7 +62,7 @@ final class OfflineMapManager {
 
     private let storageKey = "com.columba.offlineMapRegions"
     private let styleURL = URL(string: "https://tiles.openfreemap.org/styles/liberty")!
-    private let logger = Logger(subsystem: "com.columba.app", category: "OfflineMapManager")
+    private let logger = Logger(subsystem: "network.columba.Columba", category: "OfflineMapManager")
     private nonisolated(unsafe) var observers: [NSObjectProtocol] = []
 
     // MARK: - Init

--- a/Sources/ColumbaApp/Services/PropagationNodeManager.swift
+++ b/Sources/ColumbaApp/Services/PropagationNodeManager.swift
@@ -87,7 +87,7 @@ public final class PropagationNodeManager {
 
     private weak var appServices: AppServices?
     private let settingsRepository = SettingsRepository()
-    private let logger = Logger(subsystem: "com.columba.app", category: "PropagationNodeManager")
+    private let logger = Logger(subsystem: "network.columba.Columba", category: "PropagationNodeManager")
 
     /// Task for listening to path table updates.
     private var listenTask: Task<Void, Never>?

--- a/Sources/ColumbaApp/Services/SettingsRepository.swift
+++ b/Sources/ColumbaApp/Services/SettingsRepository.swift
@@ -17,7 +17,7 @@ public actor SettingsRepository {
     // MARK: - Constants
 
     /// App Group identifier for shared container.
-    private static let appGroupSuiteName = "group.network.columba.app"
+    private static let appGroupSuiteName = "group.network.columba.Columba"
 
     // MARK: - Keys
 

--- a/Sources/ColumbaApp/Services/SettingsRepository.swift
+++ b/Sources/ColumbaApp/Services/SettingsRepository.swift
@@ -14,11 +14,6 @@ import LXMFSwift
 /// Uses App Group UserDefaults for data sharing between main app
 /// and Network Extension. Stores server configuration and identity info.
 public actor SettingsRepository {
-    // MARK: - Constants
-
-    /// App Group identifier for shared container.
-    private static let appGroupSuiteName = "group.network.columba.Columba"
-
     // MARK: - Keys
 
     private enum Keys {
@@ -48,7 +43,7 @@ public actor SettingsRepository {
     public init() {
         // Use App Group UserDefaults for sharing with Network Extension
         // Falls back to standard UserDefaults if App Group not available
-        self.defaults = UserDefaults(suiteName: Self.appGroupSuiteName) ?? .standard
+        self.defaults = UserDefaults(suiteName: appGroupIdentifier) ?? .standard
     }
 
     // MARK: - Identity

--- a/Sources/ColumbaApp/Services/TunnelManager.swift
+++ b/Sources/ColumbaApp/Services/TunnelManager.swift
@@ -35,7 +35,7 @@ public final class TunnelManager: @unchecked Sendable {
     /// The loaded tunnel provider manager
     private var manager: NETunnelProviderManager?
 
-    private let logger = Logger(subsystem: "com.columba.app", category: "TunnelManager")
+    private let logger = Logger(subsystem: "network.columba.Columba", category: "TunnelManager")
 
     // MARK: - Lifecycle
 
@@ -78,7 +78,7 @@ public final class TunnelManager: @unchecked Sendable {
         }
 
         let proto = NETunnelProviderProtocol()
-        proto.providerBundleIdentifier = "com.columba.app.tunnel"
+        proto.providerBundleIdentifier = "network.columba.Columba.tunnel"
         proto.serverAddress = "Columba Transport"
 
         mgr.protocolConfiguration = proto

--- a/Sources/ColumbaApp/ViewModels/InterfaceManagementViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/InterfaceManagementViewModel.swift
@@ -11,7 +11,7 @@ import SwiftUI
 import ReticulumSwift
 import os.log
 
-private let logger = Logger(subsystem: "com.columba.app", category: "InterfaceManagementVM")
+private let logger = Logger(subsystem: "network.columba.Columba", category: "InterfaceManagementVM")
 
 // MARK: - Interface Management ViewModel
 

--- a/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
@@ -50,7 +50,7 @@ public final class MessagingViewModel {
     private let appServices: AppServices
     private let settingsRepository = SettingsRepository()
     private let displayName: String?
-    private let logger = Logger(subsystem: "com.columba.app", category: "MessagingViewModel")
+    private let logger = Logger(subsystem: "network.columba.Columba", category: "MessagingViewModel")
 
     /// Observation token for incoming message notifications.
     private var notificationTask: Any?

--- a/Sources/ColumbaApp/ViewModels/MigrationViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/MigrationViewModel.swift
@@ -63,7 +63,7 @@ final class MigrationViewModel {
 
     private let exporter: MigrationExporter
     private let importer: MigrationImporter
-    private let logger = Logger(subsystem: "com.columba.app", category: "MigrationViewModel")
+    private let logger = Logger(subsystem: "network.columba.Columba", category: "MigrationViewModel")
 
     // MARK: - Cached data for import flow
 

--- a/Sources/ColumbaApp/Views/Messaging/MessageBubble.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageBubble.swift
@@ -13,7 +13,7 @@ import os.log
 import UIKit
 #endif
 
-private let logger = Logger(subsystem: "com.columba.app", category: "MessageBubble")
+private let logger = Logger(subsystem: "network.columba.Columba", category: "MessageBubble")
 
 /// Individual message bubble view.
 ///

--- a/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
@@ -21,7 +21,7 @@ import UIKit
 import AppKit
 #endif
 
-private let logger = Logger(subsystem: "com.columba.app", category: "MessagingView")
+private let logger = Logger(subsystem: "network.columba.Columba", category: "MessagingView")
 
 /// Main messaging/chat screen view.
 ///

--- a/Sources/ColumbaApp/Views/Settings/RNodeWizard/RNodeProbeScanner.swift
+++ b/Sources/ColumbaApp/Views/Settings/RNodeWizard/RNodeProbeScanner.swift
@@ -81,7 +81,7 @@ final class RNodeProbeScanner: NSObject {
     /// capture their generation and no-op if it no longer matches, preventing
     /// stale 3s notify timeouts from firing on subsequent reconnect attempts.
     private var probeGeneration = 0
-    private let logger = Logger(subsystem: "com.columba.app", category: "RNodeProbe")
+    private let logger = Logger(subsystem: "network.columba.Columba", category: "RNodeProbe")
 
     /// File-based diagnostic log (readable via idevice tools).
     private static let diagURL: URL = {

--- a/Sources/ColumbaNetworkExtension/ColumbaNetworkExtension.entitlements
+++ b/Sources/ColumbaNetworkExtension/ColumbaNetworkExtension.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.network.columba.app</string>
+		<string>group.network.columba.Columba</string>
 	</array>
 	<key>com.apple.developer.networking.networkextension</key>
 	<array>

--- a/Sources/ColumbaNetworkExtension/PacketTunnelProvider.swift
+++ b/Sources/ColumbaNetworkExtension/PacketTunnelProvider.swift
@@ -18,7 +18,6 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
     // MARK: - Constants
 
-    private static let appGroupId = "group.network.columba.Columba"
     private static let packetReadyNotification = "network.columba.packetReady"
     private static let interfacesKey = "com.columba.interfaces"
 
@@ -26,7 +25,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
     private var tcpConnection: NWConnection?
     private var autoListener: NWConnectionGroup?
-    private lazy var frameQueue = SharedFrameQueue(appGroupIdentifier: Self.appGroupId)
+    private lazy var frameQueue = SharedFrameQueue(appGroupIdentifier: appGroupIdentifier)
 
     /// HDLC receive buffer for TCP stream framing
     private var tcpReceiveBuffer = Data()
@@ -42,7 +41,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         NSLog("[EXT] startTunnel called")
 
         // Read interface configs from shared UserDefaults
-        let defaults = UserDefaults(suiteName: Self.appGroupId) ?? .standard
+        let defaults = UserDefaults(suiteName: appGroupIdentifier) ?? .standard
         let configs = loadInterfaceConfigs(from: defaults)
 
         // Start TCP connection if configured
@@ -117,7 +116,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         NSLog("[EXT] wake")
         // Reconnect if needed
         if tcpConnection?.state == .cancelled || tcpConnection?.state == .failed(NWError.posix(.ECONNRESET)) {
-            let defaults = UserDefaults(suiteName: Self.appGroupId) ?? .standard
+            let defaults = UserDefaults(suiteName: appGroupIdentifier) ?? .standard
             let configs = loadInterfaceConfigs(from: defaults)
             if let tcp = configs.tcp {
                 startTCPConnection(host: tcp.host, port: tcp.port)

--- a/Sources/ColumbaNetworkExtension/PacketTunnelProvider.swift
+++ b/Sources/ColumbaNetworkExtension/PacketTunnelProvider.swift
@@ -18,7 +18,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
     // MARK: - Constants
 
-    private static let appGroupId = "group.network.columba.app"
+    private static let appGroupId = "group.network.columba.Columba"
     private static let packetReadyNotification = "network.columba.packetReady"
     private static let interfacesKey = "com.columba.interfaces"
 

--- a/Sources/Shared/SharedFrameQueue.swift
+++ b/Sources/Shared/SharedFrameQueue.swift
@@ -11,6 +11,10 @@
 
 import Foundation
 
+/// App Group identifier shared between the main app and the Network Extension.
+/// Defined here because `Sources/Shared` is compiled into both targets.
+public let appGroupIdentifier = "group.network.columba.Columba"
+
 /// Interface tag identifying which network interface a frame arrived on.
 public enum FrameInterfaceTag: UInt8 {
     case tcp = 0x01

--- a/Sources/Shared/SharedFrameQueue.swift
+++ b/Sources/Shared/SharedFrameQueue.swift
@@ -49,7 +49,7 @@ public final class SharedFrameQueue: @unchecked Sendable {
 
     /// Create a shared frame queue in the given App Group container.
     ///
-    /// - Parameter appGroupIdentifier: The App Group identifier (e.g., "group.network.columba.app")
+    /// - Parameter appGroupIdentifier: The App Group identifier (e.g., "group.network.columba.Columba")
     public init(appGroupIdentifier: String) {
         guard let containerURL = FileManager.default.containerURL(
             forSecurityApplicationGroupIdentifier: appGroupIdentifier


### PR DESCRIPTION
## Summary

Fixes the Xcode Cloud post-merge build failure where archive succeeds but `xcodebuild -exportArchive` exits 70 on all distribution types (ad-hoc, app-store, development).

After upgrading to org team `M2977H5PM5` on 2026-04-22, automatic signing on Xcode Cloud could not synthesize provisioning profiles because the old App IDs (`network.columba.app`, `com.columba.app.tunnel`) were not registered on the new team.

## Changes

**Commit 1 — bundle IDs + team (7 files, signing-critical):**
- App: `network.columba.app` → `network.columba.Columba`
- Tunnel: `com.columba.app.tunnel` → `network.columba.Columba.tunnel`
- Tests: `network.columba.app.tests` → `network.columba.Columba.tests`
- Pin `DEVELOPMENT_TEAM = M2977H5PM5` in `Config/Signing.xcconfig` (still overridable via the optional `LocalSigning.xcconfig` include)
- App Group identifier: `group.network.columba.app` → `group.network.columba.Columba` in both entitlements files and the three Swift constants that read the suite (otherwise app↔tunnel IPC via `UserDefaults` and `SharedFrameQueue` silently breaks)

**Commit 2 — remaining identifier cleanup (25 files):**
- *Functional:* `TunnelManager.swift` `proto.providerBundleIdentifier` (would have prevented the app from starting the renamed extension)
- *Functional:* `BGTaskSchedulerPermittedIdentifiers` in `Info.plist` + matching `BGTaskScheduler.register` calls in `ColumbaApp.swift`
- *Cosmetic:* ~22 `Logger(subsystem:)` strings, `CFBundleURLName`, in-process `Notification.Name`, one doc comment

## Prerequisites (already done on the dev portal)

- App IDs `network.columba.Columba` and `network.columba.Columba.tunnel` registered on team M2977H5PM5 with **App Groups** + **Network Extensions (Packet Tunnel)** capabilities
- App Group `group.network.columba.Columba` registered and assigned to both App IDs

## Test plan

- [x] Local sim build succeeds with new bundle ID (`--bundle-id network.columba.Columba` confirmed in build log)
- [ ] Xcode Cloud archive + export succeed on all three distribution types
- [ ] Tunnel starts on device after install (verifies `providerBundleIdentifier` change)
- [ ] BG sync task fires (verifies BGTask identifier match between code and Info.plist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)