### PR TITLE
fix: macOS build errors in NomadNet browser views

### DIFF
--- a/Sources/ColumbaApp/Views/NomadNet/MicronDocumentView.swift
+++ b/Sources/ColumbaApp/Views/NomadNet/MicronDocumentView.swift
@@ -121,7 +121,7 @@ struct MicronDocumentView: View {
                     .font(.system(size: style.fontSize, design: .monospaced))
                     .padding(8)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(Color(.systemGray6))
+                    .background(Color.platformSystemGray6)
                     .cornerRadius(6)
                     .padding(.vertical, 4)
             }
@@ -274,7 +274,7 @@ private struct MicronSimpleElementView: View {
             Text(text)
                 .font(.system(.body, design: .monospaced))
                 .padding(8)
-                .background(Color(.systemGray6))
+                .background(Color.platformSystemGray6)
                 .cornerRadius(6)
         case .formField, .partial:
             EmptyView()

--- a/Sources/ColumbaApp/Views/NomadNet/NomadNetBrowserView.swift
+++ b/Sources/ColumbaApp/Views/NomadNet/NomadNetBrowserView.swift
@@ -55,51 +55,11 @@ struct NomadNetBrowserView: View {
             }
 
             #if os(iOS)
-            ToolbarItem(placement: .navigationBarLeading) {
-                if viewModel.canGoBack {
-                    Button {
-                        Task { await viewModel.goBack() }
-                    } label: {
-                        Image(systemName: "chevron.left")
-                    }
-                }
-            }
-
-            ToolbarItem(placement: .navigationBarTrailing) {
-                Menu {
-                    Button {
-                        Task { await viewModel.refresh() }
-                    } label: {
-                        Label("Refresh", systemImage: "arrow.clockwise")
-                    }
-
-                    Button {
-                        Task { await viewModel.identifyToNode() }
-                    } label: {
-                        Label("Identify to Node", systemImage: "person.badge.key")
-                    }
-
-                    Divider()
-
-                    Menu {
-                        ForEach(NomadNetRenderingMode.allCases, id: \.self) { mode in
-                            Button {
-                                viewModel.renderingMode = mode
-                            } label: {
-                                if viewModel.renderingMode == mode {
-                                    Label(mode.displayName, systemImage: "checkmark")
-                                } else {
-                                    Text(mode.displayName)
-                                }
-                            }
-                        }
-                    } label: {
-                        Label("Rendering Mode", systemImage: viewModel.renderingMode.iconName)
-                    }
-                } label: {
-                    Image(systemName: "ellipsis.circle")
-                }
-            }
+            ToolbarItem(placement: .navigationBarLeading) { backButton }
+            ToolbarItem(placement: .navigationBarTrailing) { actionsMenu }
+            #else
+            ToolbarItem(placement: .navigation) { backButton }
+            ToolbarItem(placement: .primaryAction) { actionsMenu }
             #endif
         }
         .task {
@@ -139,6 +99,53 @@ struct NomadNetBrowserView: View {
             .truncationMode(.middle)
             .foregroundStyle(.secondary)
             .frame(maxWidth: 220)
+    }
+
+    @ViewBuilder
+    private var backButton: some View {
+        if viewModel.canGoBack {
+            Button {
+                Task { await viewModel.goBack() }
+            } label: {
+                Image(systemName: "chevron.left")
+            }
+        }
+    }
+
+    private var actionsMenu: some View {
+        Menu {
+            Button {
+                Task { await viewModel.refresh() }
+            } label: {
+                Label("Refresh", systemImage: "arrow.clockwise")
+            }
+
+            Button {
+                Task { await viewModel.identifyToNode() }
+            } label: {
+                Label("Identify to Node", systemImage: "person.badge.key")
+            }
+
+            Divider()
+
+            Menu {
+                ForEach(NomadNetRenderingMode.allCases, id: \.self) { mode in
+                    Button {
+                        viewModel.renderingMode = mode
+                    } label: {
+                        if viewModel.renderingMode == mode {
+                            Label(mode.displayName, systemImage: "checkmark")
+                        } else {
+                            Text(mode.displayName)
+                        }
+                    }
+                }
+            } label: {
+                Label("Rendering Mode", systemImage: viewModel.renderingMode.iconName)
+            }
+        } label: {
+            Image(systemName: "ellipsis.circle")
+        }
     }
 
     private var loadingOverlay: some View {

--- a/Sources/ColumbaApp/Views/NomadNet/NomadNetBrowserView.swift
+++ b/Sources/ColumbaApp/Views/NomadNet/NomadNetBrowserView.swift
@@ -54,6 +54,7 @@ struct NomadNetBrowserView: View {
                 urlBar
             }
 
+            #if os(iOS)
             ToolbarItem(placement: .navigationBarLeading) {
                 if viewModel.canGoBack {
                     Button {
@@ -99,6 +100,7 @@ struct NomadNetBrowserView: View {
                     Image(systemName: "ellipsis.circle")
                 }
             }
+            #endif
         }
         .task {
             await viewModel.loadPage()
@@ -156,7 +158,7 @@ struct NomadNetBrowserView: View {
            let color = MicronTextStyle.colorFrom3Hex(bgHex) {
             color
         } else {
-            Color(.systemBackground)
+            Color.platformSystemBackground
         }
     }
 }

--- a/Sources/ColumbaApp/Views/PlatformCompat.swift
+++ b/Sources/ColumbaApp/Views/PlatformCompat.swift
@@ -21,6 +21,26 @@ extension Image {
     }
 }
 
+// MARK: - Cross-platform system colors
+
+extension Color {
+    static var platformSystemBackground: Color {
+        #if os(iOS)
+        Color(.systemBackground)
+        #else
+        Color(NSColor.windowBackgroundColor)
+        #endif
+    }
+
+    static var platformSystemGray6: Color {
+        #if os(iOS)
+        Color(.systemGray6)
+        #else
+        Color(NSColor.controlBackgroundColor)
+        #endif
+    }
+}
+
 #if os(iOS)
 typealias PlatformImage = UIImage
 #else

--- a/Sources/ColumbaApp/Views/PlatformCompat.swift
+++ b/Sources/ColumbaApp/Views/PlatformCompat.swift
@@ -7,6 +7,9 @@
 //
 
 import SwiftUI
+#if !os(iOS)
+import AppKit
+#endif
 
 // MARK: - Cross-platform Image helper
 
@@ -44,7 +47,6 @@ extension Color {
 #if os(iOS)
 typealias PlatformImage = UIImage
 #else
-import AppKit
 typealias PlatformImage = NSImage
 
 // MARK: - NavigationBarItem shim


### PR DESCRIPTION
## Summary

Xcode Cloud's macOS build fails on main with 5 errors against iOS-only SwiftUI APIs in the NomadNet browser views:

- `NomadNetBrowserView.swift:57` — `navigationBarLeading` unavailable in macOS
- `NomadNetBrowserView.swift:67` — `navigationBarTrailing` unavailable in macOS
- `NomadNetBrowserView.swift:159` — `Color(.systemBackground)` cannot be resolved
- `MicronDocumentView.swift:124` — `Color(.systemGray6)` cannot be resolved
- `MicronDocumentView.swift:277` — `Color(.systemGray6)` cannot be resolved

## Fix

- Wrap the `.navigationBarLeading` / `.navigationBarTrailing` ToolbarItems in `#if os(iOS)`. The `.principal` toolbar item is cross-platform and stays unguarded so the URL bar still shows on macOS.
- Add `Color.platformSystemBackground` and `Color.platformSystemGray6` to `PlatformCompat.swift` (mirroring the existing pattern of platform shims) and route the three call sites through them.

## Test plan

- [x] `xcodebuild -destination 'platform=macOS' -scheme ColumbaApp build` succeeds locally
- [ ] Xcode Cloud macOS build succeeds
- [ ] iOS build still succeeds (no regressions; iOS path still uses `Color(.systemBackground)` / `Color(.systemGray6)` via the shim)

🤖 Generated with [Claude Code](https://claude.com/claude-code)