### PR TITLE
fix: remove invalid 'network-extension' from UIBackgroundModes

### DIFF
--- a/Sources/ColumbaApp/Resources/Info.plist
+++ b/Sources/ColumbaApp/Resources/Info.plist
@@ -40,7 +40,6 @@
 		<string>bluetooth-peripheral</string>
 		<string>location</string>
 		<string>voip</string>
-		<string>network-extension</string>
 	</array>
 	<key>UILaunchScreen</key>
 	<dict/>


### PR DESCRIPTION
## Summary

App Store Connect rejected build `0.0.2 (10)` with:

> **ITMS-90112**: Invalid Info.plist value. The Info.plist key `UIBackgroundModes` contains an invalid value: `'network-extension'`.

`network-extension` isn't in Apple's allowed `UIBackgroundModes` list (`audio`, `bluetooth-central`, `bluetooth-peripheral`, `external-accessory`, `fetch`, `location`, `network-authentication`, `processing`, `push`, `remote-notification`, `voip`). Network Extensions declare themselves via `NSExtension` / `NSExtensionPointIdentifier` in the extension target's own Info.plist (which we already do correctly in `Sources/ColumbaNetworkExtension/Info.plist`).

The host app doesn't need any background mode for the packet tunnel — the system keeps the extension running on its own once `NEPacketTunnelProvider` is started.

## Test plan

- [x] Diff is one line removed from Info.plist
- [ ] Xcode Cloud Build #11 archive uploads successfully (no ITMS-90112)
- [ ] Build appears in TestFlight as 0.0.2 (N)

🤖 Generated with [Claude Code](https://claude.com/claude-code)