### PR TITLE
fix: show configured interface name in message details

### DIFF
--- a/Sources/ColumbaApp/Views/Messaging/MessageDetailView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageDetailView.swift
@@ -18,10 +18,12 @@ struct MessageDetailView: View {
     let message: Message
     @Environment(\.dismiss) private var dismiss
 
-    /// Lazily-loaded InterfaceRepository for resolving interface UUIDs to
-    /// their configured friendly name and connection details. Loaded on first
-    /// view appearance (UserDefaults-backed; cheap to construct).
-    @State private var interfaceRepository: InterfaceRepository?
+    /// Eagerly-constructed InterfaceRepository for resolving interface UUIDs
+    /// to their configured friendly name and connection details. Init is
+    /// synchronous (UserDefaults-backed), so constructing at view init time
+    /// avoids a first-render flicker where the receiving-interface card would
+    /// briefly fall through to the orphan branch.
+    @State private var interfaceRepository: InterfaceRepository = InterfaceRepository()
 
     var body: some View {
         NavigationStack {
@@ -64,14 +66,6 @@ struct MessageDetailView: View {
             #endif
         }
         .preferredColorScheme(.dark)
-        .onAppear {
-            // Lazily load the interface repo so receivedInterfaceCard can
-            // resolve UUIDs to the user's configured names. The repo reads
-            // from UserDefaults in init, which is cheap.
-            if interfaceRepository == nil {
-                interfaceRepository = InterfaceRepository()
-            }
-        }
     }
 
     // MARK: - Message Preview
@@ -243,7 +237,7 @@ struct MessageDetailView: View {
         // Look up the interface by its UUID in the repository so we can show
         // the user's configured friendly name (e.g. "beleth") and connection
         // target (e.g. "example.com:4242") instead of raw UUID substrings.
-        let entity = interfaceRepository?.getInterface(id: interfaceId)
+        let entity = interfaceRepository.getInterface(id: interfaceId)
         let (icon, name, subtitle) = interfaceCardDisplay(for: entity, fallbackId: interfaceId)
 
         return InfoCard(
@@ -271,31 +265,27 @@ struct MessageDetailView: View {
             return ("globe", "Network", fallbackId)
         }
 
-        let icon: String
+        // Use the canonical icon from InterfaceType to keep this view aligned
+        // with the rest of the app (interface list, settings, etc.).
+        let icon = entity.type.icon
         let subtitle: String
         switch entity.config {
         case .tcpClient(let cfg):
-            icon = "globe"
             subtitle = "\(cfg.targetHost):\(cfg.targetPort)"
         case .tcpServer(let cfg):
-            icon = "globe"
             subtitle = "Listening on \(cfg.listenIp):\(cfg.listenPort)"
         case .autoInterface(let cfg):
-            icon = "wifi"
             if let groupId = cfg.groupId, !groupId.isEmpty {
                 subtitle = "Auto Discovery / \(groupId)"
             } else {
                 subtitle = "Auto Discovery (\(cfg.discoveryScope))"
             }
         case .ble:
-            icon = "wave.3.right"
             subtitle = "Bluetooth LE Mesh"
         case .rnode(let cfg):
-            icon = "antenna.radiowaves.left.and.right"
             let device = cfg.deviceName.isEmpty ? "RNode" : cfg.deviceName
             subtitle = "RNode LoRa / \(device)"
         case .multipeer(let cfg):
-            icon = "apple.logo"
             subtitle = "Nearby / \(cfg.serviceType)"
         }
 

--- a/Sources/ColumbaApp/Views/Messaging/MessageDetailView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageDetailView.swift
@@ -13,10 +13,15 @@ import SwiftUI
 /// Shows different cards based on message direction:
 /// - **Sent**: Timestamp, Status, Delivery Method, Error (if failed)
 /// - **Received**: Timestamp, Delivery Method, RSSI, SNR
-@available(iOS 17.0, *)
+@available(iOS 17.0, macOS 14.0, *)
 struct MessageDetailView: View {
     let message: Message
     @Environment(\.dismiss) private var dismiss
+
+    /// Lazily-loaded InterfaceRepository for resolving interface UUIDs to
+    /// their configured friendly name and connection details. Loaded on first
+    /// view appearance (UserDefaults-backed; cheap to construct).
+    @State private var interfaceRepository: InterfaceRepository?
 
     var body: some View {
         NavigationStack {
@@ -59,6 +64,14 @@ struct MessageDetailView: View {
             #endif
         }
         .preferredColorScheme(.dark)
+        .onAppear {
+            // Lazily load the interface repo so receivedInterfaceCard can
+            // resolve UUIDs to the user's configured names. The repo reads
+            // from UserDefaults in init, which is cheap.
+            if interfaceRepository == nil {
+                interfaceRepository = InterfaceRepository()
+            }
+        }
     }
 
     // MARK: - Message Preview
@@ -227,28 +240,66 @@ struct MessageDetailView: View {
     }
 
     private func receivedInterfaceCard(_ interfaceId: String) -> some View {
-        let id = interfaceId.lowercased()
-        let (icon, name): (String, String) = {
-            if id.contains("ble") {
-                return ("wave.3.right", "Bluetooth LE")
-            } else if id.contains("rnode") {
-                return ("antenna.radiowaves.left.and.right", "RNode")
-            } else if id.contains("auto") {
-                return ("wifi", "AutoInterface (WiFi/LAN)")
-            } else if id.contains("tcp") {
-                return ("globe", "TCP")
-            } else {
-                return ("globe", "Network")
-            }
-        }()
+        // Look up the interface by its UUID in the repository so we can show
+        // the user's configured friendly name (e.g. "beleth") and connection
+        // target (e.g. "example.com:4242") instead of raw UUID substrings.
+        let entity = interfaceRepository?.getInterface(id: interfaceId)
+        let (icon, name, subtitle) = interfaceCardDisplay(for: entity, fallbackId: interfaceId)
 
         return InfoCard(
             icon: icon,
             iconColor: .cyan,
             title: "Receiving Interface",
             content: name,
-            subtitle: interfaceId
+            subtitle: subtitle
         )
+    }
+
+    /// Resolve an InterfaceEntity to display values for the receiving-interface card.
+    ///
+    /// Returns `(icon, content, subtitle)`:
+    /// - `content` is the user-configured friendly name (or "Network" for an orphan).
+    /// - `subtitle` is the connection target (host:port, multicast group, BLE/USB, etc.)
+    ///   or the raw UUID when the interface no longer exists in the repository.
+    private func interfaceCardDisplay(
+        for entity: InterfaceEntity?,
+        fallbackId: String
+    ) -> (icon: String, name: String, subtitle: String) {
+        guard let entity else {
+            // Orphan: the message arrived on an interface that has since been
+            // deleted. Render gracefully with the raw UUID as the subtitle.
+            return ("globe", "Network", fallbackId)
+        }
+
+        let icon: String
+        let subtitle: String
+        switch entity.config {
+        case .tcpClient(let cfg):
+            icon = "globe"
+            subtitle = "\(cfg.targetHost):\(cfg.targetPort)"
+        case .tcpServer(let cfg):
+            icon = "globe"
+            subtitle = "Listening on \(cfg.listenIp):\(cfg.listenPort)"
+        case .autoInterface(let cfg):
+            icon = "wifi"
+            if let groupId = cfg.groupId, !groupId.isEmpty {
+                subtitle = "Auto Discovery / \(groupId)"
+            } else {
+                subtitle = "Auto Discovery (\(cfg.discoveryScope))"
+            }
+        case .ble:
+            icon = "wave.3.right"
+            subtitle = "Bluetooth LE Mesh"
+        case .rnode(let cfg):
+            icon = "antenna.radiowaves.left.and.right"
+            let device = cfg.deviceName.isEmpty ? "RNode" : cfg.deviceName
+            subtitle = "RNode LoRa / \(device)"
+        case .multipeer(let cfg):
+            icon = "apple.logo"
+            subtitle = "Nearby / \(cfg.serviceType)"
+        }
+
+        return (icon, entity.name, subtitle)
     }
 
     private func rssiCard(_ rssi: Double) -> some View {


### PR DESCRIPTION
## Summary

The Message Details "Receiving Interface" card was substring-matching the raw `interfaceId` (a UUID stored as `config.id`) against the literal strings `"tcp"`, `"ble"`, `"rnode"`, and `"auto"`. UUIDs never contain those substrings, so every received message fell through to the default branch and rendered as **"Network"** with the bare UUID below it.

This change looks the UUID up in `InterfaceRepository` and renders the user-configured name with a type-appropriate icon and a connection target as the subtitle.

### Before

```
Receiving Interface
Network
9C3A1F2E-...-UUID
```

### After

```
Receiving Interface
beleth
example.com:4242
```

### Mapping

| Type | content | subtitle |
| --- | --- | --- |
| TCP client | configured name | `host:port` |
| TCP server | configured name | `Listening on ip:port` |
| Auto | configured name | `Auto Discovery (scope)` or group id |
| BLE | configured name | `Bluetooth LE Mesh` |
| RNode | configured name | `RNode LoRa / device` |
| Multipeer | configured name | `Nearby / service-type` |
| Orphan (UUID not in repo) | `Network` | raw UUID |

## Implementation notes

- `MessageDetailView` gains an `@State InterfaceRepository?` lazily initialised in `.onAppear`, matching the existing `SettingsView` pattern (the repo reads from UserDefaults in `init`, so it's cheap).
- Icon selection is driven by `InterfaceTypeConfig` (an enum), not substring matching.
- Storage format is unchanged — only the display layer changed. The DB still stores the UUID.
- `MessageDetailView.deliveryMethodCard` is intentionally untouched (separate PR).
- `@available` was widened from `iOS 17.0` to `iOS 17.0, macOS 14.0` to match `InterfaceRepository`'s availability.

## Test plan

- [x] iOS simulator build (`xcodebuild ... -sdk iphonesimulator`) — passes
- [x] macOS build (`xcodebuild ... -destination 'platform=macOS'`) — passes
- [ ] On device: open a received message → Details → confirm friendly name + host:port show instead of "Network" + UUID
- [ ] Delete the interface a message arrived on, then open Details → confirm graceful "Network" + UUID fallback

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>