### PR TITLE
fix: wait for caller identity before showing incoming-call UI

### DIFF
--- a/Sources/ColumbaApp/App/ColumbaApp.swift
+++ b/Sources/ColumbaApp/App/ColumbaApp.swift
@@ -12,6 +12,8 @@ import UserNotifications
 import BackgroundTasks
 import os
 
+private let logger = Logger(subsystem: "network.columba.Columba", category: "ColumbaApp")
+
 /// Main SwiftUI App entry point.
 ///
 /// Creates MainTabView as the root navigation container.
@@ -208,7 +210,13 @@ struct RootView: View {
                         // establishment (before LINKIDENTIFY), when peerName and
                         // peerHash are both nil — which would render as
                         // "Unknown" until the identify signal arrives.
-                        guard cm.peerHash != nil || cm.peerName != nil else { return }
+                        guard cm.peerHash != nil || cm.peerName != nil else {
+                            // Defensive: if this fires, CallKit's lock-screen UI
+                            // is ringing but the in-app sheet is suppressed —
+                            // a callback-ordering regression in CallManager.
+                            logger.error("[CALL] Reached .ringing with both peerHash and peerName nil; in-app sheet suppressed but CallKit UI may still be ringing — regression in CallManager identify ordering")
+                            return
+                        }
                         if !showIncomingCall {
                             showIncomingCall = true
                         }

--- a/Sources/ColumbaApp/App/ColumbaApp.swift
+++ b/Sources/ColumbaApp/App/ColumbaApp.swift
@@ -194,9 +194,21 @@ struct RootView: View {
                     }
                 }
                 .onChange(of: appServices.callManager?.callState) { _, newState in
-                    guard let newState, appServices.callManager?.isIncoming == true else { return }
+                    guard let cm = appServices.callManager,
+                          let newState,
+                          cm.isIncoming else { return }
                     switch newState {
-                    case .connecting, .ringing:
+                    case .ringing:
+                        // Only present the incoming-call sheet once we know who's
+                        // calling. peerHash is populated in CallManager's ringing
+                        // callback (after LINKIDENTIFY arrives) right before the
+                        // state transitions to .ringing — so by this point peer
+                        // info is set. We deliberately do NOT trigger on
+                        // .connecting because that state is reached at link
+                        // establishment (before LINKIDENTIFY), when peerName and
+                        // peerHash are both nil — which would render as
+                        // "Unknown" until the identify signal arrives.
+                        guard cm.peerHash != nil || cm.peerName != nil else { return }
                         if !showIncomingCall {
                             showIncomingCall = true
                         }


### PR DESCRIPTION
## Summary

Fixes a sporadic UX bug where the incoming voice-call screen briefly displayed the caller as "**Unknown**".

## Root cause

The fullScreenCover in `RootView` (`Sources/ColumbaApp/App/ColumbaApp.swift`) was opening on `callState` transitions to either `.connecting` **or** `.ringing`:

```swift
case .connecting, .ringing:
    if !showIncomingCall { showIncomingCall = true }
```

For incoming LXST calls, `CallManager.handleIncomingLink()` sets `callState = .connecting` immediately at link establishment — i.e. the moment the transport hands us a `Link` to the telephony destination, before any LXST signaling. At that point we have **no idea who's calling**: `peerName` and `peerHash` are both still `nil`. They are populated later in `CallManager`'s `ringingCallback`, which fires only after the LXST `LINKIDENTIFY` signal arrives and Telephone transitions to `.ringing`:

```swift
// CallManager.swift:160-165
await phone.setRingingCallback { [weak self] remoteIdentity in
    await MainActor.run {
        guard let self else { return }
        self.peerHash = remoteIdentity.hexHash      // <-- populated here
        self.callState = .ringing
        ...
```

So between link-establishment and LINKIDENTIFY, the cover was already presented and `IncomingCallScreen.swift:57` rendered the defense-in-depth fallback `"Unknown"`. On a slow path it could persist for the whole flash of the screen; on a fast path the user saw "Unknown" → real name flicker.

## Fix

Drop `.connecting` from the trigger condition. Open the cover only on `.ringing`, by which time `peerHash` is guaranteed to be set (it's assigned on the same `MainActor.run` hop, before the state flip). Added a defensive guard requiring `peerHash != nil || peerName != nil` to make the precondition explicit and protect against any future callback ordering changes.

## Before / after

| | Before | After |
|---|---|---|
| Link established, no LINKIDENTIFY yet | Sheet shown, caller name = "Unknown" | Sheet not shown |
| LINKIDENTIFY arrives → `.ringing` | Caller name updates to real value (after a flicker) | Sheet opens with caller name already set |
| Trigger sites | `.connecting`, `.ringing` | `.ringing` only |

The defense-in-depth `peerName ?? peerHash ?? "Unknown"` rendering in `IncomingCallScreen` is left intact — it now serves purely as belt-and-suspenders for impossible states.

CallKit's own incoming-call notification (lock-screen UI) is unaffected — `CallManager.handleIncomingLink` still calls `reportIncomingCall(...)` immediately so the system UI still shows promptly. CallKit already substitutes "Unknown Caller" when `peerName` is nil and `updateCallerName` is invoked from `resolveContactName` once the identity resolves.

## Test plan

- [x] Build succeeds for `Columba` scheme on iPhone simulator
- [ ] Manual: incoming call from a known contact shows the contact name immediately on the in-app sheet (no "Unknown" flash)
- [ ] Manual: incoming call from an unknown peer shows the peer hash (no "Unknown" flash)
- [ ] Manual: rapid back-to-back incoming calls do not present a phantom sheet
- [ ] Manual: outgoing call flow remains unchanged (uses `.calling` → `.ringing` → `.established`)