### PR TITLE
chore: bump SPM pins to LXMFSwift 0.3.1 / ReticulumSwift 0.2.1

### DIFF
--- a/Columba.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Columba.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
       "state" : {
-        "revision" : "e45a26384239e028ec87fbcc788f513b67e10d8f",
-        "version" : "1.9.0"
+        "revision" : "f2a627b84c1ff96f21ac2fcb623ab36142dd5512",
+        "version" : "1.10.0"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/torlando-tech/LXMF-swift.git",
       "state" : {
-        "revision" : "97c4871bae3dcf392c0a2e10a7c1eb56639270ec",
-        "version" : "0.3.0"
+        "revision" : "b1f4899ae548a67ae7d95e519abbb4616b875059",
+        "version" : "0.3.1"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/maplibre/maplibre-gl-native-distribution",
       "state" : {
-        "revision" : "4cbd3f5f25583627006e60c5fcdaf5339813118c",
-        "version" : "6.23.0"
+        "revision" : "40e1a0db6d055abf8a1b6e2f6127a8bb6e895cf8",
+        "version" : "6.25.1"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/torlando-tech/reticulum-swift.git",
       "state" : {
-        "revision" : "254410a83b287f78f21ae2a0234813abff3e4305",
-        "version" : "0.2.0"
+        "revision" : "f5dc4bf83f5786b1ccc81f1eb13978ab66affd53",
+        "version" : "0.2.1"
       }
     },
     {


### PR DESCRIPTION
## Summary

Picks up two interop bug fixes that landed during recent testing against Sideband and Android Columba. Both libraries had patch releases tagged after the fixes merged.

### What's fixed at runtime

| Library | Tag | Fix |
|---|---|---|
| LXMFSwift | 0.3.1 | Incoming opportunistic LXMF messages now record `method = .opportunistic` instead of always defaulting to `.direct`, so the message-details screen classifies deliveries correctly. |
| ReticulumSwift | 0.2.1 | `handleRegularData`'s auto-proof for SINGLE destinations now uses `destinationType = .single` (was `.plain`, causing Python receivers to drop the proof) and routes through `sendToInterface` so `applyIFAC` wraps it (was bypassed, causing IFAC peers to reject the proof). |

End-to-end effect: opportunistic LXMF roundtrips with delivery confirmation now correctly interoperate with Python RNS / Android Columba / Sideband over both bare and IFAC-configured TCP links.

### Transitive bumps

`from:` constraints picked up minor floats unrelated to this change:

- CryptoSwift 1.9.0 → 1.10.0
- MapLibre 6.23.0 → 6.25.1

## Diff

One file: `Columba.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved`. No code changes.

## Test plan

- [x] Local iOS sim build succeeds against the new pins
- [ ] Xcode Cloud iOS + macOS builds pass
- [ ] After merge, on-device test: send a 1-char LXMF message Android→iOS and confirm:
  - iOS shows ✓✓ (delivered) within seconds (proof returns)
  - Message Details shows "Opportunistic" delivery method

🤖 Generated with [Claude Code](https://claude.com/claude-code)