### PR TITLE
feat: rename Sites filter, add Browse Site action for NomadNet contacts

### DIFF
--- a/Sources/ColumbaApp/ViewModels/ContactsViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/ContactsViewModel.swift
@@ -241,7 +241,7 @@ public enum AnnounceFilter: String, Sendable, Equatable, Hashable, CaseIterable 
     case all = "All"
     case peers = "Peers"
     case audio = "Audio"
-    case nodes = "Nodes"
+    case sites = "Sites"
     case relays = "Relays"
 }
 
@@ -334,7 +334,7 @@ public final class ContactsViewModel {
             results = results.filter { $0.aspect == "lxmf.delivery" || $0.aspect == nil }
         case .audio:
             results = results.filter { $0.isAudio }
-        case .nodes:
+        case .sites:
             results = results.filter { $0.badgeType == .node }
         case .relays:
             results = results.filter { $0.isRelay }

--- a/Sources/ColumbaApp/Views/Contacts/ContactsView.swift
+++ b/Sources/ColumbaApp/Views/Contacts/ContactsView.swift
@@ -9,6 +9,20 @@
 import SwiftUI
 import LXMFSwift
 
+// MARK: - Navigation Target
+
+/// Single sum-type for the contacts navigation stack.
+///
+/// Holding all destinations in one `@State` lets us replace the stack atomically
+/// in a single render cycle (e.g. NodeDetails -> Chat) without the pop-then-push
+/// timing race that requiring a sleep between two separate state mutations.
+@available(iOS 17.0, macOS 14.0, *)
+enum ContactsNavTarget: Hashable {
+    case nodeDetails(Contact)
+    case chat(Conversation)
+    case browseSite(Contact)
+}
+
 // MARK: - Contacts View
 
 /// Main contacts screen with tabs and search.
@@ -33,14 +47,13 @@ public struct ContactsView: View {
     /// Whether search is active.
     @State private var isSearching = false
 
-    /// Contact selected for node details navigation.
-    @State private var selectedContact: Contact?
-
-    /// Contact selected for NomadNet browser navigation (set by "Browse Site" action).
-    @State private var browsingContact: Contact?
-
-    /// Conversation to navigate to after "Start Chat".
-    @State private var chatConversation: Conversation?
+    /// Active destination on the contacts navigation stack.
+    ///
+    /// Single binding for all pushable destinations so transitions like
+    /// "node details -> chat" or "node details -> browse site" can be performed
+    /// as one atomic mutation (pop + push in the same render pass), avoiding
+    /// the prior timing-heuristic workaround.
+    @State private var navTarget: ContactsNavTarget?
 
     /// Whether the QR scanner is shown.
     @State private var showQRScanner = false
@@ -101,43 +114,44 @@ public struct ContactsView: View {
                 .toolbar {
                     toolbarContent(vm)
                 }
-                .navigationDestination(item: $selectedContact) { contact in
-                    NodeDetailsView(
-                        contact: contact,
-                        appServices: appServices,
-                        onStartChat: contact.badgeType == .node ? nil : { contact in
-                            startChat(with: contact)
-                        },
-                        onBrowseSite: contact.badgeType == .node ? { contact in
-                            browseSite(for: contact)
-                        } : nil
-                    )
-                }
-                .navigationDestination(item: $browsingContact) { contact in
-                    if let transport = appServices.transport,
-                       let pathTable = appServices.pathTable,
-                       let identity = appServices.identity {
-                        NomadNetBrowserView(
-                            nodeHash: contact.identityHash,
-                            nodeName: contact.displayName,
-                            transport: transport,
-                            pathTable: pathTable,
-                            identity: identity
+                .navigationDestination(item: $navTarget) { target in
+                    switch target {
+                    case .nodeDetails(let contact):
+                        NodeDetailsView(
+                            contact: contact,
+                            appServices: appServices,
+                            onStartChat: contact.badgeType == .node ? nil : { contact in
+                                startChat(with: contact)
+                            },
+                            onBrowseSite: contact.badgeType == .node ? { contact in
+                                browseSite(for: contact)
+                            } : nil
                         )
-                    } else {
-                        ContentUnavailableView(
-                            "Browser Unavailable",
-                            systemImage: "globe.badge.chevron.backward",
-                            description: Text("The NomadNet browser requires an active transport.")
+                    case .chat(let conversation):
+                        MessagingView(
+                            conversation: conversation,
+                            appServices: appServices,
+                            messageRepository: messageRepository
                         )
+                    case .browseSite(let contact):
+                        if let transport = appServices.transport,
+                           let pathTable = appServices.pathTable,
+                           let identity = appServices.identity {
+                            NomadNetBrowserView(
+                                nodeHash: contact.identityHash,
+                                nodeName: contact.displayName,
+                                transport: transport,
+                                pathTable: pathTable,
+                                identity: identity
+                            )
+                        } else {
+                            ContentUnavailableView(
+                                "Browser Unavailable",
+                                systemImage: "globe.badge.chevron.backward",
+                                description: Text("The NomadNet browser requires an active transport.")
+                            )
+                        }
                     }
-                }
-                .navigationDestination(item: $chatConversation) { conversation in
-                    MessagingView(
-                        conversation: conversation,
-                        appServices: appServices,
-                        messageRepository: messageRepository
-                    )
                 }
                 .onAppear {
                     vm.startListening()
@@ -279,7 +293,7 @@ public struct ContactsView: View {
             NetworkAnnouncesTab(
                 viewModel: vm,
                 onContactSelected: { contact in
-                    selectedContact = contact
+                    navTarget = .nodeDetails(contact)
                 }
             )
         }
@@ -332,13 +346,13 @@ public struct ContactsView: View {
                                 vm.toggleFavorite(for: contact.id)
                             },
                             onTap: {
-                                selectedContact = contact
+                                navTarget = .nodeDetails(contact)
                             },
                             onPin: {
                                 vm.togglePin(for: contact.id)
                             },
                             onViewDetails: {
-                                selectedContact = contact
+                                navTarget = .nodeDetails(contact)
                             },
                             onEditNickname: {
                                 nicknameText = contact.displayName ?? ""
@@ -400,25 +414,19 @@ public struct ContactsView: View {
                 isFavorite: false
             )
 
-            // Dismiss node details, then navigate to chat
-            selectedContact = nil
-            // Small delay to let navigation pop before pushing new destination
-            try? await Task.sleep(for: .milliseconds(300))
-            chatConversation = conversation
+            // Atomic pop-and-push: a single mutation of `navTarget` replaces the
+            // current destination (NodeDetailsView) with the chat in one render
+            // cycle, so the back button still returns to the contacts list.
+            navTarget = .chat(conversation)
         }
     }
 
     // MARK: - Browse Site
 
-    /// Pop the node details view, then push the NomadNet browser for the given site.
+    /// Replace the node details destination with the NomadNet browser for the given site.
     private func browseSite(for contact: Contact) {
-        Task {
-            // Dismiss node details, then navigate to browser
-            selectedContact = nil
-            // Small delay to let navigation pop before pushing new destination
-            try? await Task.sleep(for: .milliseconds(300))
-            browsingContact = contact
-        }
+        // Atomic pop-and-push (see `startChat` for rationale).
+        navTarget = .browseSite(contact)
     }
 
     private var toolbarButtons: some View {

--- a/Sources/ColumbaApp/Views/Contacts/ContactsView.swift
+++ b/Sources/ColumbaApp/Views/Contacts/ContactsView.swift
@@ -36,6 +36,9 @@ public struct ContactsView: View {
     /// Contact selected for node details navigation.
     @State private var selectedContact: Contact?
 
+    /// Contact selected for NomadNet browser navigation (set by "Browse Site" action).
+    @State private var browsingContact: Contact?
+
     /// Conversation to navigate to after "Start Chat".
     @State private var chatConversation: Conversation?
 
@@ -99,8 +102,19 @@ public struct ContactsView: View {
                     toolbarContent(vm)
                 }
                 .navigationDestination(item: $selectedContact) { contact in
-                    if contact.badgeType == .node,
-                       let transport = appServices.transport,
+                    NodeDetailsView(
+                        contact: contact,
+                        appServices: appServices,
+                        onStartChat: contact.badgeType == .node ? nil : { contact in
+                            startChat(with: contact)
+                        },
+                        onBrowseSite: contact.badgeType == .node ? { contact in
+                            browseSite(for: contact)
+                        } : nil
+                    )
+                }
+                .navigationDestination(item: $browsingContact) { contact in
+                    if let transport = appServices.transport,
                        let pathTable = appServices.pathTable,
                        let identity = appServices.identity {
                         NomadNetBrowserView(
@@ -111,12 +125,10 @@ public struct ContactsView: View {
                             identity: identity
                         )
                     } else {
-                        NodeDetailsView(
-                            contact: contact,
-                            appServices: appServices,
-                            onStartChat: { contact in
-                                startChat(with: contact)
-                            }
+                        ContentUnavailableView(
+                            "Browser Unavailable",
+                            systemImage: "globe.badge.chevron.backward",
+                            description: Text("The NomadNet browser requires an active transport.")
                         )
                     }
                 }
@@ -393,6 +405,19 @@ public struct ContactsView: View {
             // Small delay to let navigation pop before pushing new destination
             try? await Task.sleep(for: .milliseconds(300))
             chatConversation = conversation
+        }
+    }
+
+    // MARK: - Browse Site
+
+    /// Pop the node details view, then push the NomadNet browser for the given site.
+    private func browseSite(for contact: Contact) {
+        Task {
+            // Dismiss node details, then navigate to browser
+            selectedContact = nil
+            // Small delay to let navigation pop before pushing new destination
+            try? await Task.sleep(for: .milliseconds(300))
+            browsingContact = contact
         }
     }
 

--- a/Sources/ColumbaApp/Views/Contacts/NetworkAnnouncesTab.swift
+++ b/Sources/ColumbaApp/Views/Contacts/NetworkAnnouncesTab.swift
@@ -102,7 +102,7 @@ struct NetworkAnnouncesTab: View {
         switch viewModel.announceFilter {
         case .relays: return "server.rack"
         case .audio: return "phone.down"
-        case .nodes: return "globe"
+        case .sites: return "globe.americas"
         case .peers: return "person.2"
         case .all: return "antenna.radiowaves.left.and.right.slash"
         }
@@ -186,7 +186,7 @@ struct NetworkAnnouncesTab: View {
         case .all: return nil
         case .peers: return "person.2"
         case .audio: return "phone"
-        case .nodes: return "globe"
+        case .sites: return "globe.americas"
         case .relays: return "server.rack"
         }
     }

--- a/Sources/ColumbaApp/Views/Contacts/NodeDetailsView.swift
+++ b/Sources/ColumbaApp/Views/Contacts/NodeDetailsView.swift
@@ -10,11 +10,15 @@ import SwiftUI
 import LXMFSwift
 import ReticulumSwift
 
-/// Node details screen showing identity info and a Start Chat action.
+/// Node details screen showing identity info and a primary action.
 ///
 /// Layout:
 /// - Header: Large identicon, display name, online/expired status badge
-/// - Action: "Start Chat" button (accent gradient, full width)
+/// - Action: "Start Chat" or "Browse Site" button (accent gradient, full width).
+///   For NomadNet sites (`badgeType == .node`), shows "Browse Site" when
+///   `onBrowseSite` is provided; otherwise shows "Start Chat" when
+///   `onStartChat` is provided. If neither callback is provided for the
+///   relevant badge type, no primary action is rendered.
 /// - Details cards: Destination hash, hop count, discovered/expires timestamps
 @available(iOS 17.0, macOS 14.0, *)
 struct NodeDetailsView: View {
@@ -27,7 +31,12 @@ struct NodeDetailsView: View {
     let appServices: AppServices
 
     /// Called when "Start Chat" is tapped; receives the contact.
+    /// Only rendered for non-NomadNet contacts when this callback is non-nil.
     var onStartChat: ((Contact) -> Void)?
+
+    /// Called when "Browse Site" is tapped on a NomadNet site contact.
+    /// Only rendered for `.node` badge contacts when this callback is non-nil.
+    var onBrowseSite: ((Contact) -> Void)?
 
     // MARK: - State
 
@@ -46,7 +55,7 @@ struct NodeDetailsView: View {
                 if propagationInfo != nil {
                     setAsRelayButton
                 } else {
-                    startChatButton
+                    primaryActionButton
                 }
                 detailsSection
                 if propagationInfo != nil {
@@ -110,15 +119,35 @@ struct NodeDetailsView: View {
         }
     }
 
-    // MARK: - Start Chat Button
+    // MARK: - Primary Action Button
 
-    private var startChatButton: some View {
-        Button {
-            onStartChat?(contact)
-        } label: {
+    /// Renders "Browse Site" for NomadNet sites or "Start Chat" otherwise.
+    /// Returns an `EmptyView` when no callback is provided for the contact's
+    /// badge type — the parent owns whether the action should appear.
+    @ViewBuilder
+    private var primaryActionButton: some View {
+        if contact.badgeType == .node, let onBrowseSite {
+            actionButton(
+                icon: "globe.americas",
+                title: "Browse Site"
+            ) {
+                onBrowseSite(contact)
+            }
+        } else if contact.badgeType != .node, let onStartChat {
+            actionButton(
+                icon: "bubble.left.fill",
+                title: "Start Chat"
+            ) {
+                onStartChat(contact)
+            }
+        }
+    }
+
+    private func actionButton(icon: String, title: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
             HStack(spacing: 8) {
-                Image(systemName: "bubble.left.fill")
-                Text("Start Chat")
+                Image(systemName: icon)
+                Text(title)
             }
             .font(.headline)
             .foregroundStyle(.white)


### PR DESCRIPTION
## Summary

- Rename the **Nodes** announce-filter chip to **Sites** (with a `globe.americas` SF Symbol). The chip already filtered exclusively to NomadNet sites — the label was just misleading. `ContactBadgeType.node` itself is unchanged so future "node" badge types stay reserved.
- Replace the single `Start Chat` action on `NodeDetailsView` with a context-aware primary action:
  - `.node` (NomadNet site) → **Browse Site** (`globe.americas`, accent gradient) → opens `NomadNetBrowserView` for that destination hash.
  - everything else → **Start Chat** as before.
- `NodeDetailsView` only renders each button when its corresponding callback is non-nil, so callers can opt out cleanly (no hidden no-ops). `ContactsView` now always lands on `NodeDetailsView` for any contact (previously NomadNet sites bypassed details), and `Browse Site` pops details then pushes the browser via a separate `browsingContact` navigation destination — mirroring the existing `startChat → MessagingView` pattern.
- `ChatsView`'s existing `onStartChat: nil` call site is unaffected (it never sees `.node` contacts via that flow).

## Test plan

- [x] `xcodebuild ... -sdk iphonesimulator` → BUILD SUCCEEDED
- [x] `xcodebuild ... -destination 'platform=macOS'` → BUILD SUCCEEDED
- [ ] Manual: announce a NomadNet site, confirm Network tab shows the **Sites** chip, tap a site → NodeDetailsView appears with "Browse Site" → opens browser at `/page/index.mu`.
- [ ] Manual: tap a regular peer → NodeDetailsView still shows "Start Chat".

## Design notes

- Picked `globe.americas` over alternatives (`safari`, `network`) because it reads as "browsable web content" without implying Apple's browser.
- `NomadNetBrowserView` already supports being opened standalone with `(nodeHash, nodeName, transport, pathTable, identity)`, so no plumbing in the browser layer was needed — only the navigation in `ContactsView`.
- Added a `ContentUnavailableView` fallback for the rare case where `transport`/`pathTable`/`identity` are nil at navigation time (e.g. before bootstrap completes), so the browser route never silently no-ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)