### PR TITLE
chore: rename Share Your Identity to Share your contact info

### DIFF
--- a/Sources/ColumbaApp/Views/Settings/MyIdentityView.swift
+++ b/Sources/ColumbaApp/Views/Settings/MyIdentityView.swift
@@ -313,7 +313,7 @@ struct MyIdentityView: View {
                     .font(.system(size: 18, weight: .medium))
                     .foregroundStyle(Theme.accentColor)
 
-                Text("Share Your Identity")
+                Text("Share your contact info")
                     .font(.system(size: 16, weight: .semibold))
                     .foregroundStyle(Theme.textPrimary)
             }
@@ -330,12 +330,6 @@ struct MyIdentityView: View {
 
                 Spacer()
             }
-
-            // Caption
-            Text("Scan to add \(viewModel.identity.displayName.isEmpty ? "peer" : viewModel.identity.displayName) as a contact")
-                .font(.caption)
-                .foregroundStyle(Theme.textSecondary)
-                .frame(maxWidth: .infinity, alignment: .center)
 
             // Full Screen and Share buttons
             HStack(spacing: 12) {


### PR DESCRIPTION
Header text on the QR-share card in Settings → My Identity changes from **Share Your Identity** to **Share your contact info** — the QR encodes contact info, not the identity material, so the new phrasing matches the action. Also removes the caption subtext "Scan to add … as a contact" which was just restating what the qrcode icon and QR itself already make obvious.

Pure copy change. iOS sim build succeeds.