### PR TITLE
feat: show Last Heard timestamp on Node Details

### DIFF
--- a/Sources/ColumbaApp/Views/Contacts/NodeDetailsView.swift
+++ b/Sources/ColumbaApp/Views/Contacts/NodeDetailsView.swift
@@ -186,11 +186,16 @@ struct NodeDetailsView: View {
                 value: interfaceName ?? "Unknown"
             )
 
-            detailRow(
-                icon: "clock.arrow.circlepath",
-                label: "Last Heard",
-                value: formattedLastHeard(contact.timestamp)
-            )
+            // TimelineView re-evaluates the relative portion ("5 min ago")
+            // every 60 seconds so it ticks forward while the view is open
+            // instead of freezing at first-render time.
+            TimelineView(.periodic(from: .now, by: 60)) { context in
+                detailRow(
+                    icon: "clock.arrow.circlepath",
+                    label: "Last Heard",
+                    value: formattedLastHeard(contact.timestamp, now: context.date)
+                )
+            }
 
             if let expires = expiresDate {
                 detailRow(
@@ -340,8 +345,11 @@ struct NodeDetailsView: View {
     ///
     /// Renders as "5 min ago  •  Apr 26, 2026 at 2:03 PM" so the user gets an
     /// at-a-glance recency cue plus the precise wall-clock timestamp.
-    private func formattedLastHeard(_ date: Date) -> String {
-        let relative = Self.relativeFormatter.localizedString(for: date, relativeTo: Date())
+    ///
+    /// The `now` parameter lets callers (e.g. `TimelineView`) drive the
+    /// "relative" reference point so the string ticks forward over time.
+    private func formattedLastHeard(_ date: Date, now: Date = Date()) -> String {
+        let relative = Self.relativeFormatter.localizedString(for: date, relativeTo: now)
         let absolute = Self.dateFormatter.string(from: date)
         return "\(relative)  \u{2022}  \(absolute)"
     }

--- a/Sources/ColumbaApp/Views/Contacts/NodeDetailsView.swift
+++ b/Sources/ColumbaApp/Views/Contacts/NodeDetailsView.swift
@@ -19,7 +19,7 @@ import ReticulumSwift
 ///   `onBrowseSite` is provided; otherwise shows "Start Chat" when
 ///   `onStartChat` is provided. If neither callback is provided for the
 ///   relevant badge type, no primary action is rendered.
-/// - Details cards: Destination hash, hop count, discovered/expires timestamps
+/// - Details cards: Destination hash, hop count, last heard/expires timestamps
 @available(iOS 17.0, macOS 14.0, *)
 struct NodeDetailsView: View {
     // MARK: - Properties
@@ -187,9 +187,9 @@ struct NodeDetailsView: View {
             )
 
             detailRow(
-                icon: "clock",
-                label: "Discovered",
-                value: formattedDate(contact.timestamp)
+                icon: "clock.arrow.circlepath",
+                label: "Last Heard",
+                value: formattedLastHeard(contact.timestamp)
             )
 
             if let expires = expiresDate {
@@ -326,8 +326,24 @@ struct NodeDetailsView: View {
         return f
     }()
 
+    private static let relativeFormatter: RelativeDateTimeFormatter = {
+        let f = RelativeDateTimeFormatter()
+        f.unitsStyle = .abbreviated
+        return f
+    }()
+
     private func formattedDate(_ date: Date) -> String {
         Self.dateFormatter.string(from: date)
+    }
+
+    /// Combined relative + absolute formatting for the "Last Heard" card.
+    ///
+    /// Renders as "5 min ago  •  Apr 26, 2026 at 2:03 PM" so the user gets an
+    /// at-a-glance recency cue plus the precise wall-clock timestamp.
+    private func formattedLastHeard(_ date: Date) -> String {
+        let relative = Self.relativeFormatter.localizedString(for: date, relativeTo: Date())
+        let absolute = Self.dateFormatter.string(from: date)
+        return "\(relative)  \u{2022}  \(absolute)"
     }
 
     private func loadPathDetails() async {


### PR DESCRIPTION
## Summary

- The "Discovered" card on the Node Details screen was sourced from `PathEntry.timestamp`, which `PathTable.record(...)` overwrites on every accepted announce. The label was misleading — it's actually "last heard".
- Rename the card to **Last Heard** and update the icon to `clock.arrow.circlepath` (suggests a refreshing/updated time).
- Format the value as `"<relative>  •  <absolute>"` (e.g. `"5 min ago  •  Apr 26, 2026 at 2:03 PM"`) so users get an at-a-glance recency cue plus the precise wall-clock timestamp.

## Investigation notes

- `PathEntry` (in `reticulum-swift`) exposes only a single `timestamp: Date` field. There is no separate `firstSeen` / `createdAt` to surface as "Discovered". `PathTable.record()` replaces the existing `paths[key]` with the new entry on every accepted announce, and `init` defaults `timestamp = Date()` — so the field is unambiguously "last heard".
- Therefore: **rename only** (no second "Discovered" card; nothing in `Contact` needed to change).
- `Contact.timestamp` semantics are unchanged — other call sites (sort order in `ContactsViewModel`, `Contact.timeAgo`) already treat it as the most-recent-announce time.

## Compatibility with parallel agents

- `feat/node-details-auto-refresh` may also touch `NodeDetailsView` for state observation. Once that lands, binding the value to `currentContact.timestamp` will make this card update live; until then it shows the at-load value, which is right for the manual-refresh case.
- Stayed out of `Sources/ColumbaApp/Views/Messaging/` per task scope.

## Test plan

- [x] `xcodebuild -project Columba.xcodeproj -scheme Columba -sdk iphonesimulator` — BUILD SUCCEEDED
- [x] `xcodebuild -project Columba.xcodeproj -scheme Columba -destination 'platform=macOS,arch=arm64'` — BUILD SUCCEEDED
- [ ] Manual: open Node Details for a recently-heard contact; verify "Last Heard" card shows e.g. "30 sec ago  •  Apr 26, 2026 at 2:03 PM" and the icon is the circular-arrow clock.
- [ ] Manual: open Node Details for an expired contact; verify the relative phrasing is something like "2 hours ago" and matches the absolute timestamp shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)