### PR TITLE
chore: bump SPM pins to LXMFSwift 0.3.4 / ReticulumSwift 0.2.2

### DIFF
--- a/Columba.xcodeproj/project.pbxproj
+++ b/Columba.xcodeproj/project.pbxproj
@@ -1179,7 +1179,7 @@
 			repositoryURL = "https://github.com/torlando-tech/LXMF-swift.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.3.2;
+				minimumVersion = 0.3.4;
 			};
 		};
 		PKGREF2 /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */ = {

--- a/Columba.xcodeproj/project.pbxproj
+++ b/Columba.xcodeproj/project.pbxproj
@@ -1179,7 +1179,7 @@
 			repositoryURL = "https://github.com/torlando-tech/LXMF-swift.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.3.0;
+				minimumVersion = 0.3.2;
 			};
 		};
 		PKGREF2 /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */ = {
@@ -1203,7 +1203,7 @@
 			repositoryURL = "https://github.com/torlando-tech/reticulum-swift.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.2.0;
+				minimumVersion = 0.2.2;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Columba.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Columba.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/torlando-tech/LXMF-swift.git",
       "state" : {
-        "revision" : "b1f4899ae548a67ae7d95e519abbb4616b875059",
-        "version" : "0.3.2"
+        "revision" : "b31a14a8fe9ab9626ce9b333d5978098910b54ea",
+        "version" : "0.3.4"
       }
     },
     {

--- a/Columba.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Columba.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -34,7 +34,7 @@
       "location" : "https://github.com/torlando-tech/LXMF-swift.git",
       "state" : {
         "revision" : "b1f4899ae548a67ae7d95e519abbb4616b875059",
-        "version" : "0.3.1"
+        "version" : "0.3.2"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/torlando-tech/reticulum-swift.git",
       "state" : {
-        "revision" : "f5dc4bf83f5786b1ccc81f1eb13978ab66affd53",
-        "version" : "0.2.1"
+        "revision" : "a884851b150b81be718eec072e067436ae2a3154",
+        "version" : "0.2.2"
       }
     },
     {


### PR DESCRIPTION
## Summary

Brings the LXMF DIRECT delivery proof fix into the iOS app.

- **reticulum-swift 0.2.2** — adds `Link.provePacket(_:)` (Python-compatible explicit-format link-context proof signed with the destination identity) and fixes two related bugs in `handleDataProof` and `handleLinkData` ([PR #12](https://github.com/torlando-tech/reticulum-swift/pull/12)).
- **LXMF-swift 0.3.4** — registers a delivery-proof callback before sending small DIRECT link DATA so outbound state advances to `.delivered`; routes link-context proofs through `Link.provePacket` ([PR #5](https://github.com/torlando-tech/LXMF-swift/pull/5)).

> **Note on tag numbering:** 0.3.2 and 0.3.3 were cut from a stale local main and ended up pointing at the pre-PR-#5 commit. 0.3.4 is the first tag that actually points at the post-PR-#5 commit and carries the proof-callback fix. Don't pin 0.3.2 or 0.3.3.

## Why
Before this, a DIRECT message sent by Columba would arrive at the peer correctly but the iOS UI would stop at the single checkmark forever — the proof was silently rejected because we were sending SINGLE-implicit instead of LINK-explicit, and there was no proof callback registered for small DIRECT packets in the first place.

## Verification
The full chain is exercised by the [lxmf-conformance](https://github.com/torlando-tech/lxmf-conformance) cross-impl suite — 28 trios green across (python|swift)×(python|swift):
- announce_discovery, opportunistic, direct, direct_large, attachments, combined, propagation.

Local build: `xcodebuild build -project Columba.xcodeproj -scheme Columba -sdk iphonesimulator` ✅

## Test plan
- [x] `xcodebuild` clean against new pins.
- [ ] Smoke test on device: send DIRECT message; verify the local UI advances from single → double checkmark when peer acks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)