### PR TITLE
fix: Start Chat button broken after Node Details refresh (#30)

### DIFF
--- a/Sources/ColumbaApp/Views/Contacts/ContactsView.swift
+++ b/Sources/ColumbaApp/Views/Contacts/ContactsView.swift
@@ -418,7 +418,16 @@ public struct ContactsView: View {
             // an unconditional assignment of `[.chat(conversation)]`
             // would push the chat onto the root anyway — silent
             // navigation the user didn't ask for.
-            guard path.last == .nodeDetails(contact) else { return }
+            //
+            // Compare by `id` rather than the whole Contact value:
+            // NodeDetailsView's polling loop refreshes `liveContact`
+            // (timestamp / isOnline / hopCount), so `displayedContact`
+            // passed in here can hold newer field values than the
+            // Contact stored when the path was first pushed. Equality
+            // over all fields would silently fail and the button
+            // would do nothing.
+            guard case .nodeDetails(let pathContact) = path.last,
+                  pathContact.id == contact.id else { return }
 
             let conversation = Conversation(
                 id: contact.id,


### PR DESCRIPTION
Fixes #30.

## What broke

PR #25 added a guard in `ContactsView.startChat(with:)` to prevent the path-write from racing with a Back tap during the async `addToContacts` hop:

```swift
guard path.last == .nodeDetails(contact) else { return }
```

PR #28 then added live path-table polling to `NodeDetailsView` — `displayedContact` (which is what gets passed to `onStartChat`) refreshes with newer timestamp / isOnline / hopCount values whenever the path table sees an update. Since `Contact`'s `Equatable` is auto-synthesized over all fields, the guard silently fails every time the polling loop has fired, and Start Chat does nothing.

## Fix

Compare by stable `id` (destination hash) instead. The guard's intent is "is the user still looking at this node's details" which is independent of any path-derived field having ticked.

## Test plan

- [x] `xcodebuild build -project Columba.xcodeproj -scheme Columba -sdk iphonesimulator` — succeeds
- [ ] Manual: tap a contact card → Node Details → wait for a path update / pull-to-refresh → tap Start Chat → conversation appears
- [ ] Manual: tap Start Chat, immediately tap Back — confirm we don't get yanked into the chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)