### PR TITLE
fix: allow un-starring contacts from the network tab (#33)

### DIFF
--- a/Sources/ColumbaApp/Views/Contacts/NetworkAnnouncesTab.swift
+++ b/Sources/ColumbaApp/Views/Contacts/NetworkAnnouncesTab.swift
@@ -211,7 +211,12 @@ struct NetworkAnnouncesTab: View {
                         contact: contact,
                         showInterfaceIcon: true,
                         onFavoriteToggle: {
-                            Task { await viewModel.addToContacts(contact) }
+                            // Route through `toggleFavorite` so an
+                            // already-favorited announce can be un-starred
+                            // without first switching to the My Contacts
+                            // tab. Calling `addToContacts` directly was a
+                            // no-op when the contact was already saved.
+                            viewModel.toggleFavorite(for: contact.id)
                         },
                         onTap: {
                             onContactSelected?(contact)


### PR DESCRIPTION
Fixes #33.

## What broke

`NetworkAnnouncesTab.onFavoriteToggle` unconditionally called `viewModel.addToContacts(contact)`. That function early-returns when the contact is already in `myContacts`, so tapping the star on an already-favorited announce was a no-op. Users had to navigate to the My Contacts tab to un-star.

## Fix

Route through `viewModel.toggleFavorite(for:)` (the handler the My Contacts tab already uses). It covers both directions:
- if the contact is already in `myContacts` → unfavorite + remove + clear the network announce's `isFavorite` flag
- if not → fall through to `addToContacts`

## Test plan

- [x] `xcodebuild build -project Columba.xcodeproj -scheme Columba -sdk iphonesimulator` — succeeds
- [ ] Manual: tap star on a network announce that isn't yet a contact → contact added (My Contacts shows it)
- [ ] Manual: tap star again on the same network announce → contact removed (My Contacts no longer shows it, network tab star fills/empties accordingly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)