### PR TITLE
fix: anchor existing conversations to the latest message on open (#36)

### DIFF
--- a/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
@@ -56,6 +56,11 @@ struct MessagingView: View {
     @State private var pendingRawImage: UIImage?
     @State private var selectedImagePreset: SettingsViewModel.ImageQualityPreset = .high
     @State private var isNearBottom = true
+    /// One-shot flag so the post-load scroll-to-bottom only fires the
+    /// first time messages populate. Subsequent message arrivals use
+    /// `onChange(of: messages.last?.id)` and only scroll when already
+    /// near the bottom.
+    @State private var didInitialScroll = false
     @State private var showCallScreen = false
     @State private var detailMessage: Message?
     @State private var deleteConfirmMessage: Message?
@@ -193,6 +198,21 @@ struct MessagingView: View {
                             to: nil, from: nil, for: nil
                         )
                         #endif
+                    }
+                    // First-render anchor.
+                    //
+                    // `.defaultScrollAnchor(.bottom)` is unreliable when the
+                    // LazyVStack is populated before the ScrollView lays out:
+                    // the bottom-anchor row hasn't been realized yet, so the
+                    // anchor lands somewhere inside unrendered space and the
+                    // user sees a blank viewport until they scroll. Explicit
+                    // scrollTo after the first layout pass guarantees the
+                    // latest message is visible.
+                    .task(id: vm.messages.first?.id) {
+                        guard !didInitialScroll, !vm.messages.isEmpty else { return }
+                        try? await Task.sleep(for: .milliseconds(50))
+                        proxy.scrollTo("bottom-anchor", anchor: .bottom)
+                        didInitialScroll = true
                     }
                     // Scroll to bottom when a new message arrives (if already near bottom)
                     .onChange(of: vm.messages.last?.id) { _, _ in

--- a/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
@@ -126,11 +126,30 @@ struct MessagingView: View {
                                 ))
                             }
 
-                            // Invisible anchor at bottom to track scroll position
+                            // Invisible anchor at bottom: tracks scroll position
+                            // AND drives the one-shot initial scroll. `onAppear`
+                            // fires only once SwiftUI has actually realized this
+                            // 1px row in the layout — which is the exact signal
+                            // the previous `.task` + 50 ms sleep was guessing
+                            // at, but without the arbitrary delay or the
+                            // cancellation race that came with it. If
+                            // `.defaultScrollAnchor(.bottom)` lands the
+                            // viewport correctly, this row is realized
+                            // immediately and the scroll is a no-op; if the
+                            // anchor lands inside unrealized space, the
+                            // explicit `scrollTo` here forces the LazyVStack
+                            // to lay out the bottom and the user sees the
+                            // latest message.
                             Color.clear
                                 .frame(height: 1)
                                 .id("bottom-anchor")
-                                .onAppear { isNearBottom = true }
+                                .onAppear {
+                                    isNearBottom = true
+                                    if !didInitialScroll {
+                                        proxy.scrollTo("bottom-anchor", anchor: .bottom)
+                                        didInitialScroll = true
+                                    }
+                                }
                                 .onDisappear { isNearBottom = false }
                         }
                         .padding(.horizontal, 16)
@@ -199,30 +218,13 @@ struct MessagingView: View {
                         )
                         #endif
                     }
-                    // First-render anchor.
-                    //
-                    // `.defaultScrollAnchor(.bottom)` is unreliable when the
-                    // LazyVStack is populated before the ScrollView lays out:
-                    // the bottom-anchor row hasn't been realized yet, so the
-                    // anchor lands somewhere inside unrendered space and the
-                    // user sees a blank viewport until they scroll. Explicit
-                    // scrollTo after the first layout pass guarantees the
-                    // latest message is visible.
-                    .task(id: vm.messages.first?.id) {
-                        guard !didInitialScroll, !vm.messages.isEmpty else { return }
-                        try? await Task.sleep(for: .milliseconds(50))
-                        // Re-check cancellation after the sleep. `try?`
-                        // swallows CancellationError, so without this guard
-                        // a task that was cancelled mid-sleep (e.g. because
-                        // loadMoreMessages prepended older messages and the
-                        // observed id changed) would still issue the scroll
-                        // and flip `didInitialScroll = true`, racing the
-                        // freshly-spawned task that exits early via the
-                        // top-of-block guard.
-                        guard !Task.isCancelled else { return }
-                        proxy.scrollTo("bottom-anchor", anchor: .bottom)
-                        didInitialScroll = true
-                    }
+                    // First-render anchor is now driven from the
+                    // bottom-anchor's `onAppear` (see the LazyVStack
+                    // above). That fires exactly when SwiftUI has
+                    // realized the 1px row, eliminating both the
+                    // arbitrary 50 ms timing window and the
+                    // task-cancellation race that the prior
+                    // `.task(id:)` approach needed.
                     // Scroll to bottom when a new message arrives (if already near bottom)
                     .onChange(of: vm.messages.last?.id) { _, _ in
                         if isNearBottom {

--- a/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
@@ -211,6 +211,15 @@ struct MessagingView: View {
                     .task(id: vm.messages.first?.id) {
                         guard !didInitialScroll, !vm.messages.isEmpty else { return }
                         try? await Task.sleep(for: .milliseconds(50))
+                        // Re-check cancellation after the sleep. `try?`
+                        // swallows CancellationError, so without this guard
+                        // a task that was cancelled mid-sleep (e.g. because
+                        // loadMoreMessages prepended older messages and the
+                        // observed id changed) would still issue the scroll
+                        // and flip `didInitialScroll = true`, racing the
+                        // freshly-spawned task that exits early via the
+                        // top-of-block guard.
+                        guard !Task.isCancelled else { return }
                         proxy.scrollTo("bottom-anchor", anchor: .bottom)
                         didInitialScroll = true
                     }


### PR DESCRIPTION
Fixes #36.

## What broke

Opening a conversation from the Chats screen showed a blank message area until the user scrolled up "a bunch", at which point all the messages appeared.

`.defaultScrollAnchor(.bottom)` is unreliable on iOS 17 when a `LazyVStack` is populated before the ScrollView's layout pass. The 1 px `bottom-anchor` row hasn't been realized yet (it's at the bottom of an unrendered list), so the system picks an anchor inside unrendered space — the viewport lands on emptiness until manual scrolling forces enough rows to materialize.

## Fix

Add a one-shot explicit `proxy.scrollTo("bottom-anchor", anchor: .bottom)` keyed on the first message id, fired after a 50 ms delay so the LazyVStack has time to lay out. A `didInitialScroll` state flag ensures it runs once per view instance — subsequent message arrivals continue to use the existing `onChange(of: messages.last?.id)` path that respects whether the user is currently near the bottom.

`.defaultScrollAnchor(.bottom)` is left in place as a belt-and-braces hint for the cases where it does work; the explicit scrollTo is the load-bearing piece.

## Test plan

- [x] `xcodebuild build -project Columba.xcodeproj -scheme Columba -sdk iphonesimulator` — succeeds
- [ ] Manual: open an existing conversation with many messages → latest message visible immediately, no need to scroll up
- [ ] Manual: scroll up to view older messages → no auto-scroll fires
- [ ] Manual: receive new message while at bottom → auto-scrolls (existing behavior)
- [ ] Manual: receive new message while scrolled up → does NOT auto-scroll (existing behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)