### PR TITLE
fix: stop reordering Network tab while user is scrolling (#34)

### DIFF
--- a/Sources/ColumbaApp/ViewModels/ContactsViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/ContactsViewModel.swift
@@ -268,6 +268,12 @@ public final class ContactsViewModel {
     /// Network announces from the mesh (from path table).
     public var networkAnnounces: [Contact] = []
 
+    /// Buffered new announces that haven't been merged into the visible
+    /// list yet. The Network tab pushes incoming announces here instead
+    /// of inserting them inline so the rendered order stays stable while
+    /// the user is scrolling — a "show N new" pill at the top flushes.
+    public var pendingAnnounces: [Contact] = []
+
     /// Currently selected tab.
     public var selectedTab: ContactsTab = .myContacts
 
@@ -454,12 +460,23 @@ public final class ContactsViewModel {
         }
 
         if let existingIndex = networkAnnounces.firstIndex(where: { $0.id == contact.id }) {
+            // Already visible → update data in place. We deliberately do NOT
+            // re-sort here: rearranging the visible list while the user is
+            // scrolling the Network tab caused mistaps (#34). Position only
+            // refreshes on pull-to-refresh / tab reload / "show new" tap.
             networkAnnounces[existingIndex] = contact
+        } else if pendingAnnounces.contains(where: { $0.id == contact.id }) {
+            // New announce for an id we've already buffered — just refresh
+            // the buffered copy so the eventual flush has the latest data.
+            if let i = pendingAnnounces.firstIndex(where: { $0.id == contact.id }) {
+                pendingAnnounces[i] = contact
+            }
         } else {
-            networkAnnounces.insert(contact, at: 0)
+            // First time seeing this id since the last user-driven refresh.
+            // Hold it in the pending bucket so the visible list keeps its
+            // current order; the UI surfaces a banner that flushes on tap.
+            pendingAnnounces.append(contact)
         }
-
-        networkAnnounces.sort { $0.timestamp > $1.timestamp }
 
         // Update myContacts badge if this announce changes the contact type
         if let myIndex = myContacts.firstIndex(where: { $0.id == contact.id }),
@@ -471,6 +488,17 @@ public final class ContactsViewModel {
 
         // Re-sync relay state (auto-select may have picked this new node)
         syncRelayState()
+    }
+
+    /// Merge any buffered new announces into the visible list and re-sort.
+    /// Called when the user pulls to refresh, taps the "show N new" banner,
+    /// or otherwise asks for the latest data.
+    @MainActor
+    public func flushPendingAnnounces() {
+        guard !pendingAnnounces.isEmpty else { return }
+        networkAnnounces.append(contentsOf: pendingAnnounces)
+        pendingAnnounces.removeAll()
+        networkAnnounces.sort { $0.timestamp > $1.timestamp }
     }
 
     // MARK: - Public Methods
@@ -496,6 +524,11 @@ public final class ContactsViewModel {
                     .map { Contact(from: $0) }
                     .sorted { $0.timestamp > $1.timestamp }
             }
+            // Fresh load reads everything from the path table, so any
+            // announces buffered for an in-progress session no longer
+            // need to be held back — clear the bucket so the "show new"
+            // pill resets to zero.
+            pendingAnnounces.removeAll()
 
             // Mark network announces that are already saved contacts
             markSavedContacts()
@@ -544,6 +577,10 @@ public final class ContactsViewModel {
                 .map { Contact(from: $0) }
                 .sorted { $0.timestamp > $1.timestamp }
         }
+        // Refresh re-reads the full path table, so the buffered new
+        // announces are already present in the rebuilt list — drop the
+        // bucket so the "show new" pill resets.
+        pendingAnnounces.removeAll()
 
         // Mark network announces that are already saved contacts
         markSavedContacts()

--- a/Sources/ColumbaApp/ViewModels/ContactsViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/ContactsViewModel.swift
@@ -330,7 +330,25 @@ public final class ContactsViewModel {
 
     /// Filtered network announces based on search, aspect filter, and interface filter.
     public var filteredNetworkAnnounces: [Contact] {
-        var results = networkAnnounces
+        applyAnnounceFilters(to: networkAnnounces)
+    }
+
+    /// `pendingAnnounces` filtered by the currently-active announce
+    /// filters. Used to drive the "Show N new" pill so the count
+    /// reflects how many will actually appear in the visible list
+    /// after a flush, not the raw buffer size — otherwise an active
+    /// filter (peers / audio / sites / relays / interface / search)
+    /// could overstate the pill and surprise the user.
+    public var filteredPendingAnnounces: [Contact] {
+        applyAnnounceFilters(to: pendingAnnounces)
+    }
+
+    /// Apply the active aspect / interface / search filters to a
+    /// list of announces. Shared between `filteredNetworkAnnounces`
+    /// (drives the rendered list) and `filteredPendingAnnounces`
+    /// (drives the pill count) so both stay in sync.
+    private func applyAnnounceFilters(to announces: [Contact]) -> [Contact] {
+        var results = announces
 
         // Apply aspect filter
         switch announceFilter {

--- a/Sources/ColumbaApp/ViewModels/ContactsViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/ContactsViewModel.swift
@@ -524,11 +524,15 @@ public final class ContactsViewModel {
                     .map { Contact(from: $0) }
                     .sorted { $0.timestamp > $1.timestamp }
             }
-            // Fresh load reads everything from the path table, so any
-            // announces buffered for an in-progress session no longer
-            // need to be held back — clear the bucket so the "show new"
-            // pill resets to zero.
-            pendingAnnounces.removeAll()
+            // Drop only the pending entries that the fresh path-table
+            // snapshot already covers. `handleNewPathEntry` is also
+            // @MainActor and can interleave with the await above, so a
+            // blanket `removeAll()` would silently delete announces
+            // that arrived *during* the suspension and aren't in the
+            // snapshot yet. Filtering by id keeps those late arrivals
+            // queued for the next flush.
+            let visibleIds = Set(networkAnnounces.map(\.id))
+            pendingAnnounces.removeAll { visibleIds.contains($0.id) }
 
             // Mark network announces that are already saved contacts
             markSavedContacts()
@@ -577,10 +581,13 @@ public final class ContactsViewModel {
                 .map { Contact(from: $0) }
                 .sorted { $0.timestamp > $1.timestamp }
         }
-        // Refresh re-reads the full path table, so the buffered new
-        // announces are already present in the rebuilt list — drop the
-        // bucket so the "show new" pill resets.
-        pendingAnnounces.removeAll()
+        // Drop only the pending entries the fresh path-table snapshot
+        // already covers — see `loadContacts` for the same race
+        // (handleNewPathEntry can interleave with the await above and
+        // queue announces that aren't in the snapshot yet; a blanket
+        // removeAll() would silently lose them).
+        let visibleIds = Set(networkAnnounces.map(\.id))
+        pendingAnnounces.removeAll { visibleIds.contains($0.id) }
 
         // Mark network announces that are already saved contacts
         markSavedContacts()

--- a/Sources/ColumbaApp/Views/Contacts/NetworkAnnouncesTab.swift
+++ b/Sources/ColumbaApp/Views/Contacts/NetworkAnnouncesTab.swift
@@ -29,6 +29,17 @@ struct NetworkAnnouncesTab: View {
 
     var body: some View {
         VStack(spacing: 0) {
+            // Hoist the pill to body-level so it's visible regardless
+            // of whether the visible list is empty / filter-empty /
+            // populated. Otherwise an active filter or a fresh-empty
+            // network tab would suppress the pill even though new
+            // matching announces are pending.
+            if !viewModel.filteredPendingAnnounces.isEmpty {
+                showNewBanner
+                    .padding(.horizontal, 16)
+                    .padding(.top, 8)
+            }
+
             // Always show filter bar when there are any announces
             if !viewModel.networkAnnounces.isEmpty {
                 filterBar
@@ -206,9 +217,6 @@ struct NetworkAnnouncesTab: View {
     private var announcesList: some View {
         ScrollView {
             LazyVStack(spacing: 12) {
-                if !viewModel.filteredPendingAnnounces.isEmpty {
-                    showNewBanner
-                }
                 ForEach(viewModel.filteredNetworkAnnounces) { contact in
                     ContactCard(
                         contact: contact,

--- a/Sources/ColumbaApp/Views/Contacts/NetworkAnnouncesTab.swift
+++ b/Sources/ColumbaApp/Views/Contacts/NetworkAnnouncesTab.swift
@@ -206,7 +206,7 @@ struct NetworkAnnouncesTab: View {
     private var announcesList: some View {
         ScrollView {
             LazyVStack(spacing: 12) {
-                if !viewModel.pendingAnnounces.isEmpty {
+                if !viewModel.filteredPendingAnnounces.isEmpty {
                     showNewBanner
                 }
                 ForEach(viewModel.filteredNetworkAnnounces) { contact in
@@ -234,7 +234,9 @@ struct NetworkAnnouncesTab: View {
     /// Lets the user merge them in on demand instead of having the visible
     /// list reorder under their finger as new announces stream in.
     private var showNewBanner: some View {
-        let count = viewModel.pendingAnnounces.count
+        // Use the filter-aware count so the pill matches what will
+        // actually appear in the list after a flush.
+        let count = viewModel.filteredPendingAnnounces.count
         return Button {
             withAnimation(.easeOut(duration: 0.25)) {
                 viewModel.flushPendingAnnounces()

--- a/Sources/ColumbaApp/Views/Contacts/NetworkAnnouncesTab.swift
+++ b/Sources/ColumbaApp/Views/Contacts/NetworkAnnouncesTab.swift
@@ -206,6 +206,9 @@ struct NetworkAnnouncesTab: View {
     private var announcesList: some View {
         ScrollView {
             LazyVStack(spacing: 12) {
+                if viewModel.pendingAnnounces.count > 0 {
+                    showNewBanner
+                }
                 ForEach(viewModel.filteredNetworkAnnounces) { contact in
                     ContactCard(
                         contact: contact,
@@ -225,6 +228,33 @@ struct NetworkAnnouncesTab: View {
         .refreshable {
             await viewModel.refreshAnnounces()
         }
+    }
+
+    /// Tappable banner shown above the list while new announces are buffered.
+    /// Lets the user merge them in on demand instead of having the visible
+    /// list reorder under their finger as new announces stream in.
+    private var showNewBanner: some View {
+        let count = viewModel.pendingAnnounces.count
+        return Button {
+            withAnimation(.easeOut(duration: 0.25)) {
+                viewModel.flushPendingAnnounces()
+            }
+        } label: {
+            HStack(spacing: 8) {
+                Image(systemName: "arrow.up.circle.fill")
+                Text("Show \(count) new announce\(count == 1 ? "" : "s")")
+                    .fontWeight(.medium)
+            }
+            .font(.subheadline)
+            .foregroundStyle(.white)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 8)
+            .background {
+                Capsule().fill(Theme.accentColor)
+            }
+        }
+        .buttonStyle(.plain)
+        .frame(maxWidth: .infinity)
     }
 }
 

--- a/Sources/ColumbaApp/Views/Contacts/NetworkAnnouncesTab.swift
+++ b/Sources/ColumbaApp/Views/Contacts/NetworkAnnouncesTab.swift
@@ -206,7 +206,7 @@ struct NetworkAnnouncesTab: View {
     private var announcesList: some View {
         ScrollView {
             LazyVStack(spacing: 12) {
-                if viewModel.pendingAnnounces.count > 0 {
+                if !viewModel.pendingAnnounces.isEmpty {
                     showNewBanner
                 }
                 ForEach(viewModel.filteredNetworkAnnounces) { contact in


### PR DESCRIPTION
Fixes #34.

## What broke

The Network tab re-sorted `networkAnnounces` by timestamp on every fresh path entry. New identities inserted at the top pushed every other card down — so users mis-tapped while scrolling, and the cards' positions jumped under their finger as announces streamed in.

## Fix

Defer new identities to a `pendingAnnounces` buffer. The visible list keeps its current order while the user is interacting; an accent-color pill at the top labeled **"Show N new announces"** flushes the buffer and re-sorts on tap. Pull-to-refresh and reload paths also flush (and clear the buffer, since they re-read the full path table).

In-place data updates for already-visible identities still flow through — when an announce arrives for an id we're already showing, the existing card refreshes its timestamp / hops / isOnline / etc. without moving. Only newly-discovered ids get held back.

## Test plan

- [x] `xcodebuild build -project Columba.xcodeproj -scheme Columba -sdk iphonesimulator` — succeeds
- [ ] Manual: open Network tab, observe new announces over BLE/Auto/etc → existing cards don't move; "Show N new" pill appears at top with the count
- [ ] Manual: tap pill → buffered announces merge in, re-sorted by timestamp
- [ ] Manual: pull-to-refresh while pill is showing → list rebuilt, pill disappears
- [ ] Manual: an existing card's timestamp / hop count refreshes when its identity re-announces (in-place update path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)