### PR TITLE
fix: append (don't replace) nav stack from Start Chat / Browse Site

### DIFF
--- a/Sources/ColumbaApp/Views/Contacts/ContactsView.swift
+++ b/Sources/ColumbaApp/Views/Contacts/ContactsView.swift
@@ -411,21 +411,17 @@ public struct ContactsView: View {
         Task {
             await viewModel?.addToContacts(contact)
 
-            // If the user popped back to the contacts list (or
-            // navigated elsewhere) while `addToContacts` was awaiting,
-            // don't yank them into the chat. The async hop opens a
-            // window where `path` can be `[]` (after a Back tap) but
-            // an unconditional assignment of `[.chat(conversation)]`
-            // would push the chat onto the root anyway — silent
-            // navigation the user didn't ask for.
+            // Bail if the user navigated away during the async hop —
+            // either popped Back to the contacts list (`path == []`)
+            // or replaced the destination another way. Without this
+            // guard an unconditional `path` write would push the chat
+            // onto whatever stack they navigated to, hijacking their
+            // navigation.
             //
-            // Compare by `id` rather than the whole Contact value:
-            // NodeDetailsView's polling loop refreshes `liveContact`
-            // (timestamp / isOnline / hopCount), so `displayedContact`
-            // passed in here can hold newer field values than the
-            // Contact stored when the path was first pushed. Equality
-            // over all fields would silently fail and the button
-            // would do nothing.
+            // Compare by `id`, not full Contact equality: NodeDetails
+            // polls the path table and refreshes `liveContact`
+            // (timestamp / isOnline / hopCount), so the contact passed
+            // in here will not `==` the value held in `path`.
             guard case .nodeDetails(let pathContact) = path.last,
                   pathContact.id == contact.id else { return }
 
@@ -439,23 +435,34 @@ public struct ContactsView: View {
                 isFavorite: false
             )
 
-            // Replace the entire navigation stack in one assignment so SwiftUI
-            // performs a single push-style crossfade from NodeDetails to the
-            // chat instead of popping to the Contacts root first. The
-            // intermediate pop-then-push that `navigationDestination(item:)`
-            // produced was visible as a flash of the tab's root (and on iOS
-            // 17 sometimes the wrong tab's root) before the chat appeared.
-            // The back button still returns to the contacts list (path: []).
-            path = [.chat(conversation)]
+            // Append, don't replace.
+            //
+            // `NavigationStack(path:)` reconciles by diffing the array.
+            // Replacing `[.nodeDetails]` with `[.chat]` is computed as
+            // "pop nodeDetails, push chat" — and SwiftUI runs that as a
+            // pop-to-root-then-push, briefly exposing the contacts list
+            // (the regression the user reported on issue #30 follow-up).
+            // PR #25 claimed single-assignment was a "single crossfade"
+            // but that wasn't really how NavigationStack works; the
+            // flash was just tighter on the device that PR was tested
+            // on.
+            //
+            // Pushing instead means the chat slides in over NodeDetails
+            // — no root flash. Trade-off: Back from the chat now lands
+            // on NodeDetails (one tap to contacts list), which is
+            // arguably better UX anyway since that's the screen they
+            // came from.
+            path.append(.chat(conversation))
         }
     }
 
     // MARK: - Browse Site
 
-    /// Replace the node details destination with the NomadNet browser for the given site.
+    /// Push the NomadNet browser on top of the current node details screen.
     private func browseSite(for contact: Contact) {
-        // Single-assignment stack replacement (see `startChat` for rationale).
-        path = [.browseSite(contact)]
+        // Append rather than replace — see `startChat` for the rationale on
+        // why `path = [..]` causes a contacts-root flash.
+        path.append(.browseSite(contact))
     }
 
     private var toolbarButtons: some View {

--- a/Sources/ColumbaApp/Views/Contacts/ContactsView.swift
+++ b/Sources/ColumbaApp/Views/Contacts/ContactsView.swift
@@ -13,13 +13,15 @@ import LXMFSwift
 
 /// Single sum-type for the contacts navigation stack.
 ///
-/// Held inside a typed `[ContactsNavTarget]` `NavigationStack` path so that
-/// transitions like NodeDetails -> Chat can be performed by replacing the
-/// entire path array in one assignment. SwiftUI animates that as a single
-/// crossfade rather than the visible pop-to-root-then-push that
-/// `navigationDestination(item:)` produced when the item value changed —
-/// which on iOS 17 briefly exposed the underlying tab during the gap and
-/// could surface the wrong tab's root content before the new push landed.
+/// Held inside a typed `[ContactsNavTarget]` `NavigationStack` path so
+/// transitions like NodeDetails → Chat or NodeDetails → Browser can be
+/// performed by appending to the path. SwiftUI animates each `.append`
+/// as a clean push slide, keeping the contacts list hidden during the
+/// transition. Replacing the entire array (e.g. `path = [.chat]`) is
+/// computed by SwiftUI's path-diffing as pop-then-push and briefly
+/// exposes the contacts root — see `startChat(with:)` for the
+/// full rationale and the now-removed regression that came from
+/// trusting "single-assignment is a crossfade".
 @available(iOS 17.0, macOS 14.0, *)
 enum ContactsNavTarget: Hashable {
     case nodeDetails(Contact)
@@ -53,13 +55,14 @@ public struct ContactsView: View {
 
     /// Explicit navigation stack for the Contacts tab.
     ///
-    /// A typed array bound to `NavigationStack(path:)` lets us replace the
-    /// entire stack in one assignment — e.g. swapping `[.nodeDetails]` for
-    /// `[.chat]` from the "Start Chat" button — so SwiftUI performs a single
-    /// crossfade transition instead of pop-to-root-then-push. The latter
-    /// could briefly reveal the tab's root (or, due to TabView/NavigationStack
-    /// interaction during a transition, even a sibling tab's root) before
-    /// the new destination landed.
+    /// A typed array bound to `NavigationStack(path:)`. Transitions
+    /// between destinations (NodeDetails → Chat, NodeDetails → Browser)
+    /// are performed via `path.append(...)` so SwiftUI sees a pure push
+    /// and slides the new screen in over the previous one, keeping the
+    /// contacts list hidden. Wholesale replacement (`path = [...]`)
+    /// reconciles as pop-then-push and briefly exposes the contacts
+    /// root — `startChat(with:)` and `browseSite(for:)` document the
+    /// regression that came from doing it the wrong way.
     @State private var path: [ContactsNavTarget] = []
 
     /// Whether the QR scanner is shown.


### PR DESCRIPTION
Follow-up to #38 (which fixed the no-op guard). Addresses the regression where Start Chat now visibly transitions through the contacts list before pushing the conversation.

## Why this kept getting it wrong

PR #25's design comment claimed that replacing the entire `NavigationStack(path:)` array in one assignment produces a "single push-style crossfade". That isn't actually how NavigationStack reconciles. The path-diff between `[.nodeDetails]` and `[.chat]` is computed as **pop nodeDetails, push chat**, and SwiftUI animates it as pop-to-root then push — briefly exposing the contacts list. PR #25 happened to be tested on a device fast enough that the flash was imperceptible; on the user's phone it's clearly visible, which is exactly the symptom they reported.

The id-based guard in #38 fixed a different bug (the button being a no-op due to over-strict equality post-#28); it didn't and couldn't fix the flash because the flash is in the navigation transition itself.

## The fix

Append instead of replace.

```swift
- path = [.chat(conversation)]
+ path.append(.chat(conversation))
```

`NavigationStack(path:)` sees a pure push, slides the chat in over NodeDetails, no root flash possible.

Trade-off: Back from the chat now lands on NodeDetails (one tap to contacts list) instead of skipping straight to the contacts list. Arguably better UX — that's the screen the user came from.

Same change applied to `browseSite` (NodeDetails → NomadNet browser) which used the identical replace pattern.

## Test plan

- [x] `xcodebuild build -project Columba.xcodeproj -scheme Columba -sdk iphonesimulator` — succeeds
- [ ] Manual: tap a contact → Node Details → Start Chat → conversation slides in cleanly with no contacts-list flash
- [ ] Manual: from the chat, tap Back → returns to Node Details (changed behavior, intentional)
- [ ] Manual: tap a NomadNet site contact → Node Details → Browse Site → browser slides in cleanly; Back returns to Node Details
- [ ] Manual: tap Start Chat then immediately tap Back during the addToContacts hop — guard still prevents the rogue push (regression check on #30)

🤖 Generated with [Claude Code](https://claude.com/claude-code)