### PR TITLE
build: enable network extension so background TCP keeps running (#54)

### DIFF
--- a/Columba.xcodeproj/project.pbxproj
+++ b/Columba.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		T001 /* AudioRingBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FT01 /* AudioRingBufferTests.swift */; };
 		T002 /* AudioManagerConfigChangeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FT02 /* AudioManagerConfigChangeTests.swift */; };
 		T004 /* CallManagerCallKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FT04 /* CallManagerCallKitTests.swift */; };
+		EEMBED /* ColumbaNetworkExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = EPROD /* ColumbaNetworkExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		001 /* ColumbaApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F001 /* ColumbaApp.swift */; };
 		002 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = F002 /* Theme.swift */; };
 		003 /* ChatsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F003 /* ChatsViewModel.swift */; };
@@ -124,6 +125,20 @@
 		E002 /* SharedFrameQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = F076 /* SharedFrameQueue.swift */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		EMBEDPH /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				EEMBED /* ColumbaNetworkExtension.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXContainerItemProxy section */
 		TTPROXY /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -131,6 +146,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = TTARG;
 			remoteInfo = ColumbaAppTests;
+		};
+		EPROXY /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = PROJ /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = ETARG;
+			remoteInfo = ColumbaNetworkExtension;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -612,10 +634,12 @@
 				SRCBP /* Sources */,
 				FWBP /* Frameworks */,
 				RESBP /* Resources */,
+				EMBEDPH /* Embed Foundation Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				EDEP /* PBXTargetDependency */,
 			);
 			name = ColumbaApp;
 			packageProductDependencies = (
@@ -710,6 +734,11 @@
 			isa = PBXTargetDependency;
 			target = TARG /* ColumbaApp */;
 			targetProxy = TTPROXY /* PBXContainerItemProxy */;
+		};
+		EDEP /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = ETARG /* ColumbaNetworkExtension */;
+			targetProxy = EPROXY /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -1052,6 +1081,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SUPPORTS_MACCATALYST = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "ENABLE_NETWORK_EXTENSION DEBUG";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1090,6 +1120,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SUPPORTS_MACCATALYST = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = ENABLE_NETWORK_EXTENSION;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
Fixes #54.

## What broke

`ColumbaNetworkExtension` target, `PacketTunnelProvider`, `TunnelManager`, the `backgroundTransportCard` toggle, and the entitlements (`packet-tunnel-provider`, `group.network.columba.Columba`) were all already in the repo — but the **project never wired them up**.

Three holes in the app target:

1. No `ENABLE_NETWORK_EXTENSION` in `SWIFT_ACTIVE_COMPILATION_CONDITIONS` → every `#if ENABLE_NETWORK_EXTENSION` block compiled out. `TunnelManager` body empty, `appServices.tunnelManager` always nil, Background Transport toggle never rendered.
2. No `PBXTargetDependency` on `ColumbaNetworkExtension` → extension never built alongside the app.
3. No `PBXCopyFilesBuildPhase` to embed the `.appex` into `ColumbaApp.app/PlugIns/` → even if the extension had built, iOS wouldn't have found it.

End result: the app fully suspended on lock / background. TCP stalled. Peer's sends queued at the OS level. Unlock fired the "all messages received and acked" burst the user described.

## Project changes

- Add `ENABLE_NETWORK_EXTENSION` to the app target's Debug + Release `SWIFT_ACTIVE_COMPILATION_CONDITIONS`
- New `PBXTargetDependency` (`EDEP`, ColumbaApp → ColumbaNetworkExtension) via `PBXContainerItemProxy` (`EPROXY`)
- New `PBXCopyFilesBuildPhase` (`EMBEDPH`, "Embed Foundation Extensions", `dstSubfolderSpec = 13` = PlugIns) carrying a new `PBXBuildFile` (`EEMBED`)
- Wire `EDEP` into ColumbaApp's `dependencies` and `EMBEDPH` into `buildPhases`

## What this means at runtime

First launch after this lands prompts the user for a VPN profile (NEPacketTunnelProvider requirement) — granted once in system settings. After that, the Background Transport toggle in Settings is real and functional, and TCP/LAN connections stay alive when the phone is locked or the app is backgrounded.

## Test plan

- [x] `xcodebuild build -sdk iphonesimulator` — succeeds; `.appex` lands in `ColumbaApp.app/PlugIns/`
- [x] `xcodebuild build -sdk iphoneos -destination "id=…" CODE_SIGN_STYLE=Automatic DEVELOPMENT_TEAM=M2977H5PM5 -allowProvisioningUpdates` — succeeds; both `network.columba.Columba` and `network.columba.Columba.tunnel` provisioning profiles resolve cleanly
- [x] `xcrun devicectl device install app …` — installs without complaint, extension lands inside the bundle
- [ ] Manual: launch app, accept VPN prompt, toggle Background Transport on
- [ ] Manual: lock phone, have a peer send a message, unlock — message should arrive without the "burst on unlock" pattern from #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)