### PR TITLE
feat: tunnel-mode wiring (Phase 1 of background-connectivity plan)

### DIFF
--- a/Columba.xcodeproj/project.pbxproj
+++ b/Columba.xcodeproj/project.pbxproj
@@ -1207,7 +1207,7 @@
 			repositoryURL = "https://github.com/torlando-tech/reticulum-swift.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.2.2;
+				minimumVersion = 0.2.3;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Columba.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Columba.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/torlando-tech/reticulum-swift.git",
       "state" : {
-        "revision" : "a884851b150b81be718eec072e067436ae2a3154",
-        "version" : "0.2.2"
+        "revision" : "b8ae6491d5ca62db30b097382cdf8553edda9b92",
+        "version" : "0.2.3"
       }
     },
     {

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -599,11 +599,70 @@ public final class AppServices {
         // 13. Load tunnel manager
         let tunnel = TunnelManager()
         self.tunnelManager = tunnel
+
+        // Wire tunnel state -> per-interface tunnel-mode coordination.
+        // When the VPN extension reports `.connected`, switch each
+        // TCPInterface / AutoInterface into tunnel mode so its
+        // outbound traffic flows through the extension's authoritative
+        // socket instead of through a duplicate local NWConnection.
+        // When the extension goes back to `.disconnected`, restore the
+        // local NWConnection-managed path. The closure is invoked on
+        // the main actor by TunnelManager.
+        tunnel.onStatusChange = { [weak self] newStatus in
+            guard let self else { return }
+            Task { @MainActor in
+                switch newStatus {
+                case .connected:
+                    await self.applyTunnelModeToInterfaces(active: true)
+                case .disconnected, .invalid:
+                    await self.applyTunnelModeToInterfaces(active: false)
+                default:
+                    break
+                }
+            }
+        }
         await tunnel.load()
         #endif
 
         DiagLog.log("[INIT2] Initialization complete (identity: \(identityHash))")
     }
+
+    #if ENABLE_NETWORK_EXTENSION
+    /// Switch every TCPInterface and AutoInterface into or out of
+    /// tunnel mode in response to the VPN extension's status.
+    ///
+    /// In tunnel mode the interface tears down its own NWConnection
+    /// and routes outbound bytes through `TunnelManager.sendFrame`,
+    /// which the extension forwards on its authoritative socket.
+    /// Inbound continues to flow via `ExtensionFrameReader` →
+    /// `transport.handleReceivedData` regardless.
+    @MainActor
+    private func applyTunnelModeToInterfaces(active: Bool) async {
+        guard let tunnel = tunnelManager else { return }
+
+        if active {
+            for (_, iface) in tcpInterfaces {
+                await iface.beginTunnelMode { [weak tunnel] frame in
+                    await tunnel?.sendFrame(frame, interfaceTag: FrameInterfaceTag.tcp.rawValue)
+                }
+            }
+            if let auto = autoInterface {
+                await auto.beginTunnelMode { [weak tunnel] frame in
+                    await tunnel?.sendFrame(frame, interfaceTag: FrameInterfaceTag.auto.rawValue)
+                }
+            }
+            DiagLog.log("[TUNNEL] enabled tunnel mode on \(self.tcpInterfaces.count) TCP + \(self.autoInterface != nil ? 1 : 0) Auto interface(s)")
+        } else {
+            for (_, iface) in tcpInterfaces {
+                await iface.endTunnelMode()
+            }
+            if let auto = autoInterface {
+                await auto.endTunnelMode()
+            }
+            DiagLog.log("[TUNNEL] disabled tunnel mode; interfaces resuming local connections")
+        }
+    }
+    #endif
 
     /// Switch to a different identity, tearing down and re-initializing the full stack.
     ///

--- a/Sources/ColumbaApp/Services/InterfaceRepository.swift
+++ b/Sources/ColumbaApp/Services/InterfaceRepository.swift
@@ -499,6 +499,20 @@ public final class InterfaceRepository: @unchecked Sendable {
         } catch {
             logger.error("Failed to encode interfaces: \(error)")
         }
+
+        // Notify the Network Extension (if running) that interface
+        // configs changed so it can diff its current sockets against
+        // the new state and start/stop only what changed. Unrelated
+        // interfaces stay connected. The notification name lives in
+        // SharedFrameQueue because both targets need to reference it.
+        let center = CFNotificationCenterGetDarwinNotifyCenter()
+        CFNotificationCenterPostNotification(
+            center,
+            CFNotificationName(SharedDefaultsConstants.configChangedNotificationName as CFString),
+            nil,
+            nil,
+            true
+        )
     }
 
     /// Add a new interface.

--- a/Sources/ColumbaApp/Services/TunnelManager.swift
+++ b/Sources/ColumbaApp/Services/TunnelManager.swift
@@ -73,6 +73,19 @@ public final class TunnelManager: @unchecked Sendable {
                     self.onStatusChange?(newStatus)
                 }
             }
+
+            // Fire `onStatusChange` once for the post-load state. iOS
+            // keeps the extension alive across app relaunches, so the
+            // tunnel can already be `.connected` by the time the app
+            // cold-starts and wires its callback. Without this initial
+            // fire, observers (like AppServices' tunnel-mode
+            // coordinator) would never learn the tunnel is up and the
+            // app's TCPInterface would race the extension's socket —
+            // exactly the split-horizon bug Phase 2 is meant to
+            // prevent.
+            if let cb = onStatusChange {
+                cb(status)
+            }
         } catch {
             logger.error("Failed to load tunnel config: \(error)")
         }

--- a/Sources/ColumbaApp/Services/TunnelManager.swift
+++ b/Sources/ColumbaApp/Services/TunnelManager.swift
@@ -35,6 +35,14 @@ public final class TunnelManager: @unchecked Sendable {
     /// The loaded tunnel provider manager
     private var manager: NETunnelProviderManager?
 
+    /// Called whenever the tunnel's VPN status changes.
+    ///
+    /// `AppServices` uses this to coordinate transitioning each
+    /// `TCPInterface` / `AutoInterface` into and out of tunnel-mode
+    /// (where outbound is routed via the extension instead of a
+    /// duplicate local NWConnection).
+    public var onStatusChange: (@Sendable (NEVPNStatus) -> Void)?
+
     private let logger = Logger(subsystem: "network.columba.Columba", category: "TunnelManager")
 
     // MARK: - Lifecycle
@@ -60,7 +68,9 @@ public final class TunnelManager: @unchecked Sendable {
             ) { [weak self] _ in
                 guard let self else { return }
                 Task { @MainActor in
-                    self.status = self.manager?.connection.status ?? .disconnected
+                    let newStatus = self.manager?.connection.status ?? .disconnected
+                    self.status = newStatus
+                    self.onStatusChange?(newStatus)
                 }
             }
         } catch {

--- a/Sources/ColumbaNetworkExtension/PacketTunnelProvider.swift
+++ b/Sources/ColumbaNetworkExtension/PacketTunnelProvider.swift
@@ -112,6 +112,17 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         }
     }
 
+    /// Tear down the current TCP connection and clear the HDLC
+    /// receive buffer so a reconnect doesn't prepend a partial frame
+    /// from the previous session to the new connection's first
+    /// bytes (which would corrupt the next decoded packet). Always
+    /// called from `configQueue`.
+    private func teardownTCPConnectionLocked() {
+        tcpConnection?.cancel()
+        tcpConnection = nil
+        tcpReceiveBuffer = Data()
+    }
+
     /// Body of `applyConfigs` — runs on `configQueue`. Mutates
     /// `currentTCP` / `currentAutoGroupId` / `tcpConnection` /
     /// `autoListener` only from this serial context.
@@ -126,15 +137,13 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
                 // No change.
             } else {
                 NSLog("[EXT] TCP config (re)applying: \(tcp.host):\(tcp.port)")
-                tcpConnection?.cancel()
-                tcpConnection = nil
+                teardownTCPConnectionLocked()
                 startTCPConnection(host: tcp.host, port: tcp.port)
                 currentTCP = (tcp.host, tcp.port)
             }
         } else if currentTCP != nil {
             NSLog("[EXT] TCP config removed; tearing down connection")
-            tcpConnection?.cancel()
-            tcpConnection = nil
+            teardownTCPConnectionLocked()
             currentTCP = nil
         }
 
@@ -166,8 +175,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         // keeps the existing contract that the completion handler
         // fires only after teardown has finished.
         configQueue.sync {
-            tcpConnection?.cancel()
-            tcpConnection = nil
+            teardownTCPConnectionLocked()
             autoListener?.cancel()
             autoListener = nil
             currentTCP = nil
@@ -237,9 +245,17 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         // changed, so re-applying on wake is cheap.
         configQueue.async { [weak self] in
             guard let self else { return }
-            if self.tcpConnection?.state == .cancelled || self.tcpConnection == nil {
-                self.tcpConnection = nil
+            // Treat cancelled / failed / nil connections as gone so
+            // applyConfigsLocked starts a fresh one rather than seeing
+            // the cached endpoint as already-applied. Use the helper
+            // so the receive buffer is reset alongside the connection
+            // — see `teardownTCPConnectionLocked`.
+            switch self.tcpConnection?.state {
+            case .cancelled, .failed, .none:
+                self.teardownTCPConnectionLocked()
                 self.currentTCP = nil
+            default:
+                break
             }
             self.applyConfigsLocked()
         }
@@ -271,8 +287,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
                 // starts a fresh one all on the serial queue.
                 guard let self else { return }
                 self.configQueue.async {
-                    self.tcpConnection?.cancel()
-                    self.tcpConnection = nil
+                    self.teardownTCPConnectionLocked()
                     self.currentTCP = nil
                 }
                 DispatchQueue.global().asyncAfter(deadline: .now() + 5) { [weak self] in

--- a/Sources/ColumbaNetworkExtension/PacketTunnelProvider.swift
+++ b/Sources/ColumbaNetworkExtension/PacketTunnelProvider.swift
@@ -263,9 +263,20 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
                 self?.receiveTCPData()
             case .failed(let error):
                 NSLog("[EXT] TCP failed: \(error), reconnecting in 5s")
-                self?.tcpConnection?.cancel()
-                DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
-                    self?.startTCPConnection(host: host, port: port)
+                // Reconnect must go through configQueue — otherwise the
+                // .failed handler's main-queue write to `tcpConnection`
+                // would race `applyConfigsLocked` writing the same
+                // property. Routing through `applyConfigs` re-reads the
+                // current config, clears the stale connection, and
+                // starts a fresh one all on the serial queue.
+                guard let self else { return }
+                self.configQueue.async {
+                    self.tcpConnection?.cancel()
+                    self.tcpConnection = nil
+                    self.currentTCP = nil
+                }
+                DispatchQueue.global().asyncAfter(deadline: .now() + 5) { [weak self] in
+                    self?.applyConfigs()
                 }
             case .waiting(let error):
                 NSLog("[EXT] TCP waiting: \(error)")

--- a/Sources/ColumbaNetworkExtension/PacketTunnelProvider.swift
+++ b/Sources/ColumbaNetworkExtension/PacketTunnelProvider.swift
@@ -197,25 +197,30 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         let interfaceTag = messageData[0]
         let frameData = messageData.dropFirst()
 
-        switch interfaceTag {
-        case FrameInterfaceTag.tcp.rawValue:
-            tcpConnection?.send(content: frameData, completion: .contentProcessed { error in
-                if let error {
-                    NSLog("[EXT] TCP send error: \(error)")
+        // Read the connection / listener under configQueue so we can't
+        // observe a half-mutated state while applyConfigsLocked() is
+        // diffing or stopTunnel() is tearing things down.
+        configQueue.async { [weak self] in
+            guard let self else { completionHandler?(nil); return }
+            switch interfaceTag {
+            case FrameInterfaceTag.tcp.rawValue:
+                self.tcpConnection?.send(content: frameData, completion: .contentProcessed { error in
+                    if let error {
+                        NSLog("[EXT] TCP send error: \(error)")
+                    }
+                })
+            case FrameInterfaceTag.auto.rawValue:
+                // Auto frames are sent as UDP datagrams via the connection group
+                self.autoListener?.send(content: frameData) { error in
+                    if let error {
+                        NSLog("[EXT] Auto send error: \(error)")
+                    }
                 }
-            })
-        case FrameInterfaceTag.auto.rawValue:
-            // Auto frames are sent as UDP datagrams via the connection group
-            autoListener?.send(content: frameData) { error in
-                if let error {
-                    NSLog("[EXT] Auto send error: \(error)")
-                }
+            default:
+                NSLog("[EXT] Unknown interface tag: \(interfaceTag)")
             }
-        default:
-            NSLog("[EXT] Unknown interface tag: \(interfaceTag)")
+            completionHandler?(nil)
         }
-
-        completionHandler?(nil)
     }
 
     override func sleep(completionHandler: @escaping () -> Void) {
@@ -225,13 +230,18 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
     override func wake() {
         NSLog("[EXT] wake")
-        // Reconnect if needed
-        if tcpConnection?.state == .cancelled || tcpConnection?.state == .failed(NWError.posix(.ECONNRESET)) {
-            let defaults = UserDefaults(suiteName: appGroupIdentifier) ?? .standard
-            let configs = loadInterfaceConfigs(from: defaults)
-            if let tcp = configs.tcp {
-                startTCPConnection(host: tcp.host, port: tcp.port)
+        // Re-apply configs through the serial queue so a dropped TCP
+        // connection (cancelled / failed) gets restarted without
+        // racing applyConfigsLocked / stopTunnel writes. The diff
+        // logic in applyConfigsLocked is a no-op when nothing
+        // changed, so re-applying on wake is cheap.
+        configQueue.async { [weak self] in
+            guard let self else { return }
+            if self.tcpConnection?.state == .cancelled || self.tcpConnection == nil {
+                self.tcpConnection = nil
+                self.currentTCP = nil
             }
+            self.applyConfigsLocked()
         }
     }
 

--- a/Sources/ColumbaNetworkExtension/PacketTunnelProvider.swift
+++ b/Sources/ColumbaNetworkExtension/PacketTunnelProvider.swift
@@ -34,11 +34,19 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
     /// Currently-applied TCP endpoint (used to diff config changes
     /// from the app). nil when no TCP interface is configured.
+    /// Mutated only on `configQueue` to avoid races with Darwin
+    /// notification callbacks arriving on a Mach-port thread.
     private var currentTCP: (host: String, port: UInt16)?
 
     /// Currently-applied AutoInterface group id. nil when no Auto
-    /// interface is configured.
+    /// interface is configured. Mutated only on `configQueue`.
     private var currentAutoGroupId: String?
+
+    /// Serial queue serializing all config-state mutations and the
+    /// associated NWConnection lifecycle calls so a Darwin
+    /// notification fired by the app (`configChanged`) can't race
+    /// `startTunnel` / `stopTunnel` / NWConnection state handlers.
+    private let configQueue = DispatchQueue(label: "network.columba.tunnel.config")
 
     /// HDLC receive buffer for TCP stream framing
     private var tcpReceiveBuffer = Data()
@@ -94,7 +102,20 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     /// Diffs against what's already running so a single relay change
     /// doesn't disrupt unrelated interfaces. Called both on
     /// `startTunnel` and on the `configChanged` Darwin notification.
+    /// Always serialized onto `configQueue` so a Darwin callback
+    /// arriving on a Mach-port thread can't race `startTunnel` /
+    /// `stopTunnel` / NWConnection state handlers mutating the same
+    /// properties.
     private func applyConfigs() {
+        configQueue.async { [weak self] in
+            self?.applyConfigsLocked()
+        }
+    }
+
+    /// Body of `applyConfigs` — runs on `configQueue`. Mutates
+    /// `currentTCP` / `currentAutoGroupId` / `tcpConnection` /
+    /// `autoListener` only from this serial context.
+    private func applyConfigsLocked() {
         let defaults = UserDefaults(suiteName: appGroupIdentifier) ?? .standard
         let configs = loadInterfaceConfigs(from: defaults)
 
@@ -138,12 +159,20 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
     override func stopTunnel(with reason: NEProviderStopReason, completionHandler: @escaping () -> Void) {
         NSLog("[EXT] stopTunnel reason=\(reason.rawValue)")
-        tcpConnection?.cancel()
-        tcpConnection = nil
-        autoListener?.cancel()
-        autoListener = nil
-        currentTCP = nil
-        currentAutoGroupId = nil
+
+        // Serialize teardown through the same queue `applyConfigs` uses
+        // so we can't race a config-change notification arriving on the
+        // Mach-port thread mid-shutdown. `sync` (rather than `async`)
+        // keeps the existing contract that the completion handler
+        // fires only after teardown has finished.
+        configQueue.sync {
+            tcpConnection?.cancel()
+            tcpConnection = nil
+            autoListener?.cancel()
+            autoListener = nil
+            currentTCP = nil
+            currentAutoGroupId = nil
+        }
 
         // Remove the config-changed observer registered in startTunnel.
         let center = CFNotificationCenterGetDarwinNotifyCenter()

--- a/Sources/ColumbaNetworkExtension/PacketTunnelProvider.swift
+++ b/Sources/ColumbaNetworkExtension/PacketTunnelProvider.swift
@@ -18,14 +18,27 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
     // MARK: - Constants
 
-    private static let packetReadyNotification = "network.columba.packetReady"
-    private static let interfacesKey = "com.columba.interfaces"
+    /// Notification posted to the app when inbound frames are queued.
+    private static let packetReadyNotification = SharedDefaultsConstants.packetReadyNotificationName
+    /// Notification observed when the app writes interface-config
+    /// changes; triggers a reload so unrelated interfaces stay
+    /// connected while a single relay is added/removed/edited.
+    private static let configChangedNotification = SharedDefaultsConstants.configChangedNotificationName
+    private static let interfacesKey = SharedDefaultsConstants.interfacesKey
 
     // MARK: - Properties
 
     private var tcpConnection: NWConnection?
     private var autoListener: NWConnectionGroup?
     private lazy var frameQueue = SharedFrameQueue(appGroupIdentifier: appGroupIdentifier)
+
+    /// Currently-applied TCP endpoint (used to diff config changes
+    /// from the app). nil when no TCP interface is configured.
+    private var currentTCP: (host: String, port: UInt16)?
+
+    /// Currently-applied AutoInterface group id. nil when no Auto
+    /// interface is configured.
+    private var currentAutoGroupId: String?
 
     /// HDLC receive buffer for TCP stream framing
     private var tcpReceiveBuffer = Data()
@@ -40,19 +53,27 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     override func startTunnel(options: [String: NSObject]?, completionHandler: @escaping (Error?) -> Void) {
         NSLog("[EXT] startTunnel called")
 
-        // Read interface configs from shared UserDefaults
-        let defaults = UserDefaults(suiteName: appGroupIdentifier) ?? .standard
-        let configs = loadInterfaceConfigs(from: defaults)
+        // Apply current interface configs.
+        applyConfigs()
 
-        // Start TCP connection if configured
-        if let tcp = configs.tcp {
-            startTCPConnection(host: tcp.host, port: tcp.port)
-        }
-
-        // Start AutoInterface multicast listener if configured
-        if let groupId = configs.autoGroupId {
-            startAutoListener(groupId: groupId)
-        }
+        // Subscribe to live config changes so the user adding /
+        // removing / editing an interface in the app updates the
+        // extension's sockets without a tunnel restart. The handler
+        // diffs and only restarts what actually changed.
+        let center = CFNotificationCenterGetDarwinNotifyCenter()
+        let observer = Unmanaged.passUnretained(self).toOpaque()
+        CFNotificationCenterAddObserver(
+            center,
+            observer,
+            { _, observer, _, _, _ in
+                guard let observer else { return }
+                let provider = Unmanaged<PacketTunnelProvider>.fromOpaque(observer).takeUnretainedValue()
+                provider.applyConfigs()
+            },
+            Self.configChangedNotification as CFString,
+            nil,
+            .deliverImmediately
+        )
 
         // Set up dummy tunnel settings (required by NEPacketTunnelProvider)
         let settings = NEPacketTunnelNetworkSettings(tunnelRemoteAddress: "127.0.0.1")
@@ -67,12 +88,73 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         }
     }
 
+    /// Read the current interface configs from shared UserDefaults
+    /// and bring up / tear down the matching `NWConnection`s.
+    ///
+    /// Diffs against what's already running so a single relay change
+    /// doesn't disrupt unrelated interfaces. Called both on
+    /// `startTunnel` and on the `configChanged` Darwin notification.
+    private func applyConfigs() {
+        let defaults = UserDefaults(suiteName: appGroupIdentifier) ?? .standard
+        let configs = loadInterfaceConfigs(from: defaults)
+
+        // TCP: bring up if newly configured; tear down if removed;
+        // restart if endpoint changed.
+        if let tcp = configs.tcp {
+            if let existing = currentTCP, existing.host == tcp.host && existing.port == tcp.port {
+                // No change.
+            } else {
+                NSLog("[EXT] TCP config (re)applying: \(tcp.host):\(tcp.port)")
+                tcpConnection?.cancel()
+                tcpConnection = nil
+                startTCPConnection(host: tcp.host, port: tcp.port)
+                currentTCP = (tcp.host, tcp.port)
+            }
+        } else if currentTCP != nil {
+            NSLog("[EXT] TCP config removed; tearing down connection")
+            tcpConnection?.cancel()
+            tcpConnection = nil
+            currentTCP = nil
+        }
+
+        // Auto: same diff.
+        if let groupId = configs.autoGroupId {
+            if currentAutoGroupId == groupId {
+                // No change.
+            } else {
+                NSLog("[EXT] Auto config (re)applying: groupId=\(groupId)")
+                autoListener?.cancel()
+                autoListener = nil
+                startAutoListener(groupId: groupId)
+                currentAutoGroupId = groupId
+            }
+        } else if currentAutoGroupId != nil {
+            NSLog("[EXT] Auto config removed; tearing down listener")
+            autoListener?.cancel()
+            autoListener = nil
+            currentAutoGroupId = nil
+        }
+    }
+
     override func stopTunnel(with reason: NEProviderStopReason, completionHandler: @escaping () -> Void) {
         NSLog("[EXT] stopTunnel reason=\(reason.rawValue)")
         tcpConnection?.cancel()
         tcpConnection = nil
         autoListener?.cancel()
         autoListener = nil
+        currentTCP = nil
+        currentAutoGroupId = nil
+
+        // Remove the config-changed observer registered in startTunnel.
+        let center = CFNotificationCenterGetDarwinNotifyCenter()
+        let observer = Unmanaged.passUnretained(self).toOpaque()
+        CFNotificationCenterRemoveObserver(
+            center,
+            observer,
+            CFNotificationName(Self.configChangedNotification as CFString),
+            nil
+        )
+
         completionHandler()
     }
 

--- a/Sources/ColumbaNetworkExtension/PacketTunnelProvider.swift
+++ b/Sources/ColumbaNetworkExtension/PacketTunnelProvider.swift
@@ -300,11 +300,24 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             }
         }
 
-        connection.start(queue: .main)
+        // Run state callbacks AND receive callbacks on configQueue so
+        // the receive buffer (`tcpReceiveBuffer`) and connection
+        // pointer are touched only from one serial context. Without
+        // this, a `.main` receive completion could race
+        // `teardownTCPConnectionLocked` resetting the buffer on
+        // configQueue and the clear would silently lose to a stale
+        // append, corrupting the next session's HDLC framing.
+        connection.start(queue: configQueue)
     }
 
+    /// Continuation of inbound TCP receive. Must run on `configQueue`
+    /// because it both reads `tcpConnection` and feeds `handleTCPData`
+    /// which touches `tcpReceiveBuffer` — both serialized there.
     private func receiveTCPData() {
         tcpConnection?.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] data, _, isComplete, error in
+            // Callback runs on the connection's queue (configQueue
+            // since startTCPConnection switched it). No extra dispatch
+            // needed.
             if let data, !data.isEmpty {
                 self?.handleTCPData(data)
             }
@@ -324,7 +337,9 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         }
     }
 
-    /// Buffer TCP data and extract HDLC frames.
+    /// Buffer TCP data and extract HDLC frames. Runs on configQueue
+    /// (called from `receiveTCPData`'s completion which now executes
+    /// on configQueue too).
     private func handleTCPData(_ data: Data) {
         tcpReceiveBuffer.append(data)
 

--- a/Sources/Shared/SharedFrameQueue.swift
+++ b/Sources/Shared/SharedFrameQueue.swift
@@ -15,6 +15,29 @@ import Foundation
 /// Defined here because `Sources/Shared` is compiled into both targets.
 public let appGroupIdentifier = "group.network.columba.Columba"
 
+/// Identifiers shared between the Columba app target and the
+/// `ColumbaNetworkExtension` so both refer to the same notification
+/// names / UserDefaults keys without duplicating string literals.
+public enum SharedDefaultsConstants {
+    /// Darwin notification posted when the app writes to the
+    /// interface-config UserDefaults. The extension observes this and
+    /// reloads its sockets so user-facing changes (added relay,
+    /// disabled interface, etc.) take effect without a tunnel
+    /// restart.
+    public static let configChangedNotificationName = "network.columba.configChanged"
+
+    /// Darwin notification posted by the extension when inbound
+    /// frames have been written to `SharedFrameQueue`. The app's
+    /// `ExtensionFrameReader` observes this to drain the queue.
+    public static let packetReadyNotificationName = "network.columba.packetReady"
+
+    /// Shared UserDefaults key holding the JSON-encoded interface
+    /// configuration array (full `InterfaceEntity` objects). Both the
+    /// app's `InterfaceRepository` and the extension's
+    /// `loadInterfaceConfigs` read from this key.
+    public static let interfacesKey = "com.columba.interfaces"
+}
+
 /// Interface tag identifying which network interface a frame arrived on.
 public enum FrameInterfaceTag: UInt8 {
     case tcp = 0x01


### PR DESCRIPTION
First of two PRs that finish the long-dormant `NEPacketTunnelProvider` scaffold so flipping `ENABLE_NETWORK_EXTENSION` (Phase 2, separate PR) actually keeps TCP/Auto traffic flowing while the app is backgrounded — without the split-horizon bug we hit in #55 (closed) where the app's TCPInterface ran simultaneously with the extension's NWConnection.

Tracks issue #54.

## What's in here

1. **AppServices observes `TunnelManager.onStatusChange`.** When the VPN extension reports `.connected`, every `TCPInterface` and the `AutoInterface` get switched into tunnel mode via the new `beginTunnelMode(send:)` API in reticulum-swift 0.2.3. Outbound bytes route through `TunnelManager.sendFrame`, which the extension forwards on its authoritative socket — instead of a duplicate local NWConnection. Inbound continues to flow via `ExtensionFrameReader` → `transport.handleReceivedData`. On `.disconnected` we call `endTunnelMode()` and the local connections resume.

2. **`InterfaceRepository.saveInterfaces` posts a `network.columba.configChanged` Darwin notification.** The `PacketTunnelProvider` observes it, diffs the new config against what's currently running, and starts/stops only the affected `NWConnection` — adding/removing/editing a single relay no longer takes down unrelated interfaces. `applyConfigs()` is called both on `startTunnel` and on the notification.

3. **Shared notification names + UserDefaults keys consolidated** into `SharedDefaultsConstants` in `Sources/Shared` so the app and extension reference the same string in one place.

## Behavior change

**None for users.** Everything is gated by the still-disabled `ENABLE_NETWORK_EXTENSION` flag. The outbound hook in reticulum-swift 0.2.3 is a pure addition (no behavior change when the hook isn't installed). This PR is reviewable infrastructure that Phase 2 turns on.

## Phase 2 (next PR) will

- Rename `TunnelManager.stop()` → `disable()` and disable the VPN profile fully on toggle off (so iOS releases routing).
- Add `tunnel_enabled` user pref + `AppServices` auto-restart on launch.
- Replace `try?` with proper error surfacing on the Settings toggle.
- Add a Background Transport step to `OnboardingViewModel` (pre-checked ON, recommended).
- Flip `ENABLE_NETWORK_EXTENSION`, add `CODE_SIGN_ENTITLEMENTS` for the app target, add `PBXTargetDependency` + `PBXCopyFilesBuildPhase` to embed the extension.

End-to-end device test happens with that PR.

## Depends on

`reticulum-swift` 0.2.3 (just released — adds `beginTunnelMode(send:)` / `endTunnelMode()` to TCPInterface and AutoInterface). Pin updated in this PR.

## Test plan

- [x] `xcodebuild build -sdk iphonesimulator` — succeeds
- [x] `xcodebuild test -only-testing:ColumbaAppTests` — all 4 suites pass (no regressions)
- [ ] End-to-end behavior verified in Phase 2 once the flag is flipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)