### PR TITLE
feat: add Maestro UI flows for columba-suite ui-screenshotter

### DIFF
--- a/flows/README.md
+++ b/flows/README.md
@@ -1,0 +1,37 @@
+# Maestro UI flows
+
+This directory holds [Maestro](https://maestro.mobile.dev/) flows the
+columba-suite **ui-screenshotter** agent runs against the iOS Simulator on
+each `columba-suite/*` PR that touches UI files. The agent captures
+each flow at BASE_REF and HEAD, in both light and dark Simulator
+appearances, and links the resulting PNG pair from the PR's PLAN.md so
+reviewers can see the visual change before merging.
+
+## Adding a flow
+
+1. New file `flows/<name>.yml`. Use existing flows as templates.
+2. Make it deterministic: `clearState: true` + `clearKeychain: true` on
+   launch, handle the onboarding skip path, no network-state assumptions.
+3. End with `takeScreenshot: <name>` (the agent expects the PNG to land
+   at `./<name>.png`).
+4. Don't add voice-call flows yet — they need a debug-only `lxma://debug/...`
+   URL handler that doesn't exist (Stage 1 limitation).
+
+## Running locally
+
+```sh
+export JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home
+export PATH="$JAVA_HOME/bin:$HOME/.maestro/bin:$PATH"
+maestro --device <UDID> test flows/contacts-list.yml
+```
+
+The `<UDID>` is from `xcrun simctl list devices booted`.
+
+## Stage roadmap
+
+- **Stage 1** (now): capture + write the table to PLAN.md only.
+- **Stage 2**: pixel diff column.
+- **Stage 3**: regression gating (PR fails if golden flow drifts > N%).
+- **Stage 4**: graduate to PR comments + GitHub-attachment uploads.
+
+Plan: `~/.claude/plans/ui-screenshotter.md` (vault `Agent Plans/`).

--- a/flows/chats-list.yml
+++ b/flows/chats-list.yml
@@ -1,0 +1,34 @@
+appId: network.columba.Columba
+name: chats-list
+tags:
+  - smoke
+  - screenshot
+---
+# Capture the Chats tab — the default landing tab. Stable enough that the
+# onboarding-skip path lands here naturally without further taps.
+- launchApp:
+    clearState: true
+    clearKeychain: true
+- waitForAnimationToEnd:
+    timeout: 5000
+- runFlow:
+    when:
+      visible: "Skip"
+    commands:
+      - tapOn: "Skip"
+      - waitForAnimationToEnd:
+          timeout: 3000
+- runFlow:
+    when:
+      visible: "Get Started"
+    commands:
+      - tapOn: "Get Started"
+      - waitForAnimationToEnd:
+          timeout: 3000
+# Default tab is Chats — no tap needed if onboarding lands there.
+- tapOn:
+    text: "Chats"
+    optional: true
+- waitForAnimationToEnd:
+    timeout: 3000
+- takeScreenshot: "chats-list"

--- a/flows/contacts-list.yml
+++ b/flows/contacts-list.yml
@@ -15,7 +15,7 @@ tags:
     clearKeychain: true
 - waitForAnimationToEnd:
     timeout: 5000
-# Onboarding may show on a fresh install; skip if "Skip" / "Continue" is visible.
+# Onboarding may show on a fresh install; skip if "Skip" / "Get Started" is visible.
 - runFlow:
     when:
       visible: "Skip"

--- a/flows/contacts-list.yml
+++ b/flows/contacts-list.yml
@@ -1,0 +1,38 @@
+appId: network.columba.Columba
+name: contacts-list
+tags:
+  - smoke
+  - screenshot
+---
+# Visit the Contacts tab and capture the list state. This is the most stable
+# UI surface that shows in every PR (no network needed beyond app boot — the
+# contacts list renders even with no cached announces).
+#
+# The screenshot lands at <cwd>/contacts-list.png; the orchestrator moves it
+# to ~/.claude-runner/screenshots/<pr>/<phase>/contacts-list.png.
+- launchApp:
+    clearState: true
+    clearKeychain: true
+- waitForAnimationToEnd:
+    timeout: 5000
+# Onboarding may show on a fresh install; skip if "Skip" / "Continue" is visible.
+- runFlow:
+    when:
+      visible: "Skip"
+    commands:
+      - tapOn: "Skip"
+      - waitForAnimationToEnd:
+          timeout: 3000
+- runFlow:
+    when:
+      visible: "Get Started"
+    commands:
+      - tapOn: "Get Started"
+      - waitForAnimationToEnd:
+          timeout: 3000
+- tapOn:
+    text: "Contacts"
+    optional: true
+- waitForAnimationToEnd:
+    timeout: 3000
+- takeScreenshot: "contacts-list"

--- a/flows/map.yml
+++ b/flows/map.yml
@@ -1,0 +1,35 @@
+appId: network.columba.Columba
+name: map
+tags:
+  - smoke
+  - screenshot
+---
+# Capture the Map tab. PR #59/#65 changes this view's style URL based on
+# system appearance. We screenshot it in the Sim's default light appearance —
+# Stage 2 will add a dark-mode capture column.
+- launchApp:
+    clearState: true
+    clearKeychain: true
+- waitForAnimationToEnd:
+    timeout: 5000
+- runFlow:
+    when:
+      visible: "Skip"
+    commands:
+      - tapOn: "Skip"
+      - waitForAnimationToEnd:
+          timeout: 3000
+- runFlow:
+    when:
+      visible: "Get Started"
+    commands:
+      - tapOn: "Get Started"
+      - waitForAnimationToEnd:
+          timeout: 3000
+- tapOn:
+    text: "Map"
+    optional: true
+# Maps need a beat to load tile JSON + first-render
+- waitForAnimationToEnd:
+    timeout: 8000
+- takeScreenshot: "map"

--- a/flows/settings.yml
+++ b/flows/settings.yml
@@ -1,0 +1,33 @@
+appId: network.columba.Columba
+name: settings
+tags:
+  - smoke
+  - screenshot
+---
+# Open the Settings tab and capture the top of the panel — the most static UI
+# surface in the app, ideal for catching unintended typography/theme drift.
+- launchApp:
+    clearState: true
+    clearKeychain: true
+- waitForAnimationToEnd:
+    timeout: 5000
+- runFlow:
+    when:
+      visible: "Skip"
+    commands:
+      - tapOn: "Skip"
+      - waitForAnimationToEnd:
+          timeout: 3000
+- runFlow:
+    when:
+      visible: "Get Started"
+    commands:
+      - tapOn: "Get Started"
+      - waitForAnimationToEnd:
+          timeout: 3000
+- tapOn:
+    text: "Settings"
+    optional: true
+- waitForAnimationToEnd:
+    timeout: 3000
+- takeScreenshot: "settings"


### PR DESCRIPTION
## Summary

- Adds `flows/` with 4 deterministic Maestro flows: `contacts-list`, `chats-list`, `settings`, `map`
- Adds `flows/README.md` with conventions + the Stage 1→4 roadmap
- Lands these on `main` so subsequent UI PRs have flow coverage at `BASE_REF`

## Why this exists

The columba-suite ui-screenshotter agent runs Maestro flows against the iOS Simulator on every UI-touching `columba-suite/*` PR, captures BEFORE/AFTER PNGs at light + dark appearance, and links them from the PR's PLAN.md so reviewers see the visual change before merging.

The agent expects flows in `flows/`. Until those land on `main`, every run skips with `screenshot_status: skipped_no_flows`. This PR fixes that.

## Test plan

- [ ] CI builds (this PR is flow-only — no app code changes; CI should pass trivially)
- [ ] Mark this PR ready_for_review and confirm:
  - [ ] ui-screenshotter workflow fires
  - [ ] It exits cleanly with `screenshot_status: skipped_no_flows` (the PR's BASE_REF on `main` doesn't have flows/ yet — expected)
  - [ ] PLAN.md frontmatter is patched with the skip reason
- [ ] After merge: confirm `flows/` is on `main` so the *next* UI PR captures successfully

## Out of scope

- Voice-call flows (need debug-only `lxma://debug/...` URL handler — Stage 1 limitation, separate work item)
- Stage 2 pixel diff, Stage 3 regression gating, Stage 4 PR comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)