### PR TITLE
chore(deps): bump LXMF-swift 0.4.0 + reticulum-swift 0.3.0

### DIFF
--- a/Columba.xcodeproj/project.pbxproj
+++ b/Columba.xcodeproj/project.pbxproj
@@ -1223,7 +1223,7 @@
 			repositoryURL = "https://github.com/torlando-tech/LXMF-swift.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.3.4;
+				minimumVersion = 0.4.0;
 			};
 		};
 		PKGREF2 /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */ = {
@@ -1247,7 +1247,7 @@
 			repositoryURL = "https://github.com/torlando-tech/reticulum-swift.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.2.3;
+				minimumVersion = 0.3.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Columba.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Columba.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/torlando-tech/LXMF-swift.git",
       "state" : {
-        "revision" : "b31a14a8fe9ab9626ce9b333d5978098910b54ea",
-        "version" : "0.3.4"
+        "revision" : "21f877614181800116013771dcab163b08c113fc",
+        "version" : "0.4.0"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/torlando-tech/reticulum-swift.git",
       "state" : {
-        "revision" : "0d11e376f09dddea6dfb31e915a15d69c9809637",
-        "version" : "0.2.4"
+        "revision" : "034d9c7570c7428ebe5daab1ee1b8d17fc1e9c87",
+        "version" : "0.3.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -20,9 +20,9 @@ let package = Package(
         // `.swiftpm/configuration/mirrors.json` mapping the URL to a local
         // directory — see README "Local development against unreleased
         // library changes" for the exact recipe.
-        .package(url: "https://github.com/torlando-tech/LXMF-swift.git", from: "0.3.0"),
+        .package(url: "https://github.com/torlando-tech/LXMF-swift.git", from: "0.4.0"),
         .package(url: "https://github.com/torlando-tech/LXST-swift.git", from: "0.2.0"),
-        .package(url: "https://github.com/torlando-tech/reticulum-swift.git", from: "0.2.0"),
+        .package(url: "https://github.com/torlando-tech/reticulum-swift.git", from: "0.3.0"),
         .package(url: "https://github.com/maplibre/maplibre-gl-native-distribution", from: "6.9.0"),
     ],
     targets: [


### PR DESCRIPTION
## Summary

- **LXMF-swift 0.4.0** (PR #7 merged): outbound-path correctness + perf bundle — parallel stamp generation, PROPAGATED state machine fixes (RESOURCE_PRF→`.sent`, ERROR_INVALID_STAMP signal handler via FIFO+rejections-set side-channel), DIRECT crash-recovery parity, awaited-DB-write ordering parity across both paths.
- **reticulum-swift 0.3.0** (PR #16 merged): HEADER_2 link DATA conversion fix; `sendLinkData` signature change (destinationHash param removed).
- Package.swift + pbxproj `minimumVersion` + Xcode-shared `Package.resolved` all updated.

## Test plan

- [x] `xcodebuild -resolvePackageDependencies` → resolves LXMFSwift 0.4.0 + ReticulumSwift 0.3.0
- [x] `xcodebuild build` (iOS Simulator, CODE_SIGNING_ALLOWED=NO) → BUILD SUCCEEDED
- [ ] Smoke pipeline (PROPAGATED + DIRECT + OPPORTUNISTIC bidirectional with Mac LXMF echo bot) — triggered on PR ready→draft

🤖 Generated with [Claude Code](https://claude.com/claude-code)