### PR TITLE
Dual-backend 2/3 — app services + BLE bridge

### DIFF
--- a/Sources/ColumbaApp/App/ColumbaApp.swift
+++ b/Sources/ColumbaApp/App/ColumbaApp.swift
@@ -75,6 +75,15 @@ struct ColumbaApp: App {
             .id(ThemeManager.shared.themeVersion)
             .onOpenURL { url in
                 guard url.scheme == "lxma" else { return }
+                #if DEBUG
+                // Test-only deep links — DEBUG builds ONLY. In a release build
+                // these would be remote-control backdoors: a crafted
+                // lxma://test-call / test-send / test-identity-switch URL could
+                // place a call, send a message as the user, or wipe the active
+                // identity with no interaction beyond opening the URL. The
+                // interop test harness runs DEBUG builds, so it keeps them; the
+                // production lxma:// deep-link fall-through (pendingDeepLink,
+                // below) stays outside this guard.
                 // Test trigger: lxma://test-send?to=HEX&content=...
                 // bypasses the UI and directly invokes PythonRNSBackend.sendOpportunistic
                 // so external scripts can exercise the Python round-trip during the smoke test.
@@ -345,6 +354,7 @@ struct ColumbaApp: App {
                     )
                     return
                 }
+                #endif
                 pendingDeepLink = url.absoluteString
             }
         }

--- a/Sources/ColumbaApp/App/ColumbaApp.swift
+++ b/Sources/ColumbaApp/App/ColumbaApp.swift
@@ -7,7 +7,7 @@
 //
 
 import SwiftUI
-import LXMFSwift
+import RNSAPI
 import UserNotifications
 import BackgroundTasks
 import os
@@ -35,6 +35,16 @@ struct ColumbaApp: App {
     // MARK: - Init
 
     init() {
+        // Boot embedded CPython once, before anything else can touch it.
+        // PythonBridge / PythonRNSBackend depend on this; without it
+        // PyGILState_Ensure deadlocks.
+        switch PythonRuntime.shared.start() {
+        case .success(let version):
+            logger.info("Python runtime started: \(version, privacy: .public)")
+        case .failure(let err):
+            logger.error("Python runtime failed: \(err.localizedDescription, privacy: .public)")
+        }
+
         #if os(iOS)
         BGTaskScheduler.shared.register(
             forTaskWithIdentifier: "network.columba.Columba.sync",
@@ -65,6 +75,276 @@ struct ColumbaApp: App {
             .id(ThemeManager.shared.themeVersion)
             .onOpenURL { url in
                 guard url.scheme == "lxma" else { return }
+                // Test trigger: lxma://test-send?to=HEX&content=...
+                // bypasses the UI and directly invokes PythonRNSBackend.sendOpportunistic
+                // so external scripts can exercise the Python round-trip during the smoke test.
+                if url.host == "test-nomad-fetch" {
+                    // lxma://test-nomad-fetch?to=HEX&path=/page/index.mu
+                    let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+                    let to = components?.queryItems?.first(where: { $0.name == "to" })?.value ?? ""
+                    let path = components?.queryItems?.first(where: { $0.name == "path" })?.value ?? "/page/index.mu"
+                    DiagLog.log("[TEST-NOMAD] requested to=\(to) path=\(path)")
+                    NotificationCenter.default.post(
+                        name: Notification.Name("ColumbaTestNomadFetch"),
+                        object: nil,
+                        userInfo: ["to": to, "path": path]
+                    )
+                    return
+                }
+                if url.host == "test-answer" {
+                    // lxma://test-answer — accept the currently-ringing
+                    // incoming call. Sim2 fires this in commit-5 smoke
+                    // tests to drive past RINGING → ESTABLISHED so audio
+                    // frames start flowing.
+                    DiagLog.log("[TEST-ANSWER] triggered")
+                    NotificationCenter.default.post(
+                        name: Notification.Name("ColumbaTestAnswer"),
+                        object: nil
+                    )
+                    return
+                }
+                if url.host == "test-call" {
+                    // lxma://test-call?to=HEX[&profile=quality-medium]
+                    // Places an outgoing LXST call through CallManager. The
+                    // peer must already be in the path table (sim-to-sim
+                    // smoke test: bring both sims up, wait for cross-announces,
+                    // then fire test-call from sim1 toward sim2's identity hash).
+                    let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+                    let to = components?.queryItems?.first(where: { $0.name == "to" })?.value ?? ""
+                    let profileRaw = components?.queryItems?.first(where: { $0.name == "profile" })?.value
+                    DiagLog.log("[TEST-CALL] to=\(to) profile=\(profileRaw ?? "default")")
+                    NotificationCenter.default.post(
+                        name: Notification.Name("ColumbaTestCall"),
+                        object: nil,
+                        userInfo: ["to": to, "profile": profileRaw ?? ""]
+                    )
+                    return
+                }
+                if url.host == "test-link-open" {
+                    // lxma://test-link-open?to=HEX&aspect=lxst.telephony
+                    let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+                    let to = components?.queryItems?.first(where: { $0.name == "to" })?.value ?? ""
+                    let aspect = components?.queryItems?.first(where: { $0.name == "aspect" })?.value ?? "lxst.telephony"
+                    DiagLog.log("[TEST-LINK] open to=\(to) aspect=\(aspect)")
+                    NotificationCenter.default.post(
+                        name: Notification.Name("ColumbaTestLinkOpen"),
+                        object: nil,
+                        userInfo: ["to": to, "aspect": aspect]
+                    )
+                    return
+                }
+                if url.host == "test-inbound" {
+                    // lxma://test-inbound?from=HEX&content=... — synthesizes
+                    // a Python-style inbound event so we can exercise the
+                    // privacy filter (block_unknown_senders) without
+                    // requiring an actual peer.
+                    let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+                    let from = components?.queryItems?.first(where: { $0.name == "from" })?.value ?? ""
+                    let content = components?.queryItems?.first(where: { $0.name == "content" })?.value ?? "synthetic"
+                    DiagLog.log("[TEST-INBOUND] from=\(from) content=\"\(content)\"")
+                    NotificationCenter.default.post(
+                        name: Notification.Name("ColumbaTestInbound"),
+                        object: nil,
+                        userInfo: ["from": from, "content": content]
+                    )
+                    return
+                }
+                if url.host == "test-identity-switch" {
+                    // lxma://test-identity-switch — creates a fresh identity
+                    // and switches to it via the full AppServices.switchIdentity
+                    // path so we can verify Python reboots with the new keys.
+                    DiagLog.log("[TEST-IDSWITCH] requested")
+                    NotificationCenter.default.post(
+                        name: Notification.Name("ColumbaTestIdentitySwitch"),
+                        object: nil
+                    )
+                    return
+                }
+                if url.host == "test-prop-sync" {
+                    // lxma://test-prop-sync?node=HEX
+                    let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+                    let node = components?.queryItems?.first(where: { $0.name == "node" })?.value ?? ""
+                    DiagLog.log("[TEST-PROP-SYNC] node=\(node)")
+                    NotificationCenter.default.post(
+                        name: Notification.Name("ColumbaTestPropSync"),
+                        object: nil,
+                        userInfo: ["node": node]
+                    )
+                    return
+                }
+                if url.host == "test-announce" {
+                    // lxma://test-announce?name=...
+                    let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+                    let name = components?.queryItems?.first(where: { $0.name == "name" })?.value ?? ""
+                    DiagLog.log("[TEST-ANNOUNCE] name=\"\(name)\"")
+                    NotificationCenter.default.post(
+                        name: Notification.Name("ColumbaTestAnnounce"),
+                        object: nil,
+                        userInfo: ["name": name]
+                    )
+                    return
+                }
+                if url.host == "test-restart" {
+                    DiagLog.log("[TEST-RESTART] requested via URL")
+                    NotificationCenter.default.post(
+                        name: Notification.Name("ColumbaTestRestart"),
+                        object: nil
+                    )
+                    return
+                }
+                if url.host == "test-ble-diagnose" {
+                    DiagLog.log("[TEST-BLE-DIAG] requested")
+                    NotificationCenter.default.post(
+                        name: Notification.Name("ColumbaTestBLEDiagnose"),
+                        object: nil
+                    )
+                    return
+                }
+                if url.host == "test-auto-diagnose" {
+                    DiagLog.log("[TEST-AUTO-DIAG] requested")
+                    NotificationCenter.default.post(
+                        name: Notification.Name("ColumbaTestAutoDiagnose"),
+                        object: nil
+                    )
+                    return
+                }
+                if url.host == "test-path-table" {
+                    DiagLog.log("[TEST-PATH-TABLE] requested")
+                    NotificationCenter.default.post(
+                        name: Notification.Name("ColumbaTestPathTable"),
+                        object: nil
+                    )
+                    return
+                }
+                if url.host == "test-ble-status" {
+                    DiagLog.log("[TEST-BLE-STATUS] requested")
+                    NotificationCenter.default.post(
+                        name: Notification.Name("ColumbaTestBLEStatus"),
+                        object: nil
+                    )
+                    return
+                }
+                if url.host == "test-ble-peer-list" {
+                    DiagLog.log("[TEST-BLE-PEER-LIST] requested")
+                    NotificationCenter.default.post(
+                        name: Notification.Name("ColumbaTestBLEPeerList"),
+                        object: nil
+                    )
+                    return
+                }
+                if url.host == "test-ble-scan" {
+                    // lxma://test-ble-scan?action=start|stop
+                    let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+                    let action = components?.queryItems?.first(where: { $0.name == "action" })?.value ?? "start"
+                    DiagLog.log("[TEST-BLE-SCAN] action=\(action)")
+                    NotificationCenter.default.post(
+                        name: Notification.Name("ColumbaTestBLEScan"),
+                        object: nil,
+                        userInfo: ["action": action]
+                    )
+                    return
+                }
+                if url.host == "test-ble-advertise" {
+                    // lxma://test-ble-advertise?action=start|stop[&name=...]
+                    let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+                    let action = components?.queryItems?.first(where: { $0.name == "action" })?.value ?? "start"
+                    let name = components?.queryItems?.first(where: { $0.name == "name" })?.value ?? ""
+                    DiagLog.log("[TEST-BLE-ADVERTISE] action=\(action) name=\(name)")
+                    NotificationCenter.default.post(
+                        name: Notification.Name("ColumbaTestBLEAdvertise"),
+                        object: nil,
+                        userInfo: ["action": action, "name": name]
+                    )
+                    return
+                }
+                if url.host == "test-ble-callback-roundtrip" {
+                    // lxma://test-ble-callback-roundtrip[?value=N]
+                    // Phase 2 smoke test: registers a Python callable that
+                    // returns True iff the int arg is even, then invokes it
+                    // via the synchronous Swift→Python BLE callback path and
+                    // asserts the answer matches. Logs PASS/FAIL to DiagLog.
+                    let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+                    let valueStr = components?.queryItems?.first(where: { $0.name == "value" })?.value ?? "4"
+                    let value = Int(valueStr) ?? 4
+                    DiagLog.log("[TEST-BLE-CB] value=\(value)")
+                    NotificationCenter.default.post(
+                        name: Notification.Name("ColumbaTestBLECallback"),
+                        object: nil,
+                        userInfo: ["value": value]
+                    )
+                    return
+                }
+                if url.host == "test-telemetry" {
+                    // lxma://test-telemetry?to=HEX[&packed_hex=…&meta_hex=…|&cease=1]
+                    //
+                    // Drives `backend.telemetry.sendLocationTelemetry` (when
+                    // `packed_hex` is supplied) or `sendTelemetryCease`
+                    // (when `cease=1`) so the Tests/interop/ harness can pin
+                    // the RnsTelemetry seam end-to-end against a Sideband
+                    // reference peer without driving the location-sharing UI
+                    // (avoids the GPS permission prompt + timing dependence
+                    // on a real CLLocationManager fix).
+                    let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+                    func q(_ n: String) -> String? {
+                        components?.queryItems?.first(where: { $0.name == n })?.value
+                    }
+                    let to = q("to") ?? ""
+                    let packedHex = q("packed_hex") ?? ""
+                    let metaHex = q("meta_hex") ?? ""
+                    let cease = (q("cease") ?? "") == "1"
+                    DiagLog.log("[TEST-TELEMETRY] to=\(to) packed=\(packedHex.count/2)B meta=\(metaHex.count/2)B cease=\(cease)")
+                    NotificationCenter.default.post(
+                        name: Notification.Name("ColumbaTestTelemetry"),
+                        object: nil,
+                        userInfo: [
+                            "to": to,
+                            "packed_hex": packedHex,
+                            "meta_hex": metaHex,
+                            "cease": cease,
+                        ]
+                    )
+                    return
+                }
+                if url.host == "test-send" {
+                    // lxma://test-send?to=HEX&content=…[&method=direct]
+                    //   [&image_hex=…&image_format=jpeg]
+                    //   [&file_hex=…&file_name=…]
+                    //
+                    // Bypasses the UI and hands typed send args straight to
+                    // `backend.lxmf.sendLxmfMessage(...)` so the
+                    // tests/interop/ harness can exercise the full wire path
+                    // (LXMF pack + RNS encrypt) without driving the picker
+                    // UI. Hex payloads keep the URL stable under iOS's deep-
+                    // link length cap for the typical interop fixture (PNG
+                    // ≤ a few KB → ≤ 10 KB hex, well under the limit).
+                    let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+                    func q(_ n: String) -> String? {
+                        components?.queryItems?.first(where: { $0.name == n })?.value
+                    }
+                    let to = q("to") ?? ""
+                    let content = q("content") ?? ""
+                    let method = q("method") ?? ""
+                    let imageHex = q("image_hex") ?? ""
+                    let imageFormat = q("image_format") ?? ""
+                    let fileHex = q("file_hex") ?? ""
+                    let fileName = q("file_name") ?? ""
+                    logger.info("test-send to=\(to, privacy: .public) content=\(content, privacy: .public)")
+                    DiagLog.log("[TEST-SEND] to=\(to) method=\(method.isEmpty ? "opportunistic" : method) content=\"\(content)\" image=\(imageHex.isEmpty ? 0 : imageHex.count/2)B(\(imageFormat)) file=\(fileHex.isEmpty ? 0 : fileHex.count/2)B(\(fileName))")
+                    NotificationCenter.default.post(
+                        name: Notification.Name("ColumbaTestSend"),
+                        object: nil,
+                        userInfo: [
+                            "to": to,
+                            "content": content,
+                            "method": method,
+                            "image_hex": imageHex,
+                            "image_format": imageFormat,
+                            "file_hex": fileHex,
+                            "file_name": fileName,
+                        ]
+                    )
+                    return
+                }
                 pendingDeepLink = url.absoluteString
             }
         }
@@ -129,8 +409,6 @@ struct RootView: View {
     @State private var isInitialized = false
     @State private var identitySwitchTrigger = UUID()
     @State private var showOnboarding: Bool
-    @State private var showIncomingCall = false
-    @State private var showActiveCallFromIncoming = false
     @Environment(\.scenePhase) private var scenePhase
     @Environment(\.colorScheme) private var colorScheme
 
@@ -148,6 +426,7 @@ struct RootView: View {
     var body: some View {
         Group {
             if showOnboarding {
+                #if COLUMBA_ONBOARDING_ENABLED
                 OnboardingView(
                     identityManager: identityManager,
                     settingsRepository: settingsRepository,
@@ -156,6 +435,10 @@ struct RootView: View {
                         identitySwitchTrigger = UUID()
                     }
                 )
+                #else
+                // Onboarding flow disabled in this build — bypass straight to main UI.
+                Color.clear.onAppear { showOnboarding = false }
+                #endif
             } else if let error = initError {
                 errorView(error)
             } else if isInitialized,
@@ -177,54 +460,8 @@ struct RootView: View {
                         identitySwitchTrigger = UUID()
                     }
                 )
-                #if os(iOS)
-                .fullScreenCover(isPresented: $showIncomingCall) {
-                    if let cm = appServices.callManager {
-                        IncomingCallScreen(callManager: cm, onAnswer: {
-                            showIncomingCall = false
-                            showActiveCallFromIncoming = true
-                        })
-                    }
-                }
-                .fullScreenCover(isPresented: $showActiveCallFromIncoming) {
-                    if let cm = appServices.callManager {
-                        VoiceCallScreen(
-                            callManager: cm,
-                            peerName: cm.peerName ?? cm.peerHash ?? "Unknown",
-                            destinationHash: Data()
-                        )
-                    }
-                }
-                .onChange(of: appServices.callManager?.callState) { _, newState in
-                    guard let cm = appServices.callManager,
-                          let newState,
-                          cm.isIncoming else { return }
-                    switch newState {
-                    case .ringing:
-                        // Only present the incoming-call sheet once we know who's
-                        // calling. peerHash is populated in CallManager's ringing
-                        // callback (after LINKIDENTIFY arrives) right before the
-                        // state transitions to .ringing — so by this point peer
-                        // info is set. We deliberately do NOT trigger on
-                        // .connecting because that state is reached at link
-                        // establishment (before LINKIDENTIFY), when peerName and
-                        // peerHash are both nil — which would render as
-                        // "Unknown" until the identify signal arrives.
-                        guard cm.peerHash != nil || cm.peerName != nil else {
-                            // Defensive: if this fires, CallKit's lock-screen UI
-                            // is ringing but the in-app sheet is suppressed —
-                            // a callback-ordering regression in CallManager.
-                            logger.error("[CALL] Reached .ringing with both peerHash and peerName nil; in-app sheet suppressed but CallKit UI may still be ringing — regression in CallManager identify ordering")
-                            return
-                        }
-                        if !showIncomingCall {
-                            showIncomingCall = true
-                        }
-                    default:
-                        break
-                    }
-                }
-                #endif
+                // Voice / CallKit removed in the Python RNS migration (Phase 0).
+                // Will return in v2 once canonical Python LXST is ported to iOS audio.
             } else {
                 loadingView
             }
@@ -241,7 +478,8 @@ struct RootView: View {
             }
         }
         .onChange(of: scenePhase) { _, newPhase in
-            if newPhase == .active {
+            let phaseValue = newPhase
+            if phaseValue == .active {
                 NotificationService.shared.clearBadge()
                 // Sync from propagation node when app becomes active,
                 // debounced to avoid rapid re-syncs on quick app switches
@@ -256,6 +494,10 @@ struct RootView: View {
             #if os(iOS)
             if newPhase == .background {
                 scheduleBackgroundSync()
+                // Flush RNS's path table + known destinations to disk now —
+                // iOS won't run RNS's clean-exit persist, so without this a
+                // cold start can't recall previously-heard peers.
+                appServices.persistRNSStateOnBackground()
             }
             appServices.locationSharingManager?.setBackgroundState(newPhase != .active)
             #endif
@@ -399,10 +641,22 @@ struct RootView: View {
             DiagLog.log("[STARTUP] Step 1: migration check")
             await identityManager.migrateFromSingleIdentityIfNeeded(settingsRepository: settingsRepository)
 
-            // 2. Get active identity (created during onboarding)
+            // 2. Get active identity (created during onboarding, or auto-create
+            // one when onboarding is compile-guarded off — needed so the
+            // Python-RNS smoke test can run without UI taps).
             DiagLog.log("[STARTUP] Step 2: get active identity")
-            guard let active = await identityManager.getActiveIdentity() else {
+            let active: LocalIdentity
+            if let existing = await identityManager.getActiveIdentity() {
+                active = existing
+            } else {
+                #if COLUMBA_ONBOARDING_ENABLED
                 throw AppServicesError.identityNotInitialized
+                #else
+                DiagLog.log("[STARTUP] Step 2: no identity — auto-creating for smoke test")
+                let created = try await identityManager.createIdentity(displayName: "ColumbaSim")
+                let switched = try await identityManager.switchToIdentity(created.identityHash)
+                active = switched.0
+                #endif
             }
 
             // 3. Load identity keys from Keychain
@@ -412,10 +666,40 @@ struct RootView: View {
 
             // 4. Load interface configurations
             let interfaceRepo = InterfaceRepository()
+
+            // Smoke-test escape hatch: when `COLUMBA_TCP_HUB=host:port` is in
+            // the environment AND no interfaces are configured yet, inject a
+            // TCPClientInterface so a fresh-install build can join the
+            // shared hub without manual onboarding. Used by the sim↔iPhone
+            // audio-frame test where the iPhone has empty UserDefaults but
+            // needs to land on the same RNS network as the sim. The host
+            // address is environment-supplied (never committed in source).
+            if let hub = ProcessInfo.processInfo.environment["COLUMBA_TCP_HUB"],
+               !hub.isEmpty,
+               interfaceRepo.getEnabledInterfaces().isEmpty {
+                let parts = hub.split(separator: ":", maxSplits: 1).map(String.init)
+                if parts.count == 2, let port = UInt16(parts[1]) {
+                    DiagLog.log("[STARTUP] COLUMBA_TCP_HUB=\(parts[0]):\(port) — seeding TCP interface")
+                    interfaceRepo.addInterface(InterfaceEntity(
+                        name: "Hub",
+                        type: .tcpClient,
+                        config: .tcpClient(TCPClientConfig(targetHost: parts[0], targetPort: port))
+                    ))
+                    UserDefaults.standard.set(true, forKey: "has_completed_onboarding")
+                    UserDefaults.standard.set(true, forKey: "settings_initialized")
+                } else {
+                    DiagLog.log("[STARTUP] COLUMBA_TCP_HUB malformed (\(hub)) — expected host:port")
+                }
+            }
+
             let enabledInterfaces = interfaceRepo.getEnabledInterfaces()
             DiagLog.log("[STARTUP] Step 4: \(enabledInterfaces.count) enabled interfaces")
 
-            // 5. Initialize AppServices with identity (TCP connected separately below)
+            // 5. Initialize AppServices with identity. The Python RNS stack
+            //    builds its config file from InterfaceRepository's enabled
+            //    interfaces (PythonConfigWriter); when the list is empty the
+            //    app comes up offline and the user adds an interface via
+            //    Settings → Manage Interfaces.
             DiagLog.log("[STARTUP] Step 5: initialize AppServices")
             try await appServices.initialize(
                 identity: identity,
@@ -434,7 +718,10 @@ struct RootView: View {
             self.messageRepository = repo
 
             #if os(iOS)
-            // Initialize location sharing manager
+            // Initialize the location-sharing manager. iOS-only — the
+            // non-iOS Compat stub (RNSAPI/Compat.swift, `#if !os(iOS)`)
+            // takes over for cross-platform call sites. Needs `appServices`
+            // to reach `backend.telemetry` for sending the periodic updates.
             let locManager = LocationSharingManager(appServices: appServices)
             appServices.locationSharingManager = locManager
             let handler = IncomingMessageHandler(messageRepository: repo, database: db, locationSharingManager: locManager)
@@ -457,12 +744,17 @@ struct RootView: View {
                     if case .tcpClient(let config) = iface.config {
                         let entityId = iface.id
                         Task {
-                            DiagLog.log("[STARTUP] TCP connecting: \(config.targetHost):\(config.targetPort)")
+                            DiagLog.log("[STARTUP] TCP interface \(config.targetHost):\(config.targetPort) — registering")
                             do {
                                 try await services.connectTCPInterface(entityId: entityId, host: config.targetHost, port: config.targetPort)
-                                DiagLog.log("[STARTUP] TCP connected: \(entityId)")
+                                // NB: this only means the interface was added and a
+                                // connection was initiated — NOT that the socket is up.
+                                // The Swift backend's connect() is fire-and-forget; the
+                                // real connected/connecting state shows in the `[RNS] iface
+                                // … -> connected/connecting` poll lines.
+                                DiagLog.log("[STARTUP] TCP interface registered [\(entityId)] (connecting async — see [RNS] iface state)")
                             } catch {
-                                DiagLog.log("[STARTUP] TCP connect FAILED [\(entityId)]: \(error.localizedDescription)")
+                                DiagLog.log("[STARTUP] TCP interface add FAILED [\(entityId)]: \(error.localizedDescription)")
                             }
                         }
                     }
@@ -528,6 +820,40 @@ struct RootView: View {
                     await services.propagationManager?.syncNow()
                 }
             }
+
+            #if os(iOS)
+            // Smoke-test escape hatch: `COLUMBA_AUTO_CALL_TO=<hex>` places an
+            // outgoing LXST call once the target destination shows up in the
+            // path table. Used in sim↔iPhone reverse-direction audio testing
+            // where the iPhone needs to be the caller and we can't push URL
+            // events to a real device (`simctl openurl` is simulator-only,
+            // `devicectl` has no URL-open subcommand). Polls the path table
+            // for up to 60s.
+            if let targetHex = ProcessInfo.processInfo.environment["COLUMBA_AUTO_CALL_TO"],
+               !targetHex.isEmpty,
+               let targetHash = try? targetHex.hexToData() {
+                let services = appServices
+                Task { @MainActor in
+                    DiagLog.log("[AUTO_CALL] waiting for \(targetHex.prefix(8)) in path table")
+                    var attempts = 0
+                    while attempts < 30 {
+                        if let pt = services.pathTable,
+                           await pt.lookup(destinationHash: targetHash) != nil {
+                            DiagLog.log("[AUTO_CALL] target found after \(attempts * 2)s — placing call")
+                            services.callManager?.initiateCall(
+                                destinationHash: targetHash,
+                                profile: .qualityMedium,
+                                peerDisplayName: nil
+                            )
+                            return
+                        }
+                        try? await Task.sleep(for: .seconds(2))
+                        attempts += 1
+                    }
+                    DiagLog.log("[AUTO_CALL] timed out waiting for \(targetHex.prefix(8))")
+                }
+            }
+            #endif
 
         } catch {
             DiagLog.log("[STARTUP] _initializeServicesOnce FAILED: \(error)")

--- a/Sources/ColumbaApp/Models/CodecProfileInfo.swift
+++ b/Sources/ColumbaApp/Models/CodecProfileInfo.swift
@@ -7,6 +7,7 @@
 //
 
 import LXSTSwift
+import RNSAPI
 
 /// Display information for a telephony profile.
 struct CodecProfileInfo: Identifiable {

--- a/Sources/ColumbaApp/Models/DiscoveredDevice.swift
+++ b/Sources/ColumbaApp/Models/DiscoveredDevice.swift
@@ -1,0 +1,30 @@
+//
+//  DiscoveredDevice.swift
+//  ColumbaApp
+//
+//  A discovered BLE peripheral with metadata. Shared by the RNode wizard's
+//  device-discovery step (COLUMBA_RNODE_ENABLED) and the BLE device picker
+//  (COLUMBA_BLE_ENABLED). Lives here (ungated) so neither feature flag owns
+//  the type — extracted from BLEDevicePickerSheet.swift, which used to define
+//  it under COLUMBA_BLE_ENABLED only.
+//
+
+import Foundation
+
+/// A discovered BLE peripheral with metadata.
+struct DiscoveredDevice: Identifiable {
+    /// Unique identifier for SwiftUI list deduplication.
+    let id = UUID()
+
+    /// Peripheral identifier (used for deduplication).
+    let peripheralId: UUID
+
+    /// Peripheral name.
+    let name: String
+
+    /// Received signal strength indicator (dBm).
+    var rssi: Int
+
+    /// Last discovery timestamp.
+    var lastSeen: Date
+}

--- a/Sources/ColumbaApp/Models/LoRaPresets.swift
+++ b/Sources/ColumbaApp/Models/LoRaPresets.swift
@@ -8,6 +8,7 @@
 //
 
 import Foundation
+import RNSAPI
 
 // MARK: - Regional Parameters
 

--- a/Sources/ColumbaApp/Models/MicronDocument.swift
+++ b/Sources/ColumbaApp/Models/MicronDocument.swift
@@ -1,4 +1,6 @@
+#if COLUMBA_NOMADNET_ENABLED
 import SwiftUI
+import RNSAPI
 
 // MARK: - Document
 
@@ -159,3 +161,4 @@ extension MicronTextStyle {
         )
     }
 }
+#endif

--- a/Sources/ColumbaApp/Models/MicronParser.swift
+++ b/Sources/ColumbaApp/Models/MicronParser.swift
@@ -1,4 +1,6 @@
+#if COLUMBA_NOMADNET_ENABLED
 import Foundation
+import RNSAPI
 
 /// Parses micron markup text into a structured MicronDocument.
 public struct MicronParser {
@@ -550,3 +552,4 @@ public struct MicronParser {
         return .samePage(path: trimmed)
     }
 }
+#endif

--- a/Sources/ColumbaApp/Models/MigrationData.swift
+++ b/Sources/ColumbaApp/Models/MigrationData.swift
@@ -1,3 +1,4 @@
+#if COLUMBA_MIGRATION_ENABLED
 //
 //  MigrationData.swift
 //  ColumbaApp
@@ -7,6 +8,7 @@
 //
 
 import Foundation
+import RNSAPI
 
 /// Top-level migration bundle matching Android's MigrationBundle format.
 ///
@@ -251,3 +253,4 @@ struct ImportResult {
     let interfacesImported: Int
     let settingsImported: Int
 }
+#endif

--- a/Sources/ColumbaApp/Models/TcpCommunityServer.swift
+++ b/Sources/ColumbaApp/Models/TcpCommunityServer.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import RNSAPI
 
 /// A public Reticulum TCP transport node.
 struct TcpCommunityServer: Identifiable {

--- a/Sources/ColumbaApp/Python/Models/PyAnnounce.swift
+++ b/Sources/ColumbaApp/Python/Models/PyAnnounce.swift
@@ -1,0 +1,26 @@
+import Foundation
+import RNSAPI
+
+/// An `lxmf.delivery` announce surfaced from Python RNS to Swift.
+///
+/// Produced by `PythonBridge.Event.announce` after `rns_bridge._LXMFAnnounceHandler`
+/// receives one from the Python-side `RNS.Transport`. The original `app_data` from
+/// the announce packet has already been msgpack-decoded to `displayName`.
+///
+/// Named `PyAnnounce` (not `Announce`) so it doesn't collide with the old
+/// `ReticulumSwift.Announce` type during the Phase 1 transition.
+public struct PyAnnounce: Identifiable, Equatable, Sendable {
+    public let destHash: String
+    public var displayName: String
+    public var firstSeen: Date
+    public var lastSeen: Date
+
+    public var id: String { destHash }
+
+    public init(destHash: String, displayName: String, firstSeen: Date, lastSeen: Date) {
+        self.destHash = destHash
+        self.displayName = displayName
+        self.firstSeen = firstSeen
+        self.lastSeen = lastSeen
+    }
+}

--- a/Sources/ColumbaApp/Python/Models/PyConversation.swift
+++ b/Sources/ColumbaApp/Python/Models/PyConversation.swift
@@ -1,0 +1,38 @@
+import Foundation
+import RNSAPI
+
+/// A conversation-list row backed by the Python-owned SQLite store.
+///
+/// In Phase 2 this is what `MessageRepository` (the new Python-backed
+/// implementation) returns to ChatsView for the conversation list. The schema is
+/// owned in Python (`app/columba_store.py`) and read by Swift via GRDB-read or
+/// stdlib SQLite — see the migration plan for the columns.
+public struct PyConversation: Identifiable, Equatable, Sendable {
+    public let destHash: String
+    public var displayName: String
+    public var lastMessage: String?
+    public var lastMessageAt: Date?
+    public var unreadCount: Int
+    public var isFavorite: Bool
+    public var isPinned: Bool
+
+    public var id: String { destHash }
+
+    public init(
+        destHash: String,
+        displayName: String,
+        lastMessage: String? = nil,
+        lastMessageAt: Date? = nil,
+        unreadCount: Int = 0,
+        isFavorite: Bool = false,
+        isPinned: Bool = false
+    ) {
+        self.destHash = destHash
+        self.displayName = displayName
+        self.lastMessage = lastMessage
+        self.lastMessageAt = lastMessageAt
+        self.unreadCount = unreadCount
+        self.isFavorite = isFavorite
+        self.isPinned = isPinned
+    }
+}

--- a/Sources/ColumbaApp/Python/Models/PyLocalIdentity.swift
+++ b/Sources/ColumbaApp/Python/Models/PyLocalIdentity.swift
@@ -1,0 +1,19 @@
+import Foundation
+import RNSAPI
+
+/// The local RNS identity, as the Python bridge sees it after a successful
+/// `PythonBridge.start(...)`. Hashes are hex strings (16-byte truncated form,
+/// 32 hex chars) for ease of display + comparison; the raw 64-byte private key
+/// stays in Keychain, never in this struct.
+///
+/// `identityHash` is the hash of the public-key blob; `destinationHash` is the
+/// derived hash for `<identity>.lxmf.delivery` (what other peers send messages to).
+public struct PyLocalIdentity: Equatable, Sendable {
+    public let identityHash: String
+    public let destinationHash: String
+
+    public init(identityHash: String, destinationHash: String) {
+        self.identityHash = identityHash
+        self.destinationHash = destinationHash
+    }
+}

--- a/Sources/ColumbaApp/Python/Models/PyMessage.swift
+++ b/Sources/ColumbaApp/Python/Models/PyMessage.swift
@@ -1,0 +1,50 @@
+import Foundation
+import RNSAPI
+
+/// An LXMF message surfaced from / submitted to the Python bridge.
+///
+/// Wire-form invariant: when an inbound `LXMessage` lands in Python, `rns_bridge`'s
+/// `_delivery_callback` reads `.source_hash`, `.content_as_string()`,
+/// `.title_as_string()`, and the receipt timestamp, then emits
+/// `PythonBridge.Event.inbound`. The bridge marshals that dict into this struct.
+///
+/// Named `PyMessage` (not `Message`) to avoid colliding with the existing
+/// `LXMFSwift.Message` during the Phase 1 transition; the existing
+/// `MessageRepository` still hands out `LXMFSwift.Message` until the AppServices
+/// rewrite lands.
+public struct PyMessage: Identifiable, Equatable, Sendable {
+    public enum Direction: Equatable, Sendable { case inbound, outbound }
+
+    public enum DeliveryMethod: Equatable, Sendable {
+        case opportunistic
+        case direct
+        case propagated
+        case unknown
+    }
+
+    public let id: UUID
+    public let peerHash: String
+    public let direction: Direction
+    public let content: String
+    public let title: String
+    public let timestamp: Date
+    public var method: DeliveryMethod
+
+    public init(
+        id: UUID = UUID(),
+        peerHash: String,
+        direction: Direction,
+        content: String,
+        title: String = "",
+        timestamp: Date,
+        method: DeliveryMethod = .unknown
+    ) {
+        self.id = id
+        self.peerHash = peerHash
+        self.direction = direction
+        self.content = content
+        self.title = title
+        self.timestamp = timestamp
+        self.method = method
+    }
+}

--- a/Sources/ColumbaApp/Resources/ColumbaApp.entitlements
+++ b/Sources/ColumbaApp/Resources/ColumbaApp.entitlements
@@ -10,5 +10,19 @@
 	<array>
 		<string>packet-tunnel-provider</string>
 	</array>
+	<!-- Multicast Networking — iOS 14+ requires Apple approval for this
+	     to be embedded in the signed provisioning profile, requested at:
+	         https://developer.apple.com/contact/request/networking-multicast
+	     Apple's restriction is on its NW* networking APIs; RNS.AutoInterface
+	     uses BSD sockets through Python (setsockopt + IPV6_JOIN_GROUP +
+	     sendto), which historically work without the entitlement on iOS.
+	     Disabled for now to keep the debug-build signing path clean — flip
+	     back on after Apple grants approval if multicast packets stop
+	     reaching peers in foreground.
+
+	<key>com.apple.developer.networking.multicast</key>
+	<true/>
+	-->
+
 </dict>
 </plist>

--- a/Sources/ColumbaApp/Resources/Info.plist
+++ b/Sources/ColumbaApp/Resources/Info.plist
@@ -25,6 +25,10 @@
 	</array>
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>Columba uses the local network for peer-to-peer communication with nearby Reticulum devices.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Columba shares your location with contacts you explicitly choose, so they can see where you are during an active sharing session.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>Columba keeps sharing your location with the contacts you chose even when the app is in the background, so a sharing session you started doesn't silently stop. You can stop sharing at any time from the conversation or from Settings.</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>materialdesignicons.ttf</string>
@@ -41,7 +45,6 @@
 		<string>bluetooth-central</string>
 		<string>bluetooth-peripheral</string>
 		<string>location</string>
-		<string>voip</string>
 	</array>
 	<key>UILaunchScreen</key>
 	<dict/>

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -10,11 +10,15 @@
 //
 
 import Foundation
-import LXMFSwift
-#if os(iOS)
+import RNSAPI
 import LXSTSwift
+import SwiftBLEBridge
+import CryptoKit
+#if canImport(UIKit)
+import UIKit
 #endif
-import ReticulumSwift
+#if os(iOS)
+#endif
 import os.log
 
 /// Simple file logger for diagnostics when idevicesyslog isn't available (WiFi-only device).
@@ -143,10 +147,86 @@ public final class AppServices {
     #if os(iOS)
     /// Location sharing manager for telemetry exchange with peers.
     public var locationSharingManager: LocationSharingManager?
-
-    /// Call manager for LXST voice call UI integration.
-    public var callManager: CallManager?
     #endif
+    #if os(iOS)
+    /// Voice call manager — handles the LXST telephony destination
+    /// registration, outgoing-call signaling, and inbound-link routing.
+    /// Restored in commit 3 of the lxst-wiring batch, now talking through
+    /// the Compat-layer Link bridge that AppServices wires here in
+    /// configureTransportCallbacks.
+    public private(set) var callManager: CallManager?
+    #endif
+
+    /// Python-backed Reticulum + LXMF stack. Created lazily on first
+    /// `initialize(...)` and torn down on `shutdown()`. The Compat-layer
+    /// `LXMRouter` and `ReticulumTransport` stubs delegate real work
+    /// (announce listening, opportunistic LXMF send/receive) through this.
+    public private(set) var backend: (any RnsBackend)?
+
+    /// The bound backend downcast to the Python impl — for Python-only wiring
+    /// (BLE/RNode callback bridges, diagnose_* deeplinks). nil when a non-Python
+    /// backend is active; those paths are then correctly skipped.
+    public var pythonBackend: PythonRNSBackend? { backend as? PythonRNSBackend }
+
+    /// What the active backend supports — drives UI capability gating. `.unknown`
+    /// (everything unsupported) until a backend is bound; re-evaluated via
+    /// @Observable through `backend` when the backend changes.
+    public var capabilities: BackendCapabilities { backend?.capabilities ?? .unknown }
+
+    /// Background task that drains Python events (announces, inbound
+    /// messages) into Columba's existing UI plumbing.
+    private var pythonEventTask: Task<Void, Never>?
+
+    /// Identity used to start the Python backend. Cached so the
+    /// "Apply & Restart" flow can re-boot Python after the user edits
+    /// interfaces, without making AppServices re-derive it.
+    private var pythonStartIdentity: Identity?
+
+    /// Display name passed to the Python backend on start. Cached for
+    /// the restart path (same reason as pythonStartIdentity).
+    private var pythonStartDisplayName: String = ""
+
+    /// The interface entities currently live in the Python RNS stack, keyed by
+    /// entity id. Seeded when the backend starts and updated incrementally by
+    /// `applyInterfaceChanges()` as interfaces are hot-added / hot-removed.
+    /// The status poll matches Python-reported sections against this set, so
+    /// it must always reflect what's actually attached to Transport (not the
+    /// launch-time snapshot — that was the source of the stale-status bug).
+    private var pythonInterfaceEntities: [String: InterfaceEntity] = [:]
+
+/// Periodic poller that mirrors Python's RNS.Transport interface state
+    /// into the Compat TCPInterface stubs so the existing
+    /// NetworkStatusView / InterfaceManagementScreen show correct
+    /// connected/disconnected badges. Cancelled in `shutdown()`.
+    private var pythonStatusPollTask: Task<Void, Never>?
+
+    /// Last interface snapshot key we logged, so the poll only logs
+    /// changes (not every 2s tick).
+    private var lastInterfaceSnapshotKey: String = ""
+
+    /// Same idea for the python-derived auxiliary list (peer interfaces
+    /// like AutoInterfacePeer / BLEPeer that Python spawned dynamically).
+    /// Init to sentinel so the first observation always logs (even if the
+    /// count is 0 — that's useful too: "no peers discovered yet").
+    private var lastAuxiliaryKey: String = "<uninitialized>"
+
+    // MARK: - Telephony link bridge state
+    //
+    // Maps the Python RNS.Link IDs (bridge-allocated UInt64) to the Compat
+    // Link objects that lxst-swift's Telephone state machine + CallManager
+    // expect to talk to. Populated when Python emits a
+    // link_state(state=established) event, drained when it emits a
+    // link_state(state=closed) event.
+
+    /// Active Compat Links keyed by Python's bridge linkId.
+    private var activeLinksByLinkId: [UInt64: Link] = [:]
+
+    /// Inbound-link callbacks registered by CallManager via
+    /// transport.registerDestinationLinkCallback(for: telephonyDestHash).
+    /// AppServices invokes these when an inbound link establishes on a
+    /// matching destination. AppServices is @MainActor — all reads/writes
+    /// happen on the main actor, no extra lock needed.
+    private var destinationLinkCallbacks: [Data: @Sendable (Link) async -> Void] = [:]
 
     #if ENABLE_NETWORK_EXTENSION
     /// Network Extension tunnel manager.
@@ -509,7 +589,1389 @@ public final class AppServices {
         self.autoAnnounceManager = announceManager
         announceManager.start()
 
+        // 12. Start Python RNS backend. The Compat-layer LXMRouter / Transport
+        //     are stubs; the real network I/O happens through PythonBridge.
+        await startPythonBackend(
+            identity: newIdentity,
+            identityHashHex: newIdentity.hexHash,
+            router: newRouter,
+            interfaces: InterfaceRepository().getEnabledInterfaces(),
+            displayName: ""
+        )
+
         logger.info("Initialization complete")
+    }
+
+    // MARK: - Python backend
+
+    /// Boot the embedded Python RNS stack and hook `LXMRouter.sendHook` so
+    /// outbound LXMF sends go through Python. Spawns a Task that drains
+    /// Python events and feeds them into Columba's path table / inbound
+    /// message handler. Idempotent — does nothing if already started.
+    ///
+    /// The RNS config file is written from `interfaces` (the user's enabled
+    /// `InterfaceEntity` records from `InterfaceRepository`). No host/port
+    /// is hardcoded — if `interfaces` is empty the app starts offline and
+    /// the user adds an interface in Settings → Manage Interfaces.
+    private func startPythonBackend(
+        identity: Identity,
+        identityHashHex: String,
+        router: LXMRouter,
+        interfaces: [InterfaceEntity],
+        displayName: String
+    ) async {
+        DiagLog.log("[RNS] backend start entered with \(interfaces.count) interfaces")
+        if backend != nil {
+            DiagLog.log("[RNS] already started")
+            return
+        }
+        // Cache the start args so restartPythonBackend() can re-invoke
+        // this method after the user applies interface changes.
+        self.pythonStartIdentity = identity
+        self.pythonStartDisplayName = displayName
+
+        let backend = BackendFactory.make()
+        self.backend = backend
+
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let pyDir = appSupport.appendingPathComponent("Columba/python-\(identityHashHex)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: pyDir, withIntermediateDirectories: true)
+        let configDir = pyDir.path
+        let identityFile = pyDir.appendingPathComponent("identity.bin").path
+        DiagLog.log("[RNS] configDir=\(configDir)")
+
+        // Deploy iOS BLE custom interface files BEFORE Python boots so RNS's
+        // external-interface loader can `exec()` them when reading config.
+        // Always copied (regardless of whether BLE is enabled in the
+        // current config) so a later restart with BLE-enabled config finds
+        // them without an extra deployment step.
+        deployIOSBLEPythonFilesIfPossible(configDir: pyDir)
+        // Likewise deploy the RNode (LoRa) custom interface so RNS can load a
+        // `type = IOSRNodeInterface` section if the config has one. Always
+        // copied — cheap, and a later RNode-enabled restart then needs no extra
+        // deploy step (mirrors the BLE case).
+        deployIOSRNodePythonFilesIfPossible(configDir: pyDir)
+
+        // Generate the RNS config from user-saved interface entities. The
+        // file lands at `<configDir>/config` where Python's
+        // `RNS.Reticulum(config_dir)` will pick it up. Transport mode is
+        // read from the App Group UserDefaults (toggled in
+        // Settings → Advanced → Transport Mode); changing it requires
+        // tapping Apply & Restart on the same screen.
+        let transportEnabled = SharedDefaults.suite.bool(forKey: "transport_enabled")
+        let configText = PythonConfigWriter.write(interfaces: interfaces, enableTransport: transportEnabled)
+        let configFile = pyDir.appendingPathComponent("config")
+        do {
+            try configText.write(to: configFile, atomically: true, encoding: .utf8)
+            DiagLog.log("[RNS] wrote config (\(configText.count) bytes, \(interfaces.count) interfaces)")
+        } catch {
+            DiagLog.log("[RNS] config write FAILED: \(error)")
+        }
+
+        let identityBytes = try? identity.exportPrivateKeys()
+        DiagLog.log("[RNS] identityBytes=\(identityBytes?.count ?? -1)")
+
+        do {
+            DiagLog.log("[RNS] calling backend.start()")
+            let info = try await backend.start(
+                .init(
+                    configDir: configDir,
+                    identityPath: identityFile,
+                    displayName: displayName,
+                    identityBytes: identityBytes
+                )
+            )
+            DiagLog.log("[RNS] started identity=\(info.identityHash) destination=\(info.destinationHash)")
+            logger.info("Python backend started — identity=\(info.identityHash, privacy: .public) destination=\(info.destinationHash, privacy: .public)")
+        } catch {
+            DiagLog.log("[RNS] start FAILED: \(error)")
+            logger.error("Python backend start failed: \(error.localizedDescription, privacy: .public)")
+            self.backend = nil
+            return
+        }
+
+        // Install the Swift→Python RNode callback bridge. Unlike BLE (which has
+        // an explicit startBLEInterface()), an RNode interface is instantiated
+        // by RNS's config loader, whose _RNodeBLEBridge registers callbacks via
+        // rns_bridge as soon as it loads — so the invoker must already be in
+        // place. Cheap to install unconditionally: it only stores a ref; the
+        // CBCentralManager isn't created until Python calls columba_rnode_start.
+        #if canImport(CoreBluetooth)
+        if let py = backend as? PythonRNSBackend {
+            SwiftRNodeBridge.shared.setCallbackInvoker(
+                PythonRNodeCallbackBridge(pythonBridge: py.pythonBridge)
+            )
+            DiagLog.log("[RNODE] PythonRNodeCallbackBridge installed")
+        }
+        #endif
+
+        // Outbound LXMF now goes directly through `backend.lxmf.sendLxmfMessage`
+        // (MessagingViewModel + RnsLxmf) with TYPED fields, so the old Compat
+        // router sendHook — which forwarded content only and dropped every field —
+        // is retired. The Compat LXMRouter remains solely as the inbound delegate
+        // holder (IncomingMessageHandler, wired in ColumbaApp); fully retiring it
+        // would require the LXMRouterDelegate protocol to drop its router param
+        // (a separate, lower-value cleanup).
+
+        // Drain Python events into Columba's UI plumbing.
+        pythonEventTask?.cancel()
+        let weakSelf = self
+        pythonEventTask = Task { [backend] in
+            for await event in backend.events {
+                await weakSelf.handlePythonEvent(event)
+            }
+        }
+
+        // Seed Compat TCPInterface stubs for each enabled InterfaceEntity so
+        // the InterfaceManagement UI has something to render against. Their
+        // state starts `.connecting`; the periodic status poll below flips
+        // each one to `.connected` / `.disconnected` based on what Python's
+        // RNS.Transport reports.
+        for entity in interfaces where entity.type == .tcpClient || entity.type == .tcpServer {
+            if tcpInterfaces[entity.id] == nil {
+                let host: String
+                let port: UInt16
+                switch entity.config {
+                case .tcpClient(let cfg): host = cfg.targetHost; port = cfg.targetPort
+                case .tcpServer(let cfg): host = cfg.listenIp; port = cfg.listenPort
+                default: host = ""; port = 0
+                }
+                let config = InterfaceConfig(
+                    id: entity.id,
+                    name: entity.name,
+                    type: entity.type == .tcpClient ? .tcp : .tcp,
+                    enabled: entity.enabled,
+                    mode: .full,
+                    host: host,
+                    port: port
+                )
+                if let iface = try? TCPInterface(config: config) {
+                    iface.state = .connecting
+                    tcpInterfaces[entity.id] = iface
+                }
+            }
+        }
+
+        // Seed the live-interface set the status poll matches against. Kept
+        // current by applyInterfaceChanges() on every hot-add / hot-remove —
+        // the poll reads this each tick (NOT a value captured here) so a
+        // mid-session interface change is reflected without a relaunch.
+        self.pythonInterfaceEntities = Dictionary(uniqueKeysWithValues: interfaces.map { ($0.id, $0) })
+
+        // Periodic status poll: mirror Python's view of interface state into
+        // the Compat TCPInterface stubs so the existing NetworkStatusView /
+        // InterfaceManagementScreen show online / offline accurately.
+        pythonStatusPollTask?.cancel()
+        pythonStatusPollTask = Task { [weak self, backend] in
+            var tick = 0
+            DiagLog.log("[RNS-POLL] task started")
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 2_000_000_000) // 2s
+                tick += 1
+                let snapshot = await backend.statusSnapshot()
+                if snapshot == nil {
+                    if tick % 5 == 0 { DiagLog.log("[RNS-POLL] tick=\(tick) snapshot=nil") }
+                    continue
+                }
+                guard let self else { return }
+                let entityById = await MainActor.run { self.pythonInterfaceEntities }
+                await self.applyPythonInterfaceStatus(snapshot: snapshot!, entityById: entityById)
+            }
+            DiagLog.log("[RNS-POLL] task exiting (cancelled)")
+        }
+
+        // Listen for test-send deep links (lxma://test-send?to=HEX&content=…
+        // [&method=…][&image_hex=…&image_format=…][&file_hex=…&file_name=…]).
+        // Drives the full typed-LXMF send path the interop harness uses to
+        // exercise image / file attachments end-to-end against a Sideband
+        // peer (see Tests/interop/).
+        NotificationCenter.default.addObserver(
+            forName: Notification.Name("ColumbaTestSend"),
+            object: nil,
+            queue: .main
+        ) { [weak self] note in
+            guard let self else { return }
+            guard let to = note.userInfo?["to"] as? String,
+                  let content = note.userInfo?["content"] as? String else { return }
+            let method = (note.userInfo?["method"] as? String) ?? ""
+            let imageHex = (note.userInfo?["image_hex"] as? String) ?? ""
+            let imageFormat = (note.userInfo?["image_format"] as? String) ?? ""
+            let fileHex = (note.userInfo?["file_hex"] as? String) ?? ""
+            let fileName = (note.userInfo?["file_name"] as? String) ?? ""
+            // Resolve delivery method. `direct`/`propagated` ride a Link or
+            // a propagation node, respectively; everything else (including
+            // empty) goes opportunistic — matches LXDeliveryMethod's three
+            // wire-method choices.
+            let deliveryMethod: LXDeliveryMethod
+            switch method.lowercased() {
+            case "direct": deliveryMethod = .direct
+            case "propagated": deliveryMethod = .propagated
+            default: deliveryMethod = .opportunistic
+            }
+            // Hex → Data for the optional attachment payloads. Bad hex
+            // silently drops the field so a typo in the URL surfaces as a
+            // missing field in the inbound tap (loud) rather than a crash.
+            let imageData: Data? = (!imageHex.isEmpty && !imageFormat.isEmpty)
+                ? (try? imageHex.hexToData()) : nil
+            let fileAttachments: [RnsFileAttachment]?
+            if !fileHex.isEmpty && !fileName.isEmpty, let data = try? fileHex.hexToData() {
+                fileAttachments = [RnsFileAttachment(name: fileName, data: data)]
+            } else {
+                fileAttachments = nil
+            }
+            Task { @MainActor in
+                guard let backend = self.backend else {
+                    DiagLog.log("[TEST-SEND] no backend")
+                    return
+                }
+                do {
+                    let outcome = try await backend.lxmf.sendLxmfMessage(
+                        destHashHex: to,
+                        content: content,
+                        method: deliveryMethod,
+                        imageData: imageData,
+                        imageFormat: imageFormat.isEmpty ? nil : imageFormat,
+                        fileAttachments: fileAttachments,
+                        iconAppearance: nil,
+                        replyToMessageHashHex: nil,
+                        replyQuotedContent: nil,
+                        extraFields: nil
+                    )
+                    DiagLog.log("[TEST-SEND] outcome=\(outcome) method=\(deliveryMethod)")
+                } catch {
+                    DiagLog.log("[TEST-SEND] error=\(error)")
+                }
+            }
+        }
+
+        // Listen for test-telemetry deep links — the Tests/interop/ harness
+        // uses these to pin `RnsTelemetry.sendLocationTelemetry` /
+        // `sendTelemetryCease` on the active backend without driving the
+        // CLLocationManager / GPS permission flow that the production
+        // LocationSharingManager runs through.
+        NotificationCenter.default.addObserver(
+            forName: Notification.Name("ColumbaTestTelemetry"),
+            object: nil,
+            queue: .main
+        ) { [weak self] note in
+            guard let self else { return }
+            guard let to = note.userInfo?["to"] as? String else { return }
+            let packedHex = (note.userInfo?["packed_hex"] as? String) ?? ""
+            let metaHex = (note.userInfo?["meta_hex"] as? String) ?? ""
+            let cease = (note.userInfo?["cease"] as? Bool) ?? false
+            Task { @MainActor in
+                guard let backend = self.backend else {
+                    DiagLog.log("[TEST-TELEMETRY] no backend")
+                    return
+                }
+                do {
+                    if cease {
+                        // Same Android-shaped payload the UI path sends:
+                        // zeroed FIELD_TELEMETRY + msgpack {"cease":true}.
+                        let (packed, meta) = CeaseTelemetry.payload()
+                        let outcome = try await backend.telemetry.sendLocationTelemetry(
+                            destHashHex: to, packed: packed, customMeta: meta
+                        )
+                        DiagLog.log("[TEST-TELEMETRY] cease outcome=\(outcome)")
+                    } else {
+                        guard let packed = try? packedHex.hexToData(), !packed.isEmpty else {
+                            DiagLog.log("[TEST-TELEMETRY] packed_hex missing or invalid")
+                            return
+                        }
+                        let meta = (try? metaHex.hexToData()).flatMap { $0.isEmpty ? nil : $0 }
+                        let outcome = try await backend.telemetry.sendLocationTelemetry(
+                            destHashHex: to, packed: packed, customMeta: meta
+                        )
+                        DiagLog.log("[TEST-TELEMETRY] send outcome=\(outcome)")
+                    }
+                } catch {
+                    DiagLog.log("[TEST-TELEMETRY] error=\(error)")
+                }
+            }
+        }
+
+        // Listen for test-restart deep link (lxma://test-restart) so
+        // smoke tests can exercise the Apply & Restart path without UI.
+        NotificationCenter.default.addObserver(
+            forName: Notification.Name("ColumbaTestRestart"),
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self else { return }
+            Task { @MainActor in
+                DiagLog.log("[TEST-RESTART] invoking restartPythonBackend")
+                await self.restartPythonBackend()
+                DiagLog.log("[TEST-RESTART] done")
+            }
+        }
+
+        // Phase 4 smoke test: direct CB manager state probe. Bypasses the
+        // Python driver so we can isolate Swift-side CB readiness from
+        // Python wiring during early-bring-up debugging.
+        NotificationCenter.default.addObserver(
+            forName: Notification.Name("ColumbaTestBLEStatus"),
+            object: nil,
+            queue: .main
+        ) { _ in
+            #if canImport(CoreBluetooth)
+            let bridge = SwiftBLEBridge.shared
+            let isStarted = bridge.isStarted
+            let connected = bridge.getConnectedPeers()
+            DiagLog.log("[TEST-BLE-STATUS] started=\(isStarted) connected_peers=\(connected.count)")
+            #else
+            DiagLog.log("[TEST-BLE-STATUS] CoreBluetooth unavailable")
+            #endif
+        }
+
+        // Diagnose IOSBLEInterface load: exec the file in the same fresh
+        // namespace RNS uses, surface any exception to DiagLog. Helps when
+        // panic_on_interface_error=no silently swallows external-iface
+        // load errors so the row shows "disconnected" with no signal.
+        NotificationCenter.default.addObserver(
+            forName: Notification.Name("ColumbaTestBLEDiagnose"),
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self else { return }
+            Task { @MainActor in
+                guard let backend = self.pythonBackend else {
+                    DiagLog.log("[TEST-BLE-DIAG] no backend")
+                    return
+                }
+                let result = await backend.pythonBridge.callModuleFunctionReturningString(
+                    name: "diagnose_ios_ble_interface"
+                ) ?? "(call returned nil)"
+                // Multi-line tracebacks would get truncated by NSLog
+                // formatting if logged as a single line; split and log
+                // each line for readability.
+                for line in result.split(separator: "\n", omittingEmptySubsequences: false) {
+                    DiagLog.log("[TEST-BLE-DIAG] \(line)")
+                }
+            }
+        }
+
+        // Dump path-table entries so we can see what the Node Details
+        // "Interface Heard" card would render without taking a screenshot.
+        NotificationCenter.default.addObserver(
+            forName: Notification.Name("ColumbaTestPathTable"),
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self else { return }
+            Task { @MainActor in
+                guard let backend = self.pythonBackend else {
+                    DiagLog.log("[TEST-PATH-TABLE] no backend")
+                    return
+                }
+                let result = await backend.pythonBridge.callModuleFunctionReturningString(
+                    name: "diagnose_path_table"
+                ) ?? "(call returned nil)"
+                for line in result.split(separator: "\n", omittingEmptySubsequences: false) {
+                    DiagLog.log("[TEST-PATH-TABLE] \(line)")
+                }
+            }
+        }
+
+        // Diagnose AutoInterface peer discovery: introspect the live
+        // AutoInterface Python object so we can see whether multicast
+        // join succeeded, what interfaces are bound, peer count, etc.
+        NotificationCenter.default.addObserver(
+            forName: Notification.Name("ColumbaTestAutoDiagnose"),
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self else { return }
+            Task { @MainActor in
+                guard let backend = self.pythonBackend else {
+                    DiagLog.log("[TEST-AUTO-DIAG] no backend")
+                    return
+                }
+                let result = await backend.pythonBridge.callModuleFunctionReturningString(
+                    name: "diagnose_auto_interface"
+                ) ?? "(call returned nil)"
+                for line in result.split(separator: "\n", omittingEmptySubsequences: false) {
+                    DiagLog.log("[TEST-AUTO-DIAG] \(line)")
+                }
+            }
+        }
+
+        // Phase 6 smoke test: dump current connection details (Android parity).
+        NotificationCenter.default.addObserver(
+            forName: Notification.Name("ColumbaTestBLEPeerList"),
+            object: nil,
+            queue: .main
+        ) { _ in
+            #if canImport(CoreBluetooth)
+            let details = SwiftBLEBridge.shared.getConnectionDetails()
+            DiagLog.log("[TEST-BLE-PEER-LIST] count=\(details.count)")
+            for d in details {
+                let idPrefix = d.identityHashHex.map { String($0.prefix(8)) } ?? "<no-id>"
+                DiagLog.log("[TEST-BLE-PEER-LIST]   addr=\(d.address.prefix(8)) role=\(d.role.rawValue) mtu=\(d.mtu) id=\(idPrefix) rssi=\(d.rssi.map(String.init) ?? "?")")
+            }
+            #else
+            DiagLog.log("[TEST-BLE-PEER-LIST] CoreBluetooth unavailable")
+            #endif
+        }
+
+        // Phase 4 smoke test: direct CB scan toggle. Drives SwiftBLEBridge
+        // without going through Python, so we can validate scan start/stop
+        // works before plugging in the BLEDriverInterface contract.
+        NotificationCenter.default.addObserver(
+            forName: Notification.Name("ColumbaTestBLEScan"),
+            object: nil,
+            queue: .main
+        ) { note in
+            #if canImport(CoreBluetooth)
+            let action = (note.userInfo?["action"] as? String) ?? "start"
+            let bridge = SwiftBLEBridge.shared
+            // Lazy-start the bridge so the CB managers exist when we call.
+            if !bridge.isStarted {
+                bridge.start(
+                    serviceUuid: BleConstants.serviceUuid,
+                    rxCharUuid: BleConstants.rxCharUuid,
+                    txCharUuid: BleConstants.txCharUuid,
+                    identityCharUuid: BleConstants.identityCharUuid
+                )
+            }
+            if action == "stop" {
+                bridge.stopScanning()
+                DiagLog.log("[TEST-BLE-SCAN] stopScanning called")
+            } else {
+                bridge.startScanning()
+                DiagLog.log("[TEST-BLE-SCAN] startScanning called")
+            }
+            #else
+            DiagLog.log("[TEST-BLE-SCAN] CoreBluetooth unavailable")
+            #endif
+        }
+
+        // Phase 4 smoke test: direct CB advertise toggle.
+        NotificationCenter.default.addObserver(
+            forName: Notification.Name("ColumbaTestBLEAdvertise"),
+            object: nil,
+            queue: .main
+        ) { note in
+            #if canImport(CoreBluetooth)
+            let action = (note.userInfo?["action"] as? String) ?? "start"
+            let name = (note.userInfo?["name"] as? String) ?? ""
+            let bridge = SwiftBLEBridge.shared
+            if !bridge.isStarted {
+                bridge.start(
+                    serviceUuid: BleConstants.serviceUuid,
+                    rxCharUuid: BleConstants.rxCharUuid,
+                    txCharUuid: BleConstants.txCharUuid,
+                    identityCharUuid: BleConstants.identityCharUuid
+                )
+            }
+            if action == "stop" {
+                bridge.stopAdvertising()
+                DiagLog.log("[TEST-BLE-ADVERTISE] stopAdvertising called")
+            } else {
+                bridge.startAdvertising(deviceName: name.isEmpty ? nil : name)
+                DiagLog.log("[TEST-BLE-ADVERTISE] startAdvertising name=\"\(name)\"")
+            }
+            #else
+            DiagLog.log("[TEST-BLE-ADVERTISE] CoreBluetooth unavailable")
+            #endif
+        }
+
+        // Phase 2 smoke test: Swift→Python BLE callback round-trip.
+        // Installs `_test_roundtrip` Python callback that returns
+        // True iff its int arg is even, then invokes it through the
+        // synchronous bool-return BLE callback path. PASS iff Swift
+        // gets back the expected bool for both even and odd inputs.
+        NotificationCenter.default.addObserver(
+            forName: Notification.Name("ColumbaTestBLECallback"),
+            object: nil,
+            queue: .main
+        ) { [weak self] note in
+            guard let self else { return }
+            let value = (note.userInfo?["value"] as? Int) ?? 4
+            Task { @MainActor in
+                guard let backend = self.pythonBackend else {
+                    DiagLog.log("[TEST-BLE-CB] FAIL: no backend")
+                    return
+                }
+                let installed = await backend.installBLETestRoundtripCallback()
+                guard installed else {
+                    DiagLog.log("[TEST-BLE-CB] FAIL: callback install failed")
+                    return
+                }
+                let evenResult = backend.invokeBLETestRoundtrip(value: value)
+                let oddResult = backend.invokeBLETestRoundtrip(value: value + 1)
+                let evenExpected = value % 2 == 0
+                let oddExpected = (value + 1) % 2 == 0
+                let pass = evenResult == evenExpected && oddResult == oddExpected
+                DiagLog.log("[TEST-BLE-CB] value=\(value) even=\(evenResult) odd=\(oddResult) \(pass ? "PASS" : "FAIL")")
+            }
+        }
+
+        // lxma://test-answer — accept the currently-ringing call.
+        NotificationCenter.default.addObserver(
+            forName: Notification.Name("ColumbaTestAnswer"),
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self else { return }
+            Task { @MainActor in
+                #if os(iOS)
+                guard let callManager = self.callManager else {
+                    DiagLog.log("[TEST-ANSWER] no callManager")
+                    return
+                }
+                DiagLog.log("[TEST-ANSWER] calling answerCall()")
+                callManager.answerCall()
+                #endif
+            }
+        }
+
+        // lxma://test-call?to=HEX[&profile=...] — exercise the full call
+        // pipeline: CallManager.initiateCall → Telephone.call →
+        // Compat.Link.sendBytes → PythonRNSBackend.linkSend.
+        NotificationCenter.default.addObserver(
+            forName: Notification.Name("ColumbaTestCall"),
+            object: nil,
+            queue: .main
+        ) { [weak self] note in
+            guard let self else { return }
+            let to = (note.userInfo?["to"] as? String) ?? ""
+            let profileRaw = (note.userInfo?["profile"] as? String) ?? ""
+            Task { @MainActor in
+                #if os(iOS)
+                guard let callManager = self.callManager else {
+                    DiagLog.log("[TEST-CALL] no callManager")
+                    return
+                }
+                guard let destHash = try? to.hexToData() else {
+                    DiagLog.log("[TEST-CALL] bad to= hex")
+                    return
+                }
+                // Pick profile: default to qualityMedium if not specified or
+                // unrecognized; parse rawValue if present.
+                var profile: TelephonyProfile = .qualityMedium
+                if !profileRaw.isEmpty, let parsed = TelephonyProfile.allCases.first(where: { "\($0)" == profileRaw }) {
+                    profile = parsed
+                }
+                DiagLog.log("[TEST-CALL] initiating to=\(destHash.toHex().prefix(8)) profile=\(profile)")
+                callManager.initiateCall(destinationHash: destHash, profile: profile, peerDisplayName: nil)
+                #else
+                DiagLog.log("[TEST-CALL] CallManager only available on iOS")
+                #endif
+            }
+        }
+
+        // lxma://test-link-open?to=HEX&aspect=lxst.telephony — exercise the
+        // RNS.Link bridge by opening an outbound Link to a destination.
+        // Logs the link_id + waits for link_state events to surface via
+        // NotificationCenter. For commit-1 smoke testing.
+        NotificationCenter.default.addObserver(
+            forName: Notification.Name("ColumbaTestLinkOpen"),
+            object: nil,
+            queue: .main
+        ) { [weak self] note in
+            guard let self else { return }
+            let to = (note.userInfo?["to"] as? String) ?? ""
+            let aspect = (note.userInfo?["aspect"] as? String) ?? "lxst.telephony"
+            Task { @MainActor in
+                guard let backend = self.backend else {
+                    DiagLog.log("[TEST-LINK] no backend")
+                    return
+                }
+                do {
+                    let res = try await backend.openLink(destHashHex: to, aspect: aspect)
+                    DiagLog.log("[TEST-LINK] open ok=\(res.ok) linkId=\(res.linkId) reason=\(res.reason)")
+                } catch {
+                    DiagLog.log("[TEST-LINK] open error=\(error)")
+                }
+            }
+        }
+
+        // lxma://test-inbound?from=HEX&content=... — synthesize an inbound
+        // event so the privacy filter (block_unknown_senders) can be
+        // verified without needing a working peer.
+        NotificationCenter.default.addObserver(
+            forName: Notification.Name("ColumbaTestInbound"),
+            object: nil,
+            queue: .main
+        ) { [weak self] note in
+            guard let self else { return }
+            let fromHex = (note.userInfo?["from"] as? String) ?? ""
+            let content = (note.userInfo?["content"] as? String) ?? "synthetic"
+            guard let from = Data(hexString: fromHex) else {
+                DiagLog.log("[TEST-INBOUND] bad hex")
+                return
+            }
+            Task { @MainActor in
+                await self.persistInboundFromPython(
+                    sourceHash: from,
+                    content: content,
+                    title: "",
+                    fields: nil,
+                    timestamp: Date()
+                )
+            }
+        }
+
+        // lxma://test-identity-switch — exercise the multi-identity swap
+        // path: create a fresh identity in IdentityManager and call
+        // AppServices.switchIdentity. Logs the destination hash before
+        // and after so we can verify Python actually rebooted with the
+        // new keys.
+        NotificationCenter.default.addObserver(
+            forName: Notification.Name("ColumbaTestIdentitySwitch"),
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self else { return }
+            Task { @MainActor in
+                let manager = IdentityManager()
+                let before = self.backend?.localInfo?.destinationHash ?? "nil"
+                DiagLog.log("[TEST-IDSWITCH] before destination=\(before)")
+                do {
+                    let created = try await manager.createIdentity(displayName: "SwitchTarget")
+                    let (localId, identity) = try await manager.switchToIdentity(created.identityHash)
+                    try await self.switchIdentity(
+                        to: identity,
+                        identityHash: localId.identityHash,
+                        tcpServerAddress: ""
+                    )
+                    let after = self.backend?.localInfo?.destinationHash ?? "nil"
+                    DiagLog.log("[TEST-IDSWITCH] after destination=\(after) (changed=\(before != after))")
+                } catch {
+                    DiagLog.log("[TEST-IDSWITCH] error=\(error)")
+                }
+            }
+        }
+
+        // lxma://test-prop-sync?node=HEX — set propagation node, kick a sync,
+        // log the outcome.
+        NotificationCenter.default.addObserver(
+            forName: Notification.Name("ColumbaTestPropSync"),
+            object: nil,
+            queue: .main
+        ) { [weak self] note in
+            guard let self else { return }
+            let node = (note.userInfo?["node"] as? String) ?? ""
+            Task { @MainActor in
+                guard let backend = self.backend else {
+                    DiagLog.log("[TEST-PROP-SYNC] no backend")
+                    return
+                }
+                do {
+                    _ = try await backend.setPropagationNode(destHashHex: node, stampCost: 0)
+                    DiagLog.log("[TEST-PROP-SYNC] set node, starting sync")
+                    let r = try await backend.propagationSync(timeout: 30.0)
+                    DiagLog.log("[TEST-PROP-SYNC] result ok=\(r.ok) state=\(r.state.rawValue) received=\(r.receivedMessages) reason=\(r.reason)")
+                } catch {
+                    DiagLog.log("[TEST-PROP-SYNC] error=\(error)")
+                }
+            }
+        }
+
+        // lxma://test-announce?name=... — calls sendAllAnnounces with the
+        // given display name (both the LXMF delivery + LXST telephony
+        // destinations), logs the outcome.
+        NotificationCenter.default.addObserver(
+            forName: Notification.Name("ColumbaTestAnnounce"),
+            object: nil,
+            queue: .main
+        ) { [weak self] note in
+            guard let self else { return }
+            let name = (note.userInfo?["name"] as? String) ?? ""
+            Task { @MainActor in
+                do {
+                    try await self.sendAllAnnounces(displayName: name)
+                    DiagLog.log("[TEST-ANNOUNCE] sendAllAnnounces returned OK")
+                } catch {
+                    DiagLog.log("[TEST-ANNOUNCE] sendAllAnnounces failed: \(error)")
+                }
+            }
+        }
+
+        // lxma://test-nomad-fetch?to=HEX&path=/page/index.mu — calls
+        // bridge.fetchNomadNetPage and logs the response.
+        NotificationCenter.default.addObserver(
+            forName: Notification.Name("ColumbaTestNomadFetch"),
+            object: nil,
+            queue: .main
+        ) { [weak self] note in
+            guard let self else { return }
+            guard let to = note.userInfo?["to"] as? String,
+                  let path = note.userInfo?["path"] as? String else { return }
+            Task { @MainActor in
+                guard let backend = self.backend else {
+                    DiagLog.log("[TEST-NOMAD] no backend")
+                    return
+                }
+                do {
+                    let res = try await backend.fetchNomadNetPage(destHashHex: to, path: path)
+                    let preview = String(data: res.data.prefix(120), encoding: .utf8) ?? "(non-utf8 \(res.data.count) bytes)"
+                    DiagLog.log("[TEST-NOMAD] result ok=\(res.ok) status=\(res.status.rawValue) bytes=\(res.data.count) preview=\(preview)")
+                } catch {
+                    DiagLog.log("[TEST-NOMAD] error=\(error)")
+                }
+            }
+        }
+    }
+
+    /// Look up the matching Python interface for each user `InterfaceEntity`
+    /// and update the Compat TCPInterface stub's `state` to reflect the
+    /// `online` flag RNS.Transport reports.
+    private func applyPythonInterfaceStatus(
+        snapshot: StatusSnapshot,
+        entityById: [String: InterfaceEntity]
+    ) async {
+        // Log every interface Python reports so we can see AutoInterface /
+        // RNode / etc. that don't have Compat stubs yet. One-shot per
+        // section_name change.
+        let snapshotKey = snapshot.interfaces.map { "\($0.sectionName):\($0.online ? 1 : 0)" }.joined(separator: ",")
+        if snapshotKey != lastInterfaceSnapshotKey {
+            DiagLog.log("[RNS] interfaces=\(snapshotKey)")
+            lastInterfaceSnapshotKey = snapshotKey
+        }
+        // The config section name PythonConfigWriter wrote is the matching
+        // key — it's stable across the bridge and unique per entity.
+        var byEntity: [String: StatusSnapshot.InterfaceStatus] = [:]
+        var matchedSectionNames: Set<String> = []
+        for status in snapshot.interfaces {
+            for (entityId, entity) in entityById {
+                let expected = expectedSectionName(for: entity)
+                if status.sectionName == expected {
+                    byEntity[entityId] = status
+                    matchedSectionNames.insert(status.sectionName)
+                }
+            }
+        }
+        // Auxiliary: any Python interface that didn't match an entity is a
+        // dynamically-spawned peer (AutoInterfacePeer / BLEPeer / etc.).
+        // Push these into the Transport so NetworkStatusView can render them.
+        // Python AutoInterfacePeer's `name` is the class name; the `name`
+        // field of the status dict is `str(iface)` which gives us the
+        // friendly "AutoInterfacePeer[en0/fe80::xxxx]" — peel out the
+        // peer address from there for the row subtitle.
+        var auxiliary: [InterfaceSnapshot] = []
+        for status in snapshot.interfaces where !matchedSectionNames.contains(status.sectionName) {
+            // Skip user-defined sections we just couldn't match for some
+            // reason (rename race, etc.) — only emit synthetic rows for
+            // peer-style names.
+            let isAutoPeer = status.name.hasPrefix("AutoInterfacePeer")
+            let isBlePeer = status.name.hasPrefix("BLEPeerInterface") || status.name.hasPrefix("BLEPeer")
+            guard isAutoPeer || isBlePeer else { continue }
+            let typeLabel = isAutoPeer ? "AutoInterfacePeer" : "BLEPeer"
+            // Peel out the bracketed addr — "AutoInterfacePeer[en0/fe80::1]"
+            // gives "en0/fe80::1".
+            let peerAddress: String? = {
+                guard let open = status.name.firstIndex(of: "["),
+                      let close = status.name.lastIndex(of: "]"),
+                      open < close else { return nil }
+                return String(status.name[status.name.index(after: open)..<close])
+            }()
+            auxiliary.append(InterfaceSnapshot(
+                id: "py-aux:\(status.sectionName.isEmpty ? status.name : status.sectionName)",
+                name: status.name,
+                online: status.online,
+                typeLabel: typeLabel,
+                type: isAutoPeer ? .autoInterface : .ble,
+                state: status.online ? .connected : .disconnected,
+                isAutoInterfacePeer: isAutoPeer,
+                isBLEPeerInterface: isBlePeer,
+                peerAddress: peerAddress,
+                lastErrorDescription: nil
+            ))
+        }
+        if let transport = transport {
+            transport.setPythonAuxiliarySnapshots(auxiliary)
+        }
+        // One-shot log of auxiliary count changes so we can see whether
+        // LAN / BLE peer discovery is actually firing.
+        let auxKey = auxiliary.map(\.id).sorted().joined(separator: ",")
+        if auxKey != lastAuxiliaryKey {
+            DiagLog.log("[RNS] auxiliary interfaces (\(auxiliary.count)): \(auxKey)")
+            lastAuxiliaryKey = auxKey
+        }
+        for (entityId, status) in byEntity {
+            let newState: InterfaceState = status.online ? .connected : .disconnected
+            // TCP interfaces keyed by entity ID.
+            if let iface = tcpInterfaces[entityId] {
+                if iface.state != newState {
+                    DiagLog.log("[RNS] iface \(status.sectionName) -> \(newState) (rx=\(status.rxBytes) tx=\(status.txBytes))")
+                    iface.state = newState
+                    iface.online = status.online
+                }
+                continue
+            }
+            // Auto + BLE interfaces are singletons on AppServices, keyed by
+            // entity type rather than ID. Match the corresponding entity and
+            // mirror Python's reported state onto the Swift stub so the UI
+            // can render an accurate "connected/disconnected" badge.
+            guard let entity = entityById[entityId] else { continue }
+            switch entity.config {
+            case .autoInterface:
+                if let auto = self.autoInterface, auto.state != newState {
+                    DiagLog.log("[RNS] iface \(status.sectionName) -> \(newState) (Auto, rx=\(status.rxBytes) tx=\(status.txBytes))")
+                    auto.state = newState
+                    auto.online = status.online
+                }
+            case .ble:
+                if let ble = self.bleInterface, ble.state != newState {
+                    DiagLog.log("[RNS] iface \(status.sectionName) -> \(newState) (BLE, rx=\(status.rxBytes) tx=\(status.txBytes))")
+                    ble.state = newState
+                    ble.online = status.online
+                }
+            case .rnode:
+                // The real RNode runs as the Python IOSRNodeInterface; the Swift
+                // RNodeInterface stub never reaches .connected on its own, so the
+                // Network Interfaces row sat at "disconnected" even while the
+                // backend reported the interface online. Mirror Python's state
+                // onto the stub the UI polls — same as Auto/BLE above. (Was
+                // missing here, hence the gap.)
+                if let rnode = self.rnodeInterface, rnode.state != newState {
+                    DiagLog.log("[RNS] iface \(status.sectionName) -> \(newState) (RNode, rx=\(status.rxBytes) tx=\(status.txBytes))")
+                    rnode.state = newState
+                    rnode.online = status.online
+                }
+            default:
+                break
+            }
+        }
+    }
+
+    /// Stop the running Python RNS stack, regenerate the RNS config file
+    /// from `InterfaceRepository.getEnabledInterfaces()`, and start a fresh
+    /// instance. Called from the InterfaceManagementScreen's "Apply &
+    /// Restart" button after the user adds, edits, toggles, or removes an
+    /// interface. RNS has no hot-reload — the only way to pick up a new
+    /// `[interfaces]` section is a full Reticulum re-init.
+    ///
+    /// Causes a ~1-2s connectivity outage. Caller should reflect the
+    /// transition in the UI (the Apply button already shows a
+    /// ProgressView while `isApplyingChanges` is set).
+    public func restartPythonBackend() async {
+        guard let identity = pythonStartIdentity else {
+            DiagLog.log("[RNS] restart skipped — backend was never started")
+            return
+        }
+        // Rewrite the RNS config on disk so the new interface set is
+        // captured. The actual Python-side restart is DELIBERATELY skipped
+        // — in-place restart of the embedded interpreter is flaky on iOS
+        // (Reticulum is a class-level singleton, AutoInterface holds
+        // multicast socket threads that don't tear down deterministically,
+        // and the embedded Python aborts ~130ms into the second
+        // `Reticulum.__init__` when the previous instance's threads still
+        // hold the multicast bind). RNS has no hot-reload of [interfaces]
+        // anyway, so the right model is: write the config, tell the user
+        // to relaunch Columba. The full app launch on the next start gets
+        // a clean Python + clean RNS singleton.
+        _ = identity // pythonStartIdentity presence is the only precondition
+        let fresh = InterfaceRepository().getEnabledInterfaces()
+        writePythonConfig(interfaces: fresh)
+        DiagLog.log("[RNS] restartPythonBackend: config written (\(fresh.count) interfaces); awaiting next app launch to apply")
+        // Notify the UI so it can show a "relaunch Columba" prompt.
+        NotificationCenter.default.post(
+            name: Notification.Name("ColumbaRelaunchRequired"),
+            object: nil
+        )
+    }
+
+    /// Force the Python RNS stack to flush its path table + known destinations
+    /// to disk. RNS only persists on a 12h timer / clean exit, and iOS suspends
+    /// the app without a clean exit — so we call this when the app backgrounds,
+    /// otherwise RNS's `destination_table` / `known_destinations` are rarely
+    /// written and a cold start can't recall previously-heard peers.
+    ///
+    /// Wrapped in a UIKit background task so the file writes have a chance to
+    /// finish before iOS suspends us.
+    @MainActor
+    public func persistRNSStateOnBackground() {
+        guard let backend = backend else { return }
+        #if canImport(UIKit)
+        var bgTask: UIBackgroundTaskIdentifier = .invalid
+        bgTask = UIApplication.shared.beginBackgroundTask(withName: "rns-persist") {
+            if bgTask != .invalid { UIApplication.shared.endBackgroundTask(bgTask); bgTask = .invalid }
+        }
+        Task {
+            _ = await backend.persist()
+            await MainActor.run {
+                if bgTask != .invalid { UIApplication.shared.endBackgroundTask(bgTask); bgTask = .invalid }
+            }
+        }
+        #else
+        Task { _ = await backend.persist() }
+        #endif
+    }
+
+    /// Directory holding the running Python instance's RNS config, derived from
+    /// the identity the backend was started with. Returns nil if the backend
+    /// was never started (no cached identity). Creates the directory if needed.
+    private func pythonConfigDirURL() -> URL? {
+        guard let identity = pythonStartIdentity else { return nil }
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let pyDir = appSupport.appendingPathComponent("Columba/python-\(identity.hexHash)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: pyDir, withIntermediateDirectories: true)
+        return pyDir
+    }
+
+    /// Write the RNS config file from the given interface set. This is the
+    /// durability backstop: it keeps `<configDir>/config` authoritative so a
+    /// cold launch (or the transport-mode full restart) reflects the current
+    /// interfaces. It is NOT how live changes take effect — `add_interface` /
+    /// `remove_interface` reads this file but the running stack is reconfigured
+    /// by `applyInterfaceChanges()`.
+    @discardableResult
+    private func writePythonConfig(interfaces: [InterfaceEntity]) -> Bool {
+        guard let pyDir = pythonConfigDirURL() else {
+            DiagLog.log("[RNS] writePythonConfig skipped — no start identity")
+            return false
+        }
+        let transportEnabled = SharedDefaults.suite.bool(forKey: "transport_enabled")
+        let configText = PythonConfigWriter.write(interfaces: interfaces, enableTransport: transportEnabled)
+        let configFile = pyDir.appendingPathComponent("config")
+        do {
+            try configText.write(to: configFile, atomically: true, encoding: .utf8)
+            DiagLog.log("[RNS] wrote config (\(configText.count) bytes, \(interfaces.count) interfaces)")
+            return true
+        } catch {
+            DiagLog.log("[RNS] config write FAILED: \(error)")
+            return false
+        }
+    }
+
+    /// Apply pending interface changes to the *running* RNS stack with no
+    /// restart and no app relaunch.
+    ///
+    /// RNS attaches/detaches interfaces on a live `Transport` (the same
+    /// primitive its 1.x interface-discovery autoconnect uses). We diff the
+    /// just-saved enabled set against what's currently live
+    /// (`pythonInterfaceEntities`) and:
+    ///   1. rewrite the config file (durability for the next cold launch),
+    ///   2. hot-remove dropped interfaces (and the old form of edited ones),
+    ///   3. hot-add new interfaces (and the new form of edited ones),
+    ///   4. seed/tear down the Swift-side status mirrors so the UI badges
+    ///      track reality immediately,
+    ///   5. update `pythonInterfaceEntities` so the status poll matches the
+    ///      new set.
+    ///
+    /// Edited interfaces are handled as remove-then-add: `add_interface` reads
+    /// the freshly-written config section, so changed host/port/etc. take
+    /// effect. Caveat: removing an AutoInterface is not a clean teardown
+    /// upstream (its `detach()` leaves multicast sockets bound until process
+    /// exit), so re-adding the same AutoInterface mid-session may collide —
+    /// TCP is unaffected.
+    @MainActor
+    public func applyInterfaceChanges() async {
+        let fresh = InterfaceRepository().getEnabledInterfaces()
+        let freshById = Dictionary(uniqueKeysWithValues: fresh.map { ($0.id, $0) })
+
+        // 1. Durability — always persist, even if there's no live backend.
+        writePythonConfig(interfaces: fresh)
+
+        guard let backend = backend else {
+            DiagLog.log("[RNS-HOT] no running backend — config written, applies on next launch")
+            pythonInterfaceEntities = freshById
+            return
+        }
+
+        let live = pythonInterfaceEntities
+        let removed = live.values.filter { freshById[$0.id] == nil }
+        let added = fresh.filter { live[$0.id] == nil }
+        let changed = fresh.filter { e in
+            guard let old = live[e.id] else { return false }
+            return old != e
+        }
+
+        DiagLog.log("[RNS-HOT] applyInterfaceChanges: +\(added.count) -\(removed.count) ~\(changed.count)")
+
+        // 2. Remove dropped interfaces, and the OLD form of edited ones.
+        for entity in removed {
+            await hotRemoveInterface(entity, backend: backend)
+        }
+        for entity in changed {
+            if let old = live[entity.id] {
+                await hotRemoveInterface(old, backend: backend)
+            }
+        }
+
+        // 3. Add new interfaces, and the NEW form of edited ones.
+        for entity in added + changed {
+            await hotAddInterface(entity, backend: backend)
+        }
+
+        // 5. Keep the status-poll's matching set in sync with what's live.
+        pythonInterfaceEntities = freshById
+    }
+
+    /// Hot-add one interface to the running Python stack and seed its Swift
+    /// status mirror. Assumes the config file already contains the section
+    /// (callers run `writePythonConfig` first).
+    @MainActor
+    private func hotAddInterface(_ entity: InterfaceEntity, backend: any RnsBackend) async {
+        let section = PythonConfigWriter.sectionName(for: entity)
+        do {
+            let r = try await backend.addInterface(name: section)
+            DiagLog.log("[RNS-HOT] add \(section): ok=\(r.ok) reason=\(r.reason)")
+        } catch {
+            DiagLog.log("[RNS-HOT] add \(section) error: \(error)")
+        }
+        await seedSwiftStub(for: entity)
+    }
+
+    /// Hot-remove one interface from the running Python stack and tear down its
+    /// Swift status mirror.
+    @MainActor
+    private func hotRemoveInterface(_ entity: InterfaceEntity, backend: any RnsBackend) async {
+        let section = PythonConfigWriter.sectionName(for: entity)
+        do {
+            let r = try await backend.removeInterface(name: section)
+            DiagLog.log("[RNS-HOT] remove \(section): ok=\(r.ok) reason=\(r.reason)")
+        } catch {
+            DiagLog.log("[RNS-HOT] remove \(section) error: \(error)")
+        }
+        await teardownSwiftStub(for: entity)
+    }
+
+    /// Create the Swift-side status mirror for a freshly hot-added interface so
+    /// NetworkStatusView / Manage Interfaces / the Settings card can render it.
+    /// TCP interfaces get a Compat stub (state starts `.connecting`; the status
+    /// poll flips it based on Python's view). Auto/BLE/RNode reuse the existing
+    /// start* singletons, matching what the launch path (ColumbaApp Step 7) does.
+    @MainActor
+    private func seedSwiftStub(for entity: InterfaceEntity) async {
+        switch entity.config {
+        case .tcpClient(let cfg):
+            if tcpInterfaces[entity.id] == nil {
+                let config = InterfaceConfig(
+                    id: entity.id, name: entity.name, type: .tcp,
+                    enabled: true, mode: .full, host: cfg.targetHost, port: cfg.targetPort
+                )
+                if let iface = try? TCPInterface(config: config) {
+                    iface.state = .connecting
+                    tcpInterfaces[entity.id] = iface
+                }
+            }
+        case .tcpServer(let cfg):
+            if tcpInterfaces[entity.id] == nil {
+                let config = InterfaceConfig(
+                    id: entity.id, name: entity.name, type: .tcp,
+                    enabled: true, mode: .full, host: cfg.listenIp, port: cfg.listenPort
+                )
+                if let iface = try? TCPInterface(config: config) {
+                    iface.state = .connecting
+                    tcpInterfaces[entity.id] = iface
+                }
+            }
+        case .autoInterface(let cfg):
+            try? await startAutoInterface(groupId: cfg.groupId ?? "reticulum")
+        case .ble:
+            #if canImport(CoreBluetooth)
+            try? await startBLEInterface()
+            #endif
+        case .rnode(let cfg):
+            try? await startRNodeInterface(config: cfg, name: entity.name)
+        case .multipeer:
+            break // Multipeer status mirror not wired for hot-add yet.
+        }
+    }
+
+    /// Tear down the Swift-side status mirror for a hot-removed interface so the
+    /// UI stops showing it as connected. This is what fixes the stale
+    /// "Bluetooth connected" card after disabling BLE.
+    @MainActor
+    private func teardownSwiftStub(for entity: InterfaceEntity) async {
+        switch entity.config {
+        case .tcpClient, .tcpServer:
+            if let iface = tcpInterfaces[entity.id] {
+                await iface.disconnect()
+                await transport?.removeInterface(id: entity.id)
+                tcpInterfaces.removeValue(forKey: entity.id)
+            }
+        case .autoInterface:
+            await stopAutoInterface()
+        case .ble:
+            #if canImport(CoreBluetooth)
+            await stopBLEInterface()
+            #endif
+        case .rnode:
+            await stopRNodeInterface()
+        case .multipeer:
+            break
+        }
+    }
+
+    /// Re-instantiate the Swift-side interface singletons / stubs for each
+    /// enabled `InterfaceEntity` after a Python restart. Idempotent (each
+    /// start*Interface method early-exits if already up).
+    private func respawnSwiftInterfaceStubs(enabled: [InterfaceEntity]) async {
+        for entity in enabled {
+            switch entity.config {
+            case .tcpClient(let config):
+                let entityId = entity.id
+                do {
+                    try await connectTCPInterface(entityId: entityId, host: config.targetHost, port: config.targetPort)
+                    DiagLog.log("[RESPAWN] TCP \(entityId) connected")
+                } catch {
+                    DiagLog.log("[RESPAWN] TCP \(entityId) failed: \(error)")
+                }
+            case .autoInterface(let config):
+                let groupId = config.groupId ?? "reticulum"
+                do {
+                    try await startAutoInterface(groupId: groupId)
+                    DiagLog.log("[RESPAWN] AutoInterface started groupId=\(groupId)")
+                } catch {
+                    DiagLog.log("[RESPAWN] AutoInterface failed: \(error)")
+                }
+            case .ble:
+                #if canImport(CoreBluetooth)
+                do {
+                    try await startBLEInterface()
+                    DiagLog.log("[RESPAWN] BLEInterface started")
+                } catch {
+                    DiagLog.log("[RESPAWN] BLEInterface failed: \(error)")
+                }
+                #endif
+            case .tcpServer, .rnode, .multipeer:
+                // tcpServer + RNode + Multipeer aren't auto-started on
+                // restart yet (no parity with ColumbaApp.swift initial
+                // startup); add when those flows are formalized.
+                break
+            }
+        }
+    }
+
+    /// Recompute the config-section name PythonConfigWriter would have
+    /// written for an entity, so we can match Python interface objects back
+    /// to entities by section_name.
+    private func expectedSectionName(for entity: InterfaceEntity) -> String {
+        // Delegate to the single source of truth used by the config writer and
+        // the hot-add / hot-remove path, so status matching can never drift
+        // from the section names actually written to the RNS config.
+        PythonConfigWriter.sectionName(for: entity)
+    }
+
+    /// Save a Python-delivered inbound LXMF message to the repository and
+    /// notify the chats UI. Mirrors the work IncomingMessageHandler does
+    /// on receipt but is invoked directly because Python is what surfaced
+    /// the message — there's no Swift LXMRouter callback to hook.
+    ///
+    /// Honors the `block_unknown_senders` privacy toggle (Settings →
+    /// Privacy): when enabled, drops the inbound message unless the
+    /// sender is a known + favorited contact. This must live here
+    /// because we bypass IncomingMessageHandler — Python's delivery
+    /// callback feeds straight into this method.
+    /// Persist an inbound message + return it (with its fields) so the caller can
+    /// run side-channel handling (reactions/replies/telemetry/icon/cease) through
+    /// IncomingMessageHandler. Returns nil if blocked or persistence failed.
+    @discardableResult
+    private func persistInboundFromPython(sourceHash: Data, content: String, title: String, fields: [UInt8: Any]?, timestamp: Date) async -> LXMessage? {
+        guard let database = self.database else {
+            DiagLog.log("[RNS] persistInbound: no database")
+            return nil
+        }
+        let repo = MessageRepository(database: database)
+        let sourceHashHex = sourceHash.map { String(format: "%02x", $0) }.joined()
+
+        // Privacy: block_unknown_senders drops messages from anyone the
+        // user hasn't explicitly favorited (matches the existing
+        // IncomingMessageHandler check — favorite is the "this is a
+        // real contact, not a random announce hop" signal).
+        if UserDefaults.standard.bool(forKey: "block_unknown_senders") {
+            let isKnownContact: Bool
+            do {
+                let conversation = try await database.getConversation(hash: sourceHash)
+                isKnownContact = conversation != nil && conversation!.isFavorite != 0
+            } catch {
+                // Fail open: surface the message if the DB check itself
+                // fails (better than silently dropping mail).
+                isKnownContact = true
+            }
+            if !isKnownContact {
+                DiagLog.log("[RNS] persistInbound BLOCKED source=\(sourceHashHex.prefix(8)) (block_unknown_senders enabled)")
+                return nil
+            }
+        }
+
+        let displayName = "Peer \(sourceHashHex.prefix(8))"
+
+        do {
+            try await repo.ensureConversation(sourceHash, displayName: displayName)
+
+            // Build a synthetic LXMessage so saveMessage can persist it.
+            // Hash is the SHA-256 of (sourceHashHex || content || timestamp)
+            // truncated to 32 bytes — enough to dedupe; the Python side
+            // doesn't expose the canonical message hash through the event.
+            let hashInput = (sourceHashHex + content + "\(timestamp.timeIntervalSince1970)").data(using: .utf8) ?? Data()
+            let messageHash = Data(SHA256.hash(data: hashInput))
+
+            let message = LXMessage(
+                destinationHash: sourceHash,
+                sourceIdentity: nil,
+                content: content.data(using: .utf8) ?? Data(),
+                title: title.data(using: .utf8) ?? Data(),
+                fields: fields,
+                desiredMethod: .opportunistic
+            )
+            message.sourceHash = sourceHash
+            message.hash = messageHash
+            message.incoming = true
+            message.timestamp = timestamp.timeIntervalSince1970
+            message.state = .received
+
+            try await repo.saveMessage(message)
+            DiagLog.log("[RNS] persistInbound saved msg=\(messageHash.prefix(4).map { String(format: "%02x", $0) }.joined())")
+
+            // Fire the same notification IncomingMessageHandler would post
+            // so ChatsViewModel / MessagingViewModel refresh.
+            NotificationCenter.default.post(
+                name: IncomingMessageHandler.messageReceivedNotification,
+                object: nil,
+                userInfo: ["sourceHash": sourceHash]
+            )
+            return message
+        } catch {
+            DiagLog.log("[RNS] persistInbound failed: \(error)")
+            return nil
+        }
+    }
+
+    private func handlePythonEvent(_ event: BackendEvent) async {
+        switch event {
+        case .announce(let destHash, let appDataHex, let aspect, let publicKeysHex, let interfaceName, let hops, let t):
+            guard let data = Data(hexString: destHash) else { return }
+            // The bridge forwards raw app_data; decode the display name here
+            // (aspect-specific layout knowledge lives in AppDataParser, not the
+            // bridge). `appData` is also stashed on the PathEntry so the
+            // propagation-node subsystem (PropagationNodeManager / relay badge /
+            // NodeDetailsView) can parse limits + stamp cost from it.
+            let appData = Data(hexString: appDataHex) ?? Data()
+            let displayName = AppDataParser.displayName(from: appData, aspect: aspect)
+            DiagLog.log("[RNS] announce dest=\(destHash) aspect=\(aspect) name=\"\(displayName)\" iface=\"\(interfaceName)\" hops=\(hops)")
+
+            // Insert the announce into the Compat PathTable so the Contacts
+            // tab's networkAnnounces list picks it up via the pathUpdates
+            // AsyncStream subscription in ContactsViewModel.
+            if let pathTable = self.pathTable {
+                let publicKeys = Data(hexString: publicKeysHex) ?? Data()
+                // Python tells us the receiving-interface section name —
+                // e.g. "Hub-FFB1F1" / "Bluetooth_LE-77CFC2" / "AutoInterfacePeer".
+                // Fall back to the "python-rns" sentinel only when Python
+                // couldn't determine an iface (shouldn't happen post-fix).
+                let ifaceId = interfaceName.isEmpty ? "python-rns" : interfaceName
+                let entry = PathEntry(
+                    destinationHash: data,
+                    displayName: displayName,
+                    nextHop: data,
+                    hopCount: hops,
+                    lastSeen: t,
+                    publicKeys: publicKeys,
+                    interfaceId: ifaceId,
+                    appData: appData.isEmpty ? nil : appData,
+                    expires: t.addingTimeInterval(7 * 86400),
+                    timestamp: t,
+                    detectedAspect: aspect,
+                    isLXMFPropagationNode: aspect == "lxmf.propagation",
+                    isLXSTTelephony: aspect == "lxst.telephony",
+                    isKnownDestination: true
+                )
+                await pathTable.insert(entry)
+            }
+
+            NotificationCenter.default.post(
+                name: Notification.Name("ColumbaPythonAnnounce"),
+                object: nil,
+                userInfo: [
+                    "destinationHash": data,
+                    "displayName": displayName,
+                    "aspect": aspect,
+                    "timestamp": t,
+                ]
+            )
+        case .inbound(let sourceHash, let content, let title, let fieldsPacked, let t):
+            DiagLog.log("[RNS] inbound source=\(sourceHash) content=\"\(content)\" fields=\(fieldsPacked.count)B")
+            guard let data = Data(hexString: sourceHash) else { return }
+            let fields = fieldsPacked.isEmpty ? nil : LxmfFieldCodec.unpack(fieldsPacked)
+            // Persist the base message (carrying its fields), then run side-channel
+            // handling (reactions / replies / telemetry / icon / cease) through
+            // IncomingMessageHandler — the router.delegate, wired in ColumbaApp.
+            // Same path for both backends (Python sends empty fields until its
+            // bridge plumbing lands; the Swift backend populates them now).
+            if let saved = await persistInboundFromPython(sourceHash: data, content: content, title: title, fields: fields, timestamp: t),
+               fields != nil, let router = self.router {
+                router.delegate?.router(router, didReceiveMessage: saved)
+            }
+            NotificationCenter.default.post(
+                name: Notification.Name("ColumbaPythonInbound"),
+                object: nil,
+                userInfo: [
+                    "sourceHash": data,
+                    "content": content,
+                    "title": title,
+                    "timestamp": t,
+                ]
+            )
+        case .state(let value, _):
+            DiagLog.log("[RNS] state \(value)")
+            logger.info("Python state: \(value, privacy: .public)")
+        case .delivery(let messageHash, let state, _):
+            DiagLog.log("[RNS] delivery \(messageHash.prefix(16)) state=\(state)")
+            guard let hashData = Data(hexString: messageHash) else { return }
+            let newState: LXMessageState = (state == "delivered") ? .delivered : .failed
+            if let database = self.database {
+                try? database.updateMessageState(id: hashData, state: newState)
+            }
+            // Notify the open chat so it can flip the bubble's indicator
+            // (double-check for delivered / failed) without a full reload.
+            NotificationCenter.default.post(
+                name: Notification.Name("ColumbaPythonDelivery"),
+                object: nil,
+                userInfo: [
+                    "messageHash": hashData,
+                    "state": state,
+                ]
+            )
+        case .linkState(let linkId, let state, let reason, let inbound, _):
+            DiagLog.log("[RNS] link \(linkId) state=\(state) inbound=\(inbound)\(reason.isEmpty ? "" : " reason=\(reason)")")
+            // Surface via NotificationCenter for any subscribers (debug
+            // panels, smoke tests) that aren't on the Compat-Link path.
+            NotificationCenter.default.post(
+                name: Notification.Name("ColumbaPythonLinkState"),
+                object: nil,
+                userInfo: [
+                    "linkId": linkId,
+                    "state": state,
+                    "reason": reason,
+                    "inbound": inbound,
+                ]
+            )
+            // Dispatch to the Compat Link object. lxst-swift's Telephone
+            // state machine + CallManager talk to Compat Links exclusively.
+            let id = UInt64(linkId)
+            switch state {
+            case "established":
+                if inbound {
+                    Task { await self.dispatchInboundLink(linkId: id) }
+                } else {
+                    Task { await self.dispatchOutboundLinkEstablished(linkId: id) }
+                }
+            case "closed":
+                Task { await self.dispatchLinkClosed(linkId: id, reason: reason) }
+            default:
+                break  // "establishing" et al — purely informational
+            }
+        case .linkPacket(let linkId, let data, _):
+            NotificationCenter.default.post(
+                name: Notification.Name("ColumbaPythonLinkPacket"),
+                object: nil,
+                userInfo: ["linkId": linkId, "data": data]
+            )
+            Task { await self.dispatchLinkPacket(linkId: UInt64(linkId), data: data) }
+        case .linkIdentified(let linkId, let identityHashHex, _):
+            DiagLog.log("[RNS] link \(linkId) identified=\(identityHashHex.prefix(8))")
+            NotificationCenter.default.post(
+                name: Notification.Name("ColumbaPythonLinkIdentified"),
+                object: nil,
+                userInfo: ["linkId": linkId, "identityHashHex": identityHashHex]
+            )
+            Task { await self.dispatchLinkIdentified(linkId: UInt64(linkId), identityHashHex: identityHashHex) }
+        }
     }
 
     /// Initialize all LXMF components with an externally-provided identity.
@@ -568,18 +2030,11 @@ public final class AppServices {
         await newRouter.setRatchetManager(newDestination.ratchetManager)
 
         #if os(iOS)
-        // 7b. Initialize call manager BEFORE interfaces so that autoAnnounce()
-        //     (triggered by onInterfaceAdded) can send the telephony announce.
         DiagLog.log("[INIT2] Step 7b: creating CallManager")
         let cm = CallManager()
         await cm.initialize(identity: identity, transport: newTransport, pathTable: newPathTable, database: newDatabase)
         self.callManager = cm
         DiagLog.log("[INIT2] Step 7b done, telephonyDest=\(cm.telephonyDestination?.hexHash ?? "nil")")
-        // Verify telephony destination is registered with transport
-        if let telDest = cm.telephonyDestination {
-            let isRegistered = await newTransport.isDestinationRegistered(telDest.hash)
-            DiagLog.log("[INIT2] telephony dest registered in transport: \(isRegistered)")
-        }
         #endif
 
         // 8. Parse server address and create TCP interface
@@ -691,6 +2146,15 @@ public final class AppServices {
         }
         await tunnel.load()
         #endif
+
+        // Start Python RNS backend on the multi-identity path too.
+        await startPythonBackend(
+            identity: identity,
+            identityHashHex: identityHash,
+            router: newRouter,
+            interfaces: InterfaceRepository().getEnabledInterfaces(),
+            displayName: ""
+        )
 
         DiagLog.log("[INIT2] Initialization complete (identity: \(identityHash))")
     }
@@ -961,18 +2425,26 @@ public final class AppServices {
 
     #if canImport(CoreBluetooth)
     /// Start the BLE interface for Bluetooth peer-to-peer networking.
+    ///
+    /// Phase 3 flow:
+    ///   1. Copy `IOSBLEInterface.py` + `IOSBLEDriver.py` from `<bundle>/app/ble/`
+    ///      to `<configDir>/interfaces/` so RNS's external-interface loader can
+    ///      `exec()` them when reading config.
+    ///   2. Install `PythonBLECallbackBridge` as `SwiftBLEBridge.shared`'s
+    ///      callback invoker so events fire through to Python's callback
+    ///      registry.
+    ///   3. Notify Python via `set_ble_bridge` that BLE is enabled. (Phase 3
+    ///      passes a placeholder; the C-ABI shims in `BleNativeBindings.swift`
+    ///      are how `IOSBLEDriver` actually calls into Swift.)
+    ///   4. Update Compat-layer BLEInterface stub for the UI.
     public func startBLEInterface() async throws {
         logger.info("[BLE_DIAG] startBLEInterface() called")
 
-        // Stop existing BLE interface if running
         if bleInterface != nil {
             await stopBLEInterface()
-            // Give CoreBluetooth time to release the old CBCentralManager/CBPeripheralManager
-            // before creating new ones. Without this, the new managers can see "resetting" state.
             try? await Task.sleep(for: .milliseconds(500))
         }
 
-        // Ensure base stack exists
         if transport == nil {
             logger.info("[BLE_DIAG] No transport, initializing base stack")
             try await initializeBaseStack()
@@ -986,6 +2458,20 @@ public final class AppServices {
         let identityHash = identity.hash
         logger.info("[BLE_DIAG] Identity hash: \(identityHash.map { String(format: "%02x", $0) }.joined().prefix(16), privacy: .public)")
 
+        // 1. Files deployed eagerly during startPythonBackend — see
+        //    deployIOSBLEPythonFilesIfPossible. No-op here.
+
+        // 2. Wire Swift→Python callback bridge.
+        if let backend = pythonBackend {
+            let invoker = PythonBLECallbackBridge(pythonBridge: backend.pythonBridge)
+            SwiftBLEBridge.shared.setCallbackInvoker(invoker)
+            SwiftBLEBridge.shared.setIdentity(identityHash)
+            DiagLog.log("[BLE_DIAG] PythonBLECallbackBridge installed; identity set (\(identityHash.prefix(8).map { String(format: "%02x", $0) }.joined()))")
+        } else {
+            DiagLog.log("[BLE_DIAG] WARNING: no pythonBackend yet — bridge invoker not installed")
+        }
+
+        // 3. Update the Compat BLEInterface stub so UI binding has a target.
         let config = InterfaceConfig(
             id: "ble0",
             name: "Bluetooth LE",
@@ -995,13 +2481,98 @@ public final class AppServices {
             host: "",
             port: 0
         )
-
         let driver = CoreBluetoothBLEDriver(identityHash: identityHash)
         let newBLEInterface = BLEInterface(config: config, driver: driver, transportIdentity: identityHash)
         self.bleInterface = newBLEInterface
 
         try await transport.addBLEInterface(newBLEInterface)
         logger.info("[BLE_DIAG] BLEInterface started successfully")
+    }
+
+    /// Copy `IOSBLEInterface.py` and `IOSBLEDriver.py` from `<bundle>/app/ble/`
+    /// to `<configDir>/interfaces/` so RNS's external-interface loader can find
+    /// them when reading config. Idempotent — overwrites on each call so
+    /// build-time updates ship without manual cleanup.
+    ///
+    /// Called eagerly during `startPythonBackend` (before `backend.start()`)
+    /// so the files are in place whether or not the current config has BLE
+    /// enabled. A subsequent restart with BLE-enabled config then works
+    /// without a separate deploy step.
+    private func deployIOSBLEPythonFilesIfPossible(configDir: URL) {
+        let fm = FileManager.default
+        guard let bundleAppDir = Bundle.main.url(forResource: "app", withExtension: nil) else {
+            DiagLog.log("[BLE_DIAG] app/ bundle resource missing — skipping deploy")
+            return
+        }
+        let srcDir = bundleAppDir.appendingPathComponent("ble", isDirectory: true)
+        guard fm.fileExists(atPath: srcDir.path) else {
+            DiagLog.log("[BLE_DIAG] app/ble/ missing in bundle at \(srcDir.path) — skipping deploy")
+            return
+        }
+
+        let interfacesDir = configDir.appendingPathComponent("interfaces", isDirectory: true)
+        do {
+            try fm.createDirectory(at: interfacesDir, withIntermediateDirectories: true)
+        } catch {
+            DiagLog.log("[BLE_DIAG] failed to create interfaces dir: \(error)")
+            return
+        }
+
+        for name in ["IOSBLEInterface.py", "IOSBLEDriver.py"] {
+            let src = srcDir.appendingPathComponent(name)
+            let dst = interfacesDir.appendingPathComponent(name)
+            if fm.fileExists(atPath: dst.path) {
+                try? fm.removeItem(at: dst)
+            }
+            do {
+                try fm.copyItem(at: src, to: dst)
+                DiagLog.log("[BLE_DIAG] Deployed \(name) to \(dst.path)")
+            } catch {
+                DiagLog.log("[BLE_DIAG] Failed to copy \(name): \(error)")
+            }
+        }
+    }
+
+    /// Copy `IOSRNodeInterface.py` from `<bundle>/app/rnode/` to
+    /// `<configDir>/interfaces/` so RNS's external-interface loader can `exec()`
+    /// it for a `type = IOSRNodeInterface` config section. Idempotent —
+    /// overwrites each call so build-time updates ship without manual cleanup.
+    /// Called eagerly during `startPythonBackend` (before `backend.start()`),
+    /// regardless of whether the current config has an RNode interface, so a
+    /// later RNode-enabled restart finds the file. Mirror of the BLE deploy.
+    private func deployIOSRNodePythonFilesIfPossible(configDir: URL) {
+        let fm = FileManager.default
+        guard let bundleAppDir = Bundle.main.url(forResource: "app", withExtension: nil) else {
+            DiagLog.log("[RNODE] app/ bundle resource missing — skipping deploy")
+            return
+        }
+        let srcDir = bundleAppDir.appendingPathComponent("rnode", isDirectory: true)
+        guard fm.fileExists(atPath: srcDir.path) else {
+            DiagLog.log("[RNODE] app/rnode/ missing in bundle at \(srcDir.path) — skipping deploy")
+            return
+        }
+
+        let interfacesDir = configDir.appendingPathComponent("interfaces", isDirectory: true)
+        do {
+            try fm.createDirectory(at: interfacesDir, withIntermediateDirectories: true)
+        } catch {
+            DiagLog.log("[RNODE] failed to create interfaces dir: \(error)")
+            return
+        }
+
+        for name in ["IOSRNodeInterface.py"] {
+            let src = srcDir.appendingPathComponent(name)
+            let dst = interfacesDir.appendingPathComponent(name)
+            if fm.fileExists(atPath: dst.path) {
+                try? fm.removeItem(at: dst)
+            }
+            do {
+                try fm.copyItem(at: src, to: dst)
+                DiagLog.log("[RNODE] Deployed \(name) to \(dst.path)")
+            } catch {
+                DiagLog.log("[RNODE] Failed to copy \(name): \(error)")
+            }
+        }
     }
 
     /// Stop the BLE interface.
@@ -1011,6 +2582,10 @@ public final class AppServices {
         if let transport = transport {
             await transport.removeInterface(id: ble.id)
         }
+        // Tear down the Swift bridge so a subsequent start gets a clean
+        // CBCentralManager / CBPeripheralManager pair.
+        SwiftBLEBridge.shared.stop()
+        SwiftBLEBridge.shared.setCallbackInvoker(nil)
         bleInterface = nil
         logger.info("BLEInterface stopped")
     }
@@ -1119,6 +2694,33 @@ public final class AppServices {
         logger.info("RNodeInterface stopped")
     }
 
+    /// Resolve a peer's LXST **telephony** destination hash from their LXMF
+    /// delivery hash, so the conversation/contact UI can place a voice call.
+    ///
+    /// A peer's telephony destination is a different hash than their LXMF
+    /// delivery destination, but both derive from the same identity. Recall the
+    /// identity from the path table (it carries the public keys learned from
+    /// the peer's announce) and derive `<identity>.lxst.telephony` — the same
+    /// construction CallManager uses for our own telephony destination. Returns
+    /// nil when we have no path/identity for the peer yet (they haven't been
+    /// heard, so they can't be called).
+    public func telephonyHash(forPeerLxmfHash lxmfHash: Data) async -> Data? {
+        guard let pathTable,
+              let entry = await pathTable.lookup(destinationHash: lxmfHash),
+              !entry.publicKeys.isEmpty,
+              let identity = try? Identity(publicKeyBytes: entry.publicKeys) else {
+            return nil
+        }
+        let telephony = Destination(
+            identity: identity,
+            appName: "lxst",
+            aspects: ["telephony"],
+            type: .single,
+            direction: .out
+        )
+        return telephony.hash
+    }
+
     /// Initialize the base stack (identity, transport, router) without a TCP interface.
     ///
     /// Used when starting only AutoInterface without a TCP server.
@@ -1206,11 +2808,9 @@ public final class AppServices {
         }
 
         #if os(iOS)
-        // Init call manager if needed (must be before interfaces so autoAnnounce
-        // can send telephony announce when onInterfaceAdded fires)
-        if callManager == nil, let transport = transport, let pt = pathTable, let db = database {
+        if callManager == nil, let identity = self.identity, let transport = self.transport, let pt = pathTable, let db = database {
             let cm = CallManager()
-            await cm.initialize(identity: existingIdentity, transport: transport, pathTable: pt, database: db)
+            await cm.initialize(identity: identity, transport: transport, pathTable: pt, database: db)
             self.callManager = cm
         }
         #endif
@@ -1227,15 +2827,95 @@ public final class AppServices {
 
     #if canImport(CoreBluetooth)
     /// Get snapshot of all BLE peer connection info for UI display.
+    ///
+    /// The actual peer state lives in `SwiftBLEBridge.shared` — that's the
+    /// process-wide CoreBluetooth singleton our Python `IOSBLEDriver` calls
+    /// into via ctypes. Compat's `BLEInterface.getConnectionInfos()` was a
+    /// `[]` stub, which is why BLEConnectionsView showed nothing even when
+    /// a peer was visible in Network Status. Map the bridge's
+    /// `BleConnectionDetails` → `BLEConnectionInfo` here so the dedicated
+    /// connections screen renders real peers.
     public func getBLEConnectionInfos() async -> [BLEConnectionInfo] {
-        guard let ble = bleInterface else { return [] }
-        return await ble.getConnectionInfos()
+        guard bleInterface != nil else { return [] }
+        let details = SwiftBLEBridge.shared.getConnectionDetails()
+        // Group by identity. When a peer is connected via BOTH central
+        // and peripheral roles (each direction opens its own GATT link),
+        // we get two entries with the same identity hash. Pick the
+        // peripheral entry when present (typically the established path
+        // with higher MTU), but BORROW the RSSI from the central entry
+        // since CB doesn't expose central-side RSSI to a peripheral.
+        var rep: [String: BleConnectionDetails] = [:]
+        var rssiByIdentity: [String: Int] = [:]
+        var earliestConnectedAt: [String: Date] = [:]
+        for d in details {
+            guard let id = d.identityHashHex else { continue }
+            if let r = d.rssi { rssiByIdentity[id] = r }
+            // Earliest connectedAt of all the GATT paths to this peer —
+            // closer to "when we first established with them".
+            if let existing = earliestConnectedAt[id] {
+                earliestConnectedAt[id] = min(existing, d.connectedAt)
+            } else {
+                earliestConnectedAt[id] = d.connectedAt
+            }
+            if let existing = rep[id] {
+                if d.role == .peripheral && existing.role != .peripheral {
+                    rep[id] = d
+                } else if d.mtu > existing.mtu {
+                    rep[id] = d
+                }
+            } else {
+                rep[id] = d
+            }
+        }
+        let now = Date()
+        return rep.values.map { d in
+            let idHex = d.identityHashHex ?? d.address
+            let displayName = d.identityHashHex.map { String($0.prefix(8)) }
+            // Merge: prefer the picked entry's RSSI, else the borrowed
+            // central-side value, else nil.
+            let rssi = d.rssi ?? d.identityHashHex.flatMap { rssiByIdentity[$0] }
+            let startedAt = d.identityHashHex.flatMap { earliestConnectedAt[$0] } ?? d.connectedAt
+            return BLEConnectionInfo(
+                identityHex: idHex,
+                identityHash: idHex,
+                displayName: displayName,
+                rssi: rssi,
+                connected: true,
+                lastSeen: d.lastActivity,
+                lastActivity: d.lastActivity,
+                connectionType: d.role.rawValue,
+                connectionDuration: max(0, now.timeIntervalSince(startedAt)),
+                isOutgoing: d.role == .central,
+                mtu: d.mtu,
+                bytesSent: 0,
+                bytesReceived: 0,
+                packetsSent: 0,
+                packetsReceived: 0,
+                signalQuality: signalQuality(forRssi: rssi)
+            )
+        }
+    }
+
+    /// Map RSSI dBm to a coarse signal-quality bucket. Thresholds borrowed
+    /// from the existing BLEDevicePickerSheet indicator (60/80 dBm steps).
+    private func signalQuality(forRssi rssi: Int?) -> SignalQuality {
+        guard let rssi else { return .unknown }
+        let absRssi = abs(rssi)
+        if absRssi < 60 { return .excellent }
+        if absRssi < 75 { return .good }
+        if absRssi < 90 { return .fair }
+        return .poor
     }
 
     /// Disconnect a specific BLE peer.
     public func disconnectBLEPeer(identityHex: String) async {
-        guard let ble = bleInterface else { return }
-        await ble.disconnectPeer(identityHex: identityHex)
+        // Resolve identity → address via the bridge; if found, ask the
+        // bridge to drop the GATT connection. The Compat stub's
+        // disconnectPeer was a no-op, so this is the path that actually
+        // closes the link.
+        if let address = SwiftBLEBridge.shared.getPeerAddress(identityHashHex: identityHex) {
+            SwiftBLEBridge.shared.disconnect(address: address)
+        }
     }
 
     /// Whether BLE interface is currently active.
@@ -1255,10 +2935,15 @@ public final class AppServices {
         stateObserverTask?.cancel()
         stateObserverTask = nil
 
-        #if os(iOS)
-        // Stop call manager
-        await callManager?.shutdown()
-        #endif
+        // Stop Python event drain and tear down the Python RNS stack
+        pythonEventTask?.cancel()
+        pythonEventTask = nil
+        pythonStatusPollTask?.cancel()
+        pythonStatusPollTask = nil
+        if let backend = backend {
+            await backend.stop()
+            self.backend = nil
+        }
 
         // Stop auto-announce manager
         autoAnnounceManager?.stop()
@@ -1517,34 +3202,21 @@ public final class AppServices {
     /// - Parameter displayName: Display name to broadcast (e.g., "User's Mac")
     /// - Throws: AppServicesError if transport or destination not initialized
     public func sendAnnounce(displayName: String) async throws {
-        logger.info("Sending announce with display name: \(displayName)")
+        logger.info("Sending announce with display name: \(displayName, privacy: .public)")
 
-        guard let transport = transport else {
+        // Python owns the network layer now — route the announce through
+        // rns_bridge.announce(display_name), which updates the LXMF
+        // delivery destination's app_data and calls .announce() under
+        // the embedded CPython. The pre-Python-RNS path (Compat
+        // Announce.buildPacket → transport.send) was a no-op stub.
+        guard let backend = backend else {
             throw AppServicesError.transportNotConnected
         }
-
-        guard let destination = deliveryDestination else {
-            throw AppServicesError.identityNotInitialized
+        let ok = try await backend.announce(displayName: displayName)
+        if !ok {
+            throw AppServicesError.transportNotConnected
         }
-
-        // Set the display name as app data on the destination
-        destination.appData = displayName.data(using: .utf8)
-
-        // Rotate ratchet if interval elapsed, and include in announce
-        var ratchetPub: Data? = nil
-        if let mgr = destination.ratchetManager {
-            await mgr.rotateIfNeeded()
-            ratchetPub = await mgr.currentRatchetPublicBytes()
-        }
-
-        // Create and build the announce packet
-        let announce = Announce(destination: destination, ratchet: ratchetPub)
-        let packet = try announce.buildPacket()
-
-        // Send the announce via transport
-        try await transport.send(packet: packet)
-
-        logger.info("Announce sent successfully for destination: \(destination.hexHash)")
+        DiagLog.log("[ANNOUNCE] sent via Python (name=\"\(displayName)\")")
     }
 
     /// Send both the LXMF delivery announce and the LXST telephony announce.
@@ -1568,51 +3240,19 @@ public final class AppServices {
         }
 
         #if os(iOS)
-        do {
-            try await sendTelephonyAnnounce(displayName: displayName)
-        } catch {
-            DiagLog.log("[ANNOUNCE] Telephony announce failed: \(error.localizedDescription)")
-            if firstError == nil { firstError = error }
+        if let backend = backend {
+            do {
+                let ok = try await backend.announceTelephony(displayName: displayName)
+                DiagLog.log("[ANNOUNCE] Telephony announce \(ok ? "sent" : "skipped")")
+            } catch {
+                DiagLog.log("[ANNOUNCE] Telephony announce failed: \(error.localizedDescription)")
+                if firstError == nil { firstError = error }
+            }
         }
         #endif
 
         if let firstError { throw firstError }
     }
-
-    #if os(iOS)
-    /// Send an announce for the LXST telephony destination.
-    ///
-    /// This broadcasts the device's telephony endpoint to the network, allowing
-    /// remote peers to discover our LXST destination hash and initiate voice calls.
-    /// The display name is included as application data.
-    ///
-    /// - Parameter displayName: Display name to broadcast
-    /// - Throws: AppServicesError if transport or call manager not initialized
-    private func sendTelephonyAnnounce(displayName: String) async throws {
-        guard let transport = transport else {
-            DiagLog.log("[TELEPHONY_ANNOUNCE] Skipped: transport not connected")
-            throw AppServicesError.transportNotConnected
-        }
-
-        guard let destination = callManager?.telephonyDestination else {
-            DiagLog.log("[TELEPHONY_ANNOUNCE] Skipped: CallManager not initialized (callManager=\(callManager == nil ? "nil" : "exists"))")
-            return
-        }
-
-        // Set the display name as app data on the telephony destination
-        destination.appData = displayName.data(using: .utf8)
-        DiagLog.log("[TELEPHONY_ANNOUNCE] Sending for dest \(destination.hexHash), fullName=\(destination.fullName)")
-
-        // Build and send the announce packet (no ratchet for telephony)
-        let announce = Announce(destination: destination)
-        let packet = try announce.buildPacket()
-        let packetHex = packet.encode().prefix(32).map { String(format: "%02x", $0) }.joined()
-        DiagLog.log("[TELEPHONY_ANNOUNCE] Packet first 32 bytes: \(packetHex)")
-        try await transport.send(packet: packet)
-
-        DiagLog.log("[TELEPHONY_ANNOUNCE] Sent for dest \(destination.hexHash)")
-    }
-    #endif
 
     /// Wire transport callbacks that need app-layer context.
     ///
@@ -1686,6 +3326,153 @@ public final class AppServices {
         await transport.setOnDiagnostic { msg in
             DiagLog.log(msg)
         }
+
+        // ──── Telephony link bridge hooks ────
+        //
+        // Wires the Compat-layer transport calls that CallManager + the
+        // lxst-swift Telephone make against PythonRNSBackend. Python owns
+        // the actual RNS.Link cryptography + path discovery; Swift owns the
+        // call state machine + audio. The hooks are @Sendable so they hop
+        // back to the main actor before touching AppServices state.
+
+        transport.registerDestinationLinkCallbackHook = { [weak self] destHash, callback in
+            Task { @MainActor [weak self] in
+                self?.registerDestinationLinkCallbackOnMain(destHash: destHash, callback: callback)
+            }
+        }
+
+        transport.initiateLinkHook = { [weak self] destination, _ in
+            guard let self else { throw AppServicesError.transportNotConnected }
+            return try await self.openOutboundLink(to: destination)
+        }
+    }
+
+    /// Hop-to-main-actor wrapper for the registerDestinationLinkCallback hook.
+    private func registerDestinationLinkCallbackOnMain(
+        destHash: Data,
+        callback: @escaping @Sendable (Link) async -> Void
+    ) {
+        destinationLinkCallbacks[destHash] = callback
+        DiagLog.log("[TEL_BRIDGE] registered dest-link callback for \(destHash.prefix(4).map { String(format: "%02x", $0) }.joined())")
+    }
+
+    /// Open an outbound Compat Link by asking PythonRNSBackend to open the
+    /// underlying RNS.Link, then wrap it with a Swift-side Link that
+    /// forwards bytes through the bridge. AppServices-isolated so the
+    /// initiateLinkHook stays @Sendable-safe.
+    private func openOutboundLink(to destination: Destination) async throws -> Link {
+        guard let backend = self.backend else {
+            throw AppServicesError.transportNotConnected
+        }
+        let destHex = destination.hash.toHex()
+        let aspect = ([destination.appName] + destination.aspects).joined(separator: ".")
+        let result = try await backend.openLink(destHashHex: destHex, aspect: aspect)
+        guard result.ok else {
+            throw AppServicesError.transportNotConnected
+        }
+        let linkIdRaw = UInt64(result.linkId)
+        let link = Link(identityHash: destination.identity?.hash ?? Data())
+        link.linkId = linkIdRaw
+        let backendRef = backend
+        link.sendBytesHook = { data in
+            _ = try? await backendRef.linkSend(linkId: Int(linkIdRaw), data: data)
+        }
+        link.identifyHook = {
+            try? await backendRef.linkIdentify(linkId: Int(linkIdRaw))
+        }
+        activeLinksByLinkId[linkIdRaw] = link
+        DiagLog.log("[TEL_BRIDGE] opened outbound link \(linkIdRaw) → \(destHex.prefix(8))")
+        return link
+    }
+
+    /// Map a Python link_state(closed, reason=...) value to the
+    /// TeardownReason enum lxst-swift's Telephone understands. Python emits
+    /// `RNS.Link.teardown_reason` directly — that's an int (0/1/2) so the
+    /// bridge stringifies it before crossing. Earlier code only matched the
+    /// English names, so normal hangups were silently logged as
+    /// `.networkFailure`. Mirrors `RNS.Link.TIMEOUT` (0), `INITIATOR_CLOSED`
+    /// (1), `DESTINATION_CLOSED` (2) in Reticulum/Link.py.
+    private func teardownReason(from raw: String) -> TeardownReason {
+        switch raw {
+        case "0", "timeout":                            return .timeout
+        case "1", "initiator_closed", "local_closed":   return .initiatorClosed
+        case "2", "destination_closed", "remote_closed": return .destinationClosed
+        default:                                         return .networkFailure
+        }
+    }
+
+    /// Construct (or refresh) a Compat Link for an inbound Python link.
+    ///
+    /// Python's `_on_inbound_link` only fires for the `lxst.telephony`
+    /// destination today, so this maps that event onto every registered
+    /// destination-link callback. When the rns_bridge starts carrying
+    /// other inbound aspects, the Python event will need to carry a
+    /// destination-hash field and the dispatch should switch to a single
+    /// targeted callback lookup.
+    private func dispatchInboundLink(linkId: UInt64) async {
+        if let existing = activeLinksByLinkId[linkId] {
+            existing.state = .established
+            await existing.establishedCallback?(existing)
+            return
+        }
+        let link = Link(identityHash: Data())
+        link.linkId = linkId
+        link.state = .established
+        if let backend = self.backend {
+            let backendRef = backend
+            link.sendBytesHook = { data in
+                _ = try? await backendRef.linkSend(linkId: Int(linkId), data: data)
+            }
+            link.identifyHook = {
+                try? await backendRef.linkIdentify(linkId: Int(linkId))
+            }
+        }
+        activeLinksByLinkId[linkId] = link
+        let callbacks = Array(destinationLinkCallbacks.values)
+
+        for callback in callbacks {
+            await callback(link)
+        }
+        await link.establishedCallback?(link)
+    }
+
+    /// Fire the establishedCallback when Python confirms an outbound link
+    /// finished its LRRTT handshake.
+    private func dispatchOutboundLinkEstablished(linkId: UInt64) async {
+        guard let link = activeLinksByLinkId[linkId] else { return }
+        link.state = .established
+        await link.establishedCallback?(link)
+    }
+
+    /// Drop a Compat Link record when Python tells us the link tore down.
+    private func dispatchLinkClosed(linkId: UInt64, reason: String) async {
+        let link = activeLinksByLinkId.removeValue(forKey: linkId)
+        guard let link else { return }
+        link.state = .closed
+        await link.closeCallback?(teardownReason(from: reason))
+    }
+
+    /// Forward an inbound Python link_packet → Compat Link.packetCallback.
+    private func dispatchLinkPacket(linkId: UInt64, data: Data) async {
+        guard let link = activeLinksByLinkId[linkId] else { return }
+        await link.packetCallback?(data, Packet(payload: data))
+    }
+
+    /// Forward Python link_identified → Compat Link.identifyCallbacks.
+    private func dispatchLinkIdentified(linkId: UInt64, identityHashHex: String) async {
+        guard let link = activeLinksByLinkId[linkId] else { return }
+        // Build a stub Identity carrying just the remote hash so the
+        // Telephone's caller-allowed check can compare bytes. The remote's
+        // full public keys land in the path table separately when an
+        // announce comes through; the Telephone state machine doesn't
+        // need them for the allow-list check.
+        guard let remoteHash = try? identityHashHex.hexToData() else { return }
+        let remoteIdentity = Identity(
+            hash: remoteHash,
+            publicKeys: Data(),
+            privateKeyBytes: nil
+        )
+        await link.identifyCallbacks?.remoteIdentified(remoteIdentity)
     }
 
     /// Timestamp of the last successful auto-announce (debounce duplicate triggers).

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -715,10 +715,10 @@ public final class AppServices {
 
         // Drain Python events into Columba's UI plumbing.
         pythonEventTask?.cancel()
-        let weakSelf = self
-        pythonEventTask = Task { [backend] in
+        pythonEventTask = Task { [weak self, backend] in
             for await event in backend.events {
-                await weakSelf.handlePythonEvent(event)
+                guard let self else { break }
+                await self.handlePythonEvent(event)
             }
         }
 

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -1893,12 +1893,12 @@ public final class AppServices {
             switch state {
             case "established":
                 if inbound {
-                    Task { await self.dispatchInboundLink(linkId: id) }
+                    await self.dispatchInboundLink(linkId: id)
                 } else {
-                    Task { await self.dispatchOutboundLinkEstablished(linkId: id) }
+                    await self.dispatchOutboundLinkEstablished(linkId: id)
                 }
             case "closed":
-                Task { await self.dispatchLinkClosed(linkId: id, reason: reason) }
+                await self.dispatchLinkClosed(linkId: id, reason: reason)
             default:
                 break  // "establishing" et al — purely informational
             }
@@ -1908,7 +1908,7 @@ public final class AppServices {
                 object: nil,
                 userInfo: ["linkId": linkId, "data": data]
             )
-            Task { await self.dispatchLinkPacket(linkId: UInt64(linkId), data: data) }
+            await self.dispatchLinkPacket(linkId: UInt64(linkId), data: data)
         case .linkIdentified(let linkId, let identityHashHex, _):
             DiagLog.log("[RNS] link \(linkId) identified=\(identityHashHex.prefix(8))")
             NotificationCenter.default.post(
@@ -1916,7 +1916,7 @@ public final class AppServices {
                 object: nil,
                 userInfo: ["linkId": linkId, "identityHashHex": identityHashHex]
             )
-            Task { await self.dispatchLinkIdentified(linkId: UInt64(linkId), identityHashHex: identityHashHex) }
+            await self.dispatchLinkIdentified(linkId: UInt64(linkId), identityHashHex: identityHashHex)
         }
     }
 
@@ -2904,6 +2904,13 @@ public final class AppServices {
             NotificationCenter.default.removeObserver(token)
         }
         pythonNotificationObservers.removeAll()
+        // Drop stale Compat Link records. Python assigns link IDs sequentially
+        // from 0 on each fresh backend, so without this a post-restart inbound
+        // link (id 0, 1, …) would collide with a dead entry and dispatchInbound
+        // Link would fire the established callback on the stale link instead of
+        // creating a new one — silently dropping the first call(s) after a
+        // restart cycle.
+        activeLinksByLinkId.removeAll()
         if let backend = backend {
             await backend.stop()
             self.backend = nil

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -2529,9 +2529,10 @@ public final class AppServices {
             await transport.removeInterface(id: ble.id)
         }
         // Tear down the Swift bridge so a subsequent start gets a clean
-        // CBCentralManager / CBPeripheralManager pair.
+        // CBCentralManager / CBPeripheralManager pair. stop() now clears the
+        // callbackInvoker inside its serialized queue block (to drop post-stop
+        // disconnect callbacks), so no separate setCallbackInvoker(nil) here.
         SwiftBLEBridge.shared.stop()
-        SwiftBLEBridge.shared.setCallbackInvoker(nil)
         bleInterface = nil
         logger.info("BLEInterface stopped")
     }
@@ -2843,7 +2844,7 @@ public final class AppServices {
     }
 
     /// Map RSSI dBm to a coarse signal-quality bucket. Thresholds borrowed
-    /// from the existing BLEDevicePickerSheet indicator (60/80 dBm steps).
+    /// from the existing BLEDevicePickerSheet indicator (60/75/90 dBm steps).
     private func signalQuality(forRssi rssi: Int?) -> SignalQuality {
         guard let rssi else { return .unknown }
         let absRssi = abs(rssi)

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -3390,6 +3390,9 @@ public final class AppServices {
         link.identifyHook = {
             try? await backendRef.linkIdentify(linkId: Int(linkIdRaw))
         }
+        link.closeHook = {
+            _ = try? await backendRef.linkTeardown(linkId: Int(linkIdRaw))
+        }
         activeLinksByLinkId[linkIdRaw] = link
         DiagLog.log("[TEL_BRIDGE] opened outbound link \(linkIdRaw) → \(destHex.prefix(8))")
         return link
@@ -3436,10 +3439,24 @@ public final class AppServices {
             link.identifyHook = {
                 try? await backendRef.linkIdentify(linkId: Int(linkId))
             }
+            link.closeHook = {
+                _ = try? await backendRef.linkTeardown(linkId: Int(linkId))
+            }
         }
         activeLinksByLinkId[linkId] = link
         let callbacks = Array(destinationLinkCallbacks.values)
 
+        // Python's inbound-link event carries only the linkId, not the
+        // destination hash, so we can't yet route to a single matching
+        // callback. Today only the lxst.telephony destination registers one,
+        // so the single-callback path is correct. If a second destination ever
+        // registers a link callback before the rns_bridge inbound event grows
+        // a destination-hash field, fanning every inbound link out to all of
+        // them would cross call state between destinations — surface that
+        // loudly here rather than corrupting silently.
+        if callbacks.count > 1 {
+            DiagLog.log("[TEL_BRIDGE] WARNING: \(callbacks.count) destination link callbacks registered, but the Python inbound-link event has no destination hash — cannot route link \(linkId) unambiguously (needs the rns_bridge destination-hash field; see PR1)")
+        }
         for callback in callbacks {
             await callback(link)
         }

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -768,14 +768,13 @@ public final class AppServices {
             while !Task.isCancelled {
                 try? await Task.sleep(nanoseconds: 2_000_000_000) // 2s
                 tick += 1
-                let snapshot = await backend.statusSnapshot()
-                if snapshot == nil {
+                guard let snapshot = await backend.statusSnapshot() else {
                     if tick % 5 == 0 { DiagLog.log("[RNS-POLL] tick=\(tick) snapshot=nil") }
                     continue
                 }
                 guard let self else { return }
                 let entityById = await MainActor.run { self.pythonInterfaceEntities }
-                await self.applyPythonInterfaceStatus(snapshot: snapshot!, entityById: entityById)
+                await self.applyPythonInterfaceStatus(snapshot: snapshot, entityById: entityById)
             }
             DiagLog.log("[RNS-POLL] task exiting (cancelled)")
         }
@@ -1777,7 +1776,7 @@ public final class AppServices {
             let isKnownContact: Bool
             do {
                 let conversation = try await database.getConversation(hash: sourceHash)
-                isKnownContact = conversation != nil && conversation!.isFavorite != 0
+                isKnownContact = (conversation?.isFavorite ?? 0) != 0
             } catch {
                 // Fail open: surface the message if the DB check itself
                 // fails (better than silently dropping mail).
@@ -2934,6 +2933,17 @@ public final class AppServices {
 
         stateObserverTask?.cancel()
         stateObserverTask = nil
+
+        #if os(iOS)
+        // Stop call manager: ends any active CallKit call and tears down the
+        // Telephone actor + audio session. Nil it afterwards so a later
+        // initialize() (e.g. identity-change / "Apply & Restart") recreates a
+        // fresh instance — initialize() guards creation on `callManager == nil`,
+        // and CallManager.shutdown() guts the instance (telephone/callKitManager
+        // set to nil), so reusing it would leave telephony dead.
+        await callManager?.shutdown()
+        callManager = nil
+        #endif
 
         // Stop Python event drain and tear down the Python RNS stack
         pythonEventTask?.cancel()

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -2911,6 +2911,13 @@ public final class AppServices {
         // creating a new one — silently dropping the first call(s) after a
         // restart cycle.
         activeLinksByLinkId.removeAll()
+        // Clear the rest of the per-backend session state so an identity-change
+        // restart starts clean: stale destination-link callbacks (keyed by the
+        // old identity's telephony hash) would otherwise linger and get fanned
+        // an inbound link alongside the new one, and the interface-status map
+        // would mismatch the freshly-attached interfaces.
+        destinationLinkCallbacks.removeAll()
+        pythonInterfaceEntities.removeAll()
         if let backend = backend {
             await backend.stop()
             self.backend = nil

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -177,6 +177,13 @@ public final class AppServices {
     /// messages) into Columba's existing UI plumbing.
     private var pythonEventTask: Task<Void, Never>?
 
+    /// Tokens for the block-based NotificationCenter observers registered by
+    /// `startPythonBackend()` (the lxma://test-* deep-link harness). Held so
+    /// `shutdown()` can remove them — otherwise each restart cycle
+    /// (identity-change / "Apply & Restart") would stack another set and fire
+    /// every handler N times. Register via `addPythonObserver(_:_:)`.
+    private var pythonNotificationObservers: [any NSObjectProtocol] = []
+
     /// Identity used to start the Python backend. Cached so the
     /// "Apply & Restart" flow can re-boot Python after the user edits
     /// interfaces, without making AppServices re-derive it.
@@ -604,6 +611,22 @@ public final class AppServices {
 
     // MARK: - Python backend
 
+    /// Register a block-based NotificationCenter observer and retain its token
+    /// in `pythonNotificationObservers` so `shutdown()` can remove it. Use this
+    /// for every observer added by `startPythonBackend()` — keeping the tokens
+    /// is what lets a restart cycle tear the old observers down instead of
+    /// stacking duplicates.
+    private func addPythonObserver(
+        _ name: String,
+        _ block: @escaping @Sendable (Notification) -> Void
+    ) {
+        pythonNotificationObservers.append(
+            NotificationCenter.default.addObserver(
+                forName: Notification.Name(name), object: nil, queue: .main, using: block
+            )
+        )
+    }
+
     /// Boot the embedded Python RNS stack and hook `LXMRouter.sendHook` so
     /// outbound LXMF sends go through Python. Spawns a Task that drains
     /// Python events and feeds them into Columba's path table / inbound
@@ -784,11 +807,7 @@ public final class AppServices {
         // Drives the full typed-LXMF send path the interop harness uses to
         // exercise image / file attachments end-to-end against a Sideband
         // peer (see Tests/interop/).
-        NotificationCenter.default.addObserver(
-            forName: Notification.Name("ColumbaTestSend"),
-            object: nil,
-            queue: .main
-        ) { [weak self] note in
+        addPythonObserver("ColumbaTestSend") { [weak self] note in
             guard let self else { return }
             guard let to = note.userInfo?["to"] as? String,
                   let content = note.userInfo?["content"] as? String else { return }
@@ -848,11 +867,7 @@ public final class AppServices {
         // `sendTelemetryCease` on the active backend without driving the
         // CLLocationManager / GPS permission flow that the production
         // LocationSharingManager runs through.
-        NotificationCenter.default.addObserver(
-            forName: Notification.Name("ColumbaTestTelemetry"),
-            object: nil,
-            queue: .main
-        ) { [weak self] note in
+        addPythonObserver("ColumbaTestTelemetry") { [weak self] note in
             guard let self else { return }
             guard let to = note.userInfo?["to"] as? String else { return }
             let packedHex = (note.userInfo?["packed_hex"] as? String) ?? ""
@@ -891,11 +906,7 @@ public final class AppServices {
 
         // Listen for test-restart deep link (lxma://test-restart) so
         // smoke tests can exercise the Apply & Restart path without UI.
-        NotificationCenter.default.addObserver(
-            forName: Notification.Name("ColumbaTestRestart"),
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
+        addPythonObserver("ColumbaTestRestart") { [weak self] _ in
             guard let self else { return }
             Task { @MainActor in
                 DiagLog.log("[TEST-RESTART] invoking restartPythonBackend")
@@ -907,11 +918,7 @@ public final class AppServices {
         // Phase 4 smoke test: direct CB manager state probe. Bypasses the
         // Python driver so we can isolate Swift-side CB readiness from
         // Python wiring during early-bring-up debugging.
-        NotificationCenter.default.addObserver(
-            forName: Notification.Name("ColumbaTestBLEStatus"),
-            object: nil,
-            queue: .main
-        ) { _ in
+        addPythonObserver("ColumbaTestBLEStatus") { _ in
             #if canImport(CoreBluetooth)
             let bridge = SwiftBLEBridge.shared
             let isStarted = bridge.isStarted
@@ -926,11 +933,7 @@ public final class AppServices {
         // namespace RNS uses, surface any exception to DiagLog. Helps when
         // panic_on_interface_error=no silently swallows external-iface
         // load errors so the row shows "disconnected" with no signal.
-        NotificationCenter.default.addObserver(
-            forName: Notification.Name("ColumbaTestBLEDiagnose"),
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
+        addPythonObserver("ColumbaTestBLEDiagnose") { [weak self] _ in
             guard let self else { return }
             Task { @MainActor in
                 guard let backend = self.pythonBackend else {
@@ -951,11 +954,7 @@ public final class AppServices {
 
         // Dump path-table entries so we can see what the Node Details
         // "Interface Heard" card would render without taking a screenshot.
-        NotificationCenter.default.addObserver(
-            forName: Notification.Name("ColumbaTestPathTable"),
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
+        addPythonObserver("ColumbaTestPathTable") { [weak self] _ in
             guard let self else { return }
             Task { @MainActor in
                 guard let backend = self.pythonBackend else {
@@ -974,11 +973,7 @@ public final class AppServices {
         // Diagnose AutoInterface peer discovery: introspect the live
         // AutoInterface Python object so we can see whether multicast
         // join succeeded, what interfaces are bound, peer count, etc.
-        NotificationCenter.default.addObserver(
-            forName: Notification.Name("ColumbaTestAutoDiagnose"),
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
+        addPythonObserver("ColumbaTestAutoDiagnose") { [weak self] _ in
             guard let self else { return }
             Task { @MainActor in
                 guard let backend = self.pythonBackend else {
@@ -995,11 +990,7 @@ public final class AppServices {
         }
 
         // Phase 6 smoke test: dump current connection details (Android parity).
-        NotificationCenter.default.addObserver(
-            forName: Notification.Name("ColumbaTestBLEPeerList"),
-            object: nil,
-            queue: .main
-        ) { _ in
+        addPythonObserver("ColumbaTestBLEPeerList") { _ in
             #if canImport(CoreBluetooth)
             let details = SwiftBLEBridge.shared.getConnectionDetails()
             DiagLog.log("[TEST-BLE-PEER-LIST] count=\(details.count)")
@@ -1015,11 +1006,7 @@ public final class AppServices {
         // Phase 4 smoke test: direct CB scan toggle. Drives SwiftBLEBridge
         // without going through Python, so we can validate scan start/stop
         // works before plugging in the BLEDriverInterface contract.
-        NotificationCenter.default.addObserver(
-            forName: Notification.Name("ColumbaTestBLEScan"),
-            object: nil,
-            queue: .main
-        ) { note in
+        addPythonObserver("ColumbaTestBLEScan") { note in
             #if canImport(CoreBluetooth)
             let action = (note.userInfo?["action"] as? String) ?? "start"
             let bridge = SwiftBLEBridge.shared
@@ -1045,11 +1032,7 @@ public final class AppServices {
         }
 
         // Phase 4 smoke test: direct CB advertise toggle.
-        NotificationCenter.default.addObserver(
-            forName: Notification.Name("ColumbaTestBLEAdvertise"),
-            object: nil,
-            queue: .main
-        ) { note in
+        addPythonObserver("ColumbaTestBLEAdvertise") { note in
             #if canImport(CoreBluetooth)
             let action = (note.userInfo?["action"] as? String) ?? "start"
             let name = (note.userInfo?["name"] as? String) ?? ""
@@ -1079,11 +1062,7 @@ public final class AppServices {
         // True iff its int arg is even, then invokes it through the
         // synchronous bool-return BLE callback path. PASS iff Swift
         // gets back the expected bool for both even and odd inputs.
-        NotificationCenter.default.addObserver(
-            forName: Notification.Name("ColumbaTestBLECallback"),
-            object: nil,
-            queue: .main
-        ) { [weak self] note in
+        addPythonObserver("ColumbaTestBLECallback") { [weak self] note in
             guard let self else { return }
             let value = (note.userInfo?["value"] as? Int) ?? 4
             Task { @MainActor in
@@ -1106,11 +1085,7 @@ public final class AppServices {
         }
 
         // lxma://test-answer — accept the currently-ringing call.
-        NotificationCenter.default.addObserver(
-            forName: Notification.Name("ColumbaTestAnswer"),
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
+        addPythonObserver("ColumbaTestAnswer") { [weak self] _ in
             guard let self else { return }
             Task { @MainActor in
                 #if os(iOS)
@@ -1127,11 +1102,7 @@ public final class AppServices {
         // lxma://test-call?to=HEX[&profile=...] — exercise the full call
         // pipeline: CallManager.initiateCall → Telephone.call →
         // Compat.Link.sendBytes → PythonRNSBackend.linkSend.
-        NotificationCenter.default.addObserver(
-            forName: Notification.Name("ColumbaTestCall"),
-            object: nil,
-            queue: .main
-        ) { [weak self] note in
+        addPythonObserver("ColumbaTestCall") { [weak self] note in
             guard let self else { return }
             let to = (note.userInfo?["to"] as? String) ?? ""
             let profileRaw = (note.userInfo?["profile"] as? String) ?? ""
@@ -1163,11 +1134,7 @@ public final class AppServices {
         // RNS.Link bridge by opening an outbound Link to a destination.
         // Logs the link_id + waits for link_state events to surface via
         // NotificationCenter. For commit-1 smoke testing.
-        NotificationCenter.default.addObserver(
-            forName: Notification.Name("ColumbaTestLinkOpen"),
-            object: nil,
-            queue: .main
-        ) { [weak self] note in
+        addPythonObserver("ColumbaTestLinkOpen") { [weak self] note in
             guard let self else { return }
             let to = (note.userInfo?["to"] as? String) ?? ""
             let aspect = (note.userInfo?["aspect"] as? String) ?? "lxst.telephony"
@@ -1188,11 +1155,7 @@ public final class AppServices {
         // lxma://test-inbound?from=HEX&content=... — synthesize an inbound
         // event so the privacy filter (block_unknown_senders) can be
         // verified without needing a working peer.
-        NotificationCenter.default.addObserver(
-            forName: Notification.Name("ColumbaTestInbound"),
-            object: nil,
-            queue: .main
-        ) { [weak self] note in
+        addPythonObserver("ColumbaTestInbound") { [weak self] note in
             guard let self else { return }
             let fromHex = (note.userInfo?["from"] as? String) ?? ""
             let content = (note.userInfo?["content"] as? String) ?? "synthetic"
@@ -1216,11 +1179,7 @@ public final class AppServices {
         // AppServices.switchIdentity. Logs the destination hash before
         // and after so we can verify Python actually rebooted with the
         // new keys.
-        NotificationCenter.default.addObserver(
-            forName: Notification.Name("ColumbaTestIdentitySwitch"),
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
+        addPythonObserver("ColumbaTestIdentitySwitch") { [weak self] _ in
             guard let self else { return }
             Task { @MainActor in
                 let manager = IdentityManager()
@@ -1244,11 +1203,7 @@ public final class AppServices {
 
         // lxma://test-prop-sync?node=HEX — set propagation node, kick a sync,
         // log the outcome.
-        NotificationCenter.default.addObserver(
-            forName: Notification.Name("ColumbaTestPropSync"),
-            object: nil,
-            queue: .main
-        ) { [weak self] note in
+        addPythonObserver("ColumbaTestPropSync") { [weak self] note in
             guard let self else { return }
             let node = (note.userInfo?["node"] as? String) ?? ""
             Task { @MainActor in
@@ -1270,11 +1225,7 @@ public final class AppServices {
         // lxma://test-announce?name=... — calls sendAllAnnounces with the
         // given display name (both the LXMF delivery + LXST telephony
         // destinations), logs the outcome.
-        NotificationCenter.default.addObserver(
-            forName: Notification.Name("ColumbaTestAnnounce"),
-            object: nil,
-            queue: .main
-        ) { [weak self] note in
+        addPythonObserver("ColumbaTestAnnounce") { [weak self] note in
             guard let self else { return }
             let name = (note.userInfo?["name"] as? String) ?? ""
             Task { @MainActor in
@@ -1289,11 +1240,7 @@ public final class AppServices {
 
         // lxma://test-nomad-fetch?to=HEX&path=/page/index.mu — calls
         // bridge.fetchNomadNetPage and logs the response.
-        NotificationCenter.default.addObserver(
-            forName: Notification.Name("ColumbaTestNomadFetch"),
-            object: nil,
-            queue: .main
-        ) { [weak self] note in
+        addPythonObserver("ColumbaTestNomadFetch") { [weak self] note in
             guard let self else { return }
             guard let to = note.userInfo?["to"] as? String,
                   let path = note.userInfo?["path"] as? String else { return }
@@ -2950,6 +2897,13 @@ public final class AppServices {
         pythonEventTask = nil
         pythonStatusPollTask?.cancel()
         pythonStatusPollTask = nil
+        // Remove the test-deeplink NotificationCenter observers registered in
+        // startPythonBackend(); without this they'd accumulate across restart
+        // cycles and fire each handler once per past start.
+        for token in pythonNotificationObservers {
+            NotificationCenter.default.removeObserver(token)
+        }
+        pythonNotificationObservers.removeAll()
         if let backend = backend {
             await backend.stop()
             self.backend = nil

--- a/Sources/ColumbaApp/Services/AudioManager.swift
+++ b/Sources/ColumbaApp/Services/AudioManager.swift
@@ -8,6 +8,7 @@
 //
 
 import AVFoundation
+import RNSAPI
 import LXSTSwift
 import os.log
 
@@ -63,9 +64,7 @@ public final class AudioManager {
 
     /// Called with captured PCM Float32 samples ready for codec encoding.
     /// The frame size matches `samplesPerFrame` (sampleRate * frameTimeMs / 1000).
-    ///
-    /// TODO: Wire this to Telephone.sendAudioFrame() once the codec pipeline
-    /// is connected. For now, CallManager can set this to forward frames.
+    /// CallManager sets this to forward frames to `Telephone.sendAudioFrame`.
     var onCapturedFrame: (([Float]) -> Void)?
 
     // MARK: - Private State
@@ -712,12 +711,10 @@ public final class AudioManager {
 
     /// Schedule decoded PCM samples for playback through the speaker/earpiece.
     ///
-    /// Call this when the Telephone actor delivers decoded audio frames.
-    /// Handles buffer underruns gracefully by simply skipping frames (voice
-    /// audio tolerates small gaps better than stuttering).
-    ///
-    /// TODO: Wire this to Telephone's decoded frame output once the codec
-    /// pipeline is connected. CallManager should call this with decoded PCM data.
+    /// Called by CallManager when the Telephone actor delivers decoded audio
+    /// frames (via `decodedAudioCallback`). Handles buffer underruns gracefully
+    /// by simply skipping frames (voice audio tolerates small gaps better than
+    /// stuttering).
     ///
     /// - Parameter samples: Float32 PCM samples at the configured sample rate
     private var playCount: Int = 0

--- a/Sources/ColumbaApp/Services/AutoAnnounceManager.swift
+++ b/Sources/ColumbaApp/Services/AutoAnnounceManager.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import RNSAPI
 import os.log
 
 /// Manages automatic periodic announces based on user settings.

--- a/Sources/ColumbaApp/Services/BackendFactory.swift
+++ b/Sources/ColumbaApp/Services/BackendFactory.swift
@@ -1,0 +1,31 @@
+import Foundation
+import RNSAPI
+
+/// Constructs the active RNS backend. **Runtime-selected** via
+/// `BackendPreference` (persisted, App-Group-backed): the embedded-Python
+/// reference stack (`PythonRNSBackend`) or the native reticulum-swift/LXMF-swift
+/// port (`SwiftRNSBackend`). Both are compiled and linked into every build, so
+/// the Settings → Advanced → Network Backend control picks between them at
+/// runtime; the `COLUMBA_BACKEND_SWIFT` build flag only sets the first-launch
+/// default (see `BackendPreference.buildDefaultIsSwift`).
+///
+/// The rest of the app depends only on `any RnsBackend`, so swapping backends
+/// never touches the UI or `AppServices`. The selection is read once here at
+/// stack-init; changing it takes effect on the next app launch.
+@available(iOS 17.0, macOS 14.0, *)
+enum BackendFactory {
+    static func make() -> any RnsBackend {
+        // One unambiguous line stating which RNS engine is live this launch.
+        // Every other backend log is prefixed `[RNS]` (engine-neutral, since
+        // AppServices drives either backend through `any RnsBackend`), so grep
+        // `[BACKEND]` to know which engine those lines came from. `pref` is the
+        // raw stored value so a toggle-not-applying issue is visible here too.
+        let isSwift = BackendPreference.isSwift
+        DiagLog.log("[BACKEND] active=\(isSwift ? "swift" : "python") " +
+            "(pref=\(String(describing: SharedDefaults.suite.object(forKey: "useSwiftBackend"))))")
+        if isSwift {
+            return SwiftRNSBackend()
+        }
+        return PythonRNSBackend()
+    }
+}

--- a/Sources/ColumbaApp/Services/BackendPreference.swift
+++ b/Sources/ColumbaApp/Services/BackendPreference.swift
@@ -1,0 +1,61 @@
+//
+//  BackendPreference.swift
+//  ColumbaApp
+//
+//  Runtime selection of the active RNS backend.
+//
+
+import Foundation
+
+/// Persisted choice of which RNS engine `BackendFactory.make()` constructs:
+/// the embedded-Python reference stack (`PythonRNSBackend`) or the native
+/// Swift reticulum-swift/LXMF-swift port (`SwiftRNSBackend`). Both are compiled
+/// and linked into every build, so this is a pure runtime switch — the
+/// Settings → Advanced → Network Backend control writes it, `BackendFactory`
+/// reads it at stack-init time.
+///
+/// The switch takes effect on the **next app launch**: the backend is built
+/// exactly once during `AppServices.initialize`, and neither the embedded
+/// CPython interpreter (a process-global singleton) nor the Swift RNS stack
+/// can be torn down and rebuilt in place reliably on iOS — the same constraint
+/// that makes `restartPythonBackend()` defer to relaunch rather than restart
+/// the interpreter live.
+///
+/// Stored in the App Group suite (`SharedDefaults`) so it survives relaunch and
+/// is visible to the Network Extension, mirroring `transport_enabled`.
+enum BackendPreference {
+    private static let key = "useSwiftBackend"
+
+    /// Default when the user has never chosen explicitly. The `Columba-Swift`
+    /// scheme (`COLUMBA_BACKEND_SWIFT`) starts on the Swift backend; the stock
+    /// scheme starts on embedded Python.
+    static var buildDefaultIsSwift: Bool {
+        #if COLUMBA_BACKEND_SWIFT
+        return true
+        #else
+        return false
+        #endif
+    }
+
+    /// Whether the native Swift backend is selected (vs embedded Python).
+    /// Falls back to the build-flag default until the user picks explicitly.
+    static var isSwift: Bool {
+        get {
+            #if COLUMBA_BACKEND_SWIFT
+            // Swift-only build: the embedded Python wheels are stripped at
+            // build time, so Python can't run. Force Swift regardless of any
+            // stored pref — a `useSwiftBackend=false` value can linger in the
+            // shared App Group suite from a prior standard build, and honoring
+            // it here would build PythonRNSBackend and hang on start(). The
+            // Settings toggle is also hidden on this build (see SettingsView).
+            return true
+            #else
+            guard let stored = SharedDefaults.suite.object(forKey: key) as? Bool else {
+                return buildDefaultIsSwift
+            }
+            return stored
+            #endif
+        }
+        set { SharedDefaults.suite.set(newValue, forKey: key) }
+    }
+}

--- a/Sources/ColumbaApp/Services/CallKitManager.swift
+++ b/Sources/ColumbaApp/Services/CallKitManager.swift
@@ -10,6 +10,7 @@
 //
 
 import Foundation
+import RNSAPI
 import os.log
 
 #if os(iOS)

--- a/Sources/ColumbaApp/Services/CallManager.swift
+++ b/Sources/ColumbaApp/Services/CallManager.swift
@@ -437,6 +437,10 @@ public final class CallManager {
         DiagLog.log("[CALL] handleCallKitReset() triggered")
         logger.info("CallKit provider reset — cleaning up call state")
         stopAudio()
+        // Cancel ringback and clear ringbackActive — otherwise a reset during a
+        // ringing outgoing call leaves the flag set and startRingback()'s
+        // `guard !ringbackActive` suppresses ringback on every later call.
+        stopRingback()
         stopDurationTimer()
         endedDismissTask?.cancel()
         currentCallUUID = nil
@@ -895,6 +899,7 @@ public final class CallManager {
     }
 
     private func resetState() {
+        stopRingback()  // clear ringbackActive so a later call's ringback isn't suppressed
         callState = .idle
         isMuted = false
         isSpeakerOn = false

--- a/Sources/ColumbaApp/Services/CallManager.swift
+++ b/Sources/ColumbaApp/Services/CallManager.swift
@@ -8,9 +8,9 @@
 
 import AVFoundation
 import Foundation
-import LXMFSwift
+import RNSAPI
 import LXSTSwift
-import ReticulumSwift
+import RNSAPI
 import os.log
 
 #if os(iOS)
@@ -95,6 +95,9 @@ public final class CallManager {
     private var database: LXMFDatabase?
     private var durationTask: Task<Void, Never>?
     private var endedDismissTask: Task<Void, Never>?
+    /// Caller-side ring-back cadence loop (runs while the callee's phone rings).
+    private var ringbackTask: Task<Void, Never>?
+    private var ringbackActive = false
     private let logger = Logger(subsystem: "network.columba.Columba", category: "CallManager")
 
     // MARK: - Initialization
@@ -109,8 +112,31 @@ public final class CallManager {
         self.pathTable = pathTable
         self.transport = transport
         self.database = database
-        let phone = await Telephone(identity: identity, transport: transport)
+        // Build the LXST network transport over the Compat RNS layer, then the
+        // transport-agnostic Telephone on top of it. The transport owns
+        // identity, telephony-destination registration, link lifecycle,
+        // encryption, packetization, identify, and incoming-link detection.
+        let networkTransport = PythonNetworkTransport(identity: identity, transport: transport, pathTable: pathTable)
+        await networkTransport.start()
+        let phone = await Telephone.make(transport: networkTransport)
         self.telephone = phone
+
+        // Cache the telephony destination for announcing (peers need this hash
+        // to call us). The transport registers it internally; this mirror is
+        // just for display / the announce path.
+        self.telephonyDestination = Destination(
+            identity: identity,
+            appName: "lxst",
+            aspects: ["telephony"],
+            type: .single,
+            direction: .in
+        )
+
+        // Prepare the CallKit UUID as soon as an inbound link establishes
+        // (pre-identify), mirroring the old handleIncomingLink → prepare timing.
+        await networkTransport.setIncomingCallStartedHandler { [weak self] in
+            await MainActor.run { self?.prepareForIncomingCall() }
+        }
 
         // Wire diagnostic logging
         await phone.setDiagnostic { msg in DiagLog.log(msg) }
@@ -136,45 +162,29 @@ public final class CallManager {
             }
         }
 
-        // Register destination link callback with transport so incoming links
-        // to the LXST telephony destination are routed to our Telephone actor.
-        // Without this, the transport accepts LINKREQUESTs and establishes links
-        // but never notifies the Telephone about them.
-        let telephonyDest = await phone.destination
-        self.telephonyDestination = telephonyDest
-        let telephonyDestHash = telephonyDest.hash
-        let hexPrefix = telephonyDestHash.prefix(8).map { String(format: "%02x", $0) }.joined()
-        logger.error("[CALL] Registering LXST link callback for dest \(hexPrefix, privacy: .public)")
+        // Incoming-link detection now lives in PythonNetworkTransport, which
+        // registers the telephony destination and routes an established inbound
+        // link to Telephone (via the NetworkTransport seam) + to CallManager
+        // (via the incoming-call-started hook wired above).
 
-        await transport.registerDestinationLinkCallback(for: telephonyDestHash) { [weak self] (link: Link) async in
-            guard let self else { return }
-            // This callback fires BEFORE the link is fully established (pre-LRRTT).
-            // Only configure the link here — do NOT send data (no encryption keys yet).
-            // Set the link established callback to handle the incoming call once
-            // the link is active and we can safely send AVAILABLE/RINGING signals.
-            await link.setLinkEstablishedCallback { [weak self] (establishedLink: Link) async in
-                guard let self else { return }
-                await MainActor.run {
-                    self.handleIncomingLink(establishedLink)
-                }
-            }
-        }
-
-        await phone.setRingingCallback { [weak self] remoteIdentity in
+        await phone.setRingingCallback { [weak self] remoteHash in
             await MainActor.run {
-                self?.handleCallerIdentified(remoteIdentity)
+                self?.handleCallerIdentified(remoteHash)
             }
         }
 
-        await phone.setEstablishedCallback { [weak self] remoteIdentity in
+        await phone.setEstablishedCallback { [weak self] remoteHash in
             await MainActor.run {
                 guard let self else { return }
                 DiagLog.log("[CALL] establishedCallback fired, isIncoming=\(self.isIncoming), profile=\(self.activeProfile.displayName)")
                 self.callState = .established
                 self.startDurationTimer()
+                #if os(iOS)
+                self.stopRingback()  // hand off the tone engine to the call audio
+                #endif
                 self.startAudio()
                 DiagLog.log("[CALL] startAudio() done, audioManager=\(self.audioManager != nil)")
-                self.logger.error("[CALL] Established with: \(remoteIdentity.hexHash, privacy: .public)")
+                self.logger.error("[CALL] Established with: \(remoteHash.toHex(), privacy: .public)")
 
                 // Report call connected to CallKit (outgoing calls ONLY).
                 // For incoming calls, CallKit already considers the call connected
@@ -188,11 +198,13 @@ public final class CallManager {
             }
         }
 
-        await phone.setEndedCallback { [weak self] remoteIdentity, reason in
+        await phone.setEndedCallback { [weak self] _, reason in
             await MainActor.run {
                 guard let self else { return }
-                self.stopAudio()
                 self.stopDurationTimer()
+                #if os(iOS)
+                self.stopRingback()  // stop ring-back if the call ended while ringing
+                #endif
                 let reasonText: String
                 switch reason {
                 case .localHangup: reasonText = "Call Ended"
@@ -209,6 +221,19 @@ public final class CallManager {
                     self.callState = .ended(reasonText)
                 }
                 self.logger.error("[CALL] Ended: \(reasonText, privacy: .public)")
+
+                // Busy: play the caller-side busy tone before tearing down,
+                // mirroring Python LXST __play_busy_tone. playBusyTone handles
+                // the rest of teardown (stopAudio + CallKit ended + reset) once
+                // the tone finishes; returns false if it couldn't bring up
+                // output (then fall through to immediate teardown).
+                #if os(iOS)
+                if reason == .busy, self.playBusyTone() {
+                    return
+                }
+                #endif
+
+                self.stopAudio()
 
                 // Report call ended to CallKit
                 #if os(iOS)
@@ -269,25 +294,12 @@ public final class CallManager {
 
         Task {
             do {
-                // We need the remote identity to call. Look it up from the path table
-                // by resolving the destination hash to a known identity.
+                // The transport resolves the delivery hash → identity →
+                // telephony destination and establishes the link; if the peer
+                // isn't reachable, call() throws and we surface "Call Failed".
                 let destHex = destinationHash.map { String(format: "%02x", $0) }.joined()
-                self.logger.error("[CALL] resolveIdentity for dest \(destHex, privacy: .public)")
-                guard let remoteIdentity = await resolveIdentity(for: destinationHash) else {
-                    self.logger.error("[CALL] resolveIdentity FAILED — peer not in path table")
-                    await MainActor.run {
-                        self.callState = .ended("Peer not found")
-                        self.endedDismissTask?.cancel()
-                        self.endedDismissTask = Task { @MainActor [weak self] in
-                            try? await Task.sleep(for: .seconds(1.5))
-                            guard !Task.isCancelled else { return }
-                            self?.resetState()
-                        }
-                    }
-                    return
-                }
-                self.logger.error("[CALL] resolveIdentity OK, calling Telephone.call()")
-                try await telephone.call(remoteIdentity: remoteIdentity, profile: profile)
+                self.logger.error("[CALL] calling Telephone.call() for dest \(destHex, privacy: .public)")
+                try await telephone.call(destinationHash: destinationHash, profile: profile)
             } catch {
                 await MainActor.run {
                     self.callState = .ended("Call Failed")
@@ -447,18 +459,10 @@ public final class CallManager {
     /// identification completes (see `handleCallerIdentified`), so
     /// scanners / probes / aborted dials that open a link without
     /// identifying don't surface as phantom "Unknown" calls.
-    func handleIncomingLink(_ link: Link) {
-        guard let telephone else {
-            DiagLog.log("[CALL] handleIncomingLink: telephone is nil!")
-            return
-        }
-        DiagLog.log("[CALL] handleIncomingLink: starting incoming call setup (deferring CallKit until caller identifies)")
-        prepareForIncomingCall()
-
-        Task {
-            await telephone.handleIncomingLink(link)
-        }
-    }
+    // Incoming-link detection moved to PythonNetworkTransport. It fires
+    // `setIncomingCallStartedHandler` → `prepareForIncomingCall()` (below) when
+    // an inbound link establishes, and drives Telephone via the NetworkTransport
+    // seam. (Was `handleIncomingLink(_ link: Link)`.)
 
     /// Reset call state for an incoming link before the caller identifies.
     ///
@@ -493,7 +497,7 @@ public final class CallManager {
     ///
     /// Outgoing calls reach this with `isIncoming == false` and report
     /// the connecting state via `reportOutgoingCall`.
-    func handleCallerIdentified(_ remoteIdentity: Identity) {
+    func handleCallerIdentified(_ remoteDeliveryHash: Data) {
         // Bail BEFORE mutating call state if the call was reset between
         // prepareForIncomingCall (or the outgoing-call setup) and
         // identify completing — e.g. an abort or remote hangup raced
@@ -507,12 +511,12 @@ public final class CallManager {
             return
         }
 
-        self.peerHash = remoteIdentity.hexHash
+        self.peerHash = remoteDeliveryHash.toHex()
         self.callState = .ringing
-        self.logger.error("[CALL] Ringing from: \(remoteIdentity.hexHash, privacy: .public)")
+        self.logger.error("[CALL] Ringing from: \(remoteDeliveryHash.toHex(), privacy: .public)")
 
         if self.isIncoming {
-            self.resolveContactName(remoteIdentity: remoteIdentity)
+            self.resolveContactName(deliveryHash: remoteDeliveryHash)
             // Surface the incoming call to the system now that the caller
             // is verified. `resolveContactName` has populated `peerName`
             // synchronously with the `"Peer XXXXXXXX"` truncated-hash
@@ -529,10 +533,27 @@ public final class CallManager {
                 }
             }
             #endif
+            // Sim-to-sim smoke-test escape hatch: when the
+            // `COLUMBA_AUTO_ANSWER=1` env var is set, auto-answer the
+            // incoming call as soon as the caller is verified, so the
+            // commit-5 audio round-trip test can drive past RINGING
+            // without needing the simulator window to be foregrounded
+            // (sim2 is usually backgrounded behind sim1 during the test,
+            // and `simctl openurl` only delivers URLs to the frontmost
+            // simulator).
+            if ProcessInfo.processInfo.environment["COLUMBA_AUTO_ANSWER"] == "1" {
+                self.logger.error("[CALL] COLUMBA_AUTO_ANSWER=1 — auto-answering")
+                Task { @MainActor [weak self] in
+                    try? await Task.sleep(for: .milliseconds(200))
+                    self?.answerCall()
+                }
+            }
         } else {
-            // Outgoing call: report connecting state to CallKit
+            // Outgoing call: report connecting state to CallKit, and play the
+            // caller-side ring-back tone while the callee's phone rings.
             #if os(iOS)
             self.callKitManager?.reportOutgoingCall(uuid: uuid)
+            self.startRingback()
             #endif
         }
     }
@@ -636,11 +657,29 @@ public final class CallManager {
         }
 
         #if os(iOS)
-        if audioSessionActivatedByCallKit {
-            // Session already active (outgoing calls, or rare fast incoming activation).
-            // Start engine immediately — mic will work.
+        // Smoke-test escape hatch: when COLUMBA_AUTO_ANSWER=1 the test
+        // bypasses CallKit's CXAnswerCallAction flow (the env var path
+        // calls answerCall() directly without going through CallKit's
+        // provider). Without that, CallKit never fires
+        // `didActivateAudioSession` and the engine would defer forever.
+        // For the sim↔iPhone audio test, start the engine immediately
+        // and let AudioManager configure/activate AVAudioSession itself.
+        //
+        // Simulator carve-out: the iOS Simulator's AVAudioEngine input
+        // node has no real hardware behind it (sample rate reports 0Hz)
+        // so `installTap` throws an uncaught Obj-C exception and the
+        // whole app crashes. The sim never needs to capture mic for the
+        // smoke test (it's always the callee receiving frames), so we
+        // keep the deferred path there — playback works regardless of
+        // whether the engine actually started.
+        #if targetEnvironment(simulator)
+        let bypassCallKit = false
+        #else
+        let bypassCallKit = ProcessInfo.processInfo.environment["COLUMBA_AUTO_ANSWER"] == "1"
+        #endif
+        if audioSessionActivatedByCallKit || bypassCallKit {
             manager.start(speakerEnabled: isSpeakerOn)
-            DiagLog.log("[AUDIO] startAudio() engine started immediately (session already active)")
+            DiagLog.log("[AUDIO] startAudio() engine started immediately (session active=\(audioSessionActivatedByCallKit) bypass=\(bypassCallKit))")
         } else {
             // Incoming call: CallKit hasn't activated the session yet.
             // Defer engine start to handleAudioSessionActivated().
@@ -662,14 +701,140 @@ public final class CallManager {
         logger.info("Audio pipeline stopped")
     }
 
+    #if os(iOS)
+    /// LXST busy-tone duration + frequency (mirrors Python LXST: 4.25 s of
+    /// 0.25 s-on / 0.25 s-off at the 382 Hz dial-tone frequency).
+    private static let busyToneSeconds: Double = 4.25
+
+    /// Play the caller-side busy tone, then finish teardown. Returns false if
+    /// audio output couldn't be brought up (caller falls back to immediate
+    /// teardown). Only meaningful for an outgoing call (busy is received by the
+    /// caller); needs the CallKit audio session active — which it normally is
+    /// by the time an outbound link is up.
+    ///
+    /// Mirrors LXST `__play_busy_tone`, adapted to our split where audio output
+    /// lives in AudioManager. NOTE: `reportCallEnded` deactivates the audio
+    /// session, so it is deliberately deferred until after the tone.
+    /// Bring up output-only audio for call-progress tones (busy / ring-back) on
+    /// a call that hasn't reached the established/startAudio path. Gated on the
+    /// CallKit audio session being active (it normally is for an outgoing call
+    /// by the time signalling arrives). Returns the manager, or nil if output
+    /// can't be started.
+    private func ensureToneOutput() -> AudioManager? {
+        guard audioSessionActivatedByCallKit else { return nil }
+        if audioManager == nil {
+            let manager = AudioManager(profile: activeProfile)
+            self.audioManager = manager
+            manager.start(speakerEnabled: isSpeakerOn)
+        }
+        return audioManager
+    }
+
+    @discardableResult
+    private func playBusyTone() -> Bool {
+        guard let manager = ensureToneOutput() else { return false }
+
+        let samples = Self.busyTonePCM(sampleRate: manager.sampleRate, channels: manager.channels)
+        manager.playDecodedAudio(samples)
+        logger.error("[CALL] Playing busy tone (\(Self.busyToneSeconds, privacy: .public)s)")
+
+        // Finish teardown once the tone has played out.
+        endedDismissTask?.cancel()
+        endedDismissTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(Self.busyToneSeconds + 0.4))
+            guard !Task.isCancelled, let self else { return }
+            self.stopAudio()
+            if let uuid = self.currentCallUUID {
+                self.callKitManager?.reportCallEnded(uuid: uuid, reason: .failed)
+            }
+            self.resetState()
+        }
+        return true
+    }
+
+    /// Generate the busy-tone PCM: a 382 Hz sine gated 0.25 s on / 0.25 s off
+    /// for `busyToneSeconds`, interleaved across `channels` at `sampleRate`
+    /// (matching what AudioManager.playDecodedAudio expects).
+    private static func busyTonePCM(sampleRate: Double, channels: Int) -> [Float] {
+        let frequency = TelephonyConstants.dialToneFrequency
+        let frames = Int(sampleRate * busyToneSeconds)
+        let ch = max(channels, 1)
+        let window = 0.5          // 0.5 s beep cycle
+        let onThreshold = 0.25    // on for the second half of each cycle
+        let gain: Float = 0.2
+        let twoPiF = 2.0 * Double.pi * frequency
+        var out = [Float](repeating: 0, count: frames * ch)
+        for f in 0..<frames {
+            let t = Double(f) / sampleRate
+            let inWindow = t.truncatingRemainder(dividingBy: window)
+            let sample: Float = inWindow > onThreshold ? gain * Float(sin(twoPiF * t)) : 0
+            for c in 0..<ch { out[f * ch + c] = sample }
+        }
+        return out
+    }
+
+    /// Start the caller-side ring-back tone (the "ringing" the caller hears
+    /// while the callee's phone rings). Mirrors LXST `__activate_dial_tone`:
+    /// 382 Hz, ~2 s on / ~5 s off (7 s cadence), looping until the call is
+    /// answered or ends. CallKit does NOT provide ring-back for outgoing VoIP
+    /// calls, so we render it. Caller-side only (the callee's ring is CallKit's
+    /// system ringtone).
+    private func startRingback() {
+        guard !isIncoming, !ringbackActive else { return }
+        guard let manager = ensureToneOutput() else { return }
+        ringbackActive = true
+        let tone = Self.ringbackTonePCM(sampleRate: manager.sampleRate, channels: manager.channels)
+        logger.error("[CALL] Starting ring-back tone")
+        ringbackTask?.cancel()
+        ringbackTask = Task { @MainActor [weak self] in
+            // 7 s cadence: schedule the 2 s tone, then idle (silence) for the
+            // remainder before scheduling the next burst.
+            while !Task.isCancelled {
+                guard let self, self.ringbackActive else { return }
+                self.audioManager?.playDecodedAudio(tone)
+                try? await Task.sleep(for: .seconds(7))
+            }
+        }
+    }
+
+    /// Stop the ring-back loop. Tears down the tone-only output engine so the
+    /// established path recreates it fresh with the negotiated profile + mic
+    /// capture (startAudio early-returns if a manager already exists).
+    private func stopRingback() {
+        ringbackTask?.cancel()
+        ringbackTask = nil
+        if ringbackActive {
+            ringbackActive = false
+            stopAudio()
+        }
+    }
+
+    /// Generate one 2 s ring-back burst: a 382 Hz sine with 10 ms fade in/out
+    /// (to avoid clicks), interleaved across `channels` at `sampleRate`.
+    private static func ringbackTonePCM(sampleRate: Double, channels: Int) -> [Float] {
+        let frequency = TelephonyConstants.dialToneFrequency
+        let onSeconds = 2.0
+        let frames = Int(sampleRate * onSeconds)
+        let ch = max(channels, 1)
+        let gain: Float = 0.12
+        let twoPiF = 2.0 * Double.pi * frequency
+        let fade = max(Int(sampleRate * 0.01), 1)  // 10 ms ramp
+        var out = [Float](repeating: 0, count: frames * ch)
+        for f in 0..<frames {
+            var env: Float = 1
+            if f < fade { env = Float(f) / Float(fade) }
+            else if f >= frames - fade { env = Float(frames - 1 - f) / Float(fade) }
+            let sample = gain * env * Float(sin(twoPiF * Double(f) / sampleRate))
+            for c in 0..<ch { out[f * ch + c] = sample }
+        }
+        return out
+    }
+    #endif
+
     /// Feed decoded PCM audio from the remote peer for playback.
     ///
-    /// Called by the Telephone actor (via callback) when decoded audio frames
-    /// arrive from the network. Schedules samples for immediate playback.
-    ///
-    /// TODO: Wire this to Telephone's decoded frame output once the codec
-    /// pipeline delivers frames. The Telephone actor should call:
-    ///   await callManager.playReceivedAudio(decodedSamples)
+    /// Wired from `Telephone.setDecodedAudioCallback` — fires when decoded audio
+    /// frames arrive from the network. Schedules samples for immediate playback.
     ///
     /// - Parameter samples: Float32 PCM samples at the profile's sample rate
     private var playReceivedCount = 0
@@ -748,20 +913,18 @@ public final class CallManager {
     /// 3. Truncated hex hash fallback
     ///
     /// Updates CallKit with the resolved name if available.
-    private func resolveContactName(remoteIdentity: Identity) {
-        // Compute the LXMF delivery destination hash for this identity
-        // (conversations and path entries are keyed by this hash, not the raw identity hash)
-        let deliveryHash = Destination.hash(
-            identity: remoteIdentity,
-            appName: "lxmf",
-            aspects: ["delivery"]
-        )
+    private func resolveContactName(deliveryHash: Data) {
+        // `deliveryHash` is the peer's lxmf.delivery destination hash — the key
+        // conversations and path entries are stored under. (The transport
+        // computed it from the verified caller identity.)
 
         // 1. Try conversation display name from database, then path table announce name
         Task {
-            // Database lookup (actor-isolated)
+            // Database lookup (actor-isolated). `displayName` is a non-optional
+            // String in the Compat layer; empty string is the "no name" sentinel.
             if let record = try? await database?.getConversation(hash: deliveryHash),
-               let name = record.displayName, !name.isEmpty {
+               !record.displayName.isEmpty {
+                let name = record.displayName
                 await MainActor.run {
                     if self.peerName == nil || self.peerName?.hasPrefix("Peer ") == true {
                         self.peerName = name
@@ -775,9 +938,10 @@ public final class CallManager {
                 return
             }
 
-            // 2. Try path table announce name
+            // 2. Try path table announce name (non-optional String, empty == none).
             if let entry = await pathTable?.lookup(destinationHash: deliveryHash),
-               let name = entry.displayName, !name.isEmpty {
+               !entry.displayName.isEmpty {
+                let name = entry.displayName
                 await MainActor.run {
                     if self.peerName == nil || self.peerName?.hasPrefix("Peer ") == true {
                         self.peerName = name
@@ -793,7 +957,7 @@ public final class CallManager {
 
         // 3. Fallback: truncated hash
         if self.peerName == nil {
-            let hexPrefix = remoteIdentity.hexHash.prefix(8).uppercased()
+            let hexPrefix = deliveryHash.toHex().prefix(8).uppercased()
             self.peerName = "Peer " + hexPrefix
         }
 
@@ -806,16 +970,9 @@ public final class CallManager {
         // real display name (by which time the UUID is registered).
     }
 
-    /// Resolve a destination hash to a known Identity via the path table.
-    ///
-    /// Looks up the public keys stored from the peer's announce in the path table,
-    /// then constructs a public-key-only Identity from them.
-    private func resolveIdentity(for destinationHash: Data) async -> Identity? {
-        guard let pathTable else { return nil }
-        guard let entry = await pathTable.lookup(destinationHash: destinationHash) else { return nil }
-        guard entry.publicKeys.count == 64 else { return nil }
-        return try? Identity(publicKeyBytes: entry.publicKeys)
-    }
+    // Identity resolution (delivery hash → public-key Identity) moved into
+    // PythonNetworkTransport.openOutboundCall, where the telephony destination
+    // and link are built.
 
     /// Format call duration as mm:ss.
     var formattedDuration: String {

--- a/Sources/ColumbaApp/Services/CallManager.swift
+++ b/Sources/ColumbaApp/Services/CallManager.swift
@@ -541,6 +541,7 @@ public final class CallManager {
             // (sim2 is usually backgrounded behind sim1 during the test,
             // and `simctl openurl` only delivers URLs to the frontmost
             // simulator).
+            #if DEBUG
             if ProcessInfo.processInfo.environment["COLUMBA_AUTO_ANSWER"] == "1" {
                 self.logger.error("[CALL] COLUMBA_AUTO_ANSWER=1 — auto-answering")
                 Task { @MainActor [weak self] in
@@ -548,6 +549,7 @@ public final class CallManager {
                     self?.answerCall()
                 }
             }
+            #endif
         } else {
             // Outgoing call: report connecting state to CallKit, and play the
             // caller-side ring-back tone while the callee's phone rings.
@@ -672,10 +674,14 @@ public final class CallManager {
         // smoke test (it's always the callee receiving frames), so we
         // keep the deferred path there — playback works regardless of
         // whether the engine actually started.
-        #if targetEnvironment(simulator)
-        let bypassCallKit = false
-        #else
+        // Real-device DEBUG only: the COLUMBA_AUTO_ANSWER test hook starts the
+        // audio engine outside CallKit's session lifecycle, so it must never
+        // ship; the simulator always defers (no real mic hardware). Both
+        // simulator and release builds therefore force bypassCallKit false.
+        #if DEBUG && !targetEnvironment(simulator)
         let bypassCallKit = ProcessInfo.processInfo.environment["COLUMBA_AUTO_ANSWER"] == "1"
+        #else
+        let bypassCallKit = false
         #endif
         if audioSessionActivatedByCallKit || bypassCallKit {
             manager.start(speakerEnabled: isSpeakerOn)

--- a/Sources/ColumbaApp/Services/CallManager.swift
+++ b/Sources/ColumbaApp/Services/CallManager.swift
@@ -429,6 +429,18 @@ public final class CallManager {
             // Already running — restart capture in case session changed
             manager.handleAudioSessionActivated()
         }
+
+        // Outgoing ringback may have been requested before CallKit activated
+        // the audio session: handleCallerIdentified -> startRingback ->
+        // ensureToneOutput returns nil while the session is inactive, so
+        // ringbackActive stays false and the caller hears silence. Now that
+        // the session is live, start it. startRingback() re-guards on
+        // !isIncoming/!ringbackActive, and we gate on .ringing so we never
+        // (re)start a tone after the call has connected or ended.
+        if !isIncoming, callState == .ringing, !ringbackActive {
+            DiagLog.log("[AUDIO] Session active while outgoing call ringing — starting deferred ringback")
+            startRingback()
+        }
     }
 
     /// Called by CallKitManager when the provider is reset (e.g., system

--- a/Sources/ColumbaApp/Services/CeaseTelemetry.swift
+++ b/Sources/ColumbaApp/Services/CeaseTelemetry.swift
@@ -1,0 +1,48 @@
+//
+//  CeaseTelemetry.swift
+//  ColumbaApp
+//
+//  Builds the Android-compatible "stop sharing" (cease) telemetry payload.
+//
+//  A cease is NOT a bespoke wire message — it's an ordinary location-telemetry
+//  send whose Telemeter body is zeroed and which carries Columba's
+//  `FIELD_CUSTOM_META` cease flag. This mirrors Android Columba's
+//  `LocationSharingManager.sendCeaseMessage`, which builds a
+//  `LocationTelemetry(lat=0, lng=0, acc=0, ts=now, cease=true)` and routes it
+//  through the same `sendLocationTelemetry` path as a normal update.
+//
+//  Why BOTH fields are mandatory: Android's receive path
+//  (`PythonEventBridge` / `TelemeterCodec`) bails out unless `FIELD_TELEMETRY`
+//  (0x02) is present and Telemeter-decodable — only THEN does it read the
+//  `FIELD_CUSTOM_META` (0xFD) cease flag. Sending the meta alone (as iOS used
+//  to) is silently ignored by Android.
+//
+//  Not platform-gated (unlike LocationSharingManager) so the cross-platform
+//  test hook in AppServices can build the identical payload.
+//
+
+import Foundation
+import RNSAPI
+import LXMFSwift
+
+enum CeaseTelemetry {
+    /// The Android-shaped cease payload:
+    /// - `packed`: a zeroed-location Sideband Telemeter blob (`FIELD_TELEMETRY`),
+    ///   timestamped now so the receiver's staleness check (cease.ts vs last
+    ///   received location) lets the delete through.
+    /// - `meta`: msgpack `{"cease": true}` (`FIELD_CUSTOM_META`).
+    static func payload() -> (packed: Data, meta: Data) {
+        let now = Int(Date().timeIntervalSince1970)
+        let zeroed = LXMFSwift.LocationTelemetry(
+            latitude: 0,
+            longitude: 0,
+            altitude: 0,
+            speed: 0,
+            bearing: 0,
+            accuracy: 0,
+            lastUpdate: now
+        )
+        let packet = LXMFSwift.TelemetryPacket(timestamp: now, location: zeroed)
+        return (packet.encode(), ColumbaMetaCodec.packCease())
+    }
+}

--- a/Sources/ColumbaApp/Services/ExtensionFrameReader.swift
+++ b/Sources/ColumbaApp/Services/ExtensionFrameReader.swift
@@ -11,6 +11,7 @@
 #if ENABLE_NETWORK_EXTENSION
 
 import Foundation
+import RNSAPI
 import os.log
 
 /// Reads queued frames from the Network Extension and injects them into transport.

--- a/Sources/ColumbaApp/Services/IdentityManager.swift
+++ b/Sources/ColumbaApp/Services/IdentityManager.swift
@@ -7,8 +7,7 @@
 //
 
 import Foundation
-import ReticulumSwift
-import LXMFSwift
+import RNSAPI
 import os.log
 
 /// Manages multiple local identities with per-identity Keychain storage and databases.

--- a/Sources/ColumbaApp/Services/IncomingMessageHandler.swift
+++ b/Sources/ColumbaApp/Services/IncomingMessageHandler.swift
@@ -7,8 +7,7 @@
 //
 
 import Foundation
-import LXMFSwift
-import ReticulumSwift
+import RNSAPI
 import UserNotifications
 import os.log
 
@@ -91,36 +90,58 @@ public final class IncomingMessageHandler: LXMRouterDelegate {
 
         // Save to database asynchronously, then notify
         Task {
-            // Check for FIELD_APP_DATA (0x10) — reactions and replies
+            // Reaction — canonical FIELD_REACTION (0x40) = {0x00: targetHashBytes,
+            // 0x01: emojiUTF8}; the reacting user is the inbound source hash (not
+            // on the wire). Merges into the target message; the empty reaction
+            // frame itself is deleted by handleIncomingReaction.
+            if let reaction = message.fields?[LxmfFields.FIELD_REACTION] as? [UInt8: Any],
+               let toData = reaction[LxmfFields.REACTION_TO] as? Data,
+               let emojiData = reaction[LxmfFields.REACTION_CONTENT] as? Data,
+               let emoji = String(data: emojiData, encoding: .utf8) {
+                let reactionTo = toData.map { String(format: "%02x", $0) }.joined()
+                let senderHex = sourceHash.map { String(format: "%02x", $0) }.joined()
+                self.logger.info("Reaction \(emoji) (0x40) from \(senderHex.prefix(8)) to \(reactionTo.prefix(8))")
+                await self.handleIncomingReaction(
+                    targetMessageHex: reactionTo, emoji: emoji,
+                    senderHex: senderHex, reactionMessageHash: message.hash
+                )
+                NotificationCenter.default.post(
+                    name: IncomingMessageHandler.messageReceivedNotification,
+                    object: nil, userInfo: ["sourceHash": sourceHash]
+                )
+                return
+            }
+
+            // Legacy reaction / reply on FIELD_APP_DATA (0x10) — un-upgraded peers.
             if let appData = message.fields?[LXMessage.FIELD_APP_DATA] as? [String: Any] {
-                // Handle reaction messages: merge into target, delete reaction message from DB
                 if let reactionTo = appData["reaction_to"] as? String,
                    let emoji = appData["emoji"] as? String,
                    let sender = appData["sender"] as? String {
-                    self.logger.info("Reaction \(emoji) from \(sender.prefix(8)) to \(reactionTo.prefix(8))")
+                    self.logger.info("Reaction \(emoji) (0x10 legacy) from \(sender.prefix(8)) to \(reactionTo.prefix(8))")
                     await self.handleIncomingReaction(
-                        targetMessageHex: reactionTo,
-                        emoji: emoji,
-                        senderHex: sender,
-                        reactionMessageHash: message.hash
+                        targetMessageHex: reactionTo, emoji: emoji,
+                        senderHex: sender, reactionMessageHash: message.hash
                     )
-                    // Post notification so open conversation reloads with updated reactions
                     NotificationCenter.default.post(
                         name: IncomingMessageHandler.messageReceivedNotification,
-                        object: nil,
-                        userInfo: ["sourceHash": sourceHash]
+                        object: nil, userInfo: ["sourceHash": sourceHash]
                     )
-                    return  // Skip normal message processing
+                    return
                 }
-
-                // Handle reply messages: update reply_to_id column
                 if let replyTo = appData["reply_to"] as? String {
-                    self.logger.info("Reply to \(replyTo.prefix(8))")
-                    do {
-                        try await self.messageRepository.updateReplyToId(message.hash, replyToId: replyTo)
-                    } catch {
-                        self.logger.error("Failed to update reply_to_id: \(error.localizedDescription)")
-                    }
+                    self.logger.info("Reply (0x10 legacy) to \(replyTo.prefix(8))")
+                    try? await self.messageRepository.updateReplyToId(message.hash, replyToId: replyTo)
+                }
+            }
+
+            // Reply — canonical FIELD_REPLY_HASH (0x30) = raw target-hash bytes.
+            if let replyHashData = message.fields?[LxmfFields.FIELD_REPLY_HASH] as? Data {
+                let replyTo = replyHashData.map { String(format: "%02x", $0) }.joined()
+                self.logger.info("Reply (0x30) to \(replyTo.prefix(8))")
+                do {
+                    try await self.messageRepository.updateReplyToId(message.hash, replyToId: replyTo)
+                } catch {
+                    self.logger.error("Failed to update reply_to_id (0x30): \(error.localizedDescription)")
                 }
             }
 
@@ -158,30 +179,37 @@ public final class IncomingMessageHandler: LXMRouterDelegate {
             // Look up sender display name from path table (announce data) and update conversation
             if let pathTable = self.pathTable {
                 if let entry = await pathTable.lookup(destinationHash: sourceHash),
-                   let name = entry.displayName, !name.isEmpty {
-                    try? await self.messageRepository.ensureConversation(sourceHash, displayName: name)
+                   !entry.displayName.isEmpty {
+                    try? await self.messageRepository.ensureConversation(sourceHash, displayName: entry.displayName)
                 }
             }
 
-            // Check for FIELD_COLUMBA_META (0x70) cease signal (Android Columba format)
+            // Check FIELD_CUSTOM_META (0xFD) for the Columba cease flag. The
+            // canonical wire form is msgpack `{"cease": true}` (matches Android
+            // Columba's TelemeterCodec); the UTF-8-JSON fallback covers older
+            // iOS peers that emitted `{"cease": true}` as raw JSON bytes.
             var isCeaseMessage = false
             if let fields = message.fields,
                let metaRaw = fields[LXMessage.FIELD_COLUMBA_META] {
                 // Field may arrive as Data (bytes) or String depending on msgpack unpacking
-                let metaStr: String?
+                let metaData: Data?
                 if let d = metaRaw as? Data {
-                    metaStr = String(data: d, encoding: .utf8)
+                    metaData = d
                 } else if let s = metaRaw as? String {
-                    metaStr = s
+                    metaData = s.data(using: .utf8)
                 } else {
-                    metaStr = nil
+                    metaData = nil
                 }
-                if let metaStr, metaStr.contains("\"cease\"") {
-                    isCeaseMessage = true
-                    #if os(iOS)
-                    self.locationSharingManager?.handleIncomingCease(from: message.sourceHash)
-                    #endif
-                    self.logger.debug("Cease signal from \(sourceHashHex)")
+                if let metaData {
+                    let msgpackCease = ColumbaMetaCodec.unpack(metaData)?.cease == true
+                    let jsonCease = String(data: metaData, encoding: .utf8)?.contains("\"cease\"") == true
+                    if msgpackCease || jsonCease {
+                        isCeaseMessage = true
+                        #if os(iOS)
+                        await self.locationSharingManager?.handleIncomingCease(from: message.sourceHash)
+                        #endif
+                        self.logger.debug("Cease signal from \(sourceHashHex)")
+                    }
                 }
             }
 

--- a/Sources/ColumbaApp/Services/InterfaceRepository.swift
+++ b/Sources/ColumbaApp/Services/InterfaceRepository.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import ReticulumSwift
+import RNSAPI
 import os.log
 
 private let logger = Logger(subsystem: "network.columba.Columba", category: "InterfaceRepository")
@@ -280,86 +280,6 @@ public struct BLEConfig: Codable, Equatable, Sendable {
     }
 }
 
-// MARK: - RNode Config
-
-/// Configuration for RNode LoRa interface.
-///
-/// Stores BLE device name alongside all radio parameters needed
-/// for RNodeInterface. Use `toRadioConfig()` to convert to the
-/// transport-layer RadioConfig for RNodeInterface.configureRadio().
-public struct RNodeConfig: Codable, Equatable, Sendable {
-    /// BLE device name (e.g., "RNode_A9")
-    public var deviceName: String
-
-    /// Radio frequency in Hz (e.g., 915_000_000 for 915 MHz)
-    public var frequency: UInt32
-
-    /// Radio bandwidth in Hz (e.g., 125_000)
-    public var bandwidth: UInt32
-
-    /// TX power in dBm (2-22)
-    public var txPower: UInt8
-
-    /// LoRa spreading factor (7-12)
-    public var spreadingFactor: UInt8
-
-    /// LoRa coding rate (5-8)
-    public var codingRate: UInt8
-
-    /// Short-term airtime lock percentage (optional, 0-100%)
-    public var stAlock: Float?
-
-    /// Long-term airtime lock percentage (optional, 0-100%)
-    public var ltAlock: Float?
-
-    /// Convert to transport-layer RadioConfig for RNodeInterface.
-    public func toRadioConfig() -> RadioConfig {
-        RadioConfig(
-            frequency: frequency,
-            bandwidth: bandwidth,
-            txPower: txPower,
-            spreadingFactor: spreadingFactor,
-            codingRate: codingRate,
-            stAlock: stAlock,
-            ltAlock: ltAlock
-        )
-    }
-
-    /// Default RNode config for US 915 MHz ISM band.
-    public static var defaultUS915: RNodeConfig {
-        RNodeConfig(
-            deviceName: "",
-            frequency: 915_000_000,
-            bandwidth: 125_000,
-            txPower: 17,
-            spreadingFactor: 7,
-            codingRate: 5,
-            stAlock: nil,
-            ltAlock: nil
-        )
-    }
-
-    public init(
-        deviceName: String,
-        frequency: UInt32,
-        bandwidth: UInt32,
-        txPower: UInt8,
-        spreadingFactor: UInt8,
-        codingRate: UInt8,
-        stAlock: Float? = nil,
-        ltAlock: Float? = nil
-    ) {
-        self.deviceName = deviceName
-        self.frequency = frequency
-        self.bandwidth = bandwidth
-        self.txPower = txPower
-        self.spreadingFactor = spreadingFactor
-        self.codingRate = codingRate
-        self.stAlock = stAlock
-        self.ltAlock = ltAlock
-    }
-}
-
 // MARK: - Multipeer Config
 
 /// Configuration for Multipeer Connectivity interface.
@@ -372,37 +292,10 @@ public struct MultipeerConfig: Codable, Equatable, Sendable {
     }
 }
 
-// MARK: - Interface Mode
-
-/// Interface mode controlling announce propagation.
-/// Matches ReticulumSwift.InterfaceMode for consistency.
-public enum InterfaceMode: String, Codable, Sendable, Equatable, CaseIterable {
-    case full = "full"
-    case gateway = "gateway"
-    case accessPoint = "access_point"
-    case roaming = "roaming"
-    case boundary = "boundary"
-
-    public var displayName: String {
-        switch self {
-        case .full: return "Full"
-        case .gateway: return "Gateway"
-        case .accessPoint: return "Access Point"
-        case .roaming: return "Roaming"
-        case .boundary: return "Boundary"
-        }
-    }
-
-    public var description: String {
-        switch self {
-        case .full: return "All features enabled"
-        case .gateway: return "Path discovery for others"
-        case .accessPoint: return "Quiet unless active"
-        case .roaming: return "Mobile relative to others"
-        case .boundary: return "Links dissimilar segments"
-        }
-    }
-}
+// `RNodeConfig` + `InterfaceMode` are canonicalized in RNSAPI/Compat.swift.
+// They used to live here but moved into RNSAPI so LXSTSwift (and any other
+// SwiftPM consumer of RNSAPI) can see them; keeping a duplicate here caused
+// "is ambiguous for type lookup" errors in the Xcode build.
 
 // MARK: - Interface Status
 
@@ -468,7 +361,23 @@ public final class InterfaceRepository: @unchecked Sendable {
 
     public init(userDefaults: UserDefaults? = nil) {
         self.defaults = userDefaults ?? UserDefaults(suiteName: appGroupIdentifier) ?? .standard
+        migrateFromStandardDefaultsIfNeeded()
         loadInterfaces()
+    }
+
+    /// Migration shim: when the app-group entitlement first gets approved
+    /// and wired in, `UserDefaults(suiteName: appGroupIdentifier)` starts
+    /// returning a valid (but empty) defaults pointer. Before that, the
+    /// `?? .standard` fallback ran and all saved interfaces lived in the
+    /// app's regular UserDefaults under the same `storageKey`. Copy them
+    /// over once so users don't lose their config on the entitlement
+    /// rollout.
+    private func migrateFromStandardDefaultsIfNeeded() {
+        guard defaults !== UserDefaults.standard else { return }
+        guard defaults.data(forKey: storageKey) == nil else { return }
+        guard let standardData = UserDefaults.standard.data(forKey: storageKey) else { return }
+        defaults.set(standardData, forKey: storageKey)
+        logger.notice("Migrated interface store from standard UserDefaults to app group (\(standardData.count) bytes)")
     }
 
     // MARK: - CRUD Operations

--- a/Sources/ColumbaApp/Services/LocalIdentity.swift
+++ b/Sources/ColumbaApp/Services/LocalIdentity.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import RNSAPI
 
 /// Represents a locally stored identity with metadata.
 ///

--- a/Sources/ColumbaApp/Services/LocationSharingManager.swift
+++ b/Sources/ColumbaApp/Services/LocationSharingManager.swift
@@ -1,3 +1,4 @@
+#if os(iOS)
 //
 //  LocationSharingManager.swift
 //  ColumbaApp
@@ -6,11 +7,15 @@
 //  Manages CLLocationManager for GPS, periodic sending to active peers,
 //  and tracking incoming peer locations for map display.
 //
+//  iOS-only (CoreLocation + UIApplication.applicationState). The non-iOS
+//  fallback lives in `RNSAPI/Compat.swift` as a no-op stub so the
+//  `appServices.locationSharingManager?` call sites compile cross-platform.
+//
 
 import Foundation
-import CoreLocation
+import RNSAPI
 import LXMFSwift
-import ReticulumSwift
+import CoreLocation
 import os.log
 #if canImport(UIKit)
 import UIKit
@@ -48,7 +53,7 @@ public struct PeerLocation: Identifiable, Equatable {
     public var lastUpdate: Date
 
     /// Icon appearance from LXMF Field 0x04 (MDI icon + colors).
-    public var iconAppearance: IconAppearance?
+    public var iconAppearance: RNSAPI.IconAppearance?
 
     /// True if older than 5 minutes.
     public var isStale: Bool {
@@ -126,6 +131,12 @@ public final class LocationSharingManager: NSObject {
     /// Per-peer expiration date. nil value = indefinite.
     public private(set) var peerExpirations: [Data: Date?] = [:]
 
+    /// Latest CLLocationManager authorization status. Mirrored here (rather
+    /// than read via `locationManager.authorizationStatus` on demand) so
+    /// SwiftUI views observing this `@Observable` instance re-render on
+    /// `locationManagerDidChangeAuthorization` without polling.
+    public private(set) var authorizationStatus: CLAuthorizationStatus = .notDetermined
+
     // MARK: - Private State
 
     private let logger = Logger(subsystem: "network.columba.Columba", category: "LocationSharing")
@@ -165,6 +176,21 @@ public final class LocationSharingManager: NSObject {
         self.appServices = appServices
         super.init()
         loadPersistedPeers()
+        // Seed the observable from the system's current state so the
+        // Settings card renders the right status immediately (before any
+        // delegate callback fires). The CLLocationManager init is cheap;
+        // creating it here just to read the status is acceptable.
+        self.authorizationStatus = locationManager.authorizationStatus
+    }
+
+    /// Trigger a `when-in-use` permission prompt if status is
+    /// `.notDetermined`, otherwise no-op (the user must change the
+    /// answer from the system Settings app). Settings UI calls this
+    /// directly so we don't have to start a sharing session just to
+    /// surface the prompt.
+    public func requestPermission() {
+        guard authorizationStatus == .notDetermined else { return }
+        locationManager.requestWhenInUseAuthorization()
     }
 
     // MARK: - Public API
@@ -254,8 +280,11 @@ public final class LocationSharingManager: NSObject {
         logger.info("Peer \(hex) ceased location sharing (COLUMBA_META)")
     }
 
-    public func handleIncomingTelemetry(from peerHash: Data, packet: TelemetryPacket, displayName: String?, iconAppearance: IconAppearance? = nil) {
-        guard let location = packet.location else { return }
+    public func handleIncomingTelemetry(from peerHash: Data, packet: RNSAPI.TelemetryPacket, displayName: String?, iconAppearance: RNSAPI.IconAppearance? = nil) {
+        // `packet.payload` holds the raw FIELD_TELEMETRY bytes (IncomingMessageHandler
+        // wraps them in the Compat TelemetryPacket); decode with LXMF-swift's
+        // Sideband-compatible Telemeter codec to get the structured location.
+        guard let location = LXMFSwift.TelemetryPacket.decode(from: packet.payload)?.location else { return }
 
         // Preserve existing icon if new message doesn't include one
         let resolvedIcon = iconAppearance ?? peerLocations[peerHash]?.iconAppearance
@@ -277,6 +306,16 @@ public final class LocationSharingManager: NSObject {
 
         let hex = peerHash.prefix(4).map { String(format: "%02x", $0) }.joined()
         logger.info("Updated peer \(hex) location: \(location.latitude), \(location.longitude)")
+        // Test-observable mirror of the decoded inbound telemetry. The map
+        // marker is rendered on MapLibre's GL surface and isn't reachable
+        // from the accessibility tree (so neither VoiceOver nor the interop
+        // suite can read its icon), so the Tests/interop location round-trip
+        // asserts the decoded icon + coordinates here while asserting pin
+        // *presence* via the SwiftUI `map_peer_count` badge. iconName is the
+        // MDI glyph name; fg/bg are 6-char RGB hex.
+        let iconDesc = resolvedIcon.map { "\($0.iconName) fg=\($0.fgColor) bg=\($0.bgColor)" }
+            ?? "- fg=- bg=-"
+        DiagLog.log("[LOC-RECV] peer=\(hex) lat=\(location.latitude) lon=\(location.longitude) icon=\(iconDesc)")
     }
 
     /// Update foreground/background state to adjust send interval.
@@ -397,8 +436,7 @@ public final class LocationSharingManager: NSObject {
 
     private func sendLocationUpdateToPeer(_ peerHash: Data) async {
         guard let appServices = appServices,
-              let identity = appServices.identity,
-              let router = appServices.router else {
+              let backend = appServices.backend else {
             return
         }
 
@@ -432,8 +470,8 @@ public final class LocationSharingManager: NSObject {
             radiusMeters: precisionRadius
         )
 
-        // Build telemetry packet
-        let telemetry = LocationTelemetry(
+        // Build the Sideband-compatible telemetry packet (LXMF-swift Telemeter codec).
+        let telemetry = LXMFSwift.LocationTelemetry(
             latitude: finalLat,
             longitude: finalLng,
             altitude: location.altitude,
@@ -442,35 +480,24 @@ public final class LocationSharingManager: NSObject {
             accuracy: precisionRadius > 0 ? Double(precisionRadius) : location.horizontalAccuracy,
             lastUpdate: Int(location.timestamp.timeIntervalSince1970)
         )
-
-        let packet = TelemetryPacket(
+        let packet = LXMFSwift.TelemetryPacket(
             timestamp: Int(Date().timeIntervalSince1970),
             location: telemetry
         )
+        let telemetryData = packet.encode()  // FIELD_TELEMETRY (0x02) payload bytes
 
-        // Encode telemetry as FIELD_TELEMETRY bytes
-        let telemetryData = packet.encode()
-
-        // Build and send LXMF message with telemetry field
-        var fields: [UInt8: Any] = [:]
-        fields[LXMessage.FIELD_TELEMETRY] = telemetryData
-
-        var lxMessage = LXMessage(
-            destinationHash: peerHash,
-            sourceIdentity: identity,
-            content: Data(),  // No text content for telemetry-only messages
-            title: Data(),
-            fields: fields,
-            desiredMethod: .opportunistic
-        )
-
+        // Send via the neutral telemetry facet — the backend assembles the LXMF
+        // message (Swift implements it; Python is capability-gated → unsupported).
+        let destHex = peerHash.map { String(format: "%02x", $0) }.joined()
         do {
-            try await router.handleOutbound(&lxMessage)
-            lastSentLocation = location
-            lastSentTime = Date()
-
-            let hex = peerHash.prefix(4).map { String(format: "%02x", $0) }.joined()
-            logger.info("Sent location to \(hex): \(telemetry.latitude), \(telemetry.longitude)")
+            let outcome = try await backend.telemetry.sendLocationTelemetry(destHashHex: destHex, packed: telemetryData, customMeta: nil)
+            if case .queued = outcome {
+                lastSentLocation = location
+                lastSentTime = Date()
+                logger.info("Sent location to \(destHex.prefix(8)): \(telemetry.latitude), \(telemetry.longitude)")
+            } else {
+                logger.info("Telemetry send not queued (\(String(describing: outcome))) — backend may not support telemetry")
+            }
         } catch {
             logger.warning("Failed to send location: \(error.localizedDescription)")
         }
@@ -478,29 +505,21 @@ public final class LocationSharingManager: NSObject {
 
     private func sendCeaseSignal(to peerHash: Data) async {
         guard let appServices = appServices,
-              let identity = appServices.identity,
-              let router = appServices.router else {
+              let backend = appServices.backend else {
             return
         }
 
-        // Match Android Columba format: FIELD_COLUMBA_META (0x70) with JSON {"cease": true}
-        let ceaseJSON = "{\"cease\": true}"
-        var fields: [UInt8: Any] = [:]
-        fields[LXMessage.FIELD_COLUMBA_META] = ceaseJSON.data(using: .utf8)!
-
-        var lxMessage = LXMessage(
-            destinationHash: peerHash,
-            sourceIdentity: identity,
-            content: Data(),
-            title: Data(),
-            fields: fields,
-            desiredMethod: .opportunistic
-        )
-
+        // Stop-sharing signal in Android Columba's wire shape: a zeroed-location
+        // Telemeter blob (FIELD_TELEMETRY 0x02) + msgpack {"cease": true}
+        // (FIELD_CUSTOM_META 0xFD). Routed through the same sendLocationTelemetry
+        // path a normal update uses — Android's receive path requires the
+        // Telemeter body present before it reads the cease flag, and decodes the
+        // meta as msgpack (not JSON). See CeaseTelemetry.
+        let destHex = peerHash.map { String(format: "%02x", $0) }.joined()
+        let (packed, meta) = CeaseTelemetry.payload()
         do {
-            try await router.handleOutbound(&lxMessage)
-            let hex = peerHash.prefix(4).map { String(format: "%02x", $0) }.joined()
-            logger.info("Sent cease signal to \(hex)")
+            _ = try await backend.telemetry.sendLocationTelemetry(destHashHex: destHex, packed: packed, customMeta: meta)
+            logger.info("Sent cease signal to \(destHex.prefix(8))")
         } catch {
             logger.warning("Failed to send cease signal: \(error.localizedDescription)")
         }
@@ -562,6 +581,9 @@ extension LocationSharingManager: CLLocationManagerDelegate {
     public nonisolated func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
         Task { @MainActor in
             let status = manager.authorizationStatus
+            // Mirror the system status onto our @Observable property so
+            // SwiftUI views re-render the permission row without polling.
+            self.authorizationStatus = status
             switch status {
             case .authorizedWhenInUse, .authorizedAlways:
                 if isSharingWithAnyone {
@@ -586,3 +608,4 @@ extension LocationSharingManager: CLLocationManagerDelegate {
     }
 }
 
+#endif

--- a/Sources/ColumbaApp/Services/MessageRepository.swift
+++ b/Sources/ColumbaApp/Services/MessageRepository.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import LXMFSwift
+import RNSAPI
 
 /// Actor for thread-safe message database operations.
 ///

--- a/Sources/ColumbaApp/Services/MigrationCrypto.swift
+++ b/Sources/ColumbaApp/Services/MigrationCrypto.swift
@@ -1,3 +1,4 @@
+#if COLUMBA_MIGRATION_ENABLED
 //
 //  MigrationCrypto.swift
 //  ColumbaApp
@@ -9,6 +10,7 @@
 //
 
 import Foundation
+import RNSAPI
 import CryptoKit
 import CommonCrypto
 
@@ -212,3 +214,4 @@ enum MigrationCrypto {
         return derivedKey
     }
 }
+#endif

--- a/Sources/ColumbaApp/Services/MigrationExporter.swift
+++ b/Sources/ColumbaApp/Services/MigrationExporter.swift
@@ -1,3 +1,4 @@
+#if COLUMBA_MIGRATION_ENABLED
 //
 //  MigrationExporter.swift
 //  ColumbaApp
@@ -7,8 +8,7 @@
 //
 
 import Foundation
-import ReticulumSwift
-import LXMFSwift
+import RNSAPI
 import os.log
 
 /// Exports all app data into an encrypted .columba backup file.
@@ -244,3 +244,4 @@ actor MigrationExporter {
         return tempURL
     }
 }
+#endif

--- a/Sources/ColumbaApp/Services/MigrationImporter.swift
+++ b/Sources/ColumbaApp/Services/MigrationImporter.swift
@@ -1,3 +1,4 @@
+#if COLUMBA_MIGRATION_ENABLED
 //
 //  MigrationImporter.swift
 //  ColumbaApp
@@ -7,8 +8,7 @@
 //
 
 import Foundation
-import ReticulumSwift
-import LXMFSwift
+import RNSAPI
 import os.log
 
 /// Imports data from an encrypted .columba backup file.
@@ -362,3 +362,4 @@ actor MigrationImporter {
 }
 
 // Note: Data(hexString:) extension is defined in PropagationNodeManager.swift
+#endif

--- a/Sources/ColumbaApp/Services/NomadNetBrowserService.swift
+++ b/Sources/ColumbaApp/Services/NomadNetBrowserService.swift
@@ -1,26 +1,29 @@
+#if COLUMBA_NOMADNET_ENABLED
 import Foundation
-import ReticulumSwift
+import RNSAPI
 import os.log
 
 private let logger = Logger(subsystem: "network.columba.Columba", category: "NomadNetBrowser")
 
-/// Manages Link establishment and page fetching for NomadNet node browsing.
+/// One-shot page fetching for NomadNet node browsing.
+///
+/// Earlier versions of this service managed RNS Link / RequestReceipt
+/// lifecycles directly. Now it delegates the whole link-establishment +
+/// request + teardown dance to `PythonRNSBackend.fetchNomadNetPage`,
+/// which runs the canonical Mark Qvist RNS code under the embedded
+/// CPython. Trades a few hundred ms of link re-establishment per fetch
+/// for a much smaller API surface and zero protocol re-implementation
+/// in Swift.
+///
+/// The page cache (12h default, overridable by `cache_seconds` page
+/// header) stays here on the Swift side — there's no point round-tripping
+/// to Python for a cache hit.
 public actor NomadNetBrowserService {
 
     // MARK: - Dependencies
 
-    private let transport: ReticulumTransport
-    private let pathTable: PathTable
+    private let backend: any RnsBackend
     private let localIdentity: Identity
-
-    // MARK: - Link Cache
-
-    private var linkCache: [Data: Link] = [:]
-    /// Insertion-order list of destination hashes in the cache.
-    /// Used to evict the oldest link when the cache is full — Swift
-    /// dictionaries don't guarantee key ordering, so we track it explicitly.
-    private var linkCacheOrder: [Data] = []
-    private static let maxCachedLinks = 8
 
     // MARK: - Page Cache
 
@@ -39,9 +42,8 @@ public actor NomadNetBrowserService {
 
     // MARK: - Init
 
-    public init(transport: ReticulumTransport, pathTable: PathTable, identity: Identity) {
-        self.transport = transport
-        self.pathTable = pathTable
+    public init(backend: any RnsBackend, identity: Identity) {
+        self.backend = backend
         self.localIdentity = identity
     }
 
@@ -53,7 +55,8 @@ public actor NomadNetBrowserService {
         destinationHash: Data,
         path: String = "/page/index.mu"
     ) async throws -> (MicronDocument, String) {
-        let cacheKey = "\(destinationHash.hexString):\(path)"
+        let destHashHex = destinationHash.toHex()
+        let cacheKey = "\(destHashHex):\(path)"
 
         // Check page cache
         if let cached = pageCache[cacheKey] {
@@ -66,34 +69,26 @@ public actor NomadNetBrowserService {
             }
         }
 
-        // Establish or reuse link
-        statusMessage = "Establishing link..."
-        let link = try await getOrCreateLink(destinationHash: destinationHash)
+        statusMessage = "Fetching \(path)..."
+        logger.info("[NOMAD] Fetching \(path, privacy: .public) from \(destHashHex.prefix(8), privacy: .public)")
 
-        // Request page
-        statusMessage = "Requesting page..."
-        logger.info("[NOMAD] Requesting \(path, privacy: .public) from \(destinationHash.prefix(4).hexString, privacy: .public)")
+        let result = try await backend.fetchNomadNetPage(
+            destHashHex: destHashHex,
+            path: path,
+            timeout: 30.0,
+            formFields: nil
+        )
 
-        let receipt = try await link.request(path: path, data: nil, timeout: 30.0)
+        try ensureSuccess(result)
 
-        // Wait for response
-        statusMessage = "Loading response..."
-        let responseData = try await waitForResponse(receipt: receipt, timeout: 30.0)
-        logger.info("[NOMAD] Response \(responseData.count) bytes, first 32: \(responseData.prefix(32).hexString, privacy: .public)")
+        let responseData = result.data
+        logger.info("[NOMAD] Response \(responseData.count) bytes")
 
-        guard let markup = String(data: responseData, encoding: .utf8) else {
-            // Fallback: try Latin-1 (some NomadNet pages use non-UTF-8 encodings)
-            if let markup = String(data: responseData, encoding: .isoLatin1) {
-                let document = MicronParser.parse(markup)
-                statusMessage = ""
-                return (document, markup)
-            }
-            throw NomadNetError.invalidResponse("Response is not valid UTF-8 (\(responseData.count) bytes)")
+        guard let markup = decodeMarkup(responseData) else {
+            throw NomadNetError.invalidResponse("Response is not valid UTF-8 / Latin-1 (\(responseData.count) bytes)")
         }
-
         let document = MicronParser.parse(markup)
 
-        // Cache the page
         let cacheSeconds = document.headers.cacheSeconds ?? Self.defaultCacheSeconds
         if cacheSeconds > 0 {
             pageCache[cacheKey] = CachedPage(
@@ -114,28 +109,25 @@ public actor NomadNetBrowserService {
         path: String,
         fields: [String: String]
     ) async throws -> (MicronDocument, String) {
-        let link = try await getOrCreateLink(destinationHash: destinationHash)
-
         statusMessage = "Submitting form..."
 
-        // Build field data with "field_" prefix per NomadNet protocol
-        var fieldMap: [MessagePackValue: MessagePackValue] = [:]
-        for (key, value) in fields {
-            fieldMap[.string("field_\(key)")] = .string(value)
-        }
+        // NomadNet's node app expects form fields keyed with a "field_"
+        // prefix. The Python bridge msgpack-packs the dict on its side.
+        var prefixed: [String: String] = [:]
+        for (k, v) in fields { prefixed["field_\(k)"] = v }
 
-        let receipt = try await link.request(
+        let result = try await backend.fetchNomadNetPage(
+            destHashHex: destinationHash.toHex(),
             path: path,
-            data: .map(fieldMap),
-            timeout: 30.0
+            timeout: 30.0,
+            formFields: prefixed
         )
+        try ensureSuccess(result)
 
-        let responseData = try await waitForResponse(receipt: receipt, timeout: 30.0)
-
-        guard let markup = String(data: responseData, encoding: .utf8) ?? String(data: responseData, encoding: .isoLatin1) else {
-            throw NomadNetError.invalidResponse("Response is not valid UTF-8 (\(responseData.count) bytes)")
+        let responseData = result.data
+        guard let markup = decodeMarkup(responseData) else {
+            throw NomadNetError.invalidResponse("Form response is not text (\(responseData.count) bytes)")
         }
-
         let document = MicronParser.parse(markup)
         statusMessage = ""
         return (document, markup)
@@ -147,235 +139,81 @@ public actor NomadNetBrowserService {
         destinationHash: Data,
         path: String
     ) async throws -> (Data, String) {
-        let link = try await getOrCreateLink(destinationHash: destinationHash)
-
         statusMessage = "Downloading file..."
         logger.info("[NOMAD] Downloading \(path, privacy: .public)")
 
-        let receipt = try await link.request(path: path, data: nil, timeout: 60.0)
-        let data = try await waitForResponse(receipt: receipt, timeout: 60.0)
+        let result = try await backend.fetchNomadNetPage(
+            destHashHex: destinationHash.toHex(),
+            path: path,
+            timeout: 60.0,
+            formFields: nil
+        )
+        try ensureSuccess(result)
 
-        // Extract filename from path
         let filename = path.split(separator: "/").last.map(String.init) ?? "download"
         statusMessage = ""
-        return (data, filename)
+        return (result.data, filename)
     }
 
-    /// Reveal local identity to the node.
+    /// Compatibility no-op. We now establish a fresh Link for each fetch,
+    /// so there's nothing to identify against on a long-lived link.
+    /// Stateful node apps that require the identity round-trip will need
+    /// the underlying Python bridge to thread identity through each
+    /// request (rns_bridge.fetch_nomadnet_page already does
+    /// `link.identify(_state["identity"])`).
     public func identifyToNode(destinationHash: Data) async throws {
-        let link = try await getOrCreateLink(destinationHash: destinationHash)
-        statusMessage = "Identifying..."
-        try await link.identify(identity: localIdentity)
-        statusMessage = ""
-        logger.info("[NOMAD] Identified to node \(destinationHash.prefix(4).hexString, privacy: .public)")
+        logger.info("[NOMAD] identifyToNode is a no-op under PythonRNSBackend (auto-identified per request)")
     }
 
-    /// Close a cached link to a node.
-    public func closeLink(destinationHash: Data) async {
-        linkCacheOrder.removeAll { $0 == destinationHash }
-        if let link = linkCache.removeValue(forKey: destinationHash) {
-            await link.close()
-        }
-    }
+    /// Compatibility no-op. No cached links to close — each fetch
+    /// tears down its own Link in Python.
+    public func closeLink(destinationHash: Data) async {}
 
     /// Clear all caches.
     public func clearCache() {
         pageCache.removeAll()
     }
 
-    // MARK: - Link Management
+    // MARK: - Helpers
 
-    private func getOrCreateLink(destinationHash: Data) async throws -> Link {
-        // Check cache for active link
-        if let cached = linkCache[destinationHash] {
-            let linkState = await cached.state
-            if linkState.isEstablished {
-                return cached
-            }
-            linkCacheOrder.removeAll { $0 == destinationHash }
-            linkCache.removeValue(forKey: destinationHash)
-        }
-
-        // Resolve a VALID path (with a live interface). Returns nil if no path
-        // arrives within the timeout or no live interface is available.
-        guard let pathEntry = try await resolveValidPath(destinationHash: destinationHash) else {
-            throw NomadNetError.noPath(destinationHash: destinationHash)
-        }
-
-        return try await establishLink(pathEntry: pathEntry, destinationHash: destinationHash)
-    }
-
-    /// Look up a path entry whose interface is currently registered. If the
-    /// cached path points to a dead interface (e.g. leftover from a previous
-    /// app run), invalidate it and wait for a fresh path.
-    private func resolveValidPath(destinationHash: Data) async throws -> PathEntry? {
-        let liveInterfaceIds = Set(await transport.listInterfaceIds())
-
-        // First pass: is the current path valid?
-        if let entry = await pathTable.lookup(destinationHash: destinationHash),
-           liveInterfaceIds.contains(entry.interfaceId) {
-            return entry
-        }
-
-        // Path is missing or stale. Invalidate and request a fresh one.
-        statusMessage = "Resolving path..."
-        await pathTable.remove(destinationHash: destinationHash)
-        await transport.requestPath(for: destinationHash)
-
-        // Poll up to 10 seconds for a new path to arrive on a live interface.
-        for _ in 0..<40 {
-            try await Task.sleep(for: .milliseconds(250))
-            let liveNow = Set(await transport.listInterfaceIds())
-            if let entry = await pathTable.lookup(destinationHash: destinationHash),
-               liveNow.contains(entry.interfaceId) {
-                return entry
-            }
-        }
-
-        return nil
-    }
-
-    private func establishLink(pathEntry: PathEntry, destinationHash: Data) async throws -> Link {
-        statusMessage = "Establishing link..."
-
-        let remoteIdentity = try Identity(publicKeyBytes: pathEntry.publicKeys)
-        let destination = Destination(
-            identity: remoteIdentity,
-            appName: "nomadnetwork",
-            aspects: ["node"],
-            direction: .out
-        )
-
-        let link = try await transport.initiateLink(to: destination, identity: localIdentity)
-
-        // Wait for link to become active, with a hard 20s timeout.
-        // Race the state stream against a timeout task so we never hang if
-        // the link silently stops producing state updates.
-        try await withThrowingTaskGroup(of: Void.self) { group in
-            group.addTask {
-                for await linkState in await link.stateUpdates {
-                    if linkState.isEstablished { return }
-                    if case .closed = linkState {
-                        throw NomadNetError.linkFailed("Link closed during establishment")
-                    }
-                }
-                throw NomadNetError.linkFailed("State stream ended before link became active")
-            }
-            group.addTask {
-                try await Task.sleep(for: .seconds(20))
-                throw NomadNetError.linkFailed("Link establishment timed out")
-            }
-            // Wait for whichever task finishes first, then cancel the rest.
-            try await group.next()
-            group.cancelAll()
-        }
-
-        // Evict oldest (FIFO) if at capacity — dictionaries have no stable
-        // ordering, so we evict based on linkCacheOrder insertion order.
-        if linkCache.count >= Self.maxCachedLinks, let oldestKey = linkCacheOrder.first {
-            linkCacheOrder.removeFirst()
-            if let old = linkCache.removeValue(forKey: oldestKey) {
-                await old.close()
-            }
-        }
-
-        linkCache[destinationHash] = link
-        linkCacheOrder.append(destinationHash)
-        return link
-    }
-
-    // MARK: - Response Handling
-
-    /// Wait for a request to complete. Races the status stream against a
-    /// wall-clock timeout so a stalled stream (no further status updates)
-    /// can't hang indefinitely — mirrors the pattern used in establishLink.
-    /// `timeout` should be slightly longer than the link.request timeout so
-    /// the request's own .timeout status is preferred when available.
-    private func waitForResponse(receipt: RequestReceipt, timeout: TimeInterval) async throws -> Data {
-        try await withThrowingTaskGroup(of: Data.self) { group in
-            group.addTask {
-                for await status in await receipt.statusUpdates {
-                    switch status {
-                    case .responseReceived:
-                        if let data = await receipt.responseData {
-                            return self.unwrapResponseData(data)
-                        }
-                        throw NomadNetError.invalidResponse("Response received but no data")
-                    case .failed(let reason):
-                        throw NomadNetError.requestFailed(reason)
-                    case .timeout:
-                        throw NomadNetError.timeout
-                    default:
-                        continue
-                    }
-                }
-                throw NomadNetError.requestFailed("Status stream ended without response")
-            }
-            group.addTask {
-                try await Task.sleep(for: .seconds(timeout))
-                throw NomadNetError.timeout
-            }
-            guard let data = try await group.next() else {
-                throw NomadNetError.requestFailed("Response task group produced no value")
-            }
-            group.cancelAll()
-            return data
+    private func ensureSuccess(_ result: NomadNetFetchResult) throws {
+        if result.ok { return }
+        switch result.status {
+        case .noPath: throw NomadNetError.noPath(destinationHash: Data())
+        case .linkFailed: throw NomadNetError.linkFailed("Link establishment timed out or failed")
+        case .timeout: throw NomadNetError.timeout
+        case .badHash, .notStarted, .requestFailed, .unknown:
+            throw NomadNetError.requestFailed("\(result.status.rawValue) \(result.contentType)")
+        case .ok: return
         }
     }
 
-    /// Unwrap MessagePack-encoded response data if needed.
-    ///
-    /// Reticulum wraps response payloads in MessagePack. For resource-based
-    /// responses, the response data arrives as a MessagePack-packed value
-    /// (e.g. `.binary(pageBytes)` or `.string(pageText)`). Extract the raw
-    /// payload for the application layer.
-    /// Nonisolated: pure function over Data, callable from the task-group
-    /// child task used by waitForResponse.
-    nonisolated private func unwrapResponseData(_ data: Data) -> Data {
-        // Try to unpack as MessagePack and extract the inner value
-        if let value = try? unpackMsgPack(data) {
-            switch value {
-            case .binary(let bytes):
-                return bytes
-            case .string(let str):
-                return str.data(using: .utf8) ?? data
-            default:
-                break
-            }
-        }
-        return data
+    private func decodeMarkup(_ data: Data) -> String? {
+        if let s = String(data: data, encoding: .utf8) { return s }
+        return String(data: data, encoding: .isoLatin1)
     }
 }
-
-// MARK: - Errors
 
 public enum NomadNetError: Error, LocalizedError {
     case noPath(destinationHash: Data)
     case linkFailed(String)
-    case requestFailed(String)
-    case invalidResponse(String)
     case timeout
+    case invalidResponse(String)
+    case requestFailed(String)
 
     public var errorDescription: String? {
         switch self {
         case .noPath(let hash):
-            return "No path to node \(hash.prefix(4).hexString)"
-        case .linkFailed(let msg):
-            return "Link failed: \(msg)"
-        case .requestFailed(let msg):
-            return "Request failed: \(msg)"
-        case .invalidResponse(let msg):
-            return "Invalid response: \(msg)"
+            return "No path to node \(hash.prefix(4).toHex()) — try again in a few seconds"
+        case .linkFailed(let reason):
+            return "Could not connect: \(reason)"
         case .timeout:
             return "Request timed out"
+        case .invalidResponse(let reason):
+            return "Bad response: \(reason)"
+        case .requestFailed(let reason):
+            return "Request failed: \(reason)"
         }
     }
 }
-
-// MARK: - Data Hex Helper
-
-private extension Data {
-    var hexString: String {
-        map { String(format: "%02x", $0) }.joined()
-    }
-}
+#endif

--- a/Sources/ColumbaApp/Services/NotificationObserver.swift
+++ b/Sources/ColumbaApp/Services/NotificationObserver.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import RNSAPI
 
 /// Observer for Darwin notifications from Network Extension.
 ///

--- a/Sources/ColumbaApp/Services/NotificationService.swift
+++ b/Sources/ColumbaApp/Services/NotificationService.swift
@@ -7,8 +7,8 @@
 //
 
 import Foundation
+import RNSAPI
 import UserNotifications
-import LXMFSwift
 
 /// Manages local push notifications for incoming messages.
 ///

--- a/Sources/ColumbaApp/Services/OfflineMapManager.swift
+++ b/Sources/ColumbaApp/Services/OfflineMapManager.swift
@@ -8,6 +8,7 @@
 
 #if os(iOS)
 import Foundation
+import RNSAPI
 import MapLibre
 import CoreLocation
 import os.log

--- a/Sources/ColumbaApp/Services/PropagationNodeManager.swift
+++ b/Sources/ColumbaApp/Services/PropagationNodeManager.swift
@@ -7,9 +7,8 @@
 //
 
 import Foundation
+import RNSAPI
 import Observation
-import LXMFSwift
-import ReticulumSwift
 import os.log
 
 // MARK: - Propagation Node Model
@@ -206,8 +205,20 @@ public final class PropagationNodeManager {
             selectedNodeDeliveryHash = nil
         }
 
-        // Wire to router (awaited directly, not fire-and-forget)
+        // Wire to Python LXMRouter via the embedded backend. Compat
+        // LXMRouter.setOutboundPropagationNode used to set a local var
+        // only — Python's LXMF.LXMRouter.set_outbound_propagation_node
+        // is what actually affects delivery.
         let stampCost = node?.info.stampCost ?? 0
+        if let backend = appServices?.pythonBackend {
+            do {
+                _ = try await backend.setPropagationNode(destHashHex: hash.toHex(), stampCost: stampCost)
+            } catch {
+                logger.error("setPropagationNode failed: \(error.localizedDescription)")
+            }
+        }
+        // Keep the Compat-layer var in sync so any UI that still reads
+        // router.outboundPropagationNode shows the right value.
         await appServices?.router?.setOutboundPropagationNode(hash)
         await appServices?.router?.setPropagationStampCost(stampCost)
 
@@ -221,6 +232,13 @@ public final class PropagationNodeManager {
         selectedNodeDeliveryHash = nil
         selectedNodeName = nil
 
+        if let backend = appServices?.pythonBackend {
+            do {
+                _ = try await backend.setPropagationNode(destHashHex: "", stampCost: 0)
+            } catch {
+                logger.error("clear propagation node failed: \(error.localizedDescription)")
+            }
+        }
         await appServices?.router?.setOutboundPropagationNode(nil)
         await appServices?.router?.setPropagationStampCost(0)
 
@@ -234,10 +252,10 @@ public final class PropagationNodeManager {
     ///
     /// If no propagation node is selected yet, auto-selects the best available node first.
     public func syncNow() async {
-        guard let router = appServices?.router else {
-            logger.error("[SYNC] Router not available")
+        guard let backend = appServices?.pythonBackend else {
+            logger.error("[SYNC] Python backend not available")
             syncState.state = .linkFailed
-            syncState.errorDescription = "Router not available"
+            syncState.errorDescription = "Backend not available"
             return
         }
 
@@ -263,16 +281,40 @@ public final class PropagationNodeManager {
 
         let nodeHex = nodeHash.prefix(8).map { String(format: "%02x", $0) }.joined()
         logger.info("[SYNC] Starting sync from propagation node \(nodeHex)")
+        syncState.state = .linking
+        syncState.errorDescription = nil
 
         do {
-            try await router.syncFromPropagationNode()
-            syncState = await router.syncState
-            lastSyncTime = syncState.lastSync
-            logger.info("[SYNC] Sync complete. newMessages=\(self.syncState.receivedMessages)")
+            let result = try await backend.propagationSync(timeout: 60.0)
+            syncState.state = Self.mapPythonState(result.state)
+            syncState.receivedMessages = result.receivedMessages
+            syncState.errorDescription = result.ok ? nil : result.reason
+            if result.ok {
+                syncState.lastSync = Date()
+                lastSyncTime = syncState.lastSync
+            }
+            logger.info("[SYNC] Sync \(result.ok ? "complete" : "failed"). state=\(result.state.rawValue) newMessages=\(result.receivedMessages)")
         } catch {
             syncState.state = .transferFailed
             syncState.errorDescription = error.localizedDescription
             logger.error("[SYNC] Sync failed: \(error.localizedDescription)")
+        }
+    }
+
+    /// Translate Python LXMRouter PR_* state names to Compat
+    /// PropagationTransferState cases. (Subset mapped; non-terminal
+    /// intermediate states collapse to .transferring for UI purposes.)
+    private static func mapPythonState(_ state: PropagationSyncResult.State) -> PropagationTransferState.State {
+        switch state {
+        case .complete: return .complete
+        case .noPath: return .noPath
+        case .transferFailed: return .transferFailed
+        case .pathRequested, .linkEstablishing, .linkEstablished:
+            return .linking
+        case .requestSent, .receiving, .responseReceived:
+            return .transferring
+        case .idle, .noRouter, .notStarted, .noNode, .unknown:
+            return .idle
         }
     }
 

--- a/Sources/ColumbaApp/Services/PythonConfigWriter.swift
+++ b/Sources/ColumbaApp/Services/PythonConfigWriter.swift
@@ -94,7 +94,7 @@ enum PythonConfigWriter {
         switch iface.config {
         case .tcpClient(let cfg):
             lines.append("    type = TCPClientInterface")
-            lines.append("    target_host = \(cfg.targetHost)")
+            lines.append("    target_host = \(configValue(cfg.targetHost))")
             lines.append("    target_port = \(cfg.targetPort)")
             appendIFAC(networkName: cfg.networkName, passphrase: cfg.passphrase, to: &lines)
         case .tcpServer(let cfg):
@@ -104,7 +104,7 @@ enum PythonConfigWriter {
         case .autoInterface(let cfg):
             lines.append("    type = AutoInterface")
             if let group = cfg.groupId, !group.isEmpty {
-                lines.append("    group_id = \(group)")
+                lines.append("    group_id = \(configValue(group))")
             }
             lines.append("    discovery_scope = \(cfg.discoveryScope)")
             if let port = cfg.discoveryPort { lines.append("    discovery_port = \(port)") }
@@ -131,7 +131,7 @@ enum PythonConfigWriter {
             // the ported interface parses and upstream RNS's RNodeInterface
             // convention. iOS is BLE-only — no usb_* / port keys.
             lines.append("    type = IOSRNodeInterface")
-            lines.append("    target_device_name = \(cfg.deviceName)")
+            lines.append("    target_device_name = \(configValue(cfg.deviceName))")
             lines.append("    frequency = \(cfg.frequency)")
             lines.append("    bandwidth = \(cfg.bandwidth)")
             lines.append("    txpower = \(cfg.txPower)")
@@ -164,10 +164,10 @@ enum PythonConfigWriter {
 
     private static func appendIFAC(networkName: String?, passphrase: String?, to lines: inout [String]) {
         if let name = networkName, !name.isEmpty {
-            lines.append("    networkname = \(name)")
+            lines.append("    networkname = \(configValue(name))")
         }
         if let pass = passphrase, !pass.isEmpty {
-            lines.append("    passphrase = \(pass)")
+            lines.append("    passphrase = \(configValue(pass))")
         }
     }
 
@@ -183,5 +183,38 @@ enum PythonConfigWriter {
             else { out.append(ch) }
         }
         return out
+    }
+
+    /// Encode a user-supplied value so it survives a ConfigObj read round-trip.
+    /// RNS parses the config with RNS.vendor.configobj (list_values=True).
+    /// Unquoted, a `#` begins an inline comment — silently truncating the value
+    /// (e.g. a passphrase `s3cr#t` is read as `s3cr`, joining the network with
+    /// the wrong IFAC key) — a comma is parsed as a list, and a newline injects
+    /// arbitrary config lines. Mirror ConfigObj's own quoting (`_quote` /
+    /// `_get_single_quote` / `_get_triple_quote`, default settings): quote when
+    /// the value contains `#`, a comma, a quote char, or leading/trailing
+    /// whitespace, picking the quote the value lacks and falling back to triple
+    /// quotes when it contains both. CR/LF are stripped first — these fields are
+    /// single-line, so a newline can only be an injection attempt.
+    private static func configValue(_ raw: String) -> String {
+        let value = raw.replacingOccurrences(of: "\r", with: "")
+                       .replacingOccurrences(of: "\n", with: "")
+        if value.isEmpty { return "\"\"" }
+        let hasSingle = value.contains("'")
+        let hasDouble = value.contains("\"")
+        let edgeWS = value.first == " " || value.first == "\t"
+                  || value.last == " " || value.last == "\t"
+        guard value.contains("#") || value.contains(",")
+              || hasSingle || hasDouble || edgeWS else {
+            return value
+        }
+        if !(hasSingle && hasDouble) {
+            return hasDouble ? "'\(value)'" : "\"\(value)\""
+        }
+        // Both quote types present — ConfigObj requires triple quotes (prefer """).
+        if !value.contains("\"\"\"") { return "\"\"\"\(value)\"\"\"" }
+        if !value.contains("'''") { return "'''\(value)'''" }
+        // Pathological (both triple-quote sequences): drop """ so parsing stays safe.
+        return "\"\"\"\(value.replacingOccurrences(of: "\"\"\"", with: ""))\"\"\""
     }
 }

--- a/Sources/ColumbaApp/Services/PythonConfigWriter.swift
+++ b/Sources/ColumbaApp/Services/PythonConfigWriter.swift
@@ -1,0 +1,187 @@
+//
+//  PythonConfigWriter.swift
+//  ColumbaApp
+//
+//  Writes the RNS config file consumed by the embedded Python stack, based on
+//  the user's `InterfaceEntity` records from `InterfaceRepository`. Mirrors the
+//  config-from-UI flow Columba Android already uses with Chaquopy.
+//
+//  RNS's config format is ConfigObj-style (nested `[[section]]` brackets for
+//  subsections, two-space indentation). Not quite TOML.
+//
+
+import Foundation
+import RNSAPI
+
+/// Serializes Columba's interface entities to an RNS config file.
+///
+/// Lifecycle:
+/// 1. AppServices.initialize collects enabled `InterfaceEntity` records from
+///    `InterfaceRepository`.
+/// 2. Calls `PythonConfigWriter.write(...)` to produce the RNS config string.
+/// 3. Writes the string to `<configDir>/config` so the Python `RNS.Reticulum`
+///    instance picks it up on init.
+///
+/// When the user adds, removes, or edits an interface in Settings, the
+/// InterfaceRepository observes the change, AppServices re-runs the writer,
+/// and Python is restarted to pick up the new config. (Hot-reload isn't a
+/// thing in RNS — Mark Qvist noted this in upstream issue threads.)
+enum PythonConfigWriter {
+    /// Build the RNS config text from a set of enabled interfaces.
+    ///
+    /// - Parameters:
+    ///   - interfaces: enabled `InterfaceEntity` records (typically from
+    ///     `InterfaceRepository.getEnabledInterfaces()`). Disabled rows
+    ///     should be filtered before this call.
+    ///   - enableTransport: whether the local RNS instance should act as a
+    ///     transport node. Phones usually want `false` (terminal device);
+    ///     desktop relays want `true`. Set from the Settings "Transport
+    ///     Mode" toggle (stored in App Group UserDefaults under
+    ///     `transport_enabled`). Changing this requires an Apply &
+    ///     Restart since RNS reads it at `Reticulum.__init__` time.
+    /// - Returns: ConfigObj-format text suitable for writing to
+    ///   `<configDir>/config`.
+    static func write(
+        interfaces: [InterfaceEntity],
+        enableTransport: Bool = false
+    ) -> String {
+        var lines: [String] = []
+
+        lines.append("[reticulum]")
+        lines.append("  enable_transport = \(enableTransport ? "yes" : "no")")
+        lines.append("  share_instance = no")
+        lines.append("  panic_on_interface_error = no")
+        lines.append("")
+        lines.append("[logging]")
+        lines.append("  loglevel = 4")
+        lines.append("")
+
+        if interfaces.isEmpty {
+            // No interfaces configured yet — the app starts in an offline
+            // state. The Settings UI is the user's path to add some.
+            return lines.joined(separator: "\n") + "\n"
+        }
+
+        lines.append("[interfaces]")
+        for iface in interfaces {
+            appendInterface(iface, to: &lines)
+        }
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    /// The ConfigObj section name written for an interface. This is also the
+    /// `iface.name` RNS assigns once the section is synthesized, so it's the
+    /// key the Python status snapshot and the hot-add / hot-remove bridge
+    /// calls (`AppServices.applyInterfaceChanges`) use to match a live
+    /// interface back to its `InterfaceEntity`. Single source of truth — do
+    /// not recompute this elsewhere.
+    ///
+    /// RNS interface names show up in `rnstatus`; use Columba's human-readable
+    /// name (sanitized) plus the entity id so we can round-trip if multiple
+    /// have the same display name.
+    static func sectionName(for iface: InterfaceEntity) -> String {
+        sanitize(iface.name).isEmpty
+            ? iface.id
+            : "\(sanitize(iface.name))-\(iface.id.prefix(6))"
+    }
+
+    private static func appendInterface(_ iface: InterfaceEntity, to lines: inout [String]) {
+        lines.append("  [[\(sectionName(for: iface))]]")
+        lines.append("    enabled = yes")
+        lines.append("    interface_enabled = yes")
+        appendMode(iface.mode, to: &lines)
+
+        switch iface.config {
+        case .tcpClient(let cfg):
+            lines.append("    type = TCPClientInterface")
+            lines.append("    target_host = \(cfg.targetHost)")
+            lines.append("    target_port = \(cfg.targetPort)")
+            appendIFAC(networkName: cfg.networkName, passphrase: cfg.passphrase, to: &lines)
+        case .tcpServer(let cfg):
+            lines.append("    type = TCPServerInterface")
+            lines.append("    listen_ip = \(cfg.listenIp)")
+            lines.append("    listen_port = \(cfg.listenPort)")
+        case .autoInterface(let cfg):
+            lines.append("    type = AutoInterface")
+            if let group = cfg.groupId, !group.isEmpty {
+                lines.append("    group_id = \(group)")
+            }
+            lines.append("    discovery_scope = \(cfg.discoveryScope)")
+            if let port = cfg.discoveryPort { lines.append("    discovery_port = \(port)") }
+            if let port = cfg.dataPort { lines.append("    data_port = \(port)") }
+        case .ble:
+            // Loaded from <configDir>/interfaces/IOSBLEInterface.py — the
+            // file is copied there at startup by AppServices.startBLEInterface()
+            // from the app bundle. The Python `IOSBLEDriver` calls into Swift
+            // via ctypes-bound `columba_ble_*` C-ABI shims (see
+            // Sources/SwiftBLEBridge/BleNativeBindings.swift).
+            lines.append("    type = IOSBLEInterface")
+            // Optional power preset — currently informational on iOS (the
+            // OS auto-manages duty cycle). Surfaced for parity with
+            // Android's BleConnections settings.
+            lines.append("    ble_power_preset = balanced")
+        case .rnode(let cfg):
+            // Loaded from <configDir>/interfaces/IOSRNodeInterface.py (copied at
+            // startup by deployIOSRNodePythonFilesIfPossible). That Python
+            // interface runs the KISS / RNode protocol and bridges serial I/O to
+            // Swift's SwiftRNodeBridge (CoreBluetooth Nordic-UART client) via the
+            // ctypes-bound `columba_rnode_*` C-ABI shims (Sources/SwiftBLEBridge/
+            // RNodeNativeBindings.swift). Radio keys are written WITHOUT
+            // underscores (txpower / spreadingfactor / codingrate) to match what
+            // the ported interface parses and upstream RNS's RNodeInterface
+            // convention. iOS is BLE-only — no usb_* / port keys.
+            lines.append("    type = IOSRNodeInterface")
+            lines.append("    target_device_name = \(cfg.deviceName)")
+            lines.append("    frequency = \(cfg.frequency)")
+            lines.append("    bandwidth = \(cfg.bandwidth)")
+            lines.append("    txpower = \(cfg.txPower)")
+            lines.append("    spreadingfactor = \(cfg.spreadingFactor)")
+            lines.append("    codingrate = \(cfg.codingRate)")
+            if let st = cfg.stAlock { lines.append("    st_alock = \(st)") }
+            if let lt = cfg.ltAlock { lines.append("    lt_alock = \(lt)") }
+        case .multipeer:
+            // MultipeerConnectivity bridge not yet wired (separate effort, its
+            // own branch — see rnode_interface_port_plan.md). Emit a disabled
+            // placeholder so the rest of the config stays valid; the UI still
+            // gates this type out (InterfaceTypeSelector).
+            lines.append("    type = TCPClientInterface  # placeholder; \(iface.type) bridged from Swift not yet wired")
+            lines.append("    target_host = 127.0.0.1")
+            lines.append("    target_port = 65535")
+            lines.append("    enabled = no")
+        }
+        lines.append("")
+    }
+
+    private static func appendMode(_ mode: InterfaceMode, to lines: inout [String]) {
+        switch mode {
+        case .full: lines.append("    mode = full")
+        case .gateway: lines.append("    mode = gateway")
+        case .accessPoint: lines.append("    mode = access_point")
+        case .roaming: lines.append("    mode = roaming")
+        case .boundary: lines.append("    mode = boundary")
+        }
+    }
+
+    private static func appendIFAC(networkName: String?, passphrase: String?, to lines: inout [String]) {
+        if let name = networkName, !name.isEmpty {
+            lines.append("    networkname = \(name)")
+        }
+        if let pass = passphrase, !pass.isEmpty {
+            lines.append("    passphrase = \(pass)")
+        }
+    }
+
+    /// Strip characters ConfigObj doesn't like in section names (brackets,
+    /// equals, whitespace runs).
+    private static func sanitize(_ raw: String) -> String {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        let bad: Set<Character> = ["[", "]", "=", "#", "\n", "\r"]
+        var out = ""
+        for ch in trimmed {
+            if bad.contains(ch) { out.append("_") }
+            else if ch.isWhitespace { out.append("_") }
+            else { out.append(ch) }
+        }
+        return out
+    }
+}

--- a/Sources/ColumbaApp/Services/PythonConfigWriter.swift
+++ b/Sources/ColumbaApp/Services/PythonConfigWriter.swift
@@ -94,7 +94,7 @@ enum PythonConfigWriter {
         switch iface.config {
         case .tcpClient(let cfg):
             lines.append("    type = TCPClientInterface")
-            lines.append("    target_host = \(configValue(cfg.targetHost))")
+            appendValue("target_host", cfg.targetHost, to: &lines)
             lines.append("    target_port = \(cfg.targetPort)")
             appendIFAC(networkName: cfg.networkName, passphrase: cfg.passphrase, to: &lines)
         case .tcpServer(let cfg):
@@ -104,7 +104,7 @@ enum PythonConfigWriter {
         case .autoInterface(let cfg):
             lines.append("    type = AutoInterface")
             if let group = cfg.groupId, !group.isEmpty {
-                lines.append("    group_id = \(configValue(group))")
+                appendValue("group_id", group, to: &lines)
             }
             lines.append("    discovery_scope = \(cfg.discoveryScope)")
             if let port = cfg.discoveryPort { lines.append("    discovery_port = \(port)") }
@@ -131,7 +131,7 @@ enum PythonConfigWriter {
             // the ported interface parses and upstream RNS's RNodeInterface
             // convention. iOS is BLE-only — no usb_* / port keys.
             lines.append("    type = IOSRNodeInterface")
-            lines.append("    target_device_name = \(configValue(cfg.deviceName))")
+            appendValue("target_device_name", cfg.deviceName, to: &lines)
             lines.append("    frequency = \(cfg.frequency)")
             lines.append("    bandwidth = \(cfg.bandwidth)")
             lines.append("    txpower = \(cfg.txPower)")
@@ -164,10 +164,10 @@ enum PythonConfigWriter {
 
     private static func appendIFAC(networkName: String?, passphrase: String?, to lines: inout [String]) {
         if let name = networkName, !name.isEmpty {
-            lines.append("    networkname = \(configValue(name))")
+            appendValue("networkname", name, to: &lines)
         }
         if let pass = passphrase, !pass.isEmpty {
-            lines.append("    passphrase = \(configValue(pass))")
+            appendValue("passphrase", pass, to: &lines)
         }
     }
 
@@ -196,7 +196,7 @@ enum PythonConfigWriter {
     /// whitespace, picking the quote the value lacks and falling back to triple
     /// quotes when it contains both. CR/LF are stripped first — these fields are
     /// single-line, so a newline can only be an injection attempt.
-    private static func configValue(_ raw: String) -> String {
+    private static func configValue(_ raw: String) -> String? {
         let value = raw.replacingOccurrences(of: "\r", with: "")
                        .replacingOccurrences(of: "\n", with: "")
         if value.isEmpty { return "\"\"" }
@@ -214,7 +214,22 @@ enum PythonConfigWriter {
         // Both quote types present — ConfigObj requires triple quotes (prefer """).
         if !value.contains("\"\"\"") { return "\"\"\"\(value)\"\"\"" }
         if !value.contains("'''") { return "'''\(value)'''" }
-        // Pathological (both triple-quote sequences): drop """ so parsing stays safe.
-        return "\"\"\"\(value.replacingOccurrences(of: "\"\"\"", with: ""))\"\"\""
+        // Pathological: the value contains both """ and ''', so ConfigObj can't
+        // quote it on any delimiter. Return nil so the caller omits the field
+        // rather than silently corrupting it — a mangled IFAC passphrase would
+        // otherwise join the network with the wrong key. (Absurdly rare; a
+        // missing field fails the connection loudly instead.)
+        return nil
+    }
+
+    /// Append `key = <ConfigObj-encoded value>` for a user-supplied value, or —
+    /// when the value can't be safely encoded — a visible omission comment
+    /// instead of a silently-corrupted value.
+    private static func appendValue(_ key: String, _ raw: String, to lines: inout [String]) {
+        if let encoded = configValue(raw) {
+            lines.append("    \(key) = \(encoded)")
+        } else {
+            lines.append("    # \(key) omitted — value cannot be encoded for ConfigObj")
+        }
     }
 }

--- a/Sources/ColumbaApp/Services/PythonNetworkTransport.swift
+++ b/Sources/ColumbaApp/Services/PythonNetworkTransport.swift
@@ -209,7 +209,16 @@ public actor PythonNetworkTransport: NetworkTransport {
 
     private func deliverClosed(_ reason: TeardownReason) async {
         activeLink = nil
-        let mapped: TransportCloseReason = (reason == .destinationClosed) ? .remoteClosed : .linkFailed
+        // A clean remote hangup arrives as initiator_closed on inbound calls
+        // (the caller initiated the RNS link) and destination_closed on
+        // outbound calls (the callee is the destination); both should surface
+        // as a normal "Call ended". Only genuine failures (timeout / network)
+        // map to .linkFailed, which drives LXST's error state instead.
+        let mapped: TransportCloseReason
+        switch reason {
+        case .destinationClosed, .initiatorClosed: mapped = .remoteClosed
+        default:                                    mapped = .linkFailed
+        }
         await closedHandler?(mapped)
     }
 

--- a/Sources/ColumbaApp/Services/PythonNetworkTransport.swift
+++ b/Sources/ColumbaApp/Services/PythonNetworkTransport.swift
@@ -1,0 +1,230 @@
+import Foundation
+import RNSAPI
+import LXSTSwift
+import os.log
+
+/// Columba's `NetworkTransport` implementation for LXST voice calls.
+///
+/// Bridges LXSTSwift's transport seam to the Compat RNS layer
+/// (`ReticulumTransport` + `Link`) running over `PythonRNSBackend`. It owns all
+/// the Reticulum machinery `LXSTSwift.Telephone` used to do inline — telephony
+/// destination registration, incoming-link detection, link lifecycle,
+/// encryption, packetization, identify, and path resolution — so the library
+/// stays transport-agnostic. Mirrors LXST-kt's `PythonNetworkTransport`.
+///
+/// The seam speaks in the app's universal contact key: the peer's
+/// **lxmf.delivery destination hash**. `openOutboundCall` takes it and resolves
+/// the identity → telephony destination; `remoteIdentified` reports it
+/// (computed from the verified caller identity). No RNS types cross into
+/// `Telephone`.
+public actor PythonNetworkTransport: NetworkTransport {
+
+    // LXST telephony destination aspect: <identity>.lxst.telephony
+    private static let appName = "lxst"
+    private static let primitiveName = "telephony"
+    // LXMF contact key aspect: <identity>.lxmf.delivery
+    private static let lxmfApp = "lxmf"
+    private static let lxmfAspect = "delivery"
+
+    private let identity: Identity
+    private let transport: ReticulumTransport
+    private let pathTable: PathTable?
+    private let logger = Logger(subsystem: "network.columba.Columba", category: "PythonNetworkTransport")
+
+    /// The active call link (outbound or accepted inbound), if any.
+    private var activeLink: Link?
+
+    // Seam handlers (installed by Telephone).
+    private var incomingCallHandler: (@Sendable () async -> Void)?
+    private var remoteIdentifiedHandler: (@Sendable (Data) async -> Void)?
+    private var receiveHandler: (@Sendable (Data) async -> Void)?
+    private var closedHandler: (@Sendable (TransportCloseReason) async -> Void)?
+
+    /// Columba-specific: fired when an inbound link establishes, BEFORE the
+    /// caller identifies — lets CallManager `prepareForIncomingCall` (allocate
+    /// the CallKit UUID) ahead of the post-identify ringing trigger. Not part
+    /// of the `NetworkTransport` protocol.
+    private var incomingCallStartedHandler: (@Sendable () async -> Void)?
+
+    public init(identity: Identity, transport: ReticulumTransport, pathTable: PathTable?) {
+        self.identity = identity
+        self.transport = transport
+        self.pathTable = pathTable
+    }
+
+    /// Register the local telephony destination and wire incoming-link
+    /// detection. Call once after construction, before placing/receiving calls.
+    public func start() async {
+        let inDest = Destination(
+            identity: identity,
+            appName: Self.appName,
+            aspects: [Self.primitiveName],
+            type: .single,
+            direction: .in
+        )
+        await transport.registerDestination(inDest)
+        let hexPrefix = inDest.hash.prefix(8).map { String(format: "%02x", $0) }.joined()
+        logger.error("[PNT] Listening on telephony dest \(hexPrefix, privacy: .public)")
+
+        // The destination-link callback fires pre-establishment; we attach the
+        // established callback so we only take over once the link is usable.
+        transport.registerDestinationLinkCallback(for: inDest.hash) { [weak self] (link: Link) async in
+            await link.setLinkEstablishedCallback { [weak self] (established: Link) async in
+                await self?.handleIncomingLinkEstablished(established)
+            }
+        }
+    }
+
+    /// Set the pre-identify incoming-call hook (CallManager.prepareForIncomingCall).
+    public func setIncomingCallStartedHandler(_ handler: @escaping @Sendable () async -> Void) {
+        incomingCallStartedHandler = handler
+    }
+
+    // MARK: - NetworkTransport (outbound)
+
+    public func openOutboundCall(to deliveryHash: Data) async -> Bool {
+        guard let pathTable else {
+            logger.error("[PNT] openOutboundCall: no path table")
+            return false
+        }
+        // Resolve the peer's delivery hash → identity (public key from announce).
+        guard let entry = await pathTable.lookup(destinationHash: deliveryHash),
+              entry.publicKeys.count == 64,
+              let remoteIdentity = try? Identity(publicKeyBytes: entry.publicKeys) else {
+            logger.error("[PNT] openOutboundCall: peer not resolvable from path table")
+            return false
+        }
+
+        // Build the peer's telephony destination and ensure a path to it.
+        let callDest = Destination(
+            identity: remoteIdentity,
+            appName: Self.appName,
+            aspects: [Self.primitiveName],
+            type: .single,
+            direction: .out
+        )
+        let pathFound = await transport.awaitPath(for: callDest.hash, timeout: 10.0)
+        logger.error("[PNT] path to telephony dest found=\(pathFound, privacy: .public)")
+
+        do {
+            let link = try await transport.initiateLink(to: callDest, identity: identity)
+            await wireLinkCallbacks(link, incoming: false)
+            activeLink = link
+            logger.error("[PNT] Outbound link initiated")
+            return true
+        } catch {
+            logger.error("[PNT] initiateLink failed: \(error.localizedDescription, privacy: .public)")
+            return false
+        }
+    }
+
+    public func identifySelf() async {
+        guard let link = activeLink else { return }
+        try? await link.identify(identity: identity)
+    }
+
+    public func send(_ payload: Data) async {
+        guard let link = activeLink else { return }
+        do {
+            // Compat's Link.sendBytes encrypts with the link keys and emits the
+            // DATA packet internally — no manual packetization needed.
+            try await link.sendBytes(payload)
+        } catch {
+            logger.error("[PNT] send failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    public func closeCall() async {
+        guard let link = activeLink else { return }
+        // Clear the close callback first so our own teardown doesn't echo back
+        // as a spurious remote-close.
+        await link.setCloseCallback(nil)
+        if link.state.isEstablished {
+            link.close()
+        }
+        activeLink = nil
+    }
+
+    public var isCallActive: Bool { activeLink != nil }
+
+    // MARK: - NetworkTransport (inbound handler registration)
+
+    public func setIncomingCallHandler(_ handler: @escaping @Sendable () async -> Void) async {
+        incomingCallHandler = handler
+    }
+    public func setRemoteIdentifiedHandler(_ handler: @escaping @Sendable (Data) async -> Void) async {
+        remoteIdentifiedHandler = handler
+    }
+    public func setReceiveHandler(_ handler: @escaping @Sendable (Data) async -> Void) async {
+        receiveHandler = handler
+    }
+    public func setClosedHandler(_ handler: @escaping @Sendable (TransportCloseReason) async -> Void) async {
+        closedHandler = handler
+    }
+
+    // MARK: - Internal wiring
+
+    /// Attach packet/close (and, for inbound, identify) callbacks routing to the seam.
+    private func wireLinkCallbacks(_ link: Link, incoming: Bool) async {
+        await link.setPacketCallback { [weak self] data, _ in
+            await self?.deliverReceived(data)
+        }
+        await link.setCloseCallback { [weak self] reason in
+            await self?.deliverClosed(reason)
+        }
+        if incoming {
+            await link.setIdentifyCallbacks(IdentifyAdapter(owner: self))
+        }
+    }
+
+    private func handleIncomingLinkEstablished(_ link: Link) async {
+        // Already on a call → signal BUSY on the NEW link and tear it down,
+        // without disturbing the active one. Mirrors Python LXST
+        // Telephony.__incoming_link_established (`signal(STATUS_BUSY, link);
+        // link.teardown()`). The busy decision lives here at the incoming-link
+        // layer because `activeLink` belongs to the in-progress call; we send
+        // the one-byte BUSY signal directly rather than route it through
+        // Telephone (which only knows about the active call).
+        if activeLink != nil {
+            logger.error("[PNT] Incoming link while a call is active — signalling BUSY")
+            try? await link.sendBytes(LXSTWireFormat.packSignal(.busy))
+            link.close()
+            return
+        }
+        await wireLinkCallbacks(link, incoming: true)
+        activeLink = link
+        // Notify CallManager (prepare CallKit UUID) then Telephone (send AVAILABLE).
+        await incomingCallStartedHandler?()
+        await incomingCallHandler?()
+    }
+
+    private func deliverReceived(_ data: Data) async {
+        await receiveHandler?(data)
+    }
+
+    private func deliverClosed(_ reason: TeardownReason) async {
+        activeLink = nil
+        let mapped: TransportCloseReason = (reason == .destinationClosed) ? .remoteClosed : .linkFailed
+        await closedHandler?(mapped)
+    }
+
+    /// Called by the identify adapter once the remote caller is verified.
+    fileprivate func handleRemoteIdentified(_ remoteIdentity: Identity) async {
+        // Report the caller by their lxmf.delivery hash (the app's contact key).
+        let deliveryHash = Destination.hash(
+            identity: remoteIdentity,
+            appName: Self.lxmfApp,
+            aspects: [Self.lxmfAspect]
+        )
+        await remoteIdentifiedHandler?(deliveryHash)
+    }
+}
+
+/// Bridges the Compat `IdentifyCallbacks` protocol to the transport actor.
+private final class IdentifyAdapter: IdentifyCallbacks, @unchecked Sendable {
+    private weak var owner: PythonNetworkTransport?
+    init(owner: PythonNetworkTransport) { self.owner = owner }
+    func remoteIdentified(_ identity: Identity) async {
+        await owner?.handleRemoteIdentified(identity)
+    }
+}

--- a/Sources/ColumbaApp/Services/PythonNetworkTransport.swift
+++ b/Sources/ColumbaApp/Services/PythonNetworkTransport.swift
@@ -140,7 +140,10 @@ public actor PythonNetworkTransport: NetworkTransport {
         // as a spurious remote-close.
         await link.setCloseCallback(nil)
         if link.state.isEstablished {
-            link.close()
+            // Local hangup: tear the Python RNS.Link down (not just flip local
+            // state) so the remote peer's link closes promptly instead of
+            // waiting for its ~15s keepalive timeout.
+            await link.teardown()
         }
         activeLink = nil
     }
@@ -188,7 +191,9 @@ public actor PythonNetworkTransport: NetworkTransport {
         if activeLink != nil {
             logger.error("[PNT] Incoming link while a call is active — signalling BUSY")
             try? await link.sendBytes(LXSTWireFormat.packSignal(.busy))
-            link.close()
+            // Tear the Python RNS.Link down (mirrors LXST's `link.teardown()`)
+            // so the rejected caller's link closes now rather than on timeout.
+            await link.teardown()
             return
         }
         await wireLinkCallbacks(link, incoming: true)

--- a/Sources/ColumbaApp/Services/PythonNetworkTransport.swift
+++ b/Sources/ColumbaApp/Services/PythonNetworkTransport.swift
@@ -120,7 +120,14 @@ public actor PythonNetworkTransport: NetworkTransport {
 
     public func identifySelf() async {
         guard let link = activeLink else { return }
-        try? await link.identify(identity: identity)
+        do {
+            try await link.identify(identity: identity)
+        } catch {
+            // An identify failure (link torn down mid-handshake, backend error)
+            // strands the callee at AVAILABLE until connect-timeout — surface it
+            // instead of swallowing via try?, mirroring send()'s logging.
+            logger.error("[PNT] identifySelf failed: \(error.localizedDescription, privacy: .public)")
+        }
     }
 
     public func send(_ payload: Data) async {

--- a/Sources/ColumbaApp/Services/PythonNetworkTransport.swift
+++ b/Sources/ColumbaApp/Services/PythonNetworkTransport.swift
@@ -105,6 +105,13 @@ public actor PythonNetworkTransport: NetworkTransport {
         )
         let pathFound = await transport.awaitPath(for: callDest.hash, timeout: 10.0)
         logger.error("[PNT] path to telephony dest found=\(pathFound, privacy: .public)")
+        guard pathFound else {
+            // No path after the timeout — the peer is unreachable, so an
+            // RNS.Link can't establish anyway. Abort now rather than fall
+            // through to a doomed initiateLink that just times out again.
+            logger.error("[PNT] no path to telephony dest — aborting outbound call")
+            return false
+        }
 
         do {
             let link = try await transport.initiateLink(to: callDest, identity: identity)

--- a/Sources/ColumbaApp/Services/PythonNetworkTransport.swift
+++ b/Sources/ColumbaApp/Services/PythonNetworkTransport.swift
@@ -139,12 +139,13 @@ public actor PythonNetworkTransport: NetworkTransport {
         // Clear the close callback first so our own teardown doesn't echo back
         // as a spurious remote-close.
         await link.setCloseCallback(nil)
-        if link.state.isEstablished {
-            // Local hangup: tear the Python RNS.Link down (not just flip local
-            // state) so the remote peer's link closes promptly instead of
-            // waiting for its ~15s keepalive timeout.
-            await link.teardown()
-        }
+        // Local hangup: tear the Python RNS.Link down (not just flip local
+        // state) so the remote peer's link closes promptly instead of waiting
+        // for its ~15s keepalive timeout. Do this even when not yet
+        // established — aborting an outbound dial during the "calling" window
+        // (or a connect-timeout) leaves a `.pending` link whose Python side
+        // must still be torn down. teardown() is a no-op on an unwired link.
+        await link.teardown()
         activeLink = nil
     }
 
@@ -181,6 +182,10 @@ public actor PythonNetworkTransport: NetworkTransport {
     }
 
     private func handleIncomingLinkEstablished(_ link: Link) async {
+        // A re-delivered established event for the link we're already on must
+        // not be treated as a competing inbound call — otherwise the BUSY
+        // branch below would signal BUSY on and tear down our own live link.
+        if link === activeLink { return }
         // Already on a call → signal BUSY on the NEW link and tear it down,
         // without disturbing the active one. Mirrors Python LXST
         // Telephony.__incoming_link_established (`signal(STATUS_BUSY, link);

--- a/Sources/ColumbaApp/Services/SettingsRepository.swift
+++ b/Sources/ColumbaApp/Services/SettingsRepository.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import LXMFSwift
+import RNSAPI
 
 /// Actor for thread-safe settings access.
 ///

--- a/Sources/ColumbaApp/Services/SharedDefaults.swift
+++ b/Sources/ColumbaApp/Services/SharedDefaults.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import RNSAPI
 
 /// Shared UserDefaults backed by the App Group container.
 ///

--- a/Sources/ColumbaApp/Services/TunnelManager.swift
+++ b/Sources/ColumbaApp/Services/TunnelManager.swift
@@ -12,6 +12,7 @@
 #if ENABLE_NETWORK_EXTENSION
 
 import Foundation
+import RNSAPI
 import NetworkExtension
 import os.log
 

--- a/Sources/ColumbaApp/Theme/Theme.swift
+++ b/Sources/ColumbaApp/Theme/Theme.swift
@@ -7,6 +7,7 @@
 //
 
 import SwiftUI
+import RNSAPI
 
 /// App theming namespace.
 ///

--- a/Sources/ColumbaApp/Theme/ThemeColors.swift
+++ b/Sources/ColumbaApp/Theme/ThemeColors.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import RNSAPI
 
 // MARK: - Theme Colors
 

--- a/Sources/ColumbaApp/Theme/ThemeManager.swift
+++ b/Sources/ColumbaApp/Theme/ThemeManager.swift
@@ -7,6 +7,7 @@
 //
 
 import SwiftUI
+import RNSAPI
 import Observation
 
 /// Central theme state manager.

--- a/Sources/ColumbaApp/ViewModels/ChatsViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/ChatsViewModel.swift
@@ -7,9 +7,8 @@
 //
 
 import Foundation
+import RNSAPI
 import Observation
-import LXMFSwift
-import ReticulumSwift
 
 // MARK: - Conversation Model
 
@@ -73,7 +72,7 @@ public struct Conversation: Identifiable, Equatable, Hashable {
         self.id = record.destinationHash.map { String(format: "%02x", $0) }.joined()
         self.destinationHash = record.destinationHash
         self.displayName = record.displayName
-        self.lastMessageTimestamp = Date(timeIntervalSince1970: record.lastMessageTimestamp)
+        self.lastMessageTimestamp = record.lastMessageTimestamp
         self.lastMessagePreview = record.lastMessagePreview
         self.unreadCount = record.unreadCount
         self.isFavorite = record.isFavorite != 0
@@ -194,17 +193,17 @@ public final class ChatsViewModel {
         do {
             let records = try await repository.fetchConversations()
             var convos = records
-                .filter { $0.lastMessagePreview != nil }
+                .filter { !$0.lastMessagePreview.isEmpty }
                 .map { Conversation(from: $0) }
 
             // Backfill display names from path table for conversations that have none
             if let pathTable {
                 for i in convos.indices where convos[i].displayName == nil {
                     if let entry = await pathTable.lookup(destinationHash: convos[i].destinationHash),
-                       let name = entry.displayName, !name.isEmpty {
-                        convos[i].displayName = name
+                       !entry.displayName.isEmpty {
+                        convos[i].displayName = entry.displayName
                         // Persist so we don't need to look up again
-                        try? await repository.ensureConversation(convos[i].destinationHash, displayName: name)
+                        try? await repository.ensureConversation(convos[i].destinationHash, displayName: entry.displayName)
                     }
                 }
             }
@@ -225,16 +224,16 @@ public final class ChatsViewModel {
         do {
             let records = try await repository.fetchConversations()
             var convos = records
-                .filter { $0.lastMessagePreview != nil }
+                .filter { !$0.lastMessagePreview.isEmpty }
                 .map { Conversation(from: $0) }
 
             // Backfill display names from path table for conversations that have none
             if let pathTable {
                 for i in convos.indices where convos[i].displayName == nil {
                     if let entry = await pathTable.lookup(destinationHash: convos[i].destinationHash),
-                       let name = entry.displayName, !name.isEmpty {
-                        convos[i].displayName = name
-                        try? await repository.ensureConversation(convos[i].destinationHash, displayName: name)
+                       !entry.displayName.isEmpty {
+                        convos[i].displayName = entry.displayName
+                        try? await repository.ensureConversation(convos[i].destinationHash, displayName: entry.displayName)
                     }
                 }
             }

--- a/Sources/ColumbaApp/ViewModels/ContactsViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/ContactsViewModel.swift
@@ -7,9 +7,8 @@
 //
 
 import Foundation
+import RNSAPI
 import Observation
-import LXMFSwift
-import ReticulumSwift
 
 // MARK: - Contact Type
 
@@ -47,10 +46,19 @@ public struct Contact: Identifiable, Sendable, Hashable {
     /// Returns "bluetooth" (MDI name) for BLE, SF Symbol names for others.
     public var interfaceIcon: String {
         guard let iface = interfaceId else { return "globe" }
-        if iface.hasPrefix("ble") { return "bluetooth" }
-        if iface.hasPrefix("rnode") { return "antenna.radiowaves.left.and.right" }
-        if iface.hasPrefix("auto") { return "wifi" }
-        if iface.hasPrefix("mpc") { return "apple.logo" }
+        let lower = iface.lowercased()
+        // Python-side interface names that get plumbed up here:
+        //  - User-defined sections: PythonConfigWriter.sanitize → "Hub-FFB1F1",
+        //    "Bluetooth_LE-77CFC2", "Auto_Discovery-7B59DD", etc.
+        //  - Dynamically-spawned children with `name=None`: str() form like
+        //    "AutoInterfacePeer[en0/fe80::xxxx]", "BLEPeerInterface[]".
+        // Both forms need recognizing (case-insensitive substring match).
+        if lower.contains("bluetooth") || lower.contains("ble")
+            || lower.contains("blepeer") { return "bluetooth" }
+        if lower.contains("rnode") { return "antenna.radiowaves.left.and.right" }
+        if lower.contains("autointerface") || lower.contains("auto_discovery")
+            || lower.contains("autointerfacepeer") { return "wifi" }
+        if lower.contains("multipeer") || lower.contains("mpc") { return "apple.logo" }
         return "globe" // tcp and others
     }
 
@@ -62,10 +70,12 @@ public struct Contact: Identifiable, Sendable, Hashable {
     /// Interface filter category for this contact.
     public var interfaceFilterType: InterfaceFilter {
         guard let iface = interfaceId else { return .tcp }
-        if iface.hasPrefix("ble") { return .ble }
-        if iface.hasPrefix("rnode") { return .rnode }
-        if iface.hasPrefix("auto") { return .wifi }
-        if iface.hasPrefix("mpc") { return .wifi }
+        let lower = iface.lowercased()
+        if lower.contains("bluetooth") || lower.contains("ble")
+            || lower.contains("blepeer") { return .ble }
+        if lower.contains("rnode") { return .rnode }
+        if lower.contains("autointerface") || lower.contains("auto_discovery") { return .wifi }
+        if lower.contains("multipeer") || lower.contains("mpc") { return .wifi }
         return .tcp
     }
 
@@ -180,7 +190,7 @@ public struct Contact: Identifiable, Sendable, Hashable {
         self.badgeType = .peer
         self.hopCount = 0
         self.signalStrength = 4
-        self.timestamp = Date(timeIntervalSince1970: record.lastMessageTimestamp)
+        self.timestamp = record.lastMessageTimestamp
         self.isOnline = true
         self.isFavorite = record.isFavorite != 0
         self.isPinned = record.isPinned != 0

--- a/Sources/ColumbaApp/ViewModels/InterfaceManagementViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/InterfaceManagementViewModel.swift
@@ -7,8 +7,8 @@
 //
 
 import Foundation
+import RNSAPI
 import SwiftUI
-import ReticulumSwift
 import os.log
 
 private let logger = Logger(subsystem: "network.columba.Columba", category: "InterfaceManagementVM")
@@ -173,23 +173,21 @@ public final class InterfaceManagementViewModel: TCPClientWizardSaveSink {
         isLoading = false
     }
 
-    /// Toggle interface enabled state and immediately apply.
+    /// Toggle interface enabled state. Marks dirty; user must tap
+    /// "Apply & Restart" in the toolbar to push the change through to
+    /// Reticulum (which has no hot-reload — see `applyChanges()`).
     public func toggleInterface(_ interface: InterfaceEntity, enabled: Bool) {
         repository.toggleInterface(id: interface.id, enabled: enabled)
         hasPendingChanges = true
-        Task { @MainActor in
-            await applyChanges()
-        }
+        showSuccess("\(interface.name) \(enabled ? "enabled" : "disabled") — tap Apply to restart")
     }
 
-    /// Delete an interface and stop it if running.
+    /// Delete an interface. Marks dirty; the running Reticulum stack keeps
+    /// the old interface alive until "Apply & Restart" is tapped.
     public func deleteInterface(_ interface: InterfaceEntity) {
         repository.deleteInterface(id: interface.id)
         hasPendingChanges = true
-        showSuccess("Interface deleted")
-        Task { @MainActor in
-            await applyChanges()
-        }
+        showSuccess("Interface deleted — tap Apply to restart")
     }
 
     /// Confirm and delete the pending interface.
@@ -264,7 +262,7 @@ public final class InterfaceManagementViewModel: TCPClientWizardSaveSink {
             updated.config = config
 
             repository.updateInterface(updated)
-            showSuccess("Interface updated")
+            showSuccess("Interface updated — tap Apply to restart")
         } else {
             // Create new
             let newInterface = InterfaceEntity(
@@ -276,16 +274,13 @@ public final class InterfaceManagementViewModel: TCPClientWizardSaveSink {
             )
 
             repository.addInterface(newInterface)
-            showSuccess("Interface added")
+            showSuccess("Interface added — tap Apply to restart")
         }
 
         hasPendingChanges = true
         dismissConfigSheet()
-
-        // Auto-apply so the interface starts/stops immediately
-        Task { @MainActor in
-            await applyChanges()
-        }
+        // Don't auto-apply — user taps "Apply & Restart" explicitly so
+        // they're not surprised by a Reticulum restart while editing.
     }
 
     /// Save a TCP client interface from the wizard flow.
@@ -333,139 +328,37 @@ public final class InterfaceManagementViewModel: TCPClientWizardSaveSink {
 
     // MARK: - Apply Changes
 
-    /// Apply pending interface changes to the running network.
+    /// Apply pending interface changes to the running Reticulum stack live —
+    /// no restart, no relaunch.
     ///
-    /// Only starts/stops the interfaces that actually changed, leaving
-    /// other running interfaces untouched.
+    /// RNS attaches/detaches interfaces on a running `Transport` (the same
+    /// primitive its interface-discovery autoconnect uses), so changing the
+    /// `[interfaces]` set does NOT require a full `RNS.Reticulum(...)` re-init.
+    /// `AppServices.applyInterfaceChanges()` diffs the saved enabled list
+    /// against what's currently live and hot-adds / hot-removes the delta,
+    /// while also rewriting the config file so the change survives a cold
+    /// launch. New TCP interfaces connect within ~1-2s; removed ones drop
+    /// immediately.
     @MainActor
     public func applyChanges() async {
         guard hasPendingChanges else { return }
 
         isApplyingChanges = true
-
-        let enabledInterfaces = repository.getEnabledInterfaces()
-
-        // --- TCP (supports multiple simultaneous connections) ---
-        let enabledTCPs = enabledInterfaces.filter { $0.type == .tcpClient }
-        let enabledTCPIds = Set(enabledTCPs.map { $0.id })
-
-        // Connect/reconnect each enabled TCP interface, skipping ones that
-        // are already running with the same host:port. Without the skip,
-        // toggling or editing any single interface caused this loop to
-        // tear down every other healthy TCP connection alongside the one
-        // the user actually changed — and reconnecting prompted the relay
-        // to redeliver its full announce table per interface, swamping
-        // the app for ~90s per change.
-        for tcpIf in enabledTCPs {
-            if case .tcpClient(let config) = tcpIf.config {
-                let desired = AppServices.TCPEndpoint(host: config.targetHost, port: config.targetPort)
-                if appServices.tcpInterfaces[tcpIf.id] != nil,
-                   appServices.tcpEndpoints[tcpIf.id] == desired {
-                    continue
-                }
-                logger.info("Applying TCP[\(tcpIf.id)]: \(config.targetHost):\(config.targetPort)")
-                interfaceStatus[tcpIf.id] = .connecting
-                do {
-                    try await appServices.connectTCPInterface(entityId: tcpIf.id, host: config.targetHost, port: config.targetPort)
-                    showSuccess("Connecting to \(config.targetHost):\(config.targetPort)...")
-                } catch {
-                    logger.error("TCP failed [\(tcpIf.id)]: \(error)")
-                    interfaceStatus[tcpIf.id] = .error
-                    showError("TCP failed: \(error.localizedDescription)")
-                }
-            }
+        // Backend-agnostic Apply: route ALL interface changes (incl. multiple
+        // TCP) through the active backend's hot add/remove path. This replaces
+        // main's legacy per-TCP connectTCPInterface loop (the dual-backend
+        // refactor moved TCP bring-up into appServices.applyInterfaceChanges()
+        // so it works for the Swift backend too). Multi-TCP reconciliation with
+        // main's per-entity tcpInterfaces/tcpEndpoints tracking is deferred to
+        // the dual-backend landing.
+        defer {
+            hasPendingChanges = false
+            isApplyingChanges = false
         }
 
-        // Stop TCP interfaces that are no longer in the enabled set
-        let currentTCPIds = Set(appServices.tcpInterfaces.keys)
-        for oldId in currentTCPIds where !enabledTCPIds.contains(oldId) {
-            logger.info("Stopping TCP[\(oldId)]")
-            await appServices.stopTCPInterface(entityId: oldId)
-        }
-
-        // --- AutoInterface ---
-        let autoEntity = enabledInterfaces.first(where: { $0.type == .autoInterface })
-        if let autoIf = autoEntity,
-           case .autoInterface(let config) = autoIf.config {
-            if appServices.autoInterface == nil {
-                let groupId = config.groupId ?? "reticulum"
-                logger.info("Starting AutoInterface: \(groupId)")
-                interfaceStatus[autoIf.id] = .connecting
-                do {
-                    try await appServices.startAutoInterface(groupId: groupId)
-                    interfaceStatus[autoIf.id] = .connected
-                } catch {
-                    logger.error("AutoInterface failed: \(error)")
-                    interfaceStatus[autoIf.id] = .error
-                }
-            }
-        } else if autoEntity == nil {
-            await appServices.stopAutoInterface()
-        }
-
-        // --- BLE ---
-        #if canImport(CoreBluetooth)
-        let bleEntity = enabledInterfaces.first(where: { $0.type == .ble })
-        if let bleEntity = bleEntity {
-            if appServices.bleInterface == nil {
-                logger.info("Starting BLE")
-                interfaceStatus[bleEntity.id] = .connecting
-                do {
-                    try await appServices.startBLEInterface()
-                    interfaceStatus[bleEntity.id] = .connected
-                } catch {
-                    logger.error("BLE failed: \(error)")
-                    interfaceStatus[bleEntity.id] = .error
-                    showError("BLE failed: \(error.localizedDescription)")
-                }
-            }
-        } else if bleEntity == nil {
-            await appServices.stopBLEInterface()
-        }
-        #endif
-
-        // --- RNode ---
-        let rnodeEntity = enabledInterfaces.first(where: { $0.type == .rnode })
-        if let rnodeIf = rnodeEntity,
-           case .rnode(let rnodeConfig) = rnodeIf.config {
-            if appServices.rnodeInterface == nil {
-                logger.info("Starting RNode: \(rnodeConfig.deviceName)")
-                interfaceStatus[rnodeIf.id] = .connecting
-                do {
-                    try await appServices.startRNodeInterface(config: rnodeConfig, name: rnodeIf.name)
-                } catch {
-                    logger.error("RNode failed: \(error)")
-                    interfaceStatus[rnodeIf.id] = .error
-                    showError("RNode failed: \(error.localizedDescription)")
-                }
-            }
-        } else if rnodeEntity == nil {
-            await appServices.stopRNodeInterface()
-        }
-
-        // --- Multipeer Connectivity ---
-        #if canImport(MultipeerConnectivity)
-        let mpcEntity = enabledInterfaces.first(where: { $0.type == .multipeer })
-        if let mpcIf = mpcEntity {
-            if appServices.mpcInterface == nil {
-                logger.info("Starting Multipeer")
-                interfaceStatus[mpcIf.id] = .connecting
-                do {
-                    try await appServices.startMPCInterface()
-                    interfaceStatus[mpcIf.id] = .connected
-                } catch {
-                    logger.error("Multipeer failed: \(error)")
-                    interfaceStatus[mpcIf.id] = .error
-                    showError("Multipeer failed: \(error.localizedDescription)")
-                }
-            }
-        } else if mpcEntity == nil {
-            await appServices.stopMPCInterface()
-        }
-        #endif
-
-        hasPendingChanges = false
-        isApplyingChanges = false
+        logger.info("Applying interface changes live (hot add/remove)")
+        await appServices.applyInterfaceChanges()
+        showSuccess("Interface changes applied")
     }
 
     // MARK: - Status Observation
@@ -501,7 +394,8 @@ public final class InterfaceManagementViewModel: TCPClientWizardSaveSink {
                         case .connected: status = .connected
                         case .connecting: status = .connecting
                         case .reconnecting: status = .reconnecting
-                        case .disconnected: status = .disconnected
+                        case .disconnected, .notConnected: status = .disconnected
+                        case .connectionFailed, .sendFailed, .invalidConfig: status = .error
                         }
                         tcpUpdates.append((entity.id, status, err))
                     } else {
@@ -600,8 +494,10 @@ public final class InterfaceManagementViewModel: TCPClientWizardSaveSink {
                                 self.interfaceStatus[rnodeEntity.id] = .connecting
                             case .reconnecting:
                                 self.interfaceStatus[rnodeEntity.id] = .reconnecting
-                            case .disconnected:
+                            case .disconnected, .notConnected:
                                 self.interfaceStatus[rnodeEntity.id] = .disconnected
+                            case .connectionFailed, .sendFailed, .invalidConfig:
+                                self.interfaceStatus[rnodeEntity.id] = .error
                             }
                         } else {
                             self.interfaceStatus[rnodeEntity.id] = .disconnected

--- a/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
@@ -7,9 +7,8 @@
 //
 
 import SwiftUI
+import RNSAPI
 import Observation
-import LXMFSwift
-import ReticulumSwift
 import os.log
 
 /// ViewModel for the messaging screen.
@@ -54,6 +53,7 @@ public final class MessagingViewModel {
 
     /// Observation token for incoming message notifications.
     private var notificationTask: Any?
+    private var deliveryTask: Any?
 
     // MARK: - Initialization
 
@@ -90,10 +90,31 @@ public final class MessagingViewModel {
                 await self.loadMessages()
             }
         }
+
+        // Listen for delivery / failure proofs (double-check indicator). The DB
+        // row is already updated by AppServices; we just flip the in-memory
+        // bubble in place so the open chat reflects it without a full reload.
+        deliveryTask = NotificationCenter.default.addObserver(
+            forName: Notification.Name("ColumbaPythonDelivery"),
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let self,
+                  let hashData = notification.userInfo?["messageHash"] as? Data,
+                  let state = notification.userInfo?["state"] as? String else { return }
+            let hashHex = hashData.map { String(format: "%02x", $0) }.joined()
+            Task { @MainActor in
+                guard let index = self.messages.firstIndex(where: { $0.id == hashHex }) else { return }
+                self.messages[index].deliveryStatus = (state == "delivered") ? .delivered : .failed
+            }
+        }
     }
 
     deinit {
         if let token = notificationTask {
+            NotificationCenter.default.removeObserver(token)
+        }
+        if let token = deliveryTask {
             NotificationCenter.default.removeObserver(token)
         }
     }
@@ -171,6 +192,10 @@ public final class MessagingViewModel {
         }
     }
 
+    /// Thrown when the backend rejects a send pre-flight (bad hash / not started)
+    /// so the existing catch path (retry-via-relay, then failed status) runs.
+    private enum SendError: Error { case notQueued }
+
     /// Send a text-only message (convenience wrapper).
     @MainActor
     public func sendMessage(text: String) async -> Bool {
@@ -204,8 +229,8 @@ public final class MessagingViewModel {
             return false
         }
 
-        guard let router = appServices.router else {
-            errorMessage = "Router not initialized"
+        guard let backend = appServices.backend else {
+            errorMessage = "Backend not initialized"
             return false
         }
 
@@ -216,11 +241,11 @@ public final class MessagingViewModel {
         let settingsMethod = await settingsRepository.getDefaultDeliveryMethod()
         let fallbackForLargeMessages: LXDeliveryMethod = (settingsMethod == "propagated") ? .propagated : .direct
 
-        // Build fields with icon appearance if set
+        // Resolve icon once — passed to the typed backend send below and also
+        // stashed in the local Compat.LXMessage fields for persistence/display.
+        let icon = await settingsRepository.getIconAppearance()
         var fields: [UInt8: Any] = [:]
-        if let icon = await settingsRepository.getIconAppearance() {
-            fields[IconAppearance.fieldKey] = icon.toLXMFFieldValue()
-        }
+        if let icon { fields[IconAppearance.fieldKey] = icon.toLXMFFieldValue() }
 
         // Add image field (FIELD_IMAGE = 0x06): [format_string, binary_data]
         if let imageData, let imageFormat {
@@ -238,7 +263,7 @@ public final class MessagingViewModel {
         }
 
         // Create outbound LXMF message — always opportunistic first
-        var lxMessage = LXMessage(
+        let lxMessage = LXMessage(
             destinationHash: conversationHash,
             sourceIdentity: identity,
             content: trimmedText.data(using: .utf8) ?? Data(),
@@ -281,8 +306,23 @@ public final class MessagingViewModel {
         }
 
         do {
-            // Send via router (router saves to DB internally via Task.detached)
-            try await router.handleOutbound(&lxMessage)
+            // Send through the neutral LXMF facet with TYPED fields (image /
+            // attachments / icon) — the backend builds the canonical LXMF field
+            // map + routes, and returns the real message hash. (Replaces the old
+            // Compat router + sendHook path, which dropped all fields on the
+            // wire.) Nothing persists the outbound message to the local DB, so
+            // we save explicitly below once `lxMessage.hash` is stamped.
+            let outcome = try await backend.lxmf.sendLxmfMessage(
+                destHashHex: conversationHash.map { String(format: "%02x", $0) }.joined(),
+                content: trimmedText, method: .opportunistic,
+                imageData: imageData, imageFormat: imageFormat,
+                fileAttachments: attachments?.map { RnsFileAttachment(name: $0.name, data: $0.data) },
+                iconAppearance: icon,
+                replyToMessageHashHex: replyToId, replyQuotedContent: replyPreview, extraFields: nil)
+            guard case .queued(let sentHashHex) = outcome, let sentHash = Data(hexString: sentHashHex) else {
+                throw SendError.notQueued
+            }
+            lxMessage.hash = sentHash
 
             // Replace optimistic message with real one (using actual hash from pack)
             let realId = lxMessage.hash.map { String(format: "%02x", $0) }.joined()
@@ -303,6 +343,13 @@ public final class MessagingViewModel {
                 }
             }
 
+            // Persist so a subsequent loadMessages() doesn't wipe it.
+            do {
+                try await repository.saveMessage(lxMessage)
+            } catch {
+                logger.error("[MSG_VM] saveMessage(outbound) failed: \(error.localizedDescription)")
+            }
+
             return true
         } catch {
             // Retry via relay if enabled
@@ -318,7 +365,7 @@ public final class MessagingViewModel {
                 }
 
                 // Create new message with propagated method
-                var retryMessage = LXMessage(
+                let retryMessage = LXMessage(
                     destinationHash: conversationHash,
                     sourceIdentity: identity,
                     content: trimmedText.data(using: .utf8) ?? Data(),
@@ -328,8 +375,18 @@ public final class MessagingViewModel {
                 )
 
                 do {
-                    // Router saves to DB internally
-                    try await router.handleOutbound(&retryMessage)
+                    // Relay retry through the neutral facet (propagated method).
+                    let retryOutcome = try await backend.lxmf.sendLxmfMessage(
+                        destHashHex: conversationHash.map { String(format: "%02x", $0) }.joined(),
+                        content: trimmedText, method: .propagated,
+                        imageData: imageData, imageFormat: imageFormat,
+                        fileAttachments: attachments?.map { RnsFileAttachment(name: $0.name, data: $0.data) },
+                        iconAppearance: icon,
+                        replyToMessageHashHex: replyToId, replyQuotedContent: replyPreview, extraFields: nil)
+                    guard case .queued(let retryHashHex) = retryOutcome, let retryHash = Data(hexString: retryHashHex) else {
+                        throw SendError.notQueued
+                    }
+                    retryMessage.hash = retryHash
                     let realId = retryMessage.hash.map { String(format: "%02x", $0) }.joined()
                     if let index = messages.firstIndex(where: { $0.id == optimisticId }) {
                         withAnimation(.easeInOut(duration: 0.2)) {
@@ -346,6 +403,11 @@ public final class MessagingViewModel {
                                 replyToPreview: replyPreview
                             )
                         }
+                    }
+                    do {
+                        try await repository.saveMessage(retryMessage)
+                    } catch {
+                        logger.error("[MSG_VM] saveMessage(retry-relay) failed: \(error.localizedDescription)")
                     }
                     return true
                 } catch {
@@ -432,7 +494,7 @@ public final class MessagingViewModel {
     @MainActor
     public func sendReaction(targetMessageId: String, targetMessageHash: Data?, emoji: String) async {
         guard let hash = targetMessageHash else { return }
-        guard let identity = appServices.identity, let router = appServices.router else { return }
+        guard let backend = appServices.backend else { return }
 
         let localHashHex = appServices.localIdentityHash.map { String(format: "%02x", $0) }.joined()
 
@@ -476,25 +538,15 @@ public final class MessagingViewModel {
             }
         }
 
-        // Send reaction LXMF message (empty content)
-        var fields: [UInt8: Any] = [:]
-        fields[LXMessage.FIELD_APP_DATA] = [
-            "reaction_to": targetMessageId,
-            "emoji": emoji,
-            "sender": localHashHex
-        ] as [String: Any]
-
-        var lxMessage = LXMessage(
-            destinationHash: conversationHash,
-            sourceIdentity: identity,
-            content: Data(),
-            title: Data(),
-            fields: fields,
-            desiredMethod: .opportunistic
-        )
-
+        // Send via the canonical FIELD_REACTION (0x40): the backend builds the
+        // {0x00: targetHashBytes, 0x01: emojiUTF8} dict on an empty-content
+        // message; the reacting user is derived from the source hash on receive
+        // (not on the wire). Replaces the legacy 0x10 {reaction_to,emoji,sender}.
         do {
-            try await router.handleOutbound(&lxMessage)
+            try await backend.lxmf.sendReaction(
+                destHashHex: conversationHash.map { String(format: "%02x", $0) }.joined(),
+                targetMessageHashHex: targetMessageId,
+                emoji: emoji)
         } catch {
             logger.error("Failed to send reaction: \(error.localizedDescription)")
         }

--- a/Sources/ColumbaApp/ViewModels/MigrationViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/MigrationViewModel.swift
@@ -1,3 +1,4 @@
+#if COLUMBA_MIGRATION_ENABLED
 //
 //  MigrationViewModel.swift
 //  ColumbaApp
@@ -7,6 +8,7 @@
 //
 
 import Foundation
+import RNSAPI
 import SwiftUI
 import os.log
 
@@ -222,3 +224,4 @@ extension ImportResult: Equatable {
         lhs.identitiesImported == rhs.identitiesImported
     }
 }
+#endif

--- a/Sources/ColumbaApp/ViewModels/NetworkStatusViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/NetworkStatusViewModel.swift
@@ -7,8 +7,8 @@
 //
 
 import Foundation
+import RNSAPI
 import SwiftUI
-import ReticulumSwift
 
 // MARK: - Interface Info
 

--- a/Sources/ColumbaApp/ViewModels/NomadNetBrowserViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/NomadNetBrowserViewModel.swift
@@ -1,6 +1,7 @@
+#if COLUMBA_NOMADNET_ENABLED
 import Foundation
+import RNSAPI
 import SwiftUI
-import ReticulumSwift
 
 /// Rendering mode for NomadNet pages.
 public enum NomadNetRenderingMode: String, Sendable, CaseIterable {
@@ -109,15 +110,13 @@ public final class NomadNetBrowserViewModel {
     public init(
         nodeHash: Data,
         nodeName: String?,
-        transport: ReticulumTransport,
-        pathTable: PathTable,
+        backend: any RnsBackend,
         identity: Identity
     ) {
         self.currentNodeHash = nodeHash
         self.currentNodeName = nodeName
         self.browserService = NomadNetBrowserService(
-            transport: transport,
-            pathTable: pathTable,
+            backend: backend,
             identity: identity
         )
     }
@@ -445,3 +444,4 @@ public final class NomadNetBrowserViewModel {
     }
 }
 
+#endif

--- a/Sources/ColumbaApp/ViewModels/OnboardingViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/OnboardingViewModel.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import RNSAPI
 import Observation
 import UserNotifications
 

--- a/Sources/ColumbaApp/ViewModels/RNodeWizardViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/RNodeWizardViewModel.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import RNSAPI
 import SwiftUI
 
 // MARK: - Wizard Step

--- a/Sources/ColumbaApp/ViewModels/SettingsViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/SettingsViewModel.swift
@@ -7,8 +7,8 @@
 //
 
 import Foundation
+import RNSAPI
 import Observation
-import LXMFSwift
 #if canImport(UIKit)
 import UIKit
 #endif
@@ -139,6 +139,16 @@ public final class SettingsViewModel {
 
     public var isTransportEnabled: Bool = false
     public var isTransportExpanded: Bool = false
+
+    // MARK: - Network Backend (RNS engine)
+
+    /// Whether the native Swift backend is selected (vs embedded Python).
+    /// Persisted via `BackendPreference`; applied on next app launch.
+    public var useSwiftBackend: Bool = false
+    public var isBackendExpanded: Bool = false
+    /// True once the user changes the backend, surfacing the "relaunch to
+    /// apply" hint until the app is restarted.
+    public var backendChangePending: Bool = false
 
     // MARK: - Card Expansion State
 
@@ -403,6 +413,7 @@ public final class SettingsViewModel {
         let lastTs = defaults.double(forKey: "last_announce_time")
         lastAnnounceTime = lastTs > 0 ? Date(timeIntervalSince1970: lastTs) : nil
         isTransportEnabled = SharedDefaults.suite.bool(forKey: "transport_enabled")
+        useSwiftBackend = BackendPreference.isSwift
         isLocationSharingEnabled = defaults.bool(forKey: "location_sharing_enabled")
         locationPrecisionRadius = defaults.integer(forKey: "location_precision_radius")
         if let storedDuration = defaults.string(forKey: "default_sharing_duration") {
@@ -514,6 +525,16 @@ public final class SettingsViewModel {
                 manager.stop()
             }
         }
+    }
+
+    /// Persist the selected RNS backend. Takes effect on the next app launch —
+    /// the backend is constructed once at stack init and can't be hot-swapped
+    /// live (same constraint as `restartPythonBackend()`), so the UI surfaces a
+    /// relaunch hint rather than tearing the stack down mid-session.
+    @MainActor
+    public func applyBackendSelection() {
+        BackendPreference.isSwift = useSwiftBackend
+        backendChangePending = true
     }
 
     /// Update icon appearance and persist.

--- a/Sources/ColumbaApp/ViewModels/TCPClientWizardViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/TCPClientWizardViewModel.swift
@@ -8,7 +8,9 @@
 
 import Foundation
 import SwiftUI
-import ReticulumSwift
+import RNSAPI  // InterfaceMode / InterfaceEntity / InterfaceConfig live in RNSAPI on
+              // this branch (they were app-module types on main). Not ReticulumSwift,
+              // whose own InterfaceMode collided with RNSAPI's after the merge.
 
 // MARK: - Wizard Step
 

--- a/Sources/RNSAPI/Compat.swift
+++ b/Sources/RNSAPI/Compat.swift
@@ -349,6 +349,13 @@ public final class Link: @unchecked Sendable {
     /// identity and can apply its caller-allowed filter.
     public var identifyHook: (@Sendable () async throws -> Void)?
 
+    /// Hook installed by AppServices that tears the underlying Python RNS.Link
+    /// down via `PythonRNSBackend.linkTeardown(linkId:)`. `close()` only flips
+    /// local state; on a *local* hangup we must also tell Python to tear the
+    /// link down, otherwise the remote peer's RNS.Link lingers until its ~15s
+    /// keepalive timeout instead of closing promptly. nil until wired.
+    public var closeHook: (@Sendable () async -> Void)?
+
     /// Hooks installed by lxst-swift via `setCloseCallback` /
     /// `setIdentifyCallbacks` — invoked by AppServices when the corresponding
     /// Python events fire (link_state(closed) → closeCallback;
@@ -384,6 +391,17 @@ public final class Link: @unchecked Sendable {
         }
     }
     public func close() { state = .closed }
+
+    /// Local-hangup teardown: propagate the close to the Python RNS.Link (via
+    /// `closeHook` → `PythonRNSBackend.linkTeardown`) before flipping local
+    /// state. Use this instead of `close()` when *we* initiate the hangup so
+    /// the remote peer's link closes promptly rather than waiting for timeout.
+    /// Python-initiated closes go through AppServices.dispatchLinkClosed and
+    /// must NOT call this (the link is already torn down on the Python side).
+    public func teardown() async {
+        if let hook = closeHook { await hook() }
+        state = .closed
+    }
     public func request(_ path: String) {}
     public func request(_ path: String, data: Any? = nil, responseTimeout: TimeInterval? = nil) async throws -> RequestReceipt {
         RequestReceipt(linkIdentityHash: identityHash, path: path)

--- a/Sources/SwiftBLEBridge/BleConnectionState.swift
+++ b/Sources/SwiftBLEBridge/BleConnectionState.swift
@@ -1,0 +1,42 @@
+//
+//  BleConnectionState.swift
+//  SwiftBLEBridge
+//
+//  Per-peer connection state surfaced to the Python driver + the iOS Settings
+//  UI. Mirror of Android's BleConnectionDetails.
+//
+
+import Foundation
+
+public enum BleConnectionRole: String, Sendable, Equatable {
+    case central
+    case peripheral
+}
+
+public struct BleConnectionDetails: Sendable, Equatable {
+    public let address: String
+    public let identityHashHex: String?
+    public let role: BleConnectionRole
+    public let mtu: Int
+    public let rssi: Int?
+    public let lastActivity: Date
+    public let connectedAt: Date
+
+    public init(
+        address: String,
+        identityHashHex: String?,
+        role: BleConnectionRole,
+        mtu: Int,
+        rssi: Int?,
+        lastActivity: Date,
+        connectedAt: Date = Date()
+    ) {
+        self.address = address
+        self.identityHashHex = identityHashHex
+        self.role = role
+        self.mtu = mtu
+        self.rssi = rssi
+        self.lastActivity = lastActivity
+        self.connectedAt = connectedAt
+    }
+}

--- a/Sources/SwiftBLEBridge/BleConstants.swift
+++ b/Sources/SwiftBLEBridge/BleConstants.swift
@@ -1,0 +1,56 @@
+//
+//  BleConstants.swift
+//  SwiftBLEBridge
+//
+//  Wire-format constants. Must match Columba Android's BleConstants.kt and
+//  upstream ble-reticulum's BLEGATTServer.py verbatim — this is the protocol.
+//
+
+import Foundation
+#if canImport(CoreBluetooth)
+import CoreBluetooth
+#endif
+
+public enum BleConstants {
+    // MARK: - GATT UUIDs (wire-compat across iOS / Android / Linux)
+
+    /// Primary service container; advertised. Matches Android's
+    /// `BleConstants.SERVICE_UUID` and upstream
+    /// `BLEGATTServer.SERVICE_UUID`.
+    public static let serviceUuid = "37145b00-442d-4a94-917f-8f42c5da28e3"
+
+    /// RX characteristic — centrals write fragments here (and the initial
+    /// 16-byte identity handshake). WRITE + WRITE_WITHOUT_RESPONSE.
+    public static let rxCharUuid = "37145b00-442d-4a94-917f-8f42c5da28e5"
+
+    /// TX characteristic — peripherals notify fragments here. READ + NOTIFY.
+    /// Centrals subscribe by writing CCCD.
+    public static let txCharUuid = "37145b00-442d-4a94-917f-8f42c5da28e4"
+
+    /// Identity characteristic — 16-byte RNS Transport identity hash. READ.
+    public static let identityCharUuid = "37145b00-442d-4a94-917f-8f42c5da28e6"
+
+    /// Client Characteristic Configuration Descriptor — standard BLE.
+    public static let cccdDescriptorUuid = "00002902-0000-1000-8000-00805f9b34fb"
+
+    // MARK: - Protocol constants
+
+    /// 16-byte identity hash size (matches `RNS.Transport.IDENTITY_HASH_LENGTH`).
+    public static let identitySize = 16
+
+    /// Fragment header byte count: `[Type:1][Sequence:2 BE][Total:2 BE]`.
+    public static let fragmentHeaderSize = 5
+
+    /// MTU fallback when iOS reports < this. BLE 4.0 floor minus ATT overhead.
+    public static let minimumUsableMtu = 23
+
+    // MARK: - Convenience CoreBluetooth wrappers
+
+    #if canImport(CoreBluetooth)
+    public static let serviceCBUUID = CBUUID(string: serviceUuid)
+    public static let rxCharCBUUID = CBUUID(string: rxCharUuid)
+    public static let txCharCBUUID = CBUUID(string: txCharUuid)
+    public static let identityCharCBUUID = CBUUID(string: identityCharUuid)
+    public static let cccdDescriptorCBUUID = CBUUID(string: cccdDescriptorUuid)
+    #endif
+}

--- a/Sources/SwiftBLEBridge/BleDevice.swift
+++ b/Sources/SwiftBLEBridge/BleDevice.swift
@@ -1,0 +1,34 @@
+//
+//  BleDevice.swift
+//  SwiftBLEBridge
+//
+//  Plain value type passed up to Python on `on_device_discovered`. Mirrors
+//  upstream `BLEDevice` dataclass in bluetooth_driver.py.
+//
+
+import Foundation
+
+public struct BleDevice: Sendable, Equatable {
+    /// Stable per-peripheral key. On iOS this is `CBPeripheral.identifier.uuidString`.
+    /// Note: for Android / Linux peers this rotates every ~15 min when their MAC
+    /// rotates — the driver tracks address↔identity reunification to surface
+    /// `on_address_changed` to the upstream interface.
+    public let address: String
+
+    /// Friendly name from the advertisement, if present.
+    public let name: String
+
+    /// Last RSSI sample, in dBm.
+    public let rssi: Int
+
+    /// Service UUIDs the peer advertised. Used by the driver to filter
+    /// non-Columba devices before reporting.
+    public let serviceUuids: [String]
+
+    public init(address: String, name: String, rssi: Int, serviceUuids: [String]) {
+        self.address = address
+        self.name = name
+        self.rssi = rssi
+        self.serviceUuids = serviceUuids
+    }
+}

--- a/Sources/SwiftBLEBridge/BleGattClient.swift
+++ b/Sources/SwiftBLEBridge/BleGattClient.swift
@@ -52,6 +52,13 @@ internal final class BleGattClient {
     /// completes. The bridge polls periodically post-connect.
     var rssi: Int?
 
+    /// Outbound fragments awaiting CoreBluetooth transmit-queue space.
+    /// writeValue(.withoutResponse) silently drops once the per-peripheral
+    /// queue is full (iOS 11+), so frames are queued here and drained as space
+    /// frees up (see drainClientWritesLocked / peripheralIsReady). Discarded
+    /// with the client on disconnect.
+    var pendingWrites: [Data] = []
+
     init(peripheral: CBPeripheral) {
         self.peripheral = peripheral
     }

--- a/Sources/SwiftBLEBridge/BleGattClient.swift
+++ b/Sources/SwiftBLEBridge/BleGattClient.swift
@@ -1,0 +1,60 @@
+//
+//  BleGattClient.swift
+//  SwiftBLEBridge
+//
+//  Per-peer GATT client state. Tracks the discovery → handshake → data
+//  state machine for centrals (i.e. peripherals we connect to).
+//
+
+import Foundation
+#if canImport(CoreBluetooth)
+import CoreBluetooth
+
+/// State of a single GATT client (one CBPeripheral we connect to).
+internal final class BleGattClient {
+
+    /// State of the connection handshake. iOS-side mirror of Android's
+    /// `BleGattClient` state ladder.
+    enum HandshakeState {
+        case connecting          // CBCentralManager.connect issued
+        case discoveringServices // didConnect → discoverServices called
+        case discoveringChars    // didDiscoverServices → discoverCharacteristics called
+        case readingIdentity     // setNotifyValue(true) on TX done; reading Identity char
+        case writingIdentity     // Identity received; writing our own to RX
+        case established         // handshake complete; data plane open
+        case failed              // any step errored
+    }
+
+    let peripheral: CBPeripheral
+
+    var state: HandshakeState = .connecting
+    var mtu: Int = BleConstants.minimumUsableMtu
+    var rxChar: CBCharacteristic?
+    var txChar: CBCharacteristic?
+    var identityChar: CBCharacteristic?
+
+    /// Peer's identity (16 bytes) once we've read it from the Identity char.
+    var peerIdentity: Data?
+
+    /// Whether we've already fired `on_device_connected` for this peer.
+    /// Prevents duplicate fires when MTU arrives before handshake completes.
+    var connectedFired: Bool = false
+
+    /// Whether we've already fired `on_mtu_negotiated`. Same dedup reason.
+    var mtuFired: Bool = false
+
+    /// When the GATT connection was established (didConnect → service
+    /// discovery complete). Used to compute connection duration for the
+    /// BLE Connections UI screen.
+    var connectedAt: Date = Date()
+
+    /// Most-recent RSSI sample from `readRSSI()`. nil until first read
+    /// completes. The bridge polls periodically post-connect.
+    var rssi: Int?
+
+    init(peripheral: CBPeripheral) {
+        self.peripheral = peripheral
+    }
+}
+
+#endif

--- a/Sources/SwiftBLEBridge/BleGattServer.swift
+++ b/Sources/SwiftBLEBridge/BleGattServer.swift
@@ -1,0 +1,41 @@
+//
+//  BleGattServer.swift
+//  SwiftBLEBridge
+//
+//  Per-subscriber peripheral-mode state. Each central that subscribes to
+//  our TX characteristic gets a `BleGattServerPeer` so we can track its
+//  identity, MTU, and outbound queue.
+//
+
+import Foundation
+#if canImport(CoreBluetooth)
+import CoreBluetooth
+
+internal final class BleGattServerPeer {
+
+    enum HandshakeState {
+        case awaitingIdentity   // subscribed but hasn't sent its 16-byte identity yet
+        case established        // identity received; data plane open
+    }
+
+    let central: CBCentral
+    var state: HandshakeState = .awaitingIdentity
+    var identity: Data?
+    var mtu: Int
+
+    /// Outbound queue when CBPeripheralManager.updateValue returns false
+    /// (backpressure). Drained on peripheralManagerIsReady(toUpdateSubscribers:).
+    var pendingNotifies: [Data] = []
+
+    /// When this central first subscribed to our TX char (or sent its
+    /// identity handshake). Used to compute connection duration for the
+    /// BLE Connections UI screen.
+    var connectedAt: Date = Date()
+
+    init(central: CBCentral) {
+        self.central = central
+        self.mtu = central.maximumUpdateValueLength
+    }
+}
+
+#endif

--- a/Sources/SwiftBLEBridge/BleNativeBindings.swift
+++ b/Sources/SwiftBLEBridge/BleNativeBindings.swift
@@ -1,0 +1,146 @@
+//
+//  BleNativeBindings.swift
+//  SwiftBLEBridge
+//
+//  C-ABI shims exposing SwiftBLEBridge.shared to Python's ctypes. The Python
+//  `IOSBLEDriver` (app/ble/IOSBLEDriver.py) binds these via `ctypes.CDLL(None)`
+//  at module import time. Symbol names MUST match the `_decl(...)` calls there.
+//
+//  Return codes:
+//    0  = success
+//   -1  = bridge not started / invalid state
+//   -2  = argument error (null pointer, bad encoding)
+//   -3  = bridge call threw
+//
+
+import Foundation
+
+// MARK: - Helpers
+
+private func decodeCString(_ ptr: UnsafePointer<CChar>?) -> String? {
+    guard let ptr else { return nil }
+    return String(cString: ptr)
+}
+
+private func decodeBytes(_ ptr: UnsafePointer<CChar>?, length: Int32) -> Data? {
+    guard let ptr, length >= 0 else { return nil }
+    if length == 0 { return Data() }
+    return ptr.withMemoryRebound(to: UInt8.self, capacity: Int(length)) { p in
+        Data(bytes: p, count: Int(length))
+    }
+}
+
+// MARK: - Lifecycle
+
+@_cdecl("columba_ble_start")
+public func columba_ble_start(
+    _ serviceUuid: UnsafePointer<CChar>?,
+    _ rxCharUuid: UnsafePointer<CChar>?,
+    _ txCharUuid: UnsafePointer<CChar>?,
+    _ identityCharUuid: UnsafePointer<CChar>?
+) -> Int32 {
+    guard let s = decodeCString(serviceUuid),
+          let r = decodeCString(rxCharUuid),
+          let t = decodeCString(txCharUuid),
+          let i = decodeCString(identityCharUuid) else {
+        return -2
+    }
+    SwiftBLEBridge.shared.start(
+        serviceUuid: s,
+        rxCharUuid: r,
+        txCharUuid: t,
+        identityCharUuid: i
+    )
+    return 0
+}
+
+@_cdecl("columba_ble_stop")
+public func columba_ble_stop() -> Int32 {
+    SwiftBLEBridge.shared.stop()
+    return 0
+}
+
+@_cdecl("columba_ble_set_identity")
+public func columba_ble_set_identity(
+    _ bytes: UnsafePointer<CChar>?,
+    _ length: Int32
+) -> Int32 {
+    guard let data = decodeBytes(bytes, length: length) else { return -2 }
+    SwiftBLEBridge.shared.setIdentity(data)
+    return 0
+}
+
+// MARK: - Scan + advertise
+
+@_cdecl("columba_ble_start_scanning")
+public func columba_ble_start_scanning() -> Int32 {
+    SwiftBLEBridge.shared.startScanning()
+    return 0
+}
+
+@_cdecl("columba_ble_stop_scanning")
+public func columba_ble_stop_scanning() -> Int32 {
+    SwiftBLEBridge.shared.stopScanning()
+    return 0
+}
+
+@_cdecl("columba_ble_start_advertising")
+public func columba_ble_start_advertising(
+    _ deviceName: UnsafePointer<CChar>?,
+    _ identityBytes: UnsafePointer<CChar>?,
+    _ identityLength: Int32
+) -> Int32 {
+    let name = decodeCString(deviceName)
+    let identity = decodeBytes(identityBytes, length: identityLength) ?? Data()
+    SwiftBLEBridge.shared.setIdentity(identity)
+    SwiftBLEBridge.shared.startAdvertising(deviceName: name?.isEmpty == false ? name : nil)
+    return 0
+}
+
+@_cdecl("columba_ble_stop_advertising")
+public func columba_ble_stop_advertising() -> Int32 {
+    SwiftBLEBridge.shared.stopAdvertising()
+    return 0
+}
+
+// MARK: - Connection management
+
+@_cdecl("columba_ble_connect")
+public func columba_ble_connect(_ address: UnsafePointer<CChar>?) -> Int32 {
+    guard let addr = decodeCString(address) else { return -2 }
+    SwiftBLEBridge.shared.connect(address: addr)
+    return 0
+}
+
+@_cdecl("columba_ble_disconnect")
+public func columba_ble_disconnect(_ address: UnsafePointer<CChar>?) -> Int32 {
+    guard let addr = decodeCString(address) else { return -2 }
+    SwiftBLEBridge.shared.disconnect(address: addr)
+    return 0
+}
+
+@_cdecl("columba_ble_send")
+public func columba_ble_send(
+    _ address: UnsafePointer<CChar>?,
+    _ data: UnsafePointer<CChar>?,
+    _ length: Int32
+) -> Int32 {
+    guard let addr = decodeCString(address),
+          let payload = decodeBytes(data, length: length) else {
+        return -2
+    }
+    SwiftBLEBridge.shared.send(address: addr, data: payload)
+    return 0
+}
+
+// MARK: - Config
+
+@_cdecl("columba_ble_configure_power")
+public func columba_ble_configure_power(_ presetName: UnsafePointer<CChar>?) -> Int32 {
+    guard let name = decodeCString(presetName),
+          let preset = BlePowerPreset(rawValue: name) else {
+        return -2
+    }
+    SwiftBLEBridge.shared.configurePower(BlePowerSettings(preset: preset))
+    return 0
+}

--- a/Sources/SwiftBLEBridge/BlePowerSettings.swift
+++ b/Sources/SwiftBLEBridge/BlePowerSettings.swift
@@ -1,0 +1,38 @@
+//
+//  BlePowerSettings.swift
+//  SwiftBLEBridge
+//
+//  Power preset surface. iOS auto-manages scan/advertise duty cycle, so this
+//  is informational on our end; the Python driver still calls `set_power_mode`
+//  for Android-parity, we record it and report back.
+//
+
+import Foundation
+
+public enum BlePowerPreset: String, Sendable, CaseIterable {
+    case aggressive
+    case balanced
+    case saver
+}
+
+public struct BlePowerSettings: Sendable, Equatable {
+    public let preset: BlePowerPreset
+    public let discoveryIntervalMs: Int
+    public let discoveryIntervalIdleMs: Int
+    public let scanDurationMs: Int
+    public let advertisingRefreshIntervalMs: Int
+
+    public init(
+        preset: BlePowerPreset = .balanced,
+        discoveryIntervalMs: Int = 10_000,
+        discoveryIntervalIdleMs: Int = 30_000,
+        scanDurationMs: Int = 5_000,
+        advertisingRefreshIntervalMs: Int = 60_000
+    ) {
+        self.preset = preset
+        self.discoveryIntervalMs = discoveryIntervalMs
+        self.discoveryIntervalIdleMs = discoveryIntervalIdleMs
+        self.scanDurationMs = scanDurationMs
+        self.advertisingRefreshIntervalMs = advertisingRefreshIntervalMs
+    }
+}

--- a/Sources/SwiftBLEBridge/RNodeNativeBindings.swift
+++ b/Sources/SwiftBLEBridge/RNodeNativeBindings.swift
@@ -1,0 +1,65 @@
+//
+//  RNodeNativeBindings.swift
+//  SwiftBLEBridge
+//
+//  C-ABI shims exposing SwiftRNodeBridge.shared to Python's ctypes. The Python
+//  `IOSRNodeInterface` (app/rnode/IOSRNodeInterface.py) binds these via
+//  `ctypes.CDLL(None)` at module import time — symbol names + signatures MUST
+//  match the `_decl(...)` calls there. Mirror of `BleNativeBindings.swift`.
+//
+//  Return codes:
+//    0  = success
+//   -2  = argument error (null pointer / bad encoding)
+//
+
+import Foundation
+
+// File-private decoders (Swift `private` is file-scoped, so these don't
+// collide with the identically-purposed helpers in BleNativeBindings.swift).
+private func rnodeDecodeCString(_ ptr: UnsafePointer<CChar>?) -> String? {
+    guard let ptr else { return nil }
+    return String(cString: ptr)
+}
+
+private func rnodeDecodeBytes(_ ptr: UnsafePointer<CChar>?, length: Int32) -> Data? {
+    guard let ptr, length >= 0 else { return nil }
+    if length == 0 { return Data() }
+    return ptr.withMemoryRebound(to: UInt8.self, capacity: Int(length)) { p in
+        Data(bytes: p, count: Int(length))
+    }
+}
+
+@_cdecl("columba_rnode_start")
+public func columba_rnode_start() -> Int32 {
+    SwiftRNodeBridge.shared.start()
+    return 0
+}
+
+@_cdecl("columba_rnode_stop")
+public func columba_rnode_stop() -> Int32 {
+    SwiftRNodeBridge.shared.stop()
+    return 0
+}
+
+@_cdecl("columba_rnode_connect")
+public func columba_rnode_connect(_ deviceName: UnsafePointer<CChar>?) -> Int32 {
+    guard let name = rnodeDecodeCString(deviceName) else { return -2 }
+    SwiftRNodeBridge.shared.connect(deviceName: name)
+    return 0
+}
+
+@_cdecl("columba_rnode_disconnect")
+public func columba_rnode_disconnect() -> Int32 {
+    SwiftRNodeBridge.shared.disconnect()
+    return 0
+}
+
+@_cdecl("columba_rnode_write")
+public func columba_rnode_write(
+    _ bytes: UnsafePointer<CChar>?,
+    _ length: Int32
+) -> Int32 {
+    guard let payload = rnodeDecodeBytes(bytes, length: length) else { return -2 }
+    SwiftRNodeBridge.shared.write(payload)
+    return 0
+}

--- a/Sources/SwiftBLEBridge/StampGenerator.swift
+++ b/Sources/SwiftBLEBridge/StampGenerator.swift
@@ -1,0 +1,141 @@
+//
+//  StampGenerator.swift
+//  SwiftBLEBridge
+//
+//  Native multi-threaded LXMF stamp proof-of-work for iOS.
+//
+//  iOS's embedded CPython ships no `_multiprocessing` module, so upstream
+//  LXMF's `LXStamper.job_linux` (multiprocessing-based PoW) throws
+//  `ModuleNotFoundError: _multiprocessing` and no stamp is ever produced — so
+//  messages to peers that require a stamp cost (e.g. Sideband) are never
+//  delivered. macOS/Windows fall back to LXMF's single-threaded `job_simple`,
+//  which works but is slow for higher costs.
+//
+//  This mirrors Columba Android's Kotlin `StampGenerator` (offloading the PoW
+//  to native code via LXMF's external-generator hook): brute-force a 32-byte
+//  stamp across all CPU cores until SHA-256(workblock ‖ stamp) has `cost`
+//  leading zero bits — exactly the condition LXMF's `stamp_valid` (and the
+//  receiving Sideband) check. Lives in this module next to the other
+//  `columba_*` C-ABI shims so `ctypes.CDLL(None)` resolves it the same proven
+//  way. `rns_bridge.py` monkeypatches `LXStamper.generate_stamp` to call in
+//  here (keeping LXMF's workblock + value math byte-exact).
+//
+//  Optimisation over the Android version: the (~750 KB) workblock is absorbed
+//  into a SHA-256 context ONCE, then each attempt clones that context (a flat
+//  CC_SHA256_CTX value) and finalises over just the 32-byte candidate — instead
+//  of re-hashing the whole workblock every round.
+//
+
+import Foundation
+import CommonCrypto
+import os
+
+enum StampGenerator {
+
+    static let stampSize = 32  // RNS.Identity.HASHLENGTH // 8
+
+    /// Find a 32-byte stamp such that SHA-256(workblock ‖ stamp) has at least
+    /// `cost` leading zero bits. Multi-threaded across (capped) cores; blocks
+    /// until found. Returns nil only for an out-of-range cost.
+    static func generate(workblock: Data, cost: Int) -> Data? {
+        guard cost >= 0, cost <= 256 else { return nil }
+        if cost == 0 { return Data(repeating: 0, count: stampSize) }
+
+        // Absorb the workblock once. CC_SHA256_CTX is a flat value struct with
+        // no internal pointers, so `var ctx = base` is a valid clone of the
+        // partial hash state — the key per-round speedup.
+        var base = CC_SHA256_CTX()
+        CC_SHA256_Init(&base)
+        workblock.withUnsafeBytes { raw in
+            if let p = raw.baseAddress, raw.count > 0 {
+                CC_SHA256_Update(&base, p, CC_LONG(raw.count))
+            }
+        }
+
+        let workers = max(1, min(ProcessInfo.processInfo.activeProcessorCount, 8))
+        let result = StampResultBox()
+
+        DispatchQueue.concurrentPerform(iterations: workers) { _ in
+            // Distinct random 256-bit start per worker (so workers don't overlap),
+            // then increment as a big-endian counter each round — cheaper than
+            // drawing fresh randomness per attempt.
+            var candidate = [UInt8](repeating: 0, count: stampSize)
+            var rng = SystemRandomNumberGenerator()
+            for i in 0..<stampSize { candidate[i] = UInt8.random(in: 0...255, using: &rng) }
+
+            var digest = [UInt8](repeating: 0, count: stampSize)
+            var rounds: UInt = 0
+
+            while true {
+                var ctx = base  // clone partial state (workblock already absorbed)
+                _ = candidate.withUnsafeBufferPointer { CC_SHA256_Update(&ctx, $0.baseAddress, CC_LONG(stampSize)) }
+                CC_SHA256_Final(&digest, &ctx)
+
+                if leadingZeroBits(digest) >= cost {
+                    result.trySet(Data(candidate))
+                    return
+                }
+
+                // Increment candidate as a 256-bit big-endian counter.
+                var idx = stampSize - 1
+                while idx >= 0 {
+                    candidate[idx] = candidate[idx] &+ 1
+                    if candidate[idx] != 0 { break }
+                    idx -= 1
+                }
+
+                rounds &+= 1
+                // Cheap periodic stop-check so losing workers exit shortly after
+                // a sibling finds a stamp.
+                if rounds & 0xFFF == 0 && result.isFound() { return }
+            }
+        }
+
+        return result.get()
+    }
+
+    /// Leading zero BITS of a 32-byte big-endian digest.
+    @inline(__always)
+    private static func leadingZeroBits(_ d: [UInt8]) -> Int {
+        var count = 0
+        for b in d {
+            if b == 0 { count += 8 } else { count += b.leadingZeroBitCount; break }
+        }
+        return count
+    }
+}
+
+/// Thread-safe holder for the first stamp found. All access is via the lock —
+/// no data races; `isFound()` is only polled every few thousand rounds.
+private final class StampResultBox: @unchecked Sendable {
+    private let state = OSAllocatedUnfairLock<Data?>(initialState: nil)
+    func trySet(_ d: Data) { state.withLock { if $0 == nil { $0 = d } } }
+    func isFound() -> Bool { state.withLock { $0 != nil } }
+    func get() -> Data? { state.withLock { $0 } }
+}
+
+/// C-ABI shim for Python ctypes (`rns_bridge.py` → `columba_stamp_generate`).
+/// Writes the 32-byte stamp into `outStamp` and returns its length (32) on
+/// success, 0 if no stamp was produced, -1 on bad arguments.
+@_cdecl("columba_stamp_generate")
+public func columba_stamp_generate(
+    _ workblock: UnsafePointer<CChar>?,
+    _ workblockLen: Int32,
+    _ stampCost: Int32,
+    _ outStamp: UnsafeMutablePointer<CChar>?
+) -> Int32 {
+    guard let workblock, let outStamp, workblockLen >= 0, stampCost >= 0 else { return -1 }
+    let wb = workblock.withMemoryRebound(to: UInt8.self, capacity: Int(workblockLen)) {
+        Data(bytes: $0, count: Int(workblockLen))
+    }
+    guard let stamp = StampGenerator.generate(workblock: wb, cost: Int(stampCost)),
+          stamp.count == StampGenerator.stampSize else {
+        return 0
+    }
+    stamp.withUnsafeBytes { raw in
+        outStamp.withMemoryRebound(to: UInt8.self, capacity: StampGenerator.stampSize) { dst in
+            _ = memcpy(dst, raw.baseAddress!, StampGenerator.stampSize)
+        }
+    }
+    return Int32(StampGenerator.stampSize)
+}

--- a/Sources/SwiftBLEBridge/StampGenerator.swift
+++ b/Sources/SwiftBLEBridge/StampGenerator.swift
@@ -36,9 +36,19 @@ enum StampGenerator {
 
     /// Find a 32-byte stamp such that SHA-256(workblock ‖ stamp) has at least
     /// `cost` leading zero bits. Multi-threaded across (capped) cores; blocks
-    /// until found. Returns nil only for an out-of-range cost.
+    /// until found. Returns nil for an out-of-range / infeasible cost.
+    ///
+    /// `maxCost` is a hard fail-fast bound: this runs synchronously from Python
+    /// via ctypes (holding the GIL for the whole call), so an infeasible cost
+    /// would freeze all RNS I/O — message delivery, announces, link events —
+    /// with no way to cancel. The practical LXMF range is 0–22 bits (Sideband's
+    /// default); 32 leaves generous headroom (~10 bits, 1024×) while keeping
+    /// the worst case bounded. (Greptile suggested 64, but 2^33–2^64 work is
+    /// hours-to-centuries — still an indefinite GIL freeze — so 32 is the
+    /// defensible ceiling; a message requesting more is undeliverable anyway.)
+    static let maxCost = 32
     static func generate(workblock: Data, cost: Int) -> Data? {
-        guard cost >= 0, cost <= 256 else { return nil }
+        guard cost >= 0, cost <= maxCost else { return nil }
         if cost == 0 { return Data(repeating: 0, count: stampSize) }
 
         // Absorb the workblock once. CC_SHA256_CTX is a flat value struct with

--- a/Sources/SwiftBLEBridge/SwiftBLEBridge.swift
+++ b/Sources/SwiftBLEBridge/SwiftBLEBridge.swift
@@ -97,6 +97,11 @@ public final class SwiftBLEBridge: NSObject, @unchecked Sendable {
     // Keyed by `CBCentral.identifier.uuidString`.
     private var gattServerPeers: [String: BleGattServerPeer] = [:]
 
+    // Cap on a peer's backpressure notify queue (mirrors
+    // SwiftRNodeBridge.maxPendingWrites) so a stuck or vanished subscriber
+    // can't grow pendingNotifies without bound.
+    private let maxPendingNotifies = 128
+
     // Mutable characteristics published by our peripheral-mode GATT server.
     // Set once during start(); never re-added (iOS broadcasts Service Changed
     // on re-add which can break subscribed centrals).
@@ -377,7 +382,13 @@ public final class SwiftBLEBridge: NSObject, @unchecked Sendable {
                 let ok = pm.updateValue(data, for: txChar, onSubscribedCentrals: [peer.central])
                 if !ok {
                     // Backpressure — queue and drain on peripheralManagerIsReady.
-                    peer.pendingNotifies.append(data)
+                    // Bounded so a stuck/vanished subscriber can't grow it
+                    // unbounded; drop the frame (and warn) when full.
+                    if peer.pendingNotifies.count < maxPendingNotifies {
+                        peer.pendingNotifies.append(data)
+                    } else {
+                        emitError("warning", "pendingNotifies full (\(maxPendingNotifies)) for \(address); dropping frame")
+                    }
                 }
                 return
             }

--- a/Sources/SwiftBLEBridge/SwiftBLEBridge.swift
+++ b/Sources/SwiftBLEBridge/SwiftBLEBridge.swift
@@ -772,8 +772,10 @@ extension SwiftBLEBridge: CBPeripheralDelegate {
         }
         let address = peripheral.identifier.uuidString
         let value = RSSI.intValue
-        // CB sometimes returns 127 / 0 as sentinels; ignore those samples.
-        guard value != 127, value != 0 else { return }
+        // CB sometimes returns 127 / -127 / 0 as sentinels; ignore those
+        // samples (matches the scan-path filter in didDiscover) so a sentinel
+        // doesn't overwrite a good RSSI that getConnectionDetails() surfaces.
+        guard value != 127, value != -127, value != 0 else { return }
         gattClients[address]?.rssi = value
     }
 }

--- a/Sources/SwiftBLEBridge/SwiftBLEBridge.swift
+++ b/Sources/SwiftBLEBridge/SwiftBLEBridge.swift
@@ -932,12 +932,16 @@ extension SwiftBLEBridge: CBPeripheralManagerDelegate {
     public func peripheralManagerIsReady(
         toUpdateSubscribers peripheral: CBPeripheralManager
     ) {
-        // Drain queued notifies that hit backpressure earlier.
+        // Drain queued notifies that hit backpressure earlier. updateValue's
+        // transmit queue is global to the peripheral manager, so a `false`
+        // means waiting for the next ready callback — but `break` (not
+        // `return`) so one peer's backpressure or per-central failure doesn't
+        // strand the remaining peers' queued frames.
         guard let tx = serverTxChar else { return }
         for (_, peer) in gattServerPeers {
             while let next = peer.pendingNotifies.first {
                 let ok = peripheral.updateValue(next, for: tx, onSubscribedCentrals: [peer.central])
-                if !ok { return }  // Still backpressured — try again next time.
+                if !ok { break }  // this peer backpressured/failed — move to the next
                 peer.pendingNotifies.removeFirst()
             }
         }

--- a/Sources/SwiftBLEBridge/SwiftBLEBridge.swift
+++ b/Sources/SwiftBLEBridge/SwiftBLEBridge.swift
@@ -1,0 +1,972 @@
+//
+//  SwiftBLEBridge.swift
+//  SwiftBLEBridge
+//
+//  Entry point that the iOS Python driver (`app/ble/IOSBLEDriver.py`) calls
+//  into via ctypes-bound C-ABI shims in `BleNativeBindings.swift`. The bridge
+//  owns the process-wide `CBCentralManager` + `CBPeripheralManager` pair,
+//  routes CoreBluetooth delegate callbacks back to Python via the registered
+//  `BleCallbackInvoker`, and tracks per-peer connection state.
+//
+//  Phase 4 — scan + advertise implemented end-to-end. Phases 5-6 add
+//  central-mode connection + GATT and peripheral-mode GATT server.
+//
+
+import Foundation
+#if canImport(CoreBluetooth)
+import CoreBluetooth
+#endif
+
+/// Callback slots the Python driver registers with the bridge. The names
+/// match the kwargs passed up to BLEInterface (`on_device_discovered`,
+/// `on_device_connected`, etc.) so the routing layer can do a string lookup.
+public enum BleCallbackSlot: String, Sendable, CaseIterable {
+    case onDeviceDiscovered = "on_device_discovered"
+    case onDeviceConnected = "on_device_connected"
+    case onDeviceDisconnected = "on_device_disconnected"
+    case onDataReceived = "on_data_received"
+    case onMtuNegotiated = "on_mtu_negotiated"
+    case onIdentityReceived = "on_identity_received"
+    case onAddressChanged = "on_address_changed"
+    case onDuplicateIdentityDetected = "on_duplicate_identity_detected"
+    case onError = "on_error"
+}
+
+/// Abstraction over "invoke a Python callback registered under this slot".
+/// The concrete implementation lives in `PythonBLECallbackBridge.swift` (pbxproj-only,
+/// has access to Python.h); the SwiftPM target can be built and unit-tested
+/// without the Python C-API by injecting a test stub.
+public protocol BleCallbackInvoker: AnyObject, Sendable {
+    func invoke(slot: BleCallbackSlot, args: [Any])
+    func invokeBool(slot: BleCallbackSlot, args: [Any]) -> Bool
+}
+
+#if canImport(CoreBluetooth)
+
+/// Main bridge object. Mirror of Android's `KotlinBLEBridge.kt`, scoped down
+/// to what iOS / CoreBluetooth actually surface.
+public final class SwiftBLEBridge: NSObject, @unchecked Sendable {
+
+    /// Process-wide singleton — the `@_cdecl` C-ABI shims in
+    /// `BleNativeBindings.swift` (invoked from Python via ctypes) route
+    /// through here. One bridge per app is sufficient since CoreBluetooth
+    /// itself is process-wide.
+    public static let shared = SwiftBLEBridge()
+
+    // MARK: - State
+
+    internal let queue = DispatchQueue(label: "network.columba.ble", qos: .userInitiated)
+    private var callbackInvoker: BleCallbackInvoker?
+    private var isStartedFlag: Bool = false
+    private var localIdentity: Data = Data()
+    private var powerSettings: BlePowerSettings = BlePowerSettings()
+
+    // CB managers — lazily instantiated in `start(...)`. Held by strong refs
+    // for the lifetime of the bridge.
+    private var centralManager: CBCentralManager?
+    private var peripheralManager: CBPeripheralManager?
+
+    // RSSI throttling for didDiscover. Per-peer "last reported" so we
+    // don't flood the Python callback path. Matches Android's pattern.
+    private var lastDiscoveryReport: [String: (rssi: Int, time: Date)] = [:]
+    private let rssiDeltaThreshold: Int = 5
+    private let rssiThrottleInterval: TimeInterval = 1.0
+
+    // Pending operations: requested before CB managers reach .poweredOn.
+    // Drained in centralManager(_:didUpdate:) / peripheralManager(_:didUpdate:).
+    private var pendingScanRequested: Bool = false
+    private var pendingAdvertiseRequested: Bool = false
+    private var pendingAdvertiseDeviceName: String?
+
+    // Per-peer GATT client state for centrals (peripherals we connected TO).
+    // Strong refs to CBPeripheral live here — iOS deallocates peripherals
+    // without strong refs, dropping the connection.
+    private var gattClients: [String: BleGattClient] = [:]
+
+    // RSSI poll cadence for established central-side connections. Reads
+    // are async (via didReadRSSI callback) so we just kick a `readRSSI()`
+    // periodically and the result lands on the client.
+    private var rssiPollTask: Task<Void, Never>?
+    private let rssiPollInterval: TimeInterval = 3.0
+
+    // Discovered peripherals from scan, retained by `identifier.uuidString`.
+    // `connect(address:)` looks them up here.
+    private var discoveredPeripherals: [String: CBPeripheral] = [:]
+
+    // Per-subscriber state for peripheral-mode (centrals connected TO us).
+    // Keyed by `CBCentral.identifier.uuidString`.
+    private var gattServerPeers: [String: BleGattServerPeer] = [:]
+
+    // Mutable characteristics published by our peripheral-mode GATT server.
+    // Set once during start(); never re-added (iOS broadcasts Service Changed
+    // on re-add which can break subscribed centrals).
+    private var serverRxChar: CBMutableCharacteristic?
+    private var serverTxChar: CBMutableCharacteristic?
+    private var serverIdentityChar: CBMutableCharacteristic?
+    private var gattServiceAdded: Bool = false
+
+    // MARK: - Service UUIDs (set in start; injected by Python driver)
+
+    private var serviceCBUUID: CBUUID = BleConstants.serviceCBUUID
+    private var rxCharCBUUID: CBUUID = BleConstants.rxCharCBUUID
+    private var txCharCBUUID: CBUUID = BleConstants.txCharCBUUID
+    private var identityCharCBUUID: CBUUID = BleConstants.identityCharCBUUID
+
+    public override init() { super.init() }
+
+    // MARK: - Public API
+
+    public var isStarted: Bool {
+        queue.sync { isStartedFlag }
+    }
+
+    public func setCallbackInvoker(_ invoker: BleCallbackInvoker?) {
+        queue.sync {
+            self.callbackInvoker = invoker
+        }
+    }
+
+    public func setIdentity(_ identity: Data) {
+        queue.sync {
+            localIdentity = identity
+        }
+    }
+
+    public func configurePower(_ settings: BlePowerSettings) {
+        queue.sync { powerSettings = settings }
+    }
+
+    /// Bring up the CB managers. Safe to call multiple times — subsequent
+    /// calls are no-ops once `isStartedFlag` is true.
+    public func start(
+        serviceUuid: String,
+        rxCharUuid: String,
+        txCharUuid: String,
+        identityCharUuid: String
+    ) {
+        queue.sync {
+            guard !isStartedFlag else { return }
+            self.serviceCBUUID = CBUUID(string: serviceUuid)
+            self.rxCharCBUUID = CBUUID(string: rxCharUuid)
+            self.txCharCBUUID = CBUUID(string: txCharUuid)
+            self.identityCharCBUUID = CBUUID(string: identityCharUuid)
+            // Central + peripheral managers share our BLE serial queue —
+            // delegate callbacks land on this queue, callback invocations
+            // hop back to the Python serial queue inside PythonBridge.
+            //
+            // Reuse existing managers when they exist (Apply & Restart
+            // calls stop() then start() in quick succession; stop() now
+            // intentionally leaves the managers alive to avoid CB
+            // teardown races). Only create on first start.
+            if self.centralManager == nil {
+                self.centralManager = CBCentralManager(delegate: self, queue: queue)
+            }
+            if self.peripheralManager == nil {
+                self.peripheralManager = CBPeripheralManager(delegate: self, queue: queue)
+            }
+            self.isStartedFlag = true
+            // Surface any already-poweredOn managers so scan/advertise
+            // requests don't sit pending forever after a restart.
+            if self.centralManager?.state == .poweredOn {
+                tryStartScanLocked()
+            }
+            if self.peripheralManager?.state == .poweredOn {
+                setUpGattServiceIfNeeded()
+                tryStartAdvertiseLocked()
+            }
+        }
+        startRssiPolling()
+    }
+
+    /// Periodically request RSSI samples from connected centrals so the
+    /// BLE Connections UI can show a current-ish dBm reading instead of
+    /// the (often stale) scan-time RSSI. Results land asynchronously via
+    /// `peripheral(_:didReadRSSI:error:)` and get stored on the
+    /// `BleGattClient`.
+    private func startRssiPolling() {
+        rssiPollTask?.cancel()
+        rssiPollTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: UInt64((self?.rssiPollInterval ?? 3.0) * 1_000_000_000))
+                guard let self else { return }
+                self.queue.async {
+                    for (_, client) in self.gattClients
+                        where client.state == .established
+                            && client.peripheral.state == .connected {
+                        client.peripheral.readRSSI()
+                    }
+                }
+            }
+        }
+    }
+
+    public func stop() {
+        rssiPollTask?.cancel()
+        rssiPollTask = nil
+        queue.sync {
+            guard isStartedFlag else { return }
+            if let cm = centralManager, cm.isScanning { cm.stopScan() }
+            if let pm = peripheralManager {
+                if pm.isAdvertising { pm.stopAdvertising() }
+                pm.removeAllServices()
+            }
+            // Tear down all open connections.
+            for (_, client) in gattClients {
+                centralManager?.cancelPeripheralConnection(client.peripheral)
+            }
+            gattClients.removeAll()
+            discoveredPeripherals.removeAll()
+            gattServerPeers.removeAll()
+            serverRxChar = nil
+            serverTxChar = nil
+            serverIdentityChar = nil
+            gattServiceAdded = false
+            lastDiscoveryReport.removeAll()
+            pendingScanRequested = false
+            pendingAdvertiseRequested = false
+            pendingAdvertiseDeviceName = nil
+            isStartedFlag = false
+            // NOTE: do NOT null out centralManager / peripheralManager
+            // here. Tying their lifetime to the bridge singleton lets
+            // start() be called repeatedly without churning CB internals.
+            // Apple's CB stack crashes (watchdog-kills the app via
+            // exit-code-65280 abort path) if a new CBCentralManager /
+            // CBPeripheralManager is created while the previous instance
+            // is still in mid-teardown — the symptom we hit on
+            // Apply & Restart when stop() was followed milliseconds
+            // later by another start().
+        }
+    }
+
+    /// Build + register the GATT service exactly once. Called from
+    /// `peripheralManagerDidUpdateState(.poweredOn)`. Re-adding the service
+    /// at runtime causes iOS to broadcast Service Changed which can break
+    /// subscribed centrals, so we guard against re-add with `gattServiceAdded`.
+    fileprivate func setUpGattServiceIfNeeded() {
+        guard let pm = peripheralManager,
+              pm.state == .poweredOn,
+              !gattServiceAdded else { return }
+
+        let rx = CBMutableCharacteristic(
+            type: rxCharCBUUID,
+            properties: [.write, .writeWithoutResponse],
+            value: nil,
+            permissions: [.writeable]
+        )
+        let tx = CBMutableCharacteristic(
+            type: txCharCBUUID,
+            properties: [.read, .notify],
+            value: nil,
+            permissions: [.readable]
+        )
+        // Identity is published with the current localIdentity bytes (set
+        // via setIdentity before start). A static-value characteristic
+        // returns the bytes for any read; if localIdentity is empty we
+        // initialise empty and respond dynamically on read instead.
+        let identityValue: Data? = localIdentity.isEmpty ? nil : localIdentity
+        let identity = CBMutableCharacteristic(
+            type: identityCharCBUUID,
+            properties: [.read],
+            value: identityValue,
+            permissions: [.readable]
+        )
+
+        let service = CBMutableService(type: serviceCBUUID, primary: true)
+        service.characteristics = [rx, tx, identity]
+        pm.add(service)
+
+        serverRxChar = rx
+        serverTxChar = tx
+        serverIdentityChar = identity
+        gattServiceAdded = true
+        emitInfo("gatt-service-added serviceUuid=\(serviceCBUUID.uuidString)")
+    }
+
+    // MARK: - Scan + advertise
+
+    public func startScanning() {
+        queue.async { [weak self] in
+            guard let self else { return }
+            self.pendingScanRequested = true
+            self.tryStartScanLocked()
+        }
+    }
+
+    public func stopScanning() {
+        queue.async { [weak self] in
+            guard let self else { return }
+            self.pendingScanRequested = false
+            if let cm = self.centralManager, cm.isScanning {
+                cm.stopScan()
+            }
+        }
+    }
+
+    public func startAdvertising(deviceName: String?) {
+        queue.async { [weak self] in
+            guard let self else { return }
+            self.pendingAdvertiseRequested = true
+            self.pendingAdvertiseDeviceName = deviceName
+            self.tryStartAdvertiseLocked()
+        }
+    }
+
+    public func stopAdvertising() {
+        queue.async { [weak self] in
+            guard let self else { return }
+            self.pendingAdvertiseRequested = false
+            if let pm = self.peripheralManager, pm.isAdvertising {
+                pm.stopAdvertising()
+            }
+        }
+    }
+
+    // MARK: - Connection management
+
+    public func connect(address: String) {
+        queue.async { [weak self] in
+            guard let self else { return }
+            guard let cm = self.centralManager else { return }
+            // Resolve the CBPeripheral by address. Prefer the cached
+            // discovered one (active scan), fall back to retrieve-known
+            // (post-restart). If still nil we can't connect.
+            let peripheral: CBPeripheral?
+            if let cached = self.discoveredPeripherals[address] {
+                peripheral = cached
+            } else if let uuid = UUID(uuidString: address) {
+                let known = cm.retrievePeripherals(withIdentifiers: [uuid])
+                peripheral = known.first
+            } else {
+                peripheral = nil
+            }
+            guard let peripheral else {
+                self.emitError("warning", "connect: unknown address \(address)")
+                return
+            }
+            peripheral.delegate = self
+            // Hold strong ref — iOS deallocates CBPeripheral without one.
+            let client = self.gattClients[address] ?? BleGattClient(peripheral: peripheral)
+            client.state = .connecting
+            self.gattClients[address] = client
+            cm.connect(peripheral, options: nil)
+            self.emitInfo("connect-issued addr=\(address)")
+        }
+    }
+
+    public func disconnect(address: String) {
+        queue.async { [weak self] in
+            guard let self else { return }
+            guard let cm = self.centralManager,
+                  let client = self.gattClients[address] else { return }
+            cm.cancelPeripheralConnection(client.peripheral)
+        }
+    }
+
+    public func send(address: String, data: Data) {
+        queue.async { [weak self] in
+            guard let self else { return }
+            // Central role: write to peer's RX char without response.
+            if let client = self.gattClients[address], let rxChar = client.rxChar {
+                client.peripheral.writeValue(data, for: rxChar, type: .withoutResponse)
+                return
+            }
+            // Peripheral role: notify on TX char to the specific subscriber.
+            if let peer = self.gattServerPeers[address],
+               let txChar = self.serverTxChar,
+               let pm = self.peripheralManager {
+                let ok = pm.updateValue(data, for: txChar, onSubscribedCentrals: [peer.central])
+                if !ok {
+                    // Backpressure — queue and drain on peripheralManagerIsReady.
+                    peer.pendingNotifies.append(data)
+                }
+                return
+            }
+            self.emitError("warning", "send: no client / no server peer for \(address)")
+        }
+    }
+
+    // MARK: - Queries
+
+    public func getConnectedPeers() -> [String] {
+        queue.sync {
+            var peers: [String] = []
+            peers.append(contentsOf: gattClients
+                .filter { $0.value.state == .established }
+                .map { $0.key })
+            peers.append(contentsOf: gattServerPeers
+                .filter { $0.value.state == .established }
+                .map { $0.key })
+            return peers
+        }
+    }
+
+    private func hex(_ d: Data) -> String { d.map { String(format: "%02x", $0) }.joined() }
+
+    public func getPeerIdentity(address: String) -> String? {
+        queue.sync {
+            if let c = gattClients[address], let id = c.peerIdentity { return hex(id) }
+            if let s = gattServerPeers[address], let id = s.identity { return hex(id) }
+            return nil
+        }
+    }
+    public func getPeerAddress(identityHashHex: String) -> String? {
+        queue.sync {
+            for (addr, client) in gattClients {
+                if let id = client.peerIdentity, hex(id) == identityHashHex { return addr }
+            }
+            for (addr, peer) in gattServerPeers {
+                if let id = peer.identity, hex(id) == identityHashHex { return addr }
+            }
+            return nil
+        }
+    }
+    public func getPeerRssi(address: String) -> Int? {
+        queue.sync { lastDiscoveryReport[address]?.rssi }
+    }
+    public func getConnectionDetails() -> [BleConnectionDetails] {
+        queue.sync {
+            var details: [BleConnectionDetails] = []
+            for (addr, client) in gattClients {
+                // Prefer the fresh `readRSSI()` sample if we have one;
+                // fall back to the last scan-time RSSI from discovery.
+                let rssi = client.rssi ?? lastDiscoveryReport[addr]?.rssi
+                details.append(BleConnectionDetails(
+                    address: addr,
+                    identityHashHex: client.peerIdentity.map { hex($0) },
+                    role: .central,
+                    mtu: client.mtu,
+                    rssi: rssi,
+                    lastActivity: lastDiscoveryReport[addr]?.time ?? client.connectedAt,
+                    connectedAt: client.connectedAt
+                ))
+            }
+            for (addr, peer) in gattServerPeers {
+                details.append(BleConnectionDetails(
+                    address: addr,
+                    identityHashHex: peer.identity.map { hex($0) },
+                    role: .peripheral,
+                    mtu: peer.mtu,
+                    rssi: nil, // CB doesn't expose central-side RSSI to peripherals
+                    lastActivity: peer.connectedAt,
+                    connectedAt: peer.connectedAt
+                ))
+            }
+            return details
+        }
+    }
+
+    // MARK: - Private helpers (all called with `queue` held)
+
+    fileprivate func tryStartScanLocked() {
+        guard pendingScanRequested,
+              let cm = centralManager,
+              cm.state == .poweredOn else { return }
+        if cm.isScanning { return }
+        // Allowing duplicates so we get continuous RSSI updates from the
+        // same peer; throttling happens in didDiscover.
+        cm.scanForPeripherals(
+            withServices: [serviceCBUUID],
+            options: [CBCentralManagerScanOptionAllowDuplicatesKey: true]
+        )
+        emitInfo("scan-started serviceUuid=\(serviceCBUUID.uuidString)")
+    }
+
+    fileprivate func tryStartAdvertiseLocked() {
+        guard pendingAdvertiseRequested,
+              let pm = peripheralManager,
+              pm.state == .poweredOn else { return }
+        if pm.isAdvertising { pm.stopAdvertising() }
+        var ad: [String: Any] = [
+            CBAdvertisementDataServiceUUIDsKey: [serviceCBUUID]
+        ]
+        // iOS drops the local-name field when the app is backgrounded but
+        // keeps the service UUID in the overflow area. We set it for the
+        // foreground case so peer settings UIs can render a readable name.
+        if let name = pendingAdvertiseDeviceName, !name.isEmpty {
+            ad[CBAdvertisementDataLocalNameKey] = name
+        }
+        pm.startAdvertising(ad)
+        emitInfo("advertise-started name=\(pendingAdvertiseDeviceName ?? "<nil>")")
+    }
+
+    fileprivate func emitInfo(_ message: String) {
+        callbackInvoker?.invoke(slot: .onError, args: ["info", message])
+    }
+
+    fileprivate func emitError(_ severity: String, _ message: String) {
+        callbackInvoker?.invoke(slot: .onError, args: [severity, message])
+    }
+}
+
+// MARK: - CBCentralManagerDelegate
+
+extension SwiftBLEBridge: CBCentralManagerDelegate {
+
+    public func centralManagerDidUpdateState(_ central: CBCentralManager) {
+        switch central.state {
+        case .poweredOn:
+            emitInfo("centralManager poweredOn")
+            tryStartScanLocked()
+        case .poweredOff:
+            emitError("warning", "centralManager poweredOff")
+        case .unauthorized:
+            emitError("critical", "centralManager unauthorized — check Bluetooth permission")
+        case .unsupported:
+            emitError("critical", "centralManager unsupported on this device")
+        case .resetting:
+            emitError("warning", "centralManager resetting")
+        case .unknown:
+            emitInfo("centralManager state unknown")
+        @unknown default:
+            emitInfo("centralManager state \(central.state.rawValue)")
+        }
+    }
+
+    public func centralManager(
+        _ central: CBCentralManager,
+        didDiscover peripheral: CBPeripheral,
+        advertisementData: [String: Any],
+        rssi RSSI: NSNumber
+    ) {
+        let address = peripheral.identifier.uuidString
+        let rssi = RSSI.intValue
+        // Skip sentinel RSSIs (CB occasionally hands us 127 or -127 for
+        // out-of-range / invalid samples).
+        guard rssi != 127, rssi != 0 else { return }
+
+        // Cache the peripheral so `connect(address:)` can find it. iOS
+        // deallocates peripherals without strong refs, so this is required.
+        discoveredPeripherals[address] = peripheral
+
+        // RSSI throttle: drop if same peer reported < threshold dBm change
+        // within the throttle interval. Matches Android's pattern.
+        let now = Date()
+        if let last = lastDiscoveryReport[address] {
+            let dt = now.timeIntervalSince(last.time)
+            if dt < rssiThrottleInterval && abs(rssi - last.rssi) < rssiDeltaThreshold {
+                return
+            }
+        }
+        lastDiscoveryReport[address] = (rssi, now)
+
+        let name = (advertisementData[CBAdvertisementDataLocalNameKey] as? String)
+            ?? peripheral.name
+            ?? ""
+        let serviceUUIDs = (advertisementData[CBAdvertisementDataServiceUUIDsKey] as? [CBUUID])?
+            .map { $0.uuidString.lowercased() } ?? []
+
+        callbackInvoker?.invoke(
+            slot: .onDeviceDiscovered,
+            args: [address, name, rssi, serviceUUIDs]
+        )
+    }
+
+    public func centralManager(
+        _ central: CBCentralManager,
+        didConnect peripheral: CBPeripheral
+    ) {
+        let address = peripheral.identifier.uuidString
+        guard let client = gattClients[address] else {
+            emitError("warning", "didConnect for unknown client \(address)")
+            return
+        }
+        // iOS auto-negotiates MTU at connect time. Fire on_mtu_negotiated
+        // immediately with the maximum the link supports. Use the
+        // withoutResponse query — that's what we actually send with.
+        let mtu = peripheral.maximumWriteValueLength(for: .withoutResponse)
+        client.mtu = mtu
+        if !client.mtuFired {
+            client.mtuFired = true
+            callbackInvoker?.invoke(slot: .onMtuNegotiated, args: [address, mtu])
+        }
+        client.state = .discoveringServices
+        peripheral.discoverServices([serviceCBUUID])
+        emitInfo("didConnect addr=\(address) mtu=\(mtu)")
+    }
+
+    public func centralManager(
+        _ central: CBCentralManager,
+        didFailToConnect peripheral: CBPeripheral,
+        error: Error?
+    ) {
+        let address = peripheral.identifier.uuidString
+        emitError("warning", "didFailToConnect addr=\(address) error=\(String(describing: error))")
+        gattClients.removeValue(forKey: address)
+    }
+
+    public func centralManager(
+        _ central: CBCentralManager,
+        didDisconnectPeripheral peripheral: CBPeripheral,
+        error: Error?
+    ) {
+        let address = peripheral.identifier.uuidString
+        gattClients.removeValue(forKey: address)
+        callbackInvoker?.invoke(slot: .onDeviceDisconnected, args: [address])
+    }
+}
+
+// MARK: - CBPeripheralDelegate (central-mode discovery + I/O)
+
+extension SwiftBLEBridge: CBPeripheralDelegate {
+
+    public func peripheral(
+        _ peripheral: CBPeripheral,
+        didDiscoverServices error: Error?
+    ) {
+        let address = peripheral.identifier.uuidString
+        if let error {
+            emitError("warning", "didDiscoverServices error addr=\(address): \(error)")
+            return
+        }
+        guard let service = peripheral.services?.first(where: { $0.uuid == serviceCBUUID }) else {
+            emitError("warning", "didDiscoverServices: target service not found on \(address)")
+            return
+        }
+        gattClients[address]?.state = .discoveringChars
+        peripheral.discoverCharacteristics(
+            [rxCharCBUUID, txCharCBUUID, identityCharCBUUID],
+            for: service
+        )
+    }
+
+    public func peripheral(
+        _ peripheral: CBPeripheral,
+        didDiscoverCharacteristicsFor service: CBService,
+        error: Error?
+    ) {
+        let address = peripheral.identifier.uuidString
+        if let error {
+            emitError("warning", "didDiscoverCharacteristics error addr=\(address): \(error)")
+            return
+        }
+        guard let client = gattClients[address] else { return }
+        for ch in (service.characteristics ?? []) {
+            switch ch.uuid {
+            case rxCharCBUUID:       client.rxChar = ch
+            case txCharCBUUID:       client.txChar = ch
+            case identityCharCBUUID: client.identityChar = ch
+            default: break
+            }
+        }
+        guard let txChar = client.txChar, let identityChar = client.identityChar else {
+            emitError("warning", "didDiscoverCharacteristics: missing TX/Identity for \(address)")
+            return
+        }
+        client.state = .readingIdentity
+        // Subscribe to notifications on TX so peer-sent fragments arrive
+        // via `didUpdateValueFor`. Independently, kick off the Identity read.
+        peripheral.setNotifyValue(true, for: txChar)
+        peripheral.readValue(for: identityChar)
+    }
+
+    public func peripheral(
+        _ peripheral: CBPeripheral,
+        didUpdateNotificationStateFor characteristic: CBCharacteristic,
+        error: Error?
+    ) {
+        if let error {
+            emitError("warning", "didUpdateNotificationState error: \(error)")
+        }
+    }
+
+    public func peripheral(
+        _ peripheral: CBPeripheral,
+        didUpdateValueFor characteristic: CBCharacteristic,
+        error: Error?
+    ) {
+        let address = peripheral.identifier.uuidString
+        if let error {
+            emitError("warning", "didUpdateValueFor error addr=\(address) uuid=\(characteristic.uuid): \(error)")
+            return
+        }
+        guard let client = gattClients[address] else { return }
+        guard let value = characteristic.value else { return }
+
+        switch characteristic.uuid {
+        case identityCharCBUUID:
+            // Identity characteristic — 16-byte peer identity hash.
+            guard value.count == BleConstants.identitySize else {
+                emitError("warning", "identity char wrong size: \(value.count)")
+                return
+            }
+            client.peerIdentity = value
+            let identityHex = value.map { String(format: "%02x", $0) }.joined()
+            callbackInvoker?.invoke(slot: .onIdentityReceived, args: [address, identityHex])
+
+            // Synchronous duplicate-identity check. If Python says it's a
+            // duplicate (same identity already alive at a different addr),
+            // tear down this connection and bail.
+            if let invoker = callbackInvoker {
+                let isDup = invoker.invokeBool(
+                    slot: .onDuplicateIdentityDetected,
+                    args: [address, value]
+                )
+                if isDup {
+                    emitInfo("duplicate identity at \(address); dropping")
+                    centralManager?.cancelPeripheralConnection(peripheral)
+                    return
+                }
+            }
+
+            // Connection complete from upstream's perspective — fire connected
+            // (with identity) so BLEInterface spawns the peer interface.
+            if !client.connectedFired {
+                client.connectedFired = true
+                callbackInvoker?.invoke(slot: .onDeviceConnected, args: [address, value])
+            }
+
+            // Write our identity to the peer's RX char to complete the
+            // handshake on their side. Use .withoutResponse for parity with
+            // Android (no ACK needed; upstream interface handles retransmit).
+            if let rxChar = client.rxChar, !localIdentity.isEmpty {
+                client.state = .writingIdentity
+                peripheral.writeValue(localIdentity, for: rxChar, type: .withoutResponse)
+                // Move to established right after — there's no didWriteValueFor
+                // callback for .withoutResponse. Re-stamp connectedAt so the
+                // UI's "Connected Xs" starts from a meaningful point (the
+                // moment the link is actually usable, not when CB first
+                // returned didConnect).
+                client.state = .established
+                client.connectedAt = Date()
+                // Kick a one-shot RSSI read immediately so the UI doesn't
+                // wait the full poll interval for the first sample.
+                peripheral.readRSSI()
+            } else {
+                emitError("warning", "no localIdentity or rxChar; handshake incomplete")
+            }
+
+        case txCharCBUUID:
+            // Inbound fragment from peer. Pass raw bytes up; upstream
+            // BLEInterface handles reassembly via BLEFragmentation.
+            // Filter 1-byte 0x00 keepalive — upstream does this too but
+            // we avoid the Python-side callback overhead for a no-op.
+            if value.count == 1 && value[0] == 0x00 { return }
+            callbackInvoker?.invoke(slot: .onDataReceived, args: [address, value])
+
+        default:
+            break
+        }
+    }
+
+    public func peripheral(
+        _ peripheral: CBPeripheral,
+        didWriteValueFor characteristic: CBCharacteristic,
+        error: Error?
+    ) {
+        if let error {
+            emitError("warning", "didWriteValueFor error uuid=\(characteristic.uuid): \(error)")
+        }
+    }
+
+    /// Result of a `peripheral.readRSSI()` call. The `rssiPollTask` kicks
+    /// these requests every ~3s for established peers; the value lands on
+    /// the BleGattClient where getConnectionDetails picks it up.
+    public func peripheral(
+        _ peripheral: CBPeripheral,
+        didReadRSSI RSSI: NSNumber,
+        error: Error?
+    ) {
+        if let error {
+            emitError("warning", "didReadRSSI error addr=\(peripheral.identifier.uuidString): \(error)")
+            return
+        }
+        let address = peripheral.identifier.uuidString
+        let value = RSSI.intValue
+        // CB sometimes returns 127 / 0 as sentinels; ignore those samples.
+        guard value != 127, value != 0 else { return }
+        gattClients[address]?.rssi = value
+    }
+}
+
+// MARK: - CBPeripheralManagerDelegate
+
+extension SwiftBLEBridge: CBPeripheralManagerDelegate {
+
+    public func peripheralManagerDidUpdateState(_ peripheral: CBPeripheralManager) {
+        switch peripheral.state {
+        case .poweredOn:
+            emitInfo("peripheralManager poweredOn")
+            setUpGattServiceIfNeeded()
+            tryStartAdvertiseLocked()
+        case .poweredOff:
+            emitError("warning", "peripheralManager poweredOff")
+        case .unauthorized:
+            emitError("critical", "peripheralManager unauthorized")
+        case .unsupported:
+            emitError("critical", "peripheralManager unsupported on this device")
+        case .resetting:
+            emitError("warning", "peripheralManager resetting")
+        case .unknown:
+            emitInfo("peripheralManager state unknown")
+        @unknown default:
+            emitInfo("peripheralManager state \(peripheral.state.rawValue)")
+        }
+    }
+
+    public func peripheralManagerDidStartAdvertising(
+        _ peripheral: CBPeripheralManager,
+        error: Error?
+    ) {
+        if let error {
+            emitError("warning", "advertise start failed: \(error)")
+        } else {
+            emitInfo("advertise-confirmed")
+        }
+    }
+
+    public func peripheralManager(
+        _ peripheral: CBPeripheralManager,
+        didAdd service: CBService,
+        error: Error?
+    ) {
+        if let error {
+            emitError("critical", "service add failed: \(error)")
+            gattServiceAdded = false
+        } else {
+            emitInfo("service added uuid=\(service.uuid.uuidString)")
+        }
+    }
+
+    public func peripheralManager(
+        _ peripheral: CBPeripheralManager,
+        didReceiveRead request: CBATTRequest
+    ) {
+        // Identity characteristic — return the local 16-byte identity hash.
+        if request.characteristic.uuid == identityCharCBUUID {
+            let value = localIdentity
+            request.value = value
+            peripheral.respond(to: request, withResult: .success)
+            return
+        }
+        peripheral.respond(to: request, withResult: .requestNotSupported)
+    }
+
+    public func peripheralManager(
+        _ peripheral: CBPeripheralManager,
+        didReceiveWrite requests: [CBATTRequest]
+    ) {
+        for request in requests {
+            guard request.characteristic.uuid == rxCharCBUUID,
+                  let value = request.value else {
+                peripheral.respond(to: request, withResult: .writeNotPermitted)
+                continue
+            }
+            let address = request.central.identifier.uuidString
+            let peer = gattServerPeers[address] ?? BleGattServerPeer(central: request.central)
+            gattServerPeers[address] = peer
+            peer.mtu = request.central.maximumUpdateValueLength
+
+            if peer.state == .awaitingIdentity {
+                // First write per central is the 16-byte identity handshake.
+                if value.count == BleConstants.identitySize {
+                    peer.identity = value
+                    let identityHex = hex(value)
+                    callbackInvoker?.invoke(slot: .onIdentityReceived, args: [address, identityHex])
+
+                    if let invoker = callbackInvoker {
+                        let isDup = invoker.invokeBool(
+                            slot: .onDuplicateIdentityDetected,
+                            args: [address, value]
+                        )
+                        if isDup {
+                            emitInfo("duplicate identity at peripheral peer \(address); dropping")
+                            // CBPeripheralManager doesn't expose a "kick this
+                            // subscriber" op — the best we can do is stop
+                            // notifying them. Upstream interface ignores
+                            // duplicates by identity hash anyway.
+                            gattServerPeers.removeValue(forKey: address)
+                            peripheral.respond(to: request, withResult: .success)
+                            continue
+                        }
+                    }
+
+                    if peer.mtu > 0 {
+                        callbackInvoker?.invoke(slot: .onMtuNegotiated, args: [address, peer.mtu])
+                    }
+                    callbackInvoker?.invoke(slot: .onDeviceConnected, args: [address, value])
+                    peer.state = .established
+                    // Re-stamp connectedAt at the moment handshake completes
+                    // (was init-time on subscribe, but subscribe happens
+                    // before the identity write).
+                    peer.connectedAt = Date()
+                } else {
+                    emitError("warning", "first write wasn't 16-byte handshake; len=\(value.count)")
+                }
+            } else {
+                // Established — data fragment from peer. Drop 0x00 keepalive.
+                if !(value.count == 1 && value[0] == 0x00) {
+                    callbackInvoker?.invoke(slot: .onDataReceived, args: [address, value])
+                }
+            }
+            peripheral.respond(to: request, withResult: .success)
+        }
+    }
+
+    public func peripheralManager(
+        _ peripheral: CBPeripheralManager,
+        central: CBCentral,
+        didSubscribeTo characteristic: CBCharacteristic
+    ) {
+        guard characteristic.uuid == txCharCBUUID else { return }
+        let address = central.identifier.uuidString
+        let peer = gattServerPeers[address] ?? BleGattServerPeer(central: central)
+        peer.mtu = central.maximumUpdateValueLength
+        gattServerPeers[address] = peer
+        emitInfo("central subscribed addr=\(address) mtu=\(peer.mtu)")
+    }
+
+    public func peripheralManager(
+        _ peripheral: CBPeripheralManager,
+        central: CBCentral,
+        didUnsubscribeFrom characteristic: CBCharacteristic
+    ) {
+        let address = central.identifier.uuidString
+        guard let peer = gattServerPeers.removeValue(forKey: address) else { return }
+        if peer.state == .established {
+            callbackInvoker?.invoke(slot: .onDeviceDisconnected, args: [address])
+        }
+    }
+
+    public func peripheralManagerIsReady(
+        toUpdateSubscribers peripheral: CBPeripheralManager
+    ) {
+        // Drain queued notifies that hit backpressure earlier.
+        guard let tx = serverTxChar else { return }
+        for (_, peer) in gattServerPeers {
+            while let next = peer.pendingNotifies.first {
+                let ok = peripheral.updateValue(next, for: tx, onSubscribedCentrals: [peer.central])
+                if !ok { return }  // Still backpressured — try again next time.
+                peer.pendingNotifies.removeFirst()
+            }
+        }
+    }
+}
+
+#else
+
+// Non-iOS / non-Mac build (e.g., Linux SwiftPM CI) — degenerate stub so
+// `swift build` succeeds without CoreBluetooth.
+public final class SwiftBLEBridge: @unchecked Sendable {
+    public static let shared = SwiftBLEBridge()
+    public init() {}
+    public var isStarted: Bool { false }
+    public func setCallbackInvoker(_ invoker: BleCallbackInvoker?) {}
+    public func setIdentity(_ identity: Data) {}
+    public func configurePower(_ settings: BlePowerSettings) {}
+    public func start(serviceUuid: String, rxCharUuid: String, txCharUuid: String, identityCharUuid: String) {}
+    public func stop() {}
+    public func startScanning() {}
+    public func stopScanning() {}
+    public func startAdvertising(deviceName: String?) {}
+    public func stopAdvertising() {}
+    public func connect(address: String) {}
+    public func disconnect(address: String) {}
+    public func send(address: String, data: Data) {}
+    public func getConnectedPeers() -> [String] { [] }
+    public func getPeerIdentity(address: String) -> String? { nil }
+    public func getPeerAddress(identityHashHex: String) -> String? { nil }
+    public func getPeerRssi(address: String) -> Int? { nil }
+    public func getConnectionDetails() -> [BleConnectionDetails] { [] }
+}
+
+#endif

--- a/Sources/SwiftBLEBridge/SwiftBLEBridge.swift
+++ b/Sources/SwiftBLEBridge/SwiftBLEBridge.swift
@@ -243,6 +243,16 @@ public final class SwiftBLEBridge: NSObject, @unchecked Sendable {
             // is still in mid-teardown — the symptom we hit on
             // Apply & Restart when stop() was followed milliseconds
             // later by another start().
+            //
+            // Drop the callback invoker INSIDE this serialized block:
+            // cancelPeripheralConnection above makes CoreBluetooth dispatch
+            // didDisconnectPeripheral asynchronously onto `queue`, which
+            // always runs after this block completes. Clearing here (rather
+            // than via a second setCallbackInvoker(nil) hop that races those
+            // async disconnects) guarantees no post-stop .onDeviceDisconnected
+            // reaches Python for peers it has already torn down. Re-installed
+            // by startBLEInterface on the next start.
+            callbackInvoker = nil
         }
     }
 

--- a/Sources/SwiftBLEBridge/SwiftBLEBridge.swift
+++ b/Sources/SwiftBLEBridge/SwiftBLEBridge.swift
@@ -532,7 +532,7 @@ extension SwiftBLEBridge: CBCentralManagerDelegate {
         let rssi = RSSI.intValue
         // Skip sentinel RSSIs (CB occasionally hands us 127 or -127 for
         // out-of-range / invalid samples).
-        guard rssi != 127, rssi != 0 else { return }
+        guard rssi != 127, rssi != -127, rssi != 0 else { return }
 
         // Cache the peripheral so `connect(address:)` can find it. iOS
         // deallocates peripherals without strong refs, so this is required.

--- a/Sources/SwiftBLEBridge/SwiftBLEBridge.swift
+++ b/Sources/SwiftBLEBridge/SwiftBLEBridge.swift
@@ -388,19 +388,19 @@ public final class SwiftBLEBridge: NSObject, @unchecked Sendable {
             }
             // Peripheral role: notify on TX char to the specific subscriber.
             if let peer = self.gattServerPeers[address],
-               let txChar = self.serverTxChar,
-               let pm = self.peripheralManager {
-                let ok = pm.updateValue(data, for: txChar, onSubscribedCentrals: [peer.central])
-                if !ok {
-                    // Backpressure — queue and drain on peripheralManagerIsReady.
-                    // Bounded so a stuck/vanished subscriber can't grow it
-                    // unbounded; drop the frame (and warn) when full.
-                    if peer.pendingNotifies.count < maxPendingNotifies {
-                        peer.pendingNotifies.append(data)
-                    } else {
-                        emitError("warning", "pendingNotifies full (\(maxPendingNotifies)) for \(address); dropping frame")
-                    }
+               self.serverTxChar != nil,
+               self.peripheralManager != nil {
+                // Always enqueue then drain in FIFO order. Sending a new frame
+                // directly while pendingNotifies is non-empty would jump it
+                // ahead of frames already queued behind backpressure — the peer
+                // would receive fragments out of order. Bounded so a stuck or
+                // vanished subscriber can't grow the queue without limit.
+                if peer.pendingNotifies.count < maxPendingNotifies {
+                    peer.pendingNotifies.append(data)
+                } else {
+                    emitError("warning", "pendingNotifies full (\(maxPendingNotifies)) for \(address); dropping frame")
                 }
+                self.drainPeerNotifiesLocked(peer)
                 return
             }
             self.emitError("warning", "send: no client / no server peer for \(address)")
@@ -415,6 +415,17 @@ public final class SwiftBLEBridge: NSObject, @unchecked Sendable {
         let p = client.peripheral
         while !client.pendingWrites.isEmpty, p.canSendWriteWithoutResponse {
             p.writeValue(client.pendingWrites.removeFirst(), for: rx, type: .withoutResponse)
+        }
+    }
+
+    /// Drain a peripheral-role peer's queued notifies in FIFO order while the
+    /// (manager-global) transmit queue accepts them. Called on `queue` from
+    /// send() and peripheralManagerIsReady.
+    private func drainPeerNotifiesLocked(_ peer: BleGattServerPeer) {
+        guard let pm = peripheralManager, let tx = serverTxChar else { return }
+        while let next = peer.pendingNotifies.first {
+            guard pm.updateValue(next, for: tx, onSubscribedCentrals: [peer.central]) else { break }
+            peer.pendingNotifies.removeFirst()
         }
     }
 
@@ -984,18 +995,11 @@ extension SwiftBLEBridge: CBPeripheralManagerDelegate {
     public func peripheralManagerIsReady(
         toUpdateSubscribers peripheral: CBPeripheralManager
     ) {
-        // Drain queued notifies that hit backpressure earlier. updateValue's
-        // transmit queue is global to the peripheral manager, so a `false`
-        // means waiting for the next ready callback — but `break` (not
-        // `return`) so one peer's backpressure or per-central failure doesn't
-        // strand the remaining peers' queued frames.
-        guard let tx = serverTxChar else { return }
+        // Transmit queue freed up — drain each peer's queued notifies in FIFO
+        // order via the shared helper. Per-peer (not a global `return`) so one
+        // peer's backpressure doesn't strand the others' queued frames.
         for (_, peer) in gattServerPeers {
-            while let next = peer.pendingNotifies.first {
-                let ok = peripheral.updateValue(next, for: tx, onSubscribedCentrals: [peer.central])
-                if !ok { break }  // this peer backpressured/failed — move to the next
-                peer.pendingNotifies.removeFirst()
-            }
+            drainPeerNotifiesLocked(peer)
         }
     }
 }

--- a/Sources/SwiftBLEBridge/SwiftBLEBridge.swift
+++ b/Sources/SwiftBLEBridge/SwiftBLEBridge.swift
@@ -102,6 +102,9 @@ public final class SwiftBLEBridge: NSObject, @unchecked Sendable {
     // can't grow pendingNotifies without bound.
     private let maxPendingNotifies = 128
 
+    // Same bound for the central-role per-client outbound write queue.
+    private let maxPendingClientWrites = 128
+
     // Mutable characteristics published by our peripheral-mode GATT server.
     // Set once during start(); never re-added (iOS broadcasts Service Changed
     // on re-add which can break subscribed centrals).
@@ -370,9 +373,17 @@ public final class SwiftBLEBridge: NSObject, @unchecked Sendable {
     public func send(address: String, data: Data) {
         queue.async { [weak self] in
             guard let self else { return }
-            // Central role: write to peer's RX char without response.
-            if let client = self.gattClients[address], let rxChar = client.rxChar {
-                client.peripheral.writeValue(data, for: rxChar, type: .withoutResponse)
+            // Central role: queue + drain under transmit-queue backpressure.
+            // writeValue(.withoutResponse) silently drops once CoreBluetooth's
+            // per-peripheral queue is full (iOS 11+), so gate on
+            // canSendWriteWithoutResponse and resume in peripheralIsReady.
+            if let client = self.gattClients[address], client.rxChar != nil {
+                if client.pendingWrites.count < self.maxPendingClientWrites {
+                    client.pendingWrites.append(data)
+                } else {
+                    self.emitError("warning", "client pendingWrites full (\(self.maxPendingClientWrites)) for \(address); dropping frame")
+                }
+                self.drainClientWritesLocked(client)
                 return
             }
             // Peripheral role: notify on TX char to the specific subscriber.
@@ -393,6 +404,17 @@ public final class SwiftBLEBridge: NSObject, @unchecked Sendable {
                 return
             }
             self.emitError("warning", "send: no client / no server peer for \(address)")
+        }
+    }
+
+    /// Drain a central-role client's queued writes while its peripheral has
+    /// transmit-queue space. Called on `queue` (from send() and the central
+    /// peripheralIsReady delegate).
+    private func drainClientWritesLocked(_ client: BleGattClient) {
+        guard let rx = client.rxChar else { return }
+        let p = client.peripheral
+        while !client.pendingWrites.isEmpty, p.canSendWriteWithoutResponse {
+            p.writeValue(client.pendingWrites.removeFirst(), for: rx, type: .withoutResponse)
         }
     }
 
@@ -771,6 +793,13 @@ extension SwiftBLEBridge: CBPeripheralDelegate {
         if let error {
             emitError("warning", "didWriteValueFor error uuid=\(characteristic.uuid): \(error)")
         }
+    }
+
+    public func peripheralIsReady(toSendWriteWithoutResponse peripheral: CBPeripheral) {
+        // Central-role transmit queue freed up — drain the matching client's
+        // queued writes. Delivered on the bridge's `queue`.
+        guard let client = gattClients.values.first(where: { $0.peripheral === peripheral }) else { return }
+        drainClientWritesLocked(client)
     }
 
     /// Result of a `peripheral.readRSSI()` call. The `rssiPollTask` kicks

--- a/Sources/SwiftBLEBridge/SwiftBLEBridge.swift
+++ b/Sources/SwiftBLEBridge/SwiftBLEBridge.swift
@@ -648,8 +648,12 @@ extension SwiftBLEBridge: CBPeripheralDelegate {
             default: break
             }
         }
-        guard let txChar = client.txChar, let identityChar = client.identityChar else {
-            emitError("warning", "didDiscoverCharacteristics: missing TX/Identity for \(address)")
+        guard client.rxChar != nil, let txChar = client.txChar,
+              let identityChar = client.identityChar else {
+            // Missing any of RX/TX/Identity means we'd fire onDeviceConnected
+            // (after the identity read) but never be able to write our identity
+            // or data back — a half-open link Python believes is up. Bail.
+            emitError("warning", "didDiscoverCharacteristics: missing RX/TX/Identity for \(address)")
             return
         }
         client.state = .readingIdentity
@@ -847,10 +851,16 @@ extension SwiftBLEBridge: CBPeripheralManagerDelegate {
         _ peripheral: CBPeripheralManager,
         didReceiveWrite requests: [CBATTRequest]
     ) {
+        // CBPeripheralManager requires exactly one respond(to:withResult:) per
+        // didReceiveWrite — passing the first request — and that single reply
+        // ACKs the whole batch. Responding per-request throws "respond called
+        // more than once" and drops the ATT transaction, so accumulate the
+        // result and reply once after processing every request.
+        var result: CBATTError.Code = .success
         for request in requests {
             guard request.characteristic.uuid == rxCharCBUUID,
                   let value = request.value else {
-                peripheral.respond(to: request, withResult: .writeNotPermitted)
+                result = .writeNotPermitted
                 continue
             }
             let address = request.central.identifier.uuidString
@@ -877,7 +887,6 @@ extension SwiftBLEBridge: CBPeripheralManagerDelegate {
                             // notifying them. Upstream interface ignores
                             // duplicates by identity hash anyway.
                             gattServerPeers.removeValue(forKey: address)
-                            peripheral.respond(to: request, withResult: .success)
                             continue
                         }
                     }
@@ -900,7 +909,10 @@ extension SwiftBLEBridge: CBPeripheralManagerDelegate {
                     callbackInvoker?.invoke(slot: .onDataReceived, args: [address, value])
                 }
             }
-            peripheral.respond(to: request, withResult: .success)
+        }
+        // Single response for the whole batch, per the CB contract.
+        if let first = requests.first {
+            peripheral.respond(to: first, withResult: result)
         }
     }
 

--- a/Sources/SwiftBLEBridge/SwiftRNodeBridge.swift
+++ b/Sources/SwiftBLEBridge/SwiftRNodeBridge.swift
@@ -1,0 +1,381 @@
+//
+//  SwiftRNodeBridge.swift
+//  SwiftBLEBridge
+//
+//  CoreBluetooth Nordic-UART-Service (NUS) client for RNode LoRa hardware.
+//
+//  Deliberately SEPARATE from `SwiftBLEBridge`: the RNode interface and the BLE
+//  mesh are unrelated transports that can be enabled independently or at the
+//  same time, so each owns its own `CBCentralManager` + delegate (decision:
+//  Torlando, 2026-05-26 — no shared scanner, no coupling). They merely share
+//  this SwiftPM module because both are pure-CoreBluetooth code; there is no
+//  runtime coupling between the two centrals.
+//
+//  This is the Swift (I/O) half of the iOS RNode interface. The KISS framing +
+//  RNode binary protocol live in Python (`app/rnode/IOSRNodeInterface.py`,
+//  ported from Android). Python → Swift goes through the `columba_rnode_*`
+//  C-ABI shims in `RNodeNativeBindings.swift`; Swift → Python goes through the
+//  injected `RNodeCallbackInvoker` (concrete impl `PythonRNodeCallbackBridge`,
+//  which lives in the pbxproj target because it needs Python.h). Mirrors the
+//  IOSBLEInterface / SwiftBLEBridge split exactly.
+//
+//  BLE/NUS only — no USB-serial, no Bluetooth Classic (no iOS support).
+//
+
+import Foundation
+#if canImport(CoreBluetooth)
+import CoreBluetooth
+#endif
+
+/// Callback slots the Python RNode interface registers with the bridge via
+/// `rns_bridge.set_rnode_callback(slot, callable)`. Scoped to the two events a
+/// NUS client emits (cf. the richer `BleCallbackSlot` for the mesh).
+public enum RNodeCallbackSlot: String, Sendable, CaseIterable {
+    /// `cb(data: bytes)` — a payload notified on the NUS TX characteristic
+    /// (RNode → phone). Raw serial bytes; the Python side runs KISS framing.
+    case onData = "data"
+    /// `cb(connected: bool, device_name: str)` — link came up (TX notify
+    /// subscribed) or went down (disconnect).
+    case onState = "state"
+}
+
+/// Abstraction over "invoke the Python RNode callback registered under this
+/// slot". Concrete impl (`PythonRNodeCallbackBridge`) is pbxproj-only (needs
+/// Python.h); the SwiftPM target builds + unit-tests without the Python C-API
+/// by injecting a stub. Mirror of `BleCallbackInvoker`, minus the bool-return
+/// variant (RNode has no synchronous callbacks).
+public protocol RNodeCallbackInvoker: AnyObject, Sendable {
+    func invoke(slot: RNodeCallbackSlot, args: [Any])
+}
+
+#if canImport(CoreBluetooth)
+
+/// CoreBluetooth NUS client. Scans for the RNode by advertised name, connects,
+/// discovers the Nordic UART Service, subscribes to TX notifications, and
+/// writes outbound serial to RX (write-without-response, MTU-chunked). One per
+/// process — the `@_cdecl` shims route through `.shared`.
+public final class SwiftRNodeBridge: NSObject, @unchecked Sendable {
+
+    public static let shared = SwiftRNodeBridge()
+
+    // Nordic UART Service — RNode firmware exposes its BLE serial here.
+    private static let nusService = CBUUID(string: "6e400001-b5a3-f393-e0a9-e50e24dcca9e")
+    private static let nusRxChar  = CBUUID(string: "6e400002-b5a3-f393-e0a9-e50e24dcca9e") // write  (phone → RNode)
+    private static let nusTxChar  = CBUUID(string: "6e400003-b5a3-f393-e0a9-e50e24dcca9e") // notify (RNode → phone)
+
+    /// Own serial queue — distinct from SwiftBLEBridge's. CB delegate callbacks
+    /// land here; callback invocations hop to the Python serial queue inside
+    /// PythonBridge.
+    private let queue = DispatchQueue(label: "network.columba.rnode", qos: .userInitiated)
+    private var callbackInvoker: RNodeCallbackInvoker?
+
+    // Our own central — NOT shared with the mesh. Held strong for the bridge's
+    // lifetime; reused across stop()/start() to avoid CB teardown races.
+    private var central: CBCentralManager?
+    // Strong ref to the connected peripheral — iOS deallocates CBPeripheral
+    // without one, dropping the link. Also the handle for background reconnect.
+    private var peripheral: CBPeripheral?
+    private var rxChar: CBCharacteristic?
+    private var txChar: CBCharacteristic?
+
+    private var targetName: String = ""   // device name to match while scanning
+    private var wantConnected = false     // user intends a live link → drives reconnect
+    private var isLinkUp = false          // TX notify subscribed → link usable
+    private var startedFlag = false
+
+    // Writes issued before the link is up (the protocol sends radio config
+    // right after connect(), but our connect is async). Queued here and flushed
+    // on link-up so radio config isn't silently lost into a not-yet-ready link.
+    private var pendingWrites: [Data] = []
+    private let maxPendingWrites = 128
+
+    public override init() { super.init() }
+
+    // MARK: - Public API (called from the C-ABI shims / app glue)
+
+    public func setCallbackInvoker(_ invoker: RNodeCallbackInvoker?) {
+        queue.sync { self.callbackInvoker = invoker }
+    }
+
+    /// Bring up the central. Idempotent. The central isn't created until here,
+    /// so merely installing the callback invoker at app launch costs nothing.
+    public func start() {
+        queue.sync {
+            guard !startedFlag else { return }
+            if central == nil {
+                central = CBCentralManager(delegate: self, queue: queue)
+            }
+            startedFlag = true
+        }
+    }
+
+    /// Tear down the active link but keep the central alive (Apply & Restart
+    /// calls stop() then start() in quick succession). Clears reconnect intent.
+    public func stop() {
+        queue.sync {
+            wantConnected = false
+            if let c = central, c.isScanning { c.stopScan() }
+            if let p = peripheral { central?.cancelPeripheralConnection(p) }
+            teardownLinkLocked(notify: false)
+            peripheral = nil
+        }
+    }
+
+    /// Connect to the RNode advertising `deviceName`. If we already hold the
+    /// peripheral (reconnect after a drop), issue a direct pending connect
+    /// (works in the background, no scan); otherwise start scanning.
+    public func connect(deviceName: String) {
+        queue.async { [weak self] in
+            guard let self else { return }
+            self.targetName = deviceName
+            self.wantConnected = true
+            if let p = self.peripheral {
+                self.central?.connect(p, options: nil)
+                self.log("reconnect-issued name=\(deviceName)")
+            } else {
+                self.tryStartScanLocked()
+            }
+        }
+    }
+
+    public func disconnect() {
+        queue.async { [weak self] in
+            guard let self else { return }
+            self.wantConnected = false
+            if let c = self.central, c.isScanning { c.stopScan() }
+            if let p = self.peripheral { self.central?.cancelPeripheralConnection(p) }
+            self.teardownLinkLocked(notify: true)
+            self.peripheral = nil
+        }
+    }
+
+    /// Write outbound serial to the RNode RX characteristic, chunked to the
+    /// negotiated write-without-response MTU. KISS frames routinely exceed one
+    /// BLE MTU; the RNode firmware reassembles a continuous serial stream, so
+    /// sequential chunking with no inter-chunk framing is correct.
+    public func write(_ data: Data) {
+        queue.async { [weak self] in
+            guard let self else { return }
+            guard self.isLinkUp, self.peripheral != nil, self.rxChar != nil else {
+                // Link not up yet — queue (bounded) and flush on link-up.
+                if self.pendingWrites.count < self.maxPendingWrites {
+                    self.pendingWrites.append(data)
+                } else {
+                    self.log("pending-write queue full — dropping \(data.count)B")
+                }
+                return
+            }
+            self.writeChunkedLocked(data)
+        }
+    }
+
+    /// Chunk + write to the RX characteristic. Caller guarantees the link is up.
+    private func writeChunkedLocked(_ data: Data) {
+        guard let p = peripheral, let rx = rxChar else { return }
+        let mtu = max(20, p.maximumWriteValueLength(for: .withoutResponse))
+        var offset = 0
+        while offset < data.count {
+            let end = min(offset + mtu, data.count)
+            p.writeValue(data.subdata(in: offset..<end), for: rx, type: .withoutResponse)
+            offset = end
+        }
+    }
+
+    private func flushPendingWritesLocked() {
+        guard !pendingWrites.isEmpty else { return }
+        log("flushing \(pendingWrites.count) queued write(s) on link-up")
+        let queued = pendingWrites
+        pendingWrites.removeAll()
+        for d in queued { writeChunkedLocked(d) }
+    }
+
+    // MARK: - Private helpers (all called with `queue` held / on `queue`)
+
+    private func tryStartScanLocked() {
+        guard let c = central, c.state == .poweredOn else { return } // resumes in didUpdateState
+        if c.isScanning { return }
+        // nil service filter: RNode advertisements frequently omit the NUS UUID
+        // (firmware advertises only the device name), so we match on name in
+        // didDiscover. Background reconnect doesn't rely on this — it uses the
+        // cached peripheral via connect(), which needs no scan.
+        c.scanForPeripherals(withServices: nil, options: nil)
+        log("scan-started target='\(targetName)'")
+    }
+
+    private func nameMatches(_ adName: String?) -> Bool {
+        guard !targetName.isEmpty else { return true } // empty → first NUS device seen
+        let t = targetName.lowercased()
+        guard let n = adName?.lowercased() else { return false }
+        return n == t || n.contains(t)
+    }
+
+    private func teardownLinkLocked(notify: Bool) {
+        rxChar = nil
+        txChar = nil
+        // Drop queued writes — on reconnect the protocol re-runs _configure_device
+        // and re-sends radio config, so stale queued frames must not replay.
+        pendingWrites.removeAll()
+        let wasUp = isLinkUp
+        isLinkUp = false
+        if notify && wasUp {
+            callbackInvoker?.invoke(slot: .onState, args: [false, targetName])
+        }
+    }
+
+    fileprivate func log(_ message: String) {
+        print("SwiftRNodeBridge: \(message)")
+    }
+}
+
+// MARK: - CBCentralManagerDelegate
+
+extension SwiftRNodeBridge: CBCentralManagerDelegate {
+
+    public func centralManagerDidUpdateState(_ central: CBCentralManager) {
+        switch central.state {
+        case .poweredOn:
+            log("central poweredOn")
+            // Resume whatever the user asked for before the radio was ready.
+            if wantConnected {
+                if let p = peripheral { central.connect(p, options: nil) }
+                else { tryStartScanLocked() }
+            }
+        case .unauthorized: log("unauthorized — check Bluetooth permission")
+        case .poweredOff:   log("poweredOff")
+        case .unsupported:  log("unsupported on this device")
+        case .resetting:    log("resetting")
+        case .unknown:      log("state unknown")
+        @unknown default:   log("state \(central.state.rawValue)")
+        }
+    }
+
+    public func centralManager(
+        _ central: CBCentralManager,
+        didDiscover peripheral: CBPeripheral,
+        advertisementData: [String: Any],
+        rssi RSSI: NSNumber
+    ) {
+        let adName = (advertisementData[CBAdvertisementDataLocalNameKey] as? String) ?? peripheral.name
+        guard nameMatches(adName) else { return }
+        log("matched '\(adName ?? "")' rssi=\(RSSI.intValue) — connecting")
+        central.stopScan()
+        self.peripheral = peripheral          // strong ref before connect
+        peripheral.delegate = self
+        central.connect(peripheral, options: nil)
+    }
+
+    public func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
+        log("didConnect — discovering NUS")
+        peripheral.discoverServices([Self.nusService])
+    }
+
+    public func centralManager(
+        _ central: CBCentralManager,
+        didFailToConnect peripheral: CBPeripheral,
+        error: Error?
+    ) {
+        log("didFailToConnect: \(String(describing: error))")
+        // Direct connect failed (e.g. out of range) — fall back to scanning.
+        if wantConnected { tryStartScanLocked() }
+    }
+
+    public func centralManager(
+        _ central: CBCentralManager,
+        didDisconnectPeripheral peripheral: CBPeripheral,
+        error: Error?
+    ) {
+        log("didDisconnect: \(String(describing: error))")
+        teardownLinkLocked(notify: true)
+        // Auto-reconnect: RNode BLE links drop often. If the user still wants
+        // the link, issue a direct pending connect to the same peripheral; CB
+        // completes it (even backgrounded) when the RNode is back in range.
+        if wantConnected, let p = self.peripheral {
+            central.connect(p, options: nil)
+        }
+    }
+}
+
+// MARK: - CBPeripheralDelegate
+
+extension SwiftRNodeBridge: CBPeripheralDelegate {
+
+    public func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
+        if let error { log("didDiscoverServices error: \(error)"); return }
+        guard let svc = peripheral.services?.first(where: { $0.uuid == Self.nusService }) else {
+            log("NUS service not found")
+            return
+        }
+        peripheral.discoverCharacteristics([Self.nusRxChar, Self.nusTxChar], for: svc)
+    }
+
+    public func peripheral(
+        _ peripheral: CBPeripheral,
+        didDiscoverCharacteristicsFor service: CBService,
+        error: Error?
+    ) {
+        if let error { log("didDiscoverCharacteristics error: \(error)"); return }
+        for ch in (service.characteristics ?? []) {
+            switch ch.uuid {
+            case Self.nusRxChar: rxChar = ch
+            case Self.nusTxChar: txChar = ch
+            default: break
+            }
+        }
+        guard let tx = txChar, rxChar != nil else {
+            log("NUS RX/TX characteristic missing")
+            return
+        }
+        // Link comes up once the TX subscription is confirmed
+        // (didUpdateNotificationStateFor).
+        peripheral.setNotifyValue(true, for: tx)
+    }
+
+    public func peripheral(
+        _ peripheral: CBPeripheral,
+        didUpdateNotificationStateFor characteristic: CBCharacteristic,
+        error: Error?
+    ) {
+        if let error { log("didUpdateNotificationState error: \(error)"); return }
+        guard characteristic.uuid == Self.nusTxChar, characteristic.isNotifying else { return }
+        isLinkUp = true
+        let mtu = peripheral.maximumWriteValueLength(for: .withoutResponse)
+        log("link up — TX notify subscribed, mtu=\(mtu)")
+        callbackInvoker?.invoke(slot: .onState, args: [true, targetName])
+        flushPendingWritesLocked()
+    }
+
+    public func peripheral(
+        _ peripheral: CBPeripheral,
+        didUpdateValueFor characteristic: CBCharacteristic,
+        error: Error?
+    ) {
+        if let error { log("didUpdateValueFor error: \(error)"); return }
+        guard characteristic.uuid == Self.nusTxChar,
+              let value = characteristic.value, !value.isEmpty else { return }
+        callbackInvoker?.invoke(slot: .onData, args: [value])
+    }
+
+    public func peripheral(
+        _ peripheral: CBPeripheral,
+        didWriteValueFor characteristic: CBCharacteristic,
+        error: Error?
+    ) {
+        if let error { log("didWriteValueFor error: \(error)") }
+    }
+}
+
+#else
+
+/// Non-CoreBluetooth stub so `swift build` typechecks the module on Linux/CI.
+/// Mirrors the real bridge's surface (cf. the SwiftBLEBridge stub).
+public final class SwiftRNodeBridge: @unchecked Sendable {
+    public static let shared = SwiftRNodeBridge()
+    public func setCallbackInvoker(_ invoker: RNodeCallbackInvoker?) {}
+    public func start() {}
+    public func stop() {}
+    public func connect(deviceName: String) {}
+    public func disconnect() {}
+    public func write(_ data: Data) {}
+}
+
+#endif

--- a/Sources/SwiftBLEBridge/SwiftRNodeBridge.swift
+++ b/Sources/SwiftBLEBridge/SwiftRNodeBridge.swift
@@ -125,6 +125,14 @@ public final class SwiftRNodeBridge: NSObject, @unchecked Sendable {
             if let p = peripheral { central?.cancelPeripheralConnection(p) }
             teardownLinkLocked(notify: false)
             peripheral = nil
+            // Clear the invoker inside the serialized block: didUpdateValueFor
+            // notifications CoreBluetooth already queued on `queue` are
+            // delivered after this block, and their guard only matches the
+            // static TX-char UUID (no isLinkUp check), so they would otherwise
+            // fire .onData into Python's mid-teardown IOSRNodeInterface and
+            // corrupt KISS decoder state. Mirrors SwiftBLEBridge.stop();
+            // re-installed on the next start.
+            callbackInvoker = nil
         }
     }
 

--- a/Sources/SwiftBLEBridge/SwiftRNodeBridge.swift
+++ b/Sources/SwiftBLEBridge/SwiftRNodeBridge.swift
@@ -89,6 +89,13 @@ public final class SwiftRNodeBridge: NSObject, @unchecked Sendable {
     private var pendingWrites: [Data] = []
     private let maxPendingWrites = 128
 
+    // Post-link MTU-sized chunks awaiting CoreBluetooth transmit-queue space.
+    // writeValue(.withoutResponse) silently drops once the queue is full
+    // (iOS 11+), so chunks are queued here and drained as the queue frees up
+    // (see drainChunksLocked / peripheralIsReady(toSendWriteWithoutResponse:)).
+    private var pendingChunks: [Data] = []
+    private let maxPendingChunks = 4096
+
     public override init() { super.init() }
 
     // MARK: - Public API (called from the C-ABI shims / app glue)
@@ -169,15 +176,35 @@ public final class SwiftRNodeBridge: NSObject, @unchecked Sendable {
         }
     }
 
-    /// Chunk + write to the RX characteristic. Caller guarantees the link is up.
+    /// Chunk a frame to the negotiated MTU and queue the chunks for sending.
+    /// Caller guarantees the link is up. The chunks aren't written directly —
+    /// they're enqueued and drained under transmit-queue backpressure, so a
+    /// frame that exceeds the BLE queue mid-way isn't silently truncated.
     private func writeChunkedLocked(_ data: Data) {
-        guard let p = peripheral, let rx = rxChar else { return }
+        guard let p = peripheral, rxChar != nil else { return }
         let mtu = max(20, p.maximumWriteValueLength(for: .withoutResponse))
         var offset = 0
         while offset < data.count {
             let end = min(offset + mtu, data.count)
-            p.writeValue(data.subdata(in: offset..<end), for: rx, type: .withoutResponse)
+            guard pendingChunks.count < maxPendingChunks else {
+                log("pending-chunk queue full — dropping \(data.count - offset)B of frame")
+                break
+            }
+            pendingChunks.append(data.subdata(in: offset..<end))
             offset = end
+        }
+        drainChunksLocked()
+    }
+
+    /// Write queued chunks while CoreBluetooth has transmit-queue space. From
+    /// iOS 11, writeValue(.withoutResponse) silently drops the write when the
+    /// queue is full, so gate every write on `canSendWriteWithoutResponse` and
+    /// resume from `peripheralIsReady(toSendWriteWithoutResponse:)` once it
+    /// frees up — mirroring the server-side pendingNotifies discipline.
+    private func drainChunksLocked() {
+        guard let p = peripheral, let rx = rxChar else { return }
+        while !pendingChunks.isEmpty, p.canSendWriteWithoutResponse {
+            p.writeValue(pendingChunks.removeFirst(), for: rx, type: .withoutResponse)
         }
     }
 
@@ -215,6 +242,7 @@ public final class SwiftRNodeBridge: NSObject, @unchecked Sendable {
         // Drop queued writes — on reconnect the protocol re-runs _configure_device
         // and re-sends radio config, so stale queued frames must not replay.
         pendingWrites.removeAll()
+        pendingChunks.removeAll()
         let wasUp = isLinkUp
         isLinkUp = false
         if notify && wasUp {
@@ -361,6 +389,12 @@ extension SwiftRNodeBridge: CBPeripheralDelegate {
         error: Error?
     ) {
         if let error { log("didWriteValueFor error: \(error)") }
+    }
+
+    public func peripheralIsReady(toSendWriteWithoutResponse peripheral: CBPeripheral) {
+        // Transmit queue freed up — resume draining queued chunks. Delivered on
+        // the central manager's `queue`, so call the locked helper directly.
+        drainChunksLocked()
     }
 }
 


### PR DESCRIPTION
Part **2 of 3** of the path-scoped split of `feat/dual-backend-arch` (see PR 1/3 for the full rationale). **67 files.**

> Stacked on `pr1-rns-core` — review/merge **after** PR 1/3. GitHub will retarget this onto `main` once PR 1 merges.

### This slice — app services + BLE bridge
`ColumbaApp/Services` (AppServices, CallManager, LocationSharingManager, the interface/announce/propagation managers), `ColumbaApp/ViewModels`, `SwiftBLEBridge`, and app glue (`App` / `Models` / `Resources`).

Not independently buildable (depends on PR 1/3's RNS seam).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
