### PR TITLE
ci: build on macos-26 (Xcode 26) so the Python module map resolves

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,9 +52,14 @@ jobs:
       # race. One explicit resolve makes every later build/test step reuse it.
       - name: Resolve Swift packages
         run: |
+          # Pre-warm both schemes' package deps (same sibling packages, same
+          # .xcodeproj, but be explicit so the Swift-native build benefits too).
           xcodebuild -resolvePackageDependencies \
             -project Columba.xcodeproj \
             -scheme Columba
+          xcodebuild -resolvePackageDependencies \
+            -project Columba.xcodeproj \
+            -scheme Columba-Swift
 
       - name: Find simulator
         id: sim

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,11 @@ concurrency:
 
 jobs:
   test:
-    runs-on: macos-15
+    # macos-26 carries Xcode 26.x, which the embedded-Python (Columba) scheme
+    # needs — the Python.framework clang module map fails to resolve under
+    # Xcode 16.x ("module 'Python' … not defined in any loaded module map"),
+    # which is what devs build with locally (26.x). See the Select Xcode step.
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
 
@@ -32,10 +36,25 @@ jobs:
 
       - name: Select Xcode
         run: |
-          XCODE=$(ls -d /Applications/Xcode_16*.app 2>/dev/null | sort -V | tail -1)
+          echo "Available Xcodes:"; ls -d /Applications/Xcode_*.app 2>/dev/null || true
+          # Pick the newest Xcode on the runner (was pinned to 16.x, which can't
+          # build the Python scheme — see runs-on comment). Version-sort so 26.x
+          # wins over 16.x regardless of exact point release.
+          XCODE=$(ls -d /Applications/Xcode_*.app 2>/dev/null | sort -V | tail -1)
           echo "Using $XCODE"
           sudo xcode-select -s "$XCODE"
           xcodebuild -version
+
+      # Resolve the local Swift packages (reticulum-swift / LXMF-swift / LXST-swift)
+      # once, up front. Without this the `xcodebuild test` action can intermittently
+      # fail to resolve LXMFSwift/ReticulumSwift for the ColumbaAppTests target even
+      # though the app build steps resolved them fine — a fresh-runner resolution
+      # race. One explicit resolve makes every later build/test step reuse it.
+      - name: Resolve Swift packages
+        run: |
+          xcodebuild -resolvePackageDependencies \
+            -project Columba.xcodeproj \
+            -scheme Columba
 
       - name: Find simulator
         id: sim


### PR DESCRIPTION
**`main`'s `test` workflow has been red since the dual-backend merge** — every open PR inherits it (this is why #84's CI failed; it's not the CallKit change).

## Root cause
The `Build (Python backend — default)` step fails precompiling ColumbaApp's bridging header:
```
error: module 'Python' in AST file … clang importer creation failed
SwiftGeneratePch … Compiling bridging header (ColumbaApp) Failed → exit code 65
```
The embedded-Python (`Columba`) scheme's `Python.framework` clang module map only resolves under **Xcode 26.x**, but the runner was pinned to `macos-15` / `Xcode 16`. The fix was made on the combined **#82** branch (`feat/dual-backend-arch`), which was **closed, not merged** — so it was stranded (same pattern as the interop-harness fixes in #83).

## Fix (recovered verbatim from #82)
- `runs-on: macos-15` → `macos-26` (carries Xcode 26.x)
- Select Xcode: pick the newest `Xcode_*` instead of `Xcode_16*`
- Add an explicit `Resolve Swift packages` step (fresh-runner resolution race for the test target)

No app/source changes. Merging this fixes `main`'s CI; **#83 and #84 should go green on re-run once this lands** (their `pull_request` checks build the merge with `main`'s fixed workflow).