### PR TITLE
fix(ci): fetch Python.xcframework in ci_post_clone (Xcode Cloud build fix)

### DIFF
--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -48,13 +48,13 @@ rm -f "${PBXPROJ}.bak"
 # wheels it's gitignored (too large for git, see .gitignore), but the Columba
 # target *links* it, so a fresh CI clone has nothing to link against and the
 # build fails without this. fetch-python.sh is a plain curl+tar of a pinned
-# BeeWare release — no host toolchain needed. Idempotent; skipped if present.
-if [ ! -d "$REPO_ROOT/Frameworks/Python.xcframework" ]; then
-    echo "Fetching Python.xcframework (BeeWare Python-Apple-support)..."
-    "$REPO_ROOT/support/fetch-python.sh"
-else
-    echo "Python.xcframework already present, skipping fetch."
-fi
+# BeeWare release (no host toolchain needed) and is itself version-aware: it
+# bails fast when Frameworks/VERSIONS already matches the pinned build and
+# re-fetches when it's missing or stale. Call it unconditionally rather than
+# guarding on directory existence here — an outer guard would mask the
+# stale-version upgrade fetch-python.sh applies, and would duplicate the pinned
+# build tag in two places.
+"$REPO_ROOT/support/fetch-python.sh"
 
 # Fetch Python wheels. The wheel dirs are gitignored (not committed), but the
 # "Install Python stdlib & process dylibs" build phase hard-requires them, so a

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -44,6 +44,18 @@ sed -i.bak -E \
     "$PBXPROJ"
 rm -f "${PBXPROJ}.bak"
 
+# Fetch the embedded Python.xcframework (BeeWare Python-Apple-support). Like the
+# wheels it's gitignored (too large for git, see .gitignore), but the Columba
+# target *links* it, so a fresh CI clone has nothing to link against and the
+# build fails without this. fetch-python.sh is a plain curl+tar of a pinned
+# BeeWare release — no host toolchain needed. Idempotent; skipped if present.
+if [ ! -d "$REPO_ROOT/Frameworks/Python.xcframework" ]; then
+    echo "Fetching Python.xcframework (BeeWare Python-Apple-support)..."
+    "$REPO_ROOT/support/fetch-python.sh"
+else
+    echo "Python.xcframework already present, skipping fetch."
+fi
+
 # Fetch Python wheels. The wheel dirs are gitignored (not committed), but the
 # "Install Python stdlib & process dylibs" build phase hard-requires them, so a
 # fresh CI clone must build them here. fetch-wheels.sh resolves RNS from the


### PR DESCRIPTION
## Problem
Xcode Cloud builds fail after the dual-backend merge.

## Root cause
The embedded-Python dependency landed in `2e49820` (dual-backend PR 1/3), which also updated `ci_post_clone.sh` to fetch the iOS **wheels** — but **not** the `Python.xcframework` itself.

- `Frameworks/Python.xcframework/` is **gitignored** (too large for git; fetched by `support/fetch-python.sh`).
- The `Columba` target **links** `Python.xcframework` (14 references in the pbxproj), and no build phase fetches it.
- So a fresh Xcode Cloud clone has no framework to link against → build fails.

GitHub Actions doesn't hit this because its workflow fetches the framework separately; only the Xcode Cloud path was missing it.

## Fix
Fetch the framework in `ci_post_clone.sh` alongside the wheels, with the same idempotent "skip if present" guard. `fetch-python.sh` is a plain `curl + tar` of the pinned BeeWare `3.13-b13` release (no host toolchain needed); the asset currently returns HTTP 200.

## Verification
- `bash -n ci_scripts/ci_post_clone.sh` ✅
- Pinned BeeWare release asset reachable (HTTP 200) ✅
- Local framework already at `b13`, so the guard correctly skips on incremental/local runs ✅

> Note: I diagnosed this from the build wiring, not the Xcode Cloud log (no ASC API key available here). This is a real, build-breaking gap regardless. If a build still fails after this lands, the next suspect is the Xcode version — the embedded `Python` clang module map needs Xcode 26 (the same reason GitHub Actions moved to `macos-26`); verify the Xcode Cloud workflow's Xcode version.