### PR TITLE
fix(build): drop macosx from SUPPORTED_PLATFORMS (iOS-only app)

### DIFF
--- a/Columba.xcodeproj/project.pbxproj
+++ b/Columba.xcodeproj/project.pbxproj
@@ -1199,7 +1199,7 @@
 				MARKETING_VERSION = 0.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = network.columba.Columba;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) COLUMBA_BACKEND_SWIFT";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -1245,7 +1245,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = network.columba.Columba;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) COLUMBA_BACKEND_SWIFT";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -1266,7 +1266,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				PRODUCT_BUNDLE_IDENTIFIER = network.columba.Columba.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_ENABLE_EXPLICIT_MODULES = NO;
@@ -1371,7 +1371,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				PRODUCT_BUNDLE_IDENTIFIER = network.columba.Columba.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_ENABLE_EXPLICIT_MODULES = NO;
@@ -1617,7 +1617,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = network.columba.Columba;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "Sources/PythonBridge/ColumbaPython-Bridging-Header.h";
@@ -1661,7 +1661,7 @@
 				MARKETING_VERSION = 0.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = network.columba.Columba;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "Sources/PythonBridge/ColumbaPython-Bridging-Header.h";
@@ -1681,7 +1681,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				PRODUCT_BUNDLE_IDENTIFIER = network.columba.Columba.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_ENABLE_EXPLICIT_MODULES = NO;
@@ -1702,7 +1702,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				PRODUCT_BUNDLE_IDENTIFIER = network.columba.Columba.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_ENABLE_EXPLICIT_MODULES = NO;


### PR DESCRIPTION
## Problem
After #88 fixes the missing-framework fetch, Xcode Cloud hits the *next* error:
> While building for macOS, no library for this platform was found in `…/Frameworks/Python.xcframework`.

## Root cause
The dual-backend merge (`2e49820`) widened `SUPPORTED_PLATFORMS` to `"iphoneos iphonesimulator macosx"` on every target — almost certainly an Xcode side effect of adding the sibling SPM packages (`reticulum-swift`, `LXMF-swift`, `LXST-swift`), which all declare `.macOS(.v13)`.

But the embedded `Python.xcframework` (BeeWare Python-Apple-support) ships **iOS-only** slices — `ios-arm64` and `ios-arm64_x86_64-simulator`, no macOS. So as soon as the build evaluates the `macosx` platform, it can't resolve a slice and fails.

All three native targets are iOS products with `SDKROOT = iphoneos`:
| Target | Product type |
|---|---|
| `ColumbaApp` | application |
| `ColumbaNetworkExtension` | app-extension |
| `ColumbaAppTests` | unit-test |

None is a genuine macOS target, so `macosx` is spurious.

## Fix
`SUPPORTED_PLATFORMS = "iphoneos iphonesimulator"` across all 8 build configs (removes `macosx`). pbxproj lints clean.

`SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD` is unset and untouched — "iPhone/iPad Apps on Mac" uses the existing `ios-arm64` slice, so that path is unaffected.

## Order
Needs to land **with #88** — #88 makes the framework *present*, this makes the build stop targeting a platform the framework doesn't support. Neither alone produces a green build.

> Caveat (unchanged): once past this, the remaining suspect is the Xcode Cloud workflow's Xcode version — the `Python` clang module map needs Xcode 26 (the reason GitHub Actions is on `macos-26`). That's an App Store Connect setting, not in the repo.