### PR TITLE
Model B: fix opportunistic sent messages stuck at single checkmark

### DIFF
--- a/Columba.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Columba.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -34,7 +34,7 @@
       "location" : "https://github.com/torlando-tech/LXMF-swift.git",
       "state" : {
         "branch" : "feat/lxmfdb-appgroup-sharing",
-        "revision" : "584c30cc82622e0b6920e654efd9b182110490ad"
+        "revision" : "b2611b385d53eadc40e618821ebb5f2c171f9b2b"
       }
     },
     {


### PR DESCRIPTION
## Problem

Under Model B, sent messages intermittently stayed at a **single checkmark** even when the recipient confirmed delivery — the incoming delivery proof was not always processed.

## Root cause

`LXMRouter.processOutbound` (LXMF-swift) **dequeued an opportunistic message the instant it reached `.sent`**, so advancement to `.delivered` depended *entirely* on the in-memory proof callback in the transport (`pendingProofCallbacks`, not persisted). A single lost packet or proof — or, far more commonly under Model B, the iOS Network Extension being suspended/jetsammed during the proof round-trip window — stranded the message at one checkmark forever. Python doesn't hit this: its long-lived process keeps the message in `pending_outbound` and re-sends until delivered.

Diagnosed across LXMF-swift / reticulum-swift / the NE against the python reference; confirmed Columba always sends `.opportunistic` (direct is only a large-message fallback).

## Fix (LXMF-swift `b2611b3`, this PR bumps the pin)

Restores python's retry-until-delivered semantics for the opportunistic path (`LXMRouter.py:2566-2592`):

- Opportunistic messages stay in `pendingOutbound` at `.sent` and re-send every `DELIVERY_RETRY_WAIT` (=10s, python parity), removed only on `.delivered` or `MAX_DELIVERY_ATTEMPTS`. `nextDeliveryAttempt` gates re-sends (no storm).
- `handleDeliveryProofReceived` flips the in-memory entry to `.delivered` (python `__mark_delivered`) so the loop stops re-sending.
- `loadPendingOutbound` reloads opportunistic `.sent` messages, so a proof missed during NE suspension is recovered on relaunch. Scoped to `.opportunistic` (`.sent` is terminal for PROPAGATED; DIRECT unchanged).

Resends are deduped recipient-side by the stable message hash; PROVE_ALL means a duplicate resend still earns the proof that clears a stuck check. Documented in `port-deviations.md`. DIRECT full parity (link-receipt timeout retry) tracked as follow-up.

## Verification

Device (iPhone 14, Model B): `opp_echo` smoke scenario **passes** — device sends OPPORTUNISTIC → Mac echo bot round-trips → device processes the delivery proof (`delivery confirmed`) and removes the message from the queue (no resend storm). NE boots clean on the new lib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
