### PR TITLE
Model B: DIRECT messages retry until delivered (proof-wait timeout)

### DIFF
--- a/Columba.xcodeproj/project.pbxproj
+++ b/Columba.xcodeproj/project.pbxproj
@@ -1940,7 +1940,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/torlando-tech/LXMF-swift.git";
 			requirement = {
-				branch = "feat/lxmfdb-appgroup-sharing";
+				branch = main;
 				kind = branch;
 			};
 		};

--- a/Columba.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Columba.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -34,7 +34,7 @@
       "location" : "https://github.com/torlando-tech/LXMF-swift.git",
       "state" : {
         "branch" : "feat/lxmfdb-appgroup-sharing",
-        "revision" : "b2611b385d53eadc40e618821ebb5f2c171f9b2b"
+        "revision" : "72c449603455368e55e435c40a8f6df5561ed988"
       }
     },
     {

--- a/Columba.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Columba.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/torlando-tech/LXMF-swift.git",
       "state" : {
-        "branch" : "feat/lxmfdb-appgroup-sharing",
-        "revision" : "ddf9b54e8955392ca540f0844e34c4633524eb29"
+        "branch" : "main",
+        "revision" : "1f2bb311d9e0e3c65baff546dc663cb382bde7b4"
       }
     },
     {

--- a/Columba.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Columba.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -34,7 +34,7 @@
       "location" : "https://github.com/torlando-tech/LXMF-swift.git",
       "state" : {
         "branch" : "main",
-        "revision" : "1f2bb311d9e0e3c65baff546dc663cb382bde7b4"
+        "revision" : "60186710b9891d35dfb54e636935ddb506b581e6"
       }
     },
     {

--- a/Columba.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Columba.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -34,7 +34,7 @@
       "location" : "https://github.com/torlando-tech/LXMF-swift.git",
       "state" : {
         "branch" : "feat/lxmfdb-appgroup-sharing",
-        "revision" : "4e1fa6658b8fad21855be7e4cc5f1d8299839bbe"
+        "revision" : "ddf9b54e8955392ca540f0844e34c4633524eb29"
       }
     },
     {

--- a/Columba.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Columba.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -34,7 +34,7 @@
       "location" : "https://github.com/torlando-tech/LXMF-swift.git",
       "state" : {
         "branch" : "feat/lxmfdb-appgroup-sharing",
-        "revision" : "72c449603455368e55e435c40a8f6df5561ed988"
+        "revision" : "4e1fa6658b8fad21855be7e4cc5f1d8299839bbe"
       }
     },
     {


### PR DESCRIPTION
## Problem

The opportunistic delivery-proof fix (#93) left the **DIRECT** path with the same latent bug: a small-packet DIRECT message was dequeued at `.sent` and relied solely on the in-memory proof callback, so a lost link proof — or the NE being suspended/jetsammed during the proof window — stranded it at a single checkmark. DIRECT is Columba's large-message fallback, so this had to be fixed before shipping.

## Fix (LXMF-swift `72c4496`, this PR bumps the pin)

Brings DIRECT to python parity (`LXMRouter.py:2596-2673`, `LXMessage.py:471-484,613-618`):

- `processOutbound`'s `.direct` case keeps the small-packet message in `pendingOutbound` at `.sent` with `nextDeliveryAttempt = now + DELIVERY_RETRY_WAIT` (full-record persist). While awaiting the proof it's skipped by `shouldAttemptDelivery` (no duplicate during the wait — matches python's "waiting for proof"). When the window elapses and it's still `.sent`, it tears down the link (`closeAndRemoveDeliveryLink` → `Link.close(.timeout)` + `transport.unregisterLink`), reverts `.sent`→`.outbound`, and re-sends over a **fresh** link — mirroring python's `__link_packet_timed_out` teardown + re-establish. Removed only on `.delivered` or `MAX_DELIVERY_ATTEMPTS`.
- `loadPendingOutbound` now reloads DIRECT `.sent` (not just opportunistic), so a proof missed during NE jetsam recovers on relaunch. Still excludes PROPAGATED `.sent` (terminal); DIRECT RESOURCE persists `.outbound` so it's never double-handled.
- Post-send writeback is guarded on `state != .delivered` in **both** the DIRECT and opportunistic branches, so a proof landing during the send `await` isn't clobbered back to `.sent`.

**Design:** pure LXMF-swift, no reticulum-swift change. reticulum-swift has no `set_timeout_callback` primitive and RNS never retransmits link DATA — so python's DIRECT re-send is itself poll-driven by `process_outbound`; the swift poll is faithful, and a transport callback wouldn't survive NE suspension anyway. Two intentional divergences (no timeout-callback primitive; rtt*6 collapsed into `DELIVERY_RETRY_WAIT`) documented in `port-deviations.md`. Stricter-parity follow-ups (rtt-based fast dead-link detection, `Link.setCloseCallback` early-close) tracked on LXMF-swift issue #10.

## Verification

- **Unit (executes production code):** new `testLoadPendingOutboundReloadScoping` pins the reload filter — `.outbound` + OPPORTUNISTIC/DIRECT `.sent` reload, PROPAGATED `.sent` does not. All 35 router/delivery tests pass.
- **Device (iPhone 14, Model B):** `direct_echo` smoke scenario **passes** — device sends DIRECT → Mac echo bot round-trips → device processes the delivery proof (`delivery confirmed`) and reaches `.delivered` within the proof-wait window (no spurious retry); NE boots clean, no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
