### PR TITLE
fix(ios): propagation sync sheet — manual-only presentation + styling

### DIFF
--- a/Sources/ColumbaApp/Services/PropagationNodeManager.swift
+++ b/Sources/ColumbaApp/Services/PropagationNodeManager.swift
@@ -314,12 +314,20 @@ public final class PropagationNodeManager {
     /// Trigger an immediate sync from the propagation node.
     ///
     /// If no propagation node is selected yet, auto-selects the best available node first.
-    public func syncNow() async {
-        // Reset transfer state up front so any observer (the in-app status sheet) shows
-        // THIS sync's progress from a clean "connecting" slate, not the previous run's
-        // stale "Download complete / N new messages". Early-return guards below overwrite
-        // this with the appropriate terminal state (e.g. .noPath).
-        syncState = PropagationTransferState(state: .linking)
+    /// - Parameter userInitiated: `true` when the user explicitly triggered the sync (a
+    ///   refresh button, pull-to-refresh, or a Sync Now action) — i.e. the cases that may
+    ///   present the status sheet. Only these reset the displayed transfer state up front
+    ///   (see below). Background, periodic, and on-foreground auto-syncs pass `false`.
+    public func syncNow(userInitiated: Bool = false) async {
+        // For user-initiated syncs only, reset transfer state up front so a freshly-opened
+        // status sheet shows THIS sync's progress from a clean "connecting" slate, not the
+        // previous run's stale "Download complete / N new messages". Background / periodic
+        // / on-foreground syncs skip this so they never clobber a status sheet the user may
+        // have left open on a prior result. Early-return guards below overwrite this with
+        // the appropriate terminal state (e.g. .noPath).
+        if userInitiated {
+            syncState = PropagationTransferState(state: .linking)
+        }
 
         // Model B: the LXMF router lives in the NE — the app can't sync in-process.
         // Ensure a PN is selected + its config is in the seam, then fire the sync-now

--- a/Sources/ColumbaApp/Services/PropagationNodeManager.swift
+++ b/Sources/ColumbaApp/Services/PropagationNodeManager.swift
@@ -315,6 +315,12 @@ public final class PropagationNodeManager {
     ///
     /// If no propagation node is selected yet, auto-selects the best available node first.
     public func syncNow() async {
+        // Reset transfer state up front so any observer (the in-app status sheet) shows
+        // THIS sync's progress from a clean "connecting" slate, not the previous run's
+        // stale "Download complete / N new messages". Early-return guards below overwrite
+        // this with the appropriate terminal state (e.g. .noPath).
+        syncState = PropagationTransferState(state: .linking)
+
         // Model B: the LXMF router lives in the NE — the app can't sync in-process.
         // Ensure a PN is selected + its config is in the seam, then fire the sync-now
         // Darwin trigger. Real progress arrives back via the sync-state channel

--- a/Sources/ColumbaApp/ViewModels/SettingsViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/SettingsViewModel.swift
@@ -719,7 +719,7 @@ public final class SettingsViewModel {
         isSyncing = true
         syncError = nil
 
-        await propManager.syncNow()
+        await propManager.syncNow(userInitiated: true)
 
         syncProgress = propManager.syncState.progress
         lastSyncTime = propManager.lastSyncTime

--- a/Sources/ColumbaApp/Views/Chats/ChatsView.swift
+++ b/Sources/ColumbaApp/Views/Chats/ChatsView.swift
@@ -102,7 +102,7 @@ struct ChatsView: View {
                         isSyncSheetPresented = true
                         Task {
                             viewModel?.isRefreshing = true
-                            await appServices.propagationManager?.syncNow()
+                            await appServices.propagationManager?.syncNow(userInitiated: true)
                             await viewModel?.refreshConversations()
                             viewModel?.isRefreshing = false
                         }
@@ -337,7 +337,7 @@ struct ChatsView: View {
                 // Sync with timeout so pull-to-refresh doesn't hang
                 await withTaskGroup(of: Void.self) { group in
                     group.addTask {
-                        await appServices.propagationManager?.syncNow()
+                        await appServices.propagationManager?.syncNow(userInitiated: true)
                     }
                     group.addTask {
                         try? await Task.sleep(for: .seconds(15))
@@ -385,7 +385,7 @@ struct ChatsView: View {
                 // User explicitly asked to sync → surface the status sheet.
                 isSyncSheetPresented = true
                 Task {
-                    await appServices.propagationManager?.syncNow()
+                    await appServices.propagationManager?.syncNow(userInitiated: true)
                     await viewModel?.refreshConversations()
                 }
             } label: {

--- a/Sources/ColumbaApp/Views/Chats/ChatsView.swift
+++ b/Sources/ColumbaApp/Views/Chats/ChatsView.swift
@@ -45,7 +45,8 @@ struct ChatsView: View {
     /// Conversation pending deletion (confirmation alert).
     @State private var deletingConversation: Conversation?
 
-    /// Controls the propagation-sync status sheet (auto-shown while a sync is active).
+    /// Controls the propagation-sync status sheet. Presented only for user-initiated
+    /// syncs (tapping the refresh button); background / periodic syncs run silently.
     @State private var isSyncSheetPresented: Bool = false
 
     // MARK: - Theme Colors
@@ -97,6 +98,8 @@ struct ChatsView: View {
                     // Refresh button — syncs from propagation node then reloads DB
                     Button {
                         guard viewModel?.isRefreshing != true else { return }
+                        // User explicitly asked to sync → surface the status sheet.
+                        isSyncSheetPresented = true
                         Task {
                             viewModel?.isRefreshing = true
                             await appServices.propagationManager?.syncNow()
@@ -166,14 +169,16 @@ struct ChatsView: View {
         } message: {
             Text("This will permanently delete the conversation and all its messages.")
         }
-        // Auto-show the sync status sheet while a propagation sync is active (manual
-        // Sync Now / pull-to-refresh, or — under Model B — an NE-driven periodic sync).
-        // The sheet stays up through the terminal phase so the user sees the result.
-        .onChange(of: appServices.propagationManager?.syncState.isSyncing ?? false) { _, active in
-            if active { isSyncSheetPresented = true }
-        }
+        // Show the sync status sheet only for user-initiated syncs — the refresh button
+        // sets `isSyncSheetPresented`. Background / periodic syncs (including Model B's
+        // NE-driven periodic sync) update `syncState` silently without popping the sheet.
+        // Once presented, the sheet observes `syncState` for live progress and stays up
+        // through the terminal phase so the user sees the result, then dismisses manually.
         .sheet(isPresented: $isSyncSheetPresented) {
-            SyncStatusBottomSheet(state: appServices.propagationManager?.syncState ?? PropagationTransferState())
+            // Container reads `syncState` in its own view body (not just inside this
+            // closure) so SwiftUI Observation reliably re-renders the sheet on every
+            // transfer-state change — live progress and the terminal result.
+            SyncStatusSheetContainer(manager: appServices.propagationManager)
         }
         #if os(iOS)
         .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in
@@ -377,6 +382,8 @@ struct ChatsView: View {
 
             // Refresh button — syncs from propagation node then reloads DB
             Button {
+                // User explicitly asked to sync → surface the status sheet.
+                isSyncSheetPresented = true
                 Task {
                     await appServices.propagationManager?.syncNow()
                     await viewModel?.refreshConversations()
@@ -408,6 +415,22 @@ struct ChatsView: View {
                 .scaleEffect(1.2)
         }
         .ignoresSafeArea()
+    }
+}
+
+// MARK: - Sync Status Sheet Container
+
+/// Bridges the app's `@Observable` `PropagationNodeManager` to the pure, value-typed
+/// `SyncStatusBottomSheet`. Reading `manager.syncState` inside this view's `body`
+/// (rather than only inside the parent's `.sheet` content closure) guarantees SwiftUI
+/// Observation re-renders the sheet whenever the transfer state changes, so live
+/// progress and the terminal result always appear.
+@available(iOS 17.0, macOS 14.0, *)
+private struct SyncStatusSheetContainer: View {
+    let manager: PropagationNodeManager?
+
+    var body: some View {
+        SyncStatusBottomSheet(state: manager?.syncState ?? PropagationTransferState())
     }
 }
 

--- a/Sources/ColumbaApp/Views/Components/SyncStatusBottomSheet.swift
+++ b/Sources/ColumbaApp/Views/Components/SyncStatusBottomSheet.swift
@@ -20,40 +20,50 @@ struct SyncStatusBottomSheet: View {
     let state: PropagationTransferState
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            // Header
-            HStack(spacing: 12) {
-                Image(systemName: "antenna.radiowaves.left.and.right")
-                    .font(.system(size: 24, weight: .semibold))
-                    .foregroundColor(Theme.accentColor)
-                Text("Propagation Node Sync")
-                    .font(.title3.weight(.bold))
-                    .foregroundColor(Theme.textPrimary)
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                // Header
+                HStack(spacing: 12) {
+                    Image(systemName: "antenna.radiowaves.left.and.right")
+                        .font(.system(size: 24, weight: .semibold))
+                        .foregroundColor(Theme.accentColor)
+                    Text("Propagation Node Sync")
+                        .font(.title3.weight(.bold))
+                        .foregroundColor(Theme.textPrimary)
+                }
+
+                Spacer().frame(height: 24)
+
+                // Status row
+                statusRow
+
+                // Progress bar (only while actively receiving with known progress)
+                if showProgressBar {
+                    Spacer().frame(height: 16)
+                    ProgressView(value: min(max(state.progress, 0), 1))
+                        .tint(Theme.accentColor)
+                    Spacer().frame(height: 8)
+                    Text("\(Int((min(max(state.progress, 0), 1)) * 100))%")
+                        .font(.subheadline)
+                        .foregroundColor(Theme.textSecondary)
+                }
             }
-
-            Spacer().frame(height: 24)
-
-            // Status row
-            statusRow
-
-            // Progress bar (only while actively receiving with known progress)
-            if showProgressBar {
-                Spacer().frame(height: 16)
-                ProgressView(value: min(max(state.progress, 0), 1))
-                    .tint(Theme.accentColor)
-                Spacer().frame(height: 8)
-                Text("\(Int((min(max(state.progress, 0), 1)) * 100))%")
-                    .font(.subheadline)
-                    .foregroundColor(Theme.textSecondary)
-            }
+            .padding(.horizontal, 24)
+            .padding(.top, 28)
+            .padding(.bottom, 36)
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .padding(.horizontal, 24)
-        .padding(.top, 28)
-        .padding(.bottom, 36)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Theme.backgroundPrimary.ignoresSafeArea())
+        // Scrolls only when content exceeds the detent (e.g. at large Dynamic Type);
+        // otherwise behaves like a static view, so the progress bar and percentage are
+        // never clipped at the bottom of the fixed-height sheet.
+        .scrollBounceBehavior(.basedOnSize)
         .presentationDetents([.height(220)])
         .presentationDragIndicator(.visible)
+        // Color the entire sheet, not just the content. Using `.background(...)` on the
+        // content paints an opaque band sized to the VStack inside the system's default
+        // glass sheet chrome; `.presentationBackground` is the SwiftUI-correct way to set
+        // a sheet's backing surface (iOS 16.4+).
+        .presentationBackground(Theme.backgroundPrimary)
     }
 
     // MARK: - Status row

--- a/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
@@ -533,7 +533,7 @@ struct MessagingView: View {
                     Task {
                         isSyncing = true
                         defer { isSyncing = false }
-                        await appServices.propagationManager?.syncNow()
+                        await appServices.propagationManager?.syncNow(userInitiated: true)
                         await viewModel?.loadMessages()
                     }
                 } label: {


### PR DESCRIPTION
## Problem

Two issues with the propagation-node sync status sheet on the Chats screen:

1. **It popped up automatically on every sync.** The sheet was auto-presented via `.onChange(of: syncState.isSyncing)`, which fires for *all* sync sources — background, periodic, the on-foreground auto-sync (`ColumbaApp.swift`, runs whenever the app becomes active and >60s since last sync), and Model B's NE-driven periodic sync — not just user-initiated ones. So it interrupted constantly.
2. **It looked broken.** `.background(Theme.backgroundPrimary.ignoresSafeArea())` was applied to the *content*, painting an opaque band sized to the content inside the system's default glass sheet chrome — an opaque edge-to-edge block floating in a transparent sheet.

## Changes

- **`ChatsView.swift`** — Removed the auto-present `.onChange`. The sheet is now shown **only when the refresh button is tapped** (toolbar + empty-state). Background / periodic / on-foreground / pull-to-refresh syncs update `syncState` silently. Pull-to-refresh keeps its own native indicator.
- **`SyncStatusBottomSheet.swift`** — Replaced the content `.background(...)` with `.presentationBackground(Theme.backgroundPrimary)` (the SwiftUI-correct way, iOS 16.4+, to color the whole sheet surface). Wrapped content in a `ScrollView` with `.scrollBounceBehavior(.basedOnSize)` so large Dynamic Type can't clip the progress bar.
- **`PropagationNodeManager.syncNow()`** — Resets transfer state up front so the sheet opens on a clean "Connecting…" state instead of briefly flashing the previous run's "Download complete / N new messages".
- **Live-update hardening** — The sheet is presented through a small container that reads `syncState` in a real view body, so SwiftUI Observation reliably drives live progress + the terminal result (rather than relying solely on observation inside the `.sheet` content closure).

## Behavior notes

- A no-propagation-node tap now surfaces the `.noPath` error in the sheet — previously that case showed no feedback at all.

## Verification

- Builds clean: `Columba-Swift` / `Debug-Swift`, iPhone 17 simulator (`BUILD SUCCEEDED`).
- Diff reviewed across regression + SwiftUI-correctness lenses; no unit tests exercise the changed paths (UI/presentation + one state reset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
