### PR TITLE
feat(onboarding): explain "not a commercial VPN" on Background Delivery page

### DIFF
--- a/Columba.xcodeproj/project.pbxproj
+++ b/Columba.xcodeproj/project.pbxproj
@@ -114,6 +114,7 @@
 		0MBS /* ModelBBLEService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FMBS /* ModelBBLEService.swift */; };
 		13F299C3C99F5D86B797FA11 /* SwiftBLEBridge in Frameworks */ = {isa = PBXBuildFile; productRef = 5BE4B79EB452909EE61ACE6C /* SwiftBLEBridge */; };
 		1FC4483D48CABE8BF49850EF /* SyncStatusBottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67B5525A88EBCEAF05E9DE3F /* SyncStatusBottomSheet.swift */; };
+		2B502D5AFE0E2C0D54CC144C /* BackgroundVPNExplainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E85BA5BB165924E702EB877C /* BackgroundVPNExplainer.swift */; };
 		238336F8024494A8B57F9419 /* CeaseTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF48C97880B30682DC35613C /* CeaseTelemetry.swift */; };
 		266929D6972E8D373E7A926D /* ReticulumSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 021FA3D73B6F8B711A97D40F /* ReticulumSwift */; };
 		2B3A3E3FB59D1E22B424E109 /* AudioRingBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE307E24C72DBA41D76C9A6C /* AudioRingBufferTests.swift */; };
@@ -258,6 +259,7 @@
 		55FE6D8CFA13376BCD23AE86 /* PropagationSeam.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PropagationSeam.swift; sourceTree = "<group>"; };
 		56CFC5EC819F4ED82FCC4B07 /* BackgroundDeliveryGateView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BackgroundDeliveryGateView.swift; sourceTree = "<group>"; };
 		67B5525A88EBCEAF05E9DE3F /* SyncStatusBottomSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SyncStatusBottomSheet.swift; sourceTree = "<group>"; };
+		E85BA5BB165924E702EB877C /* BackgroundVPNExplainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BackgroundVPNExplainer.swift; sourceTree = "<group>"; };
 		6FE282FA3937E59BC026E072 /* AudioManagerConfigChangeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudioManagerConfigChangeTests.swift; sourceTree = "<group>"; };
 		710EBCE55DCC9E71A9AB0E86 /* PythonBridge.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PythonBridge.swift; sourceTree = "<group>"; };
 		71922EC204982A357F814F23 /* CallControlButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CallControlButton.swift; sourceTree = "<group>"; };
@@ -581,6 +583,7 @@
 				F037 /* ProfileIcon.swift */,
 				DA586EB5F8EB62D2579CEAAB /* Lucide.swift */,
 				67B5525A88EBCEAF05E9DE3F /* SyncStatusBottomSheet.swift */,
+				E85BA5BB165924E702EB877C /* BackgroundVPNExplainer.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -1224,6 +1227,7 @@
 				F4E9991226B4D464017DA247 /* Lucide.swift in Sources */,
 				AAD9231170B11C89EF80F9B8 /* PropagationSeam.swift in Sources */,
 				1FC4483D48CABE8BF49850EF /* SyncStatusBottomSheet.swift in Sources */,
+				2B502D5AFE0E2C0D54CC144C /* BackgroundVPNExplainer.swift in Sources */,
 				F83A2212E43B329830919AFF /* BackgroundDeliveryGateView.swift in Sources */,
 				80D0868B2491DB301F772D63 /* BackgroundDeliveryPage.swift in Sources */,
 			);

--- a/Sources/ColumbaApp/Views/Components/BackgroundVPNExplainer.swift
+++ b/Sources/ColumbaApp/Views/Components/BackgroundVPNExplainer.swift
@@ -1,0 +1,110 @@
+#if ENABLE_NETWORK_EXTENSION || COLUMBA_ONBOARDING_ENABLED
+//
+//  BackgroundVPNExplainer.swift
+//  ColumbaApp
+//
+//  Canonical "this isn't a traditional / commercial VPN" explainer content, shared by
+//  the Settings → Background Transport screen (`BackgroundTransportView`) and the
+//  onboarding Background Delivery page (`BackgroundDeliveryPage`) so the wording and
+//  layout stay identical and only live in one place.
+//
+//  These are inner-content views only — they intentionally carry NO card chrome. Each
+//  call site wraps them in its own card style (settings uses `.glassCard()`, onboarding
+//  uses a `Theme.backgroundSecondary` card) so the explainer reads natively in either
+//  surface while the copy stays single-sourced here.
+//
+
+import SwiftUI
+
+/// "Not a commercial VPN" privacy reassurance — the core message that this is only
+/// Apple's VPN mechanism hosting the on-device mesh node, not a traditional VPN.
+@available(iOS 17.0, macOS 14.0, *)
+struct VPNNotCommercialExplainer: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            VPNExplainerUI.sectionHeader(icon: "lock.shield.fill", title: "Not a commercial VPN")
+
+            Text("Columba uses Apple's VPN mechanism only as the way to run a background packet tunnel for the mesh. It is not a commercial VPN service.")
+                .font(.caption)
+                .foregroundStyle(Theme.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            VPNExplainerUI.explainerRow(
+                icon: "checkmark.shield.fill",
+                text: "Your internet traffic is not proxied, routed through, or monetized by Columba."
+            )
+            VPNExplainerUI.explainerRow(
+                icon: "iphone",
+                text: "The tunnel runs entirely on your device to carry Reticulum traffic. Nothing else is intercepted."
+            )
+        }
+    }
+}
+
+/// "The VPN badge" explainer — pre-empts the iOS status-bar VPN badge, the thing that
+/// makes the feature look like a traditional VPN. `featureName` fills the trailing
+/// sentence so each surface uses its own term ("background transport" vs "delivery").
+@available(iOS 17.0, macOS 14.0, *)
+struct VPNBadgeExplainer: View {
+    let featureName: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            VPNExplainerUI.sectionHeader(icon: "rectangle.topthird.inset.filled", title: "The VPN badge")
+
+            HStack(spacing: 10) {
+                Text("VPN")
+                    .font(.system(size: 11, weight: .bold))
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(Theme.accentColor)
+                    .clipShape(RoundedRectangle(cornerRadius: 4))
+
+                Text("While this is on, iOS shows a VPN badge in your status bar.")
+                    .font(.subheadline)
+                    .foregroundStyle(Theme.textPrimary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Text("The badge is iOS telling you a packet tunnel is active. It stays visible the whole time \(featureName) is enabled.")
+                .font(.caption)
+                .foregroundStyle(Theme.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+}
+
+/// Shared section-header / explainer-row primitives used by the explainer content
+/// above. Kept here so both surfaces (and the settings "What it does" card) render
+/// rows identically.
+@available(iOS 17.0, macOS 14.0, *)
+@MainActor
+enum VPNExplainerUI {
+    static func sectionHeader(icon: String, title: String) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: icon)
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(Theme.accentColor)
+            Text(title)
+                .font(.headline)
+                .foregroundStyle(Theme.textPrimary)
+            Spacer()
+        }
+    }
+
+    static func explainerRow(icon: String, text: String) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: icon)
+                .font(.system(size: 16))
+                .foregroundStyle(Theme.accentColor)
+                .frame(width: 24)
+            Text(text)
+                .font(.subheadline)
+                .foregroundStyle(Theme.textPrimary)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 0)
+        }
+    }
+}
+#endif

--- a/Sources/ColumbaApp/Views/Onboarding/BackgroundDeliveryPage.swift
+++ b/Sources/ColumbaApp/Views/Onboarding/BackgroundDeliveryPage.swift
@@ -12,6 +12,12 @@
 //  connected (iOS shows its "Allow" VPN prompt during it); on failure the page shows
 //  an error and lets the user retry rather than advancing.
 //
+//  The "Not a commercial VPN" + "VPN badge" explainer cards reuse the shared
+//  `VPNNotCommercialExplainer` / `VPNBadgeExplainer` content (see
+//  BackgroundVPNExplainer.swift) — the same copy shown on the settings Background
+//  Transport screen — so users understand up front that this isn't a traditional /
+//  commercial VPN, just Apple's VPN mechanism hosting the on-device mesh node.
+//
 
 import SwiftUI
 
@@ -54,6 +60,9 @@ struct BackgroundDeliveryPage: View {
                         .fixedSize(horizontal: false, vertical: true)
                         .padding(.horizontal, 28)
                         .padding(.bottom, 16)
+
+                    privacyCard
+                    badgeCard
 
                     if let errorMessage {
                         Text(errorMessage)
@@ -125,6 +134,45 @@ struct BackgroundDeliveryPage: View {
             }
             // On success the caller advances to the next page.
         }
+    }
+
+    // MARK: - Explainer Cards
+
+    /// "Not a commercial VPN" reassurance — the core message that this isn't a
+    /// traditional VPN. Content is shared with the settings Background Transport
+    /// screen via `VPNNotCommercialExplainer`; only the card chrome differs (onboarding
+    /// `explainerCardStyle` here vs the settings `glassCard()`).
+    private var privacyCard: some View {
+        VPNNotCommercialExplainer()
+            .explainerCardStyle()
+    }
+
+    /// "The VPN badge" note, shared with settings via `VPNBadgeExplainer`. The feature
+    /// name reads "background delivery" to match this flow (settings says "background
+    /// transport").
+    private var badgeCard: some View {
+        VPNBadgeExplainer(featureName: "background delivery")
+            .explainerCardStyle()
+    }
+}
+
+/// Shared card chrome for the onboarding explainer cards — matches the
+/// `Theme.backgroundSecondary` card style used elsewhere in onboarding
+/// (e.g. `PermissionsPage`) rather than the settings `glassCard()`.
+@available(iOS 17.0, macOS 14.0, *)
+private extension View {
+    func explainerCardStyle() -> some View {
+        self
+            .padding(16)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Theme.backgroundSecondary)
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(Theme.divider, lineWidth: 1)
+            )
+            .padding(.horizontal, 24)
+            .padding(.bottom, 12)
     }
 }
 #endif

--- a/Sources/ColumbaApp/Views/Settings/BackgroundTransportView.swift
+++ b/Sources/ColumbaApp/Views/Settings/BackgroundTransportView.swift
@@ -139,17 +139,17 @@ struct BackgroundTransportView: View {
 
     private var explainerCard: some View {
         VStack(alignment: .leading, spacing: 12) {
-            sectionHeader(icon: "questionmark.circle", title: "What it does")
+            VPNExplainerUI.sectionHeader(icon: "questionmark.circle", title: "What it does")
 
-            explainerRow(
+            VPNExplainerUI.explainerRow(
                 icon: "tray.and.arrow.down.fill",
                 text: "Receives messages, calls, and announcements even when Columba isn't open."
             )
-            explainerRow(
+            VPNExplainerUI.explainerRow(
                 icon: "point.3.connected.trianglepath.dotted",
                 text: "Keeps your TCP and local-network (LAN) links connected to the Reticulum mesh in the background."
             )
-            explainerRow(
+            VPNExplainerUI.explainerRow(
                 icon: "bolt.fill",
                 text: "Uses more battery and data than running only in the foreground."
             )
@@ -161,55 +161,17 @@ struct BackgroundTransportView: View {
     // MARK: - Status-Bar Badge Card
 
     private var badgeCard: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            sectionHeader(icon: "rectangle.topthird.inset.filled", title: "The VPN badge")
-
-            HStack(spacing: 10) {
-                Text("VPN")
-                    .font(.system(size: 11, weight: .bold))
-                    .foregroundStyle(.white)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(Theme.accentColor)
-                    .clipShape(RoundedRectangle(cornerRadius: 4))
-
-                Text("While this is on, iOS shows a VPN badge in your status bar.")
-                    .font(.subheadline)
-                    .foregroundStyle(Theme.textPrimary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-
-            Text("The badge is iOS telling you a packet tunnel is active. It stays visible the whole time background transport is enabled.")
-                .font(.caption)
-                .foregroundStyle(Theme.textSecondary)
-                .fixedSize(horizontal: false, vertical: true)
-        }
-        .padding(16)
-        .glassCard()
+        VPNBadgeExplainer(featureName: "background transport")
+            .padding(16)
+            .glassCard()
     }
 
     // MARK: - Privacy Card
 
     private var privacyCard: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            sectionHeader(icon: "lock.shield.fill", title: "Not a commercial VPN")
-
-            Text("Columba uses Apple's VPN mechanism only as the way to run a background packet tunnel for the mesh. It is not a commercial VPN service.")
-                .font(.caption)
-                .foregroundStyle(Theme.textSecondary)
-                .fixedSize(horizontal: false, vertical: true)
-
-            explainerRow(
-                icon: "checkmark.shield.fill",
-                text: "Your internet traffic is not proxied, routed through, or monetized by Columba."
-            )
-            explainerRow(
-                icon: "iphone",
-                text: "The tunnel runs entirely on your device to carry Reticulum traffic. Nothing else is intercepted."
-            )
-        }
-        .padding(16)
-        .glassCard()
+        VPNNotCommercialExplainer()
+            .padding(16)
+            .glassCard()
     }
 
     // MARK: - Error Card
@@ -362,32 +324,5 @@ struct BackgroundTransportView: View {
         }
     }
 
-    // MARK: - Reusable Bits
-
-    private func sectionHeader(icon: String, title: String) -> some View {
-        HStack(spacing: 8) {
-            Image(systemName: icon)
-                .font(.system(size: 16, weight: .semibold))
-                .foregroundStyle(Theme.accentColor)
-            Text(title)
-                .font(.headline)
-                .foregroundStyle(Theme.textPrimary)
-            Spacer()
-        }
-    }
-
-    private func explainerRow(icon: String, text: String) -> some View {
-        HStack(alignment: .top, spacing: 12) {
-            Image(systemName: icon)
-                .font(.system(size: 16))
-                .foregroundStyle(Theme.accentColor)
-                .frame(width: 24)
-            Text(text)
-                .font(.subheadline)
-                .foregroundStyle(Theme.textPrimary)
-                .fixedSize(horizontal: false, vertical: true)
-            Spacer(minLength: 0)
-        }
-    }
 }
 #endif


### PR DESCRIPTION
## What

The last onboarding page (**Background Delivery**) brings up the on-device VPN / Network Extension, but only briefly noted that "your traffic isn't sent to any server." The fuller explanation that this **isn't a traditional / commercial VPN** lived only in **Settings → Background Transport**, which users never see during onboarding.

This surfaces that same explanation on the onboarding page so users understand up front that it's not actually a VPN:

- **"Not a commercial VPN"** — Columba uses Apple's VPN mechanism only to run a background packet tunnel for the mesh; traffic isn't proxied/routed/monetized; the tunnel runs entirely on-device.
- **"The VPN badge"** — pre-empts the iOS status-bar VPN badge (the thing that makes it look like a real VPN).

## How — no duplicated copy

Rather than copy/paste the wording, the explainer content is extracted into a shared component, `Views/Components/BackgroundVPNExplainer.swift`:

- `VPNNotCommercialExplainer` and `VPNBadgeExplainer(featureName:)` hold the canonical copy + layout.
- `VPNExplainerUI` holds the shared section-header / row primitives.

**Both** the settings screen (`BackgroundTransportView`) and the onboarding page (`BackgroundDeliveryPage`) now render this single-sourced content; each supplies its own card chrome (settings `glassCard()` vs the onboarding `Theme.backgroundSecondary` card matching `PermissionsPage`). The badge sentence's feature name is parameterized ("background transport" vs "background delivery") to fit each surface. The settings screen's now-duplicate private helpers were removed.

## Verification

- `xcodebuild` `Columba-Swift` / `Debug-Swift` (the config that enables `COLUMBA_ONBOARDING_ENABLED`) → **BUILD SUCCEEDED**, no warnings on the touched files.
- Confirmed each explainer string and the row/header helpers now exist in exactly one file (the shared component) — no duplication across the two screens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
