### PR TITLE
fix(announces): type peers/relays by aspect, stop relays leaking into Peers

### DIFF
--- a/Columba.xcodeproj/project.pbxproj
+++ b/Columba.xcodeproj/project.pbxproj
@@ -196,6 +196,7 @@
 		PXI2B /* ProxyIPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = PXIF /* ProxyIPC.swift */; };
 		SRB001 /* SwiftRNSBackend.swift in Sources */ = {isa = PBXBuildFile; fileRef = SRB002 /* SwiftRNSBackend.swift */; };
 		T003 /* MicronParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FT03 /* MicronParserTests.swift */; };
+		ACT02 /* AnnounceClassificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACT01 /* AnnounceClassificationTests.swift */; };
 		TBDT /* BLESeamDriverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBDT /* BLESeamDriverTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -403,6 +404,7 @@
 		FF6CE45231CD48906B9C226D /* lucide.ttf */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; path = lucide.ttf; sourceTree = "<group>"; };
 		FMBS /* ModelBBLEService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelBBLEService.swift; sourceTree = "<group>"; };
 		FT03 /* MicronParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicronParserTests.swift; sourceTree = "<group>"; };
+		ACT01 /* AnnounceClassificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnounceClassificationTests.swift; sourceTree = "<group>"; };
 		NERN1 /* NEReticulumNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NEReticulumNode.swift; sourceTree = "<group>"; };
 		OBQF /* OutboxQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutboxQueue.swift; sourceTree = "<group>"; };
 		PNT002 /* PythonNetworkTransport.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PythonNetworkTransport.swift; sourceTree = "<group>"; };
@@ -794,6 +796,7 @@
 				6FE282FA3937E59BC026E072 /* AudioManagerConfigChangeTests.swift */,
 				30A79B9ECDB4166F8A36A670 /* CallManagerCallKitTests.swift */,
 				BC4EF2D71A3D88C71D5BEDAD /* MessageFormattedTimeTests.swift */,
+				ACT01 /* AnnounceClassificationTests.swift */,
 			);
 			path = Tests/ColumbaAppTests;
 			sourceTree = "<group>";
@@ -1239,6 +1242,7 @@
 				A0C0D9AE12F728A484F0F108 /* AudioManagerConfigChangeTests.swift in Sources */,
 				E49B977D311DA1C9ACE14CAB /* CallManagerCallKitTests.swift in Sources */,
 				9566DCEF56FEFC97BAAA47BA /* MessageFormattedTimeTests.swift in Sources */,
+				ACT02 /* AnnounceClassificationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -2329,6 +2329,19 @@ public final class AppServices {
             let displayName = AppDataParser.displayName(from: appData, aspect: aspect)
             DiagLog.log("[RNS] announce dest=\(destHash) aspect=\(aspect) name=\"\(displayName)\" iface=\"\(interfaceName)\" hops=\(hops)")
 
+            // Aspect is now the SOLE signal Contact.init uses to type an
+            // announce (peer / relay / audio / site) — the old app_data-shape
+            // relay heuristic was removed. Both backends are expected to emit
+            // one of the four known aspects (Python via per-aspect RNS
+            // handlers, native via cryptographic detectedAspect). If an empty
+            // or unrecognized aspect ever slips through, the announce silently
+            // becomes a .peer with no fallback, so surface it loudly rather
+            // than misclassifying in silence.
+            let knownAspects: Set<String> = ["lxmf.delivery", "lxmf.propagation", "lxst.telephony", "nomadnetwork.node"]
+            if !knownAspects.contains(aspect) {
+                DiagLog.log("[RNS] WARNING: announce dest=\(destHash) has empty/unrecognized aspect=\"\(aspect)\" — will be classified as a peer. Expected one of \(knownAspects.sorted()).")
+            }
+
             // Insert the announce into the Compat PathTable so the Contacts
             // tab's networkAnnounces list picks it up via the pathUpdates
             // AsyncStream subscription in ContactsViewModel.

--- a/Sources/ColumbaApp/ViewModels/ContactsViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/ContactsViewModel.swift
@@ -394,7 +394,11 @@ public final class ContactsViewModel {
             // filter and .relays and showed up under the default Peers view.
             results = results.filter { $0.badgeType == .peer }
         case .audio:
-            results = results.filter { $0.isAudio }
+            // Keyed on badgeType (== .audio iff aspect "lxst.telephony"),
+            // symmetric with .peers / .relays / .sites so all four filters
+            // discriminate on the single mutually-exclusive node type rather
+            // than a mix of badgeType and the aspect-derived isAudio.
+            results = results.filter { $0.badgeType == .audio }
         case .sites:
             results = results.filter { $0.badgeType == .node }
         case .relays:

--- a/Sources/ColumbaApp/ViewModels/ContactsViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/ContactsViewModel.swift
@@ -162,12 +162,26 @@ public struct Contact: Identifiable, Sendable, Hashable {
         self.interfaceId = entry.interfaceId
         self.aspect = entry.detectedAspect
 
-        // Detect announce type via aspect check or appData parsing
+        // Detect announce type purely from the aspect. This mirrors the
+        // reference clients exactly: Sideband types each announce by which RNS
+        // aspect handler received it (aspect_filter "lxmf.propagation" vs
+        // "lxmf.delivery"), and Android does the same via NodeType.fromAspect.
+        // `entry.isLXMFPropagationNode` is itself derived solely from
+        // aspect == "lxmf.propagation" (the Python bridge sets it via a
+        // cryptographic per-aspect handler match; the native backends compute
+        // detectedAspect cryptographically), so aspect is the SOLE relay
+        // signal. An unrecognized / empty aspect defaults to .peer, matching
+        // NodeType.fromAspect's default.
+        //
+        // The previous `PropagationNodeInfo.parse(app_data)` fallback was
+        // removed: it accepted any >=3-element msgpack app_data without
+        // verifying the destination was a propagation node, so a delivery /
+        // audio / site announce carrying such app_data was mis-flagged as a
+        // relay (leaking into the Peers filter). Both backends already
+        // guarantee a genuine propagation node arrives tagged
+        // "lxmf.propagation" or is dropped before reaching here, so the
+        // fallback only ever caught false positives.
         if entry.isLXMFPropagationNode {
-            self.badgeType = .relay
-            self.isRelay = true
-        } else if let appData = entry.appData,
-                  let _ = PropagationNodeInfo.parse(from: appData) {
             self.badgeType = .relay
             self.isRelay = true
         } else if entry.isLXSTTelephony {
@@ -177,6 +191,7 @@ public struct Contact: Identifiable, Sendable, Hashable {
             self.badgeType = .node
             self.isRelay = false
         } else {
+            // lxmf.delivery and any unrecognized/empty aspect → peer.
             self.badgeType = .peer
             self.isRelay = false
         }
@@ -370,13 +385,27 @@ public final class ContactsViewModel {
         case .all:
             break
         case .peers:
-            results = results.filter { $0.aspect == "lxmf.delivery" || $0.aspect == nil }
+            // Peers == the peer node-type only. Mirrors Android's
+            // `nodeType == PEER` (a mutually-exclusive enum): keying on
+            // badgeType excludes relays / audio / sites by construction, so a
+            // relay can't leak in. The previous aspect-only predicate
+            // (aspect == "lxmf.delivery" || aspect == nil) ignored isRelay, so
+            // a relay carrying aspect "lxmf.delivery"/nil matched both this
+            // filter and .relays and showed up under the default Peers view.
+            results = results.filter { $0.badgeType == .peer }
         case .audio:
             results = results.filter { $0.isAudio }
         case .sites:
             results = results.filter { $0.badgeType == .node }
         case .relays:
-            results = results.filter { $0.isRelay }
+            // Relays == the propagation-node type only, i.e. aspect
+            // "lxmf.propagation" (Android's nodeType == PROPAGATION_NODE,
+            // Sideband's aspect_filter == "lxmf.propagation"). Keyed on
+            // badgeType so the four node types stay mutually exclusive on a
+            // single discriminator, symmetric with .peers / .sites. Equivalent
+            // to `$0.isRelay` today (Contact.init sets them in lockstep) but
+            // removes the footgun of an entry being isRelay && badgeType != .relay.
+            results = results.filter { $0.badgeType == .relay }
         }
 
         // Apply interface filter

--- a/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
+++ b/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
@@ -1,0 +1,140 @@
+import XCTest
+@testable import ColumbaApp
+import RNSAPI
+
+/// Tests for `Contact.init(from: PathEntry)` announce classification — the
+/// single backend-independent point where every networkAnnounces entry gets
+/// its `badgeType` / `isRelay`. The Network tab's aspect filter keys on these:
+/// `.peers` shows `badgeType == .peer`, `.relays` shows `badgeType == .relay`.
+///
+/// Contract: the aspect string is the SOLE relay signal, exactly like the
+/// reference clients — Sideband types announces by which RNS aspect handler
+/// received them, and Android via NodeType.fromAspect. A propagation node is
+/// `aspect == "lxmf.propagation"` (surfaced as `entry.isLXMFPropagationNode`);
+/// every other aspect, including an unrecognized/empty one, is NOT a relay.
+///
+/// Regression target: the "Peers" filter (the default) also showed relays.
+/// The old `PropagationNodeInfo.parse(appData)` heuristic accepted ANY
+/// >=3-element msgpack array without verifying the destination was a
+/// propagation node, so a delivery peer (or audio/site announce) carrying such
+/// app_data was flagged `isRelay = true` and leaked into Peers. That heuristic
+/// has been removed; classification is now driven purely by the aspect.
+///
+/// app_data is packed with the production `packMsgPack` so the encoding matches
+/// what the device decodes off the wire. Lives in Tests/ColumbaAppTests (runs
+/// via the Columba.xcodeproj scheme) because `Contact` lives in the ColumbaApp
+/// module.
+final class AnnounceClassificationTests: XCTestCase {
+
+    private let pnMetaName: UInt64 = 0x01
+
+    // Canonical LXMF delivery app_data: [display_name, stamp_cost] — 2 elements.
+    private func deliveryAppData(name: String?) -> Data {
+        let nameVal: MessagePackValue = name.map { .binary(Data($0.utf8)) } ?? .nil
+        return packMsgPack(.array([nameVal, .nil]))
+    }
+
+    // Canonical LXMF propagation-node app_data: 7 elements, name in metadata[6].
+    private func propagationAppData(name: String? = nil, nodeState: Bool = true) -> Data {
+        var metadata: [MessagePackValue: MessagePackValue] = [:]
+        if let name { metadata[.uint(pnMetaName)] = .binary(Data(name.utf8)) }
+        return packMsgPack(.array([
+            .bool(false),                           // 0: legacy LXMF PN flag
+            .uint(1_700_000_000),                   // 1: timebase
+            .bool(nodeState),                       // 2: node state (enabled)
+            .uint(50_000),                          // 3: per-transfer limit
+            .uint(50_000),                          // 4: per-sync limit
+            .array([.uint(0), .uint(0), .uint(0)]), // 5: stamp cost
+            .map(metadata),                         // 6: metadata (name lives here)
+        ]))
+    }
+
+    // A non-propagation announce whose app_data is nonetheless a >=3-element
+    // msgpack array — the exact shape that used to fool the relay heuristic.
+    private func threeElementAppData() -> Data {
+        packMsgPack(.array([.binary(Data("Carol".utf8)), .uint(0), .uint(0)]))
+    }
+
+    private func entry(
+        aspect: String?,
+        appData: Data?,
+        isPropagation: Bool = false,
+        isTelephony: Bool = false
+    ) -> PathEntry {
+        PathEntry(
+            destinationHash: Data([0xde, 0xad, 0xbe, 0xef]),
+            displayName: "Test",
+            appData: appData,
+            detectedAspect: aspect,
+            isLXMFPropagationNode: isPropagation,
+            isLXSTTelephony: isTelephony,
+            isKnownDestination: true
+        )
+    }
+
+    // MARK: - The leak (regression)
+
+    /// A delivery peer carrying a >=3-element app_data must classify as a peer,
+    /// NOT a relay — this is the exact entry that leaked into the Peers filter.
+    func testDeliveryPeerWithThreeElementAppDataIsPeerNotRelay() {
+        let c = Contact(from: entry(aspect: "lxmf.delivery", appData: threeElementAppData()))
+        XCTAssertEqual(c.badgeType, .peer)
+        XCTAssertFalse(c.isRelay)
+    }
+
+    func testCanonicalDeliveryPeerIsPeer() {
+        let c = Contact(from: entry(aspect: "lxmf.delivery", appData: deliveryAppData(name: "Alice")))
+        XCTAssertEqual(c.badgeType, .peer)
+        XCTAssertFalse(c.isRelay)
+    }
+
+    // MARK: - Relays stay relays
+
+    /// A propagation node tagged with the propagation aspect is a relay.
+    func testTaggedPropagationNodeIsRelay() {
+        let c = Contact(from: entry(
+            aspect: "lxmf.propagation",
+            appData: propagationAppData(name: "Hub"),
+            isPropagation: true
+        ))
+        XCTAssertEqual(c.badgeType, .relay)
+        XCTAssertTrue(c.isRelay)
+    }
+
+    /// Aspect is the sole relay signal: an UNTAGGED announce (no aspect) whose
+    /// app_data happens to be propagation-shaped is NOT promoted to a relay.
+    /// (Both backends guarantee a genuine propagation node arrives tagged
+    /// "lxmf.propagation" or is dropped before reaching here, so the removed
+    /// app_data heuristic only ever caught false positives.)
+    func testUntaggedPropagationShapedAppDataIsPeerNotRelay() {
+        let c = Contact(from: entry(aspect: nil, appData: propagationAppData(name: "Hub")))
+        XCTAssertEqual(c.badgeType, .peer)
+        XCTAssertFalse(c.isRelay)
+    }
+
+    /// An unrecognized/future aspect defaults to peer (matches Android
+    /// NodeType.fromAspect's default), never a relay.
+    func testUnknownAspectIsPeerNotRelay() {
+        let c = Contact(from: entry(aspect: "some.future.aspect", appData: threeElementAppData()))
+        XCTAssertEqual(c.badgeType, .peer)
+        XCTAssertFalse(c.isRelay)
+    }
+
+    // MARK: - Audio / Site no longer mis-flagged as relays
+
+    func testTelephonyWithThreeElementAppDataIsAudioNotRelay() {
+        let c = Contact(from: entry(
+            aspect: "lxst.telephony",
+            appData: threeElementAppData(),
+            isTelephony: true
+        ))
+        XCTAssertEqual(c.badgeType, .audio)
+        XCTAssertFalse(c.isRelay)
+    }
+
+    func testNomadnetSiteWithThreeElementAppDataIsNodeNotRelay() {
+        let c = Contact(from: entry(aspect: "nomadnetwork.node", appData: threeElementAppData()))
+        XCTAssertEqual(c.badgeType, .node)
+        XCTAssertFalse(c.isRelay)
+    }
+}

--- a/app/rns_bridge.py
+++ b/app/rns_bridge.py
@@ -6,7 +6,11 @@ LXMF run on the RNS worker threads; rather than wire C-callable function pointer
 across the Swift/Python boundary, we drop events onto a thread-safe queue that
 Swift drains on a timer. Single-threaded simple, no GIL juggling for callbacks.
 
-Scope: TCPClientInterface only, lxmf.delivery announces, opportunistic LXMF only.
+Scope: TCPClientInterface only, opportunistic LXMF only. Announces are tracked
+for all aspects in `_TRACKED_ASPECTS` (lxmf.delivery, lxmf.propagation,
+lxst.telephony, nomadnetwork.node) via one per-aspect RNS announce handler each
+— do NOT narrow this to lxmf.delivery: Swift relies on the emitted aspect as the
+sole signal for typing peers vs relays vs audio vs sites.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Problem

In the Network announces tab, the **Peers** filter (the default) also showed relays.

Two stacked bugs:

1. **The filter keyed on the wrong field.** `.peers` filtered on `aspect == "lxmf.delivery" || aspect == nil` while `.relays` filtered on the independent `isRelay` flag. A contact that was `isRelay == true` *and* carried a delivery/nil aspect satisfied **both** predicates, so it appeared under the default Peers view.
2. **The classifier mis-flagged peers as relays (root cause).** `Contact.init(from:)` ran `PropagationNodeInfo.parse(app_data)` *before* the aspect branches, and that parser accepts **any ≥3-element msgpack array** without verifying the destination is a propagation node. So a `lxmf.delivery` (or audio/site) announce carrying such app_data got tagged `isRelay = true` while keeping its real aspect. (Columba's own delivery announces are 2-element arrays, which is why only *some* relays leaked — it fired on other clients / newer LXMF formats.)

## Fix

Make the **aspect the sole signal** for announce typing, matching the reference clients:
- **Sideband** types each announce by which RNS aspect handler received it (`aspect_filter == "lxmf.propagation"` vs `"lxmf.delivery"`).
- **Android** does the same via `NodeType.fromAspect`.

Changes:
- **`Contact.init`:** removed the `PropagationNodeInfo.parse(app_data)` relay heuristic. Relays are now strictly `aspect == "lxmf.propagation"` (via `entry.isLXMFPropagationNode`); an unrecognized/empty aspect defaults to `.peer` (matches `NodeType.fromAspect`'s default).
- **Filters:** `.peers` / `.relays` now key on the mutually-exclusive `badgeType` (`.peer` / `.relay`), symmetric with `.sites`, so the four node types can't overlap.
- **`handlePythonEvent`:** added a warning if an announce ever arrives with an empty/unrecognized aspect — since there's no app_data fallback anymore, this surfaces it loudly instead of silently classifying as a peer.
- **`app/rns_bridge.py`:** corrected the stale "lxmf.delivery only" scope docstring so the per-aspect propagation handler can't be narrowed away by accident.

## Why nothing regresses

Both announce backends guarantee a genuine propagation node arrives tagged `"lxmf.propagation"` or is dropped *before* reaching `Contact.init`, so the removed heuristic only ever caught false positives:
- **Python bridge** registers one RNS announce handler per aspect (`aspect_filter`), and RNS enforces the filter by **cryptographic destination-hash match** — a real propagation node can only emit `"lxmf.propagation"`. Worst case is omission (no event), which the fallback couldn't have rescued.
- **Native Swift/NE** derive `detectedAspect` cryptographically; a propagation node yields `"lxmf.propagation"` or `nil` (dropped before emit). A mistag would require a SHA-256 collision.

## Tests

Adds `AnnounceClassificationTests` (the filter had **no** prior coverage) — 7 cases pinning the classification, including the exact leak (`delivery + ≥3-element app_data → .peer`), the new strict contract (`untagged propagation-shaped app_data → .peer, not relay`), and `unknown aspect → .peer`. Full `ColumbaAppTests` suite passes (98 tests, 0 failures) on the iPhone 17 simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
