### PR TITLE
fix(interfaces): remove redundant Apply button on the Swift build (changes apply live)

### DIFF
--- a/Sources/ColumbaApp/ViewModels/InterfaceManagementViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/InterfaceManagementViewModel.swift
@@ -60,6 +60,22 @@ public final class InterfaceManagementViewModel: TCPClientWizardSaveSink {
     /// Whether changes are being applied
     public var isApplyingChanges: Bool = false
 
+    /// Whether interface edits require an explicit "Apply" tap to take effect.
+    ///
+    /// On the Swift / Model B build the NE live-reconciles every change the
+    /// instant it's saved — `InterfaceRepository.saveInterfaces()` posts
+    /// `configChanged` on each edit, which the NE observes (and
+    /// `AppServices.applyInterfaceChanges()` is a deliberate no-op on Model B).
+    /// So there is no Apply step: the toolbar omits the button and edit toasts
+    /// don't prompt for it. On the Python build, edits are staged and pushed to
+    /// the running stack only on Apply.
+    public var requiresExplicitApply: Bool { !BackendPreference.modelB }
+
+    /// Trailing hint for edit toasts — prompt to Apply only when an explicit
+    /// Apply is required; on the live (Model B) path the change is already in
+    /// effect, so no prompt is shown.
+    private var applyHint: String { requiresExplicitApply ? " — tap Apply to take effect" : "" }
+
     // MARK: - Dialog State
 
     /// Whether the add/edit dialog is shown
@@ -207,21 +223,21 @@ public final class InterfaceManagementViewModel: TCPClientWizardSaveSink {
         isLoading = false
     }
 
-    /// Toggle interface enabled state. Marks dirty; the user taps "Apply" in
-    /// the toolbar to push the change through to the running stack, which
-    /// applies it live (hot add/remove, no restart — see `applyChanges()`).
+    /// Toggle interface enabled state. On Model B the change is live the moment
+    /// it's saved; on Python it's staged until the user taps "Apply"
+    /// (see `requiresExplicitApply` / `applyChanges()`).
     public func toggleInterface(_ interface: InterfaceEntity, enabled: Bool) {
         repository.toggleInterface(id: interface.id, enabled: enabled)
         hasPendingChanges = true
-        showSuccess("\(interface.name) \(enabled ? "enabled" : "disabled") — tap Apply to take effect")
+        showSuccess("\(interface.name) \(enabled ? "enabled" : "disabled")\(applyHint)")
     }
 
-    /// Delete an interface. Marks dirty; the running stack keeps the old
-    /// interface alive until "Apply" is tapped (which removes it live).
+    /// Delete an interface. On Model B it's removed live; on Python the running
+    /// stack keeps the old interface alive until "Apply" is tapped.
     public func deleteInterface(_ interface: InterfaceEntity) {
         repository.deleteInterface(id: interface.id)
         hasPendingChanges = true
-        showSuccess("Interface deleted — tap Apply to take effect")
+        showSuccess("Interface deleted\(applyHint)")
     }
 
     /// Confirm and delete the pending interface.
@@ -296,7 +312,7 @@ public final class InterfaceManagementViewModel: TCPClientWizardSaveSink {
             updated.config = config
 
             repository.updateInterface(updated)
-            showSuccess("Interface updated — tap Apply to take effect")
+            showSuccess("Interface updated\(applyHint)")
         } else {
             // Create new
             let newInterface = InterfaceEntity(
@@ -308,13 +324,15 @@ public final class InterfaceManagementViewModel: TCPClientWizardSaveSink {
             )
 
             repository.addInterface(newInterface)
-            showSuccess("Interface added — tap Apply to take effect")
+            showSuccess("Interface added\(applyHint)")
         }
 
         hasPendingChanges = true
         dismissConfigSheet()
-        // Don't auto-apply — the user taps "Apply" explicitly so a mid-edit
-        // change isn't pushed to the live stack until they're ready.
+        // On Python, don't auto-apply — the user taps "Apply" explicitly so a
+        // mid-edit change isn't pushed to the live stack until they're ready.
+        // On Model B there's no Apply step; the change is already live (the NE
+        // reconciles on save), so `requiresExplicitApply` hides the button.
     }
 
     /// Save a TCP client interface from the wizard flow.

--- a/Sources/ColumbaApp/ViewModels/InterfaceManagementViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/InterfaceManagementViewModel.swift
@@ -207,21 +207,21 @@ public final class InterfaceManagementViewModel: TCPClientWizardSaveSink {
         isLoading = false
     }
 
-    /// Toggle interface enabled state. Marks dirty; user must tap
-    /// "Apply & Restart" in the toolbar to push the change through to
-    /// Reticulum (which has no hot-reload — see `applyChanges()`).
+    /// Toggle interface enabled state. Marks dirty; the user taps "Apply" in
+    /// the toolbar to push the change through to the running stack, which
+    /// applies it live (hot add/remove, no restart — see `applyChanges()`).
     public func toggleInterface(_ interface: InterfaceEntity, enabled: Bool) {
         repository.toggleInterface(id: interface.id, enabled: enabled)
         hasPendingChanges = true
-        showSuccess("\(interface.name) \(enabled ? "enabled" : "disabled") — tap Apply to restart")
+        showSuccess("\(interface.name) \(enabled ? "enabled" : "disabled") — tap Apply to take effect")
     }
 
-    /// Delete an interface. Marks dirty; the running Reticulum stack keeps
-    /// the old interface alive until "Apply & Restart" is tapped.
+    /// Delete an interface. Marks dirty; the running stack keeps the old
+    /// interface alive until "Apply" is tapped (which removes it live).
     public func deleteInterface(_ interface: InterfaceEntity) {
         repository.deleteInterface(id: interface.id)
         hasPendingChanges = true
-        showSuccess("Interface deleted — tap Apply to restart")
+        showSuccess("Interface deleted — tap Apply to take effect")
     }
 
     /// Confirm and delete the pending interface.
@@ -296,7 +296,7 @@ public final class InterfaceManagementViewModel: TCPClientWizardSaveSink {
             updated.config = config
 
             repository.updateInterface(updated)
-            showSuccess("Interface updated — tap Apply to restart")
+            showSuccess("Interface updated — tap Apply to take effect")
         } else {
             // Create new
             let newInterface = InterfaceEntity(
@@ -308,13 +308,13 @@ public final class InterfaceManagementViewModel: TCPClientWizardSaveSink {
             )
 
             repository.addInterface(newInterface)
-            showSuccess("Interface added — tap Apply to restart")
+            showSuccess("Interface added — tap Apply to take effect")
         }
 
         hasPendingChanges = true
         dismissConfigSheet()
-        // Don't auto-apply — user taps "Apply & Restart" explicitly so
-        // they're not surprised by a Reticulum restart while editing.
+        // Don't auto-apply — the user taps "Apply" explicitly so a mid-edit
+        // change isn't pushed to the live stack until they're ready.
     }
 
     /// Save a TCP client interface from the wizard flow.

--- a/Sources/ColumbaApp/Views/Settings/InterfaceManagementScreen.swift
+++ b/Sources/ColumbaApp/Views/Settings/InterfaceManagementScreen.swift
@@ -84,7 +84,11 @@ struct InterfaceManagementScreen: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
-                if viewModel.hasPendingChanges || viewModel.isApplyingChanges {
+                // Only shown when an explicit Apply is required (Python backend).
+                // On the Swift / Model B build the NE reconciles each change live
+                // on save, so there's nothing to apply and the button is omitted.
+                if viewModel.requiresExplicitApply,
+                   viewModel.hasPendingChanges || viewModel.isApplyingChanges {
                     Button {
                         Task {
                             await viewModel.applyChanges()


### PR DESCRIPTION
## What

On the **Swift / Model B** build, interface changes apply **live the moment you make them**, so the "Apply" button (and the "tap Apply to restart" prompt) was redundant — it did nothing. Remove it on that build; keep it on Python where it's still needed.

## Why the button was a no-op on Model B

- Every repository edit (`toggle`/`add`/`update`/`delete`) calls `InterfaceRepository.saveInterfaces()`, which writes the shared `interfacesKey` and posts `configChanged` **immediately**.
- On Model B the NE observes that and live-reconciles its `ne-tcp-relay-*` / BLE / RNode interfaces — *"a relay add/edit/remove takes effect with NO VPN restart."*
- `AppServices.applyInterfaceChanges()` **early-returns on Model B** — so tapping "Apply" did literally nothing (and nothing ever restarted, despite the old wording).

## Change

- `InterfaceManagementViewModel.requiresExplicitApply` = `!BackendPreference.modelB`.
- **Screen:** the Apply toolbar button is only shown when `requiresExplicitApply` → hidden on the Swift build, kept on Python.
- **Toasts:** on Model B, edit confirmations drop the "tap Apply" hint (the change is already live: "Interface added", "Hub enabled", …); on Python they keep "— tap Apply to take effect".
- Fixed the stale comments (no phantom "Apply & Restart" button, no "Reticulum has no hot-reload").

**Python behavior unchanged** — Apply still hot-applies via `applyInterfaceChanges()`.

Builds clean (`Columba-Swift`); verified on-device that the button is gone and changes apply live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)