### PR TITLE
chore(deps): bump reticulum-swift to main (RNode connect-by-UUID)

### DIFF
--- a/Columba.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Columba.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -61,7 +61,7 @@
       "location" : "https://github.com/torlando-tech/reticulum-swift.git",
       "state" : {
         "branch" : "main",
-        "revision" : "b366f29365232c9ee62462619f3411171bd7341b"
+        "revision" : "52e2a9a5107bf12545a0788ee637686815d47525"
       }
     },
     {


### PR DESCRIPTION
Bumps the reticulum-swift pin to `main` (52e2a9a), picking up the merged RNode-over-BLE work (reticulum-swift #25):
- `BLETransport(deviceIdentifier:)` — connect by CoreBluetooth identifier (name fallback), robust to duplicate/renamed RNodes.
- `getInterfaceSnapshots` forwards `RNodeInterface.lastErrorDescription`.

Pin bump only. The Columba-side threading that *uses* the new API (`RNodeSeamConfig`/`.connect` wire `+deviceUUID`, wizard persists `peripheralId`, server → `BLETransport(deviceIdentifier:)`, + the A12 session token) lands as a follow-up. Existing build is unaffected — the new params are optional (default nil). `xcodebuild -resolvePackageDependencies` succeeds against the new revision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)