### PR TITLE
fix(rnode): stop emitting duplicate enabled key in Python config (crash on launch)

### DIFF
--- a/Columba.xcodeproj/project.pbxproj
+++ b/Columba.xcodeproj/project.pbxproj
@@ -118,6 +118,7 @@
 		1FC4483D48CABE8BF49850EF /* SyncStatusBottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67B5525A88EBCEAF05E9DE3F /* SyncStatusBottomSheet.swift */; };
 		238336F8024494A8B57F9419 /* CeaseTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF48C97880B30682DC35613C /* CeaseTelemetry.swift */; };
 		266929D6972E8D373E7A926D /* ReticulumSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 021FA3D73B6F8B711A97D40F /* ReticulumSwift */; };
+		26D564FAEE8E3C750E8E2442 /* PythonConfigWriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C8CFC274AF9EF63E9A75238 /* PythonConfigWriterTests.swift */; };
 		2B3A3E3FB59D1E22B424E109 /* AudioRingBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE307E24C72DBA41D76C9A6C /* AudioRingBufferTests.swift */; };
 		2B502D5AFE0E2C0D54CC144C /* BackgroundVPNExplainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E85BA5BB165924E702EB877C /* BackgroundVPNExplainer.swift */; };
 		2F8EC8212FC732AB00235991 /* ReticulumSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 2F8EC8202FC732AB00235991 /* ReticulumSwift */; };
@@ -264,6 +265,7 @@
 		55FE6D8CFA13376BCD23AE86 /* PropagationSeam.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PropagationSeam.swift; sourceTree = "<group>"; };
 		56CFC5EC819F4ED82FCC4B07 /* BackgroundDeliveryGateView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BackgroundDeliveryGateView.swift; sourceTree = "<group>"; };
 		67B5525A88EBCEAF05E9DE3F /* SyncStatusBottomSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SyncStatusBottomSheet.swift; sourceTree = "<group>"; };
+		6C8CFC274AF9EF63E9A75238 /* PythonConfigWriterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PythonConfigWriterTests.swift; sourceTree = "<group>"; };
 		6FE282FA3937E59BC026E072 /* AudioManagerConfigChangeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudioManagerConfigChangeTests.swift; sourceTree = "<group>"; };
 		710EBCE55DCC9E71A9AB0E86 /* PythonBridge.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PythonBridge.swift; sourceTree = "<group>"; };
 		71922EC204982A357F814F23 /* CallControlButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CallControlButton.swift; sourceTree = "<group>"; };
@@ -810,6 +812,7 @@
 				ACT01 /* AnnounceClassificationTests.swift */,
 				EA0AA6C472B1D4EFA2896086 /* RNodeSeamTests.swift */,
 				853F1E1C2B6E5305277FCB2A /* MigrationRoundTripTests.swift */,
+				6C8CFC274AF9EF63E9A75238 /* PythonConfigWriterTests.swift */,
 			);
 			path = Tests/ColumbaAppTests;
 			sourceTree = "<group>";
@@ -1261,6 +1264,7 @@
 				ACT02 /* AnnounceClassificationTests.swift in Sources */,
 				04D735AF318341AD65ABFE61 /* RNodeSeamTests.swift in Sources */,
 				0FF6A5C5596A39C092AADA29 /* MigrationRoundTripTests.swift in Sources */,
+				26D564FAEE8E3C750E8E2442 /* PythonConfigWriterTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/ColumbaApp/Services/PythonConfigWriter.swift
+++ b/Sources/ColumbaApp/Services/PythonConfigWriter.swift
@@ -87,7 +87,18 @@ enum PythonConfigWriter {
 
     private static func appendInterface(_ iface: InterfaceEntity, to lines: inout [String]) {
         lines.append("  [[\(sectionName(for: iface))]]")
-        lines.append("    enabled = yes")
+        // RNode and Multipeer are inert placeholders on the Python backend (their
+        // real transport runs through the Swift / Model-B seam), so they must be
+        // written disabled. Emit `enabled` exactly ONCE here: appending a second
+        // `enabled` inside the per-type block produces a duplicate keyword, which
+        // RNS's configobj rejects with a DuplicateError — the whole config fails
+        // to parse and the Python backend crashes on launch.
+        let isInertPlaceholder: Bool
+        switch iface.config {
+        case .rnode, .multipeer: isInertPlaceholder = true
+        default: isInertPlaceholder = false
+        }
+        lines.append("    enabled = \(isInertPlaceholder ? "no" : "yes")")
         lines.append("    interface_enabled = yes")
         appendMode(iface.mode, to: &lines)
 
@@ -129,7 +140,7 @@ enum PythonConfigWriter {
             lines.append("    type = TCPClientInterface  # RNode moved to Model B (Swift NE); Python path retired")
             lines.append("    target_host = 127.0.0.1")
             lines.append("    target_port = 65535")
-            lines.append("    enabled = no")
+            // `enabled = no` already emitted once in the section header above.
         case .multipeer:
             // MultipeerConnectivity bridge not yet wired (separate effort, its
             // own branch — see rnode_interface_port_plan.md). Emit a disabled
@@ -138,7 +149,7 @@ enum PythonConfigWriter {
             lines.append("    type = TCPClientInterface  # placeholder; \(iface.type) bridged from Swift not yet wired")
             lines.append("    target_host = 127.0.0.1")
             lines.append("    target_port = 65535")
-            lines.append("    enabled = no")
+            // `enabled = no` already emitted once in the section header above.
         }
         lines.append("")
     }

--- a/Tests/ColumbaAppTests/PythonConfigWriterTests.swift
+++ b/Tests/ColumbaAppTests/PythonConfigWriterTests.swift
@@ -1,0 +1,64 @@
+//
+//  PythonConfigWriterTests.swift
+//  ColumbaAppTests
+//
+//  Regression coverage for the RNS config text emitted by PythonConfigWriter.
+//  Guards the crash-on-launch bug where RNode/Multipeer placeholder interfaces
+//  emitted `enabled` twice in one section (`enabled = yes` from the shared
+//  header + `enabled = no` from the per-type block) — RNS's configobj rejects a
+//  duplicate keyword with a DuplicateError, so the Python backend failed to
+//  start and the app terminated on launch.
+//
+
+import XCTest
+import RNSAPI
+@testable import ColumbaApp
+
+final class PythonConfigWriterTests: XCTestCase {
+
+    /// Count `enabled = …` lines (excluding `interface_enabled`) inside the
+    /// single interface section of a one-interface config.
+    private func enabledLines(_ config: String) -> [String] {
+        config
+            .split(separator: "\n")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { $0.hasPrefix("enabled =") }
+    }
+
+    func testRNodePlaceholderEmitsEnabledExactlyOnceAndDisabled() {
+        let iface = InterfaceEntity(
+            name: "RNode Radio",
+            type: .rnode,
+            config: .rnode(RNodeConfig())
+        )
+        let config = PythonConfigWriter.write(interfaces: [iface])
+
+        let enabled = enabledLines(config)
+        XCTAssertEqual(enabled, ["enabled = no"],
+                       "RNode placeholder must emit `enabled` exactly once, disabled — got \(enabled)\n\(config)")
+    }
+
+    func testMultipeerPlaceholderEmitsEnabledExactlyOnceAndDisabled() {
+        let iface = InterfaceEntity(
+            name: "Multipeer",
+            type: .multipeer,
+            config: .multipeer(MultipeerConfig())
+        )
+        let config = PythonConfigWriter.write(interfaces: [iface])
+
+        XCTAssertEqual(enabledLines(config), ["enabled = no"],
+                       "Multipeer placeholder must emit `enabled` exactly once, disabled\n\(config)")
+    }
+
+    func testRealInterfaceEmitsEnabledExactlyOnceAndEnabled() {
+        let iface = InterfaceEntity(
+            name: "kin",
+            type: .tcpClient,
+            config: .tcpClient(TCPClientConfig(targetHost: "rns.kin.earth", targetPort: 4242))
+        )
+        let config = PythonConfigWriter.write(interfaces: [iface])
+
+        XCTAssertEqual(enabledLines(config), ["enabled = yes"],
+                       "A real interface must emit `enabled = yes` exactly once\n\(config)")
+    }
+}


### PR DESCRIPTION
## Problem (crash on launch)

`PythonConfigWriter` writes `enabled = yes` in every interface section header, then the **RNode** and **Multipeer** placeholder blocks append `enabled = no` — producing the key `enabled` **twice in one section**. RNS's `configobj` parser rejects a duplicate keyword with a `DuplicateError`, so the embedded-Python backend fails to parse its *own* freshly-written config and the app **terminates on launch** for anyone who has an RNode (or Multipeer) interface configured on the Python backend.

Reproduced against the exact on-device config with RNS's bundled `configobj`:
```
device config: FAILED -> DuplicateError Duplicate keyword name at line 32
```
(Line 32 is the placeholder's second `enabled`.) The inline `# …` comment on the `type =` line is harmless — verified in isolation.

## Fix

Emit `enabled` exactly once in the section header — forced `no` for the inert rnode/multipeer placeholders (whose real transport runs through the Swift / Model-B seam), `yes` otherwise. Remove the duplicate `enabled = no` from the two placeholder blocks.

## Verification

- **On-device (iPhone 14, iOS 26.5):** before the fix the app logged `Could not parse the configuration` and exited 255; after, the config parses, `backend.start()` succeeds, `[RNS] state connected`, all 4 interfaces come up, and the main process stays alive. Re-pulled on-device config shows a single `enabled = no` in the RNode block.
- Adds `PythonConfigWriterTests` asserting exactly one `enabled` line per section (`no` for rnode/multipeer placeholders, `yes` for a real interface).

## Context

Surfaced while installing a Debug build to a device that had an RNode interface configured. Independent of any migration work; this is a regression in the merged RNode Model-B config writer that bites any Python-backend build with an RNode/Multipeer interface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
