### PR TITLE
Call independently announced LXST telephony destinations

### DIFF
--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -1655,7 +1655,7 @@ public final class AppServices {
                     return
                 }
                 do {
-                    let res = try await backend.openLink(destHashHex: to, aspect: aspect)
+                    let res = try await backend.openLink(destHashHex: to, aspect: aspect, identityPublicKeyHex: nil)
                     DiagLog.log("[TEST-LINK] open ok=\(res.ok) linkId=\(res.linkId) reason=\(res.reason)")
                 } catch {
                     DiagLog.log("[TEST-LINK] open error=\(error)")
@@ -3306,32 +3306,6 @@ public final class AppServices {
     }
     #endif
 
-    /// Resolve a peer's LXST **telephony** destination hash from their LXMF
-    /// delivery hash, so the conversation/contact UI can place a voice call.
-    ///
-    /// A peer's telephony destination is a different hash than their LXMF
-    /// delivery destination, but both derive from the same identity. Recall the
-    /// identity from the path table (it carries the public keys learned from
-    /// the peer's announce) and derive `<identity>.lxst.telephony` — the same
-    /// construction CallManager uses for our own telephony destination. Returns
-    /// nil when we have no path/identity for the peer yet (they haven't been
-    /// heard, so they can't be called).
-    public func telephonyHash(forPeerLxmfHash lxmfHash: Data) async -> Data? {
-        guard let pathTable,
-              let entry = await pathTable.lookup(destinationHash: lxmfHash),
-              !entry.publicKeys.isEmpty,
-              let identity = try? Identity(publicKeyBytes: entry.publicKeys) else {
-            return nil
-        }
-        let telephony = Destination(
-            identity: identity,
-            appName: "lxst",
-            aspects: ["telephony"],
-            type: .single,
-            direction: .out
-        )
-        return telephony.hash
-    }
 
     /// Initialize the base stack (identity, transport, router) without a TCP interface.
     ///
@@ -4124,7 +4098,11 @@ public final class AppServices {
         }
         let destHex = destination.hash.toHex()
         let aspect = ([destination.appName] + destination.aspects).joined(separator: ".")
-        let result = try await backend.openLink(destHashHex: destHex, aspect: aspect)
+        let result = try await backend.openLink(
+            destHashHex: destHex,
+            aspect: aspect,
+            identityPublicKeyHex: destination.identity?.publicKeyHex
+        )
         guard result.ok else {
             throw AppServicesError.transportNotConnected
         }

--- a/Sources/ColumbaApp/Services/CallManager.swift
+++ b/Sources/ColumbaApp/Services/CallManager.swift
@@ -90,6 +90,9 @@ public final class CallManager {
     // MARK: - Internal
 
     private var telephone: Telephone?
+    #if COLUMBA_RUNTIME_PYTHON
+    private var networkTransport: PythonNetworkTransport?
+    #endif
     private var transport: ReticulumTransport?
     private var pathTable: PathTable?
     private var database: LXMFDatabase?
@@ -121,6 +124,7 @@ public final class CallManager {
         await networkTransport.start()
         let phone = await Telephone.make(transport: networkTransport)
         self.telephone = phone
+        self.networkTransport = networkTransport
 
         // Cache the telephony destination for announcing (peers need this hash
         // to call us). The transport registers it internally; this mirror is
@@ -275,54 +279,102 @@ public final class CallManager {
 
     // MARK: - Call Actions
 
-    /// Initiate an outgoing call to a destination hash.
+    /// Initiate an outgoing call from either an lxmf.delivery conversation or
+    /// an independently announced lxst.telephony node.
     ///
-    /// On iOS, this registers the call with CallKit before initiating the
-    /// Telephone signaling, so the system shows the call in the native UI.
+    /// Resolution happens before CallKit starts: LXSTSwift and the backend see
+    /// only the canonical telephony destination hash.
     func initiateCall(destinationHash: Data, profile: TelephonyProfile = .qualityMedium, peerDisplayName: String?) {
-        guard let telephone else {
+        #if COLUMBA_RUNTIME_PYTHON
+        guard let telephone, let networkTransport else {
             logger.warning("Cannot call: Telephone not initialized")
             return
         }
 
-        self.isIncoming = false
-        self.peerName = peerDisplayName
-        self.peerHash = destinationHash.map { String(format: "%02x", $0) }.joined()
-        self.callState = .calling
-        self.activeProfile = profile
-
-        // Generate a UUID for CallKit tracking
-        let callUUID = UUID()
-        self.currentCallUUID = callUUID
-
-        // Register outgoing call with CallKit
-        #if os(iOS)
-        let handle = peerDisplayName ?? peerHash ?? "unknown"
-        callKitManager?.startCall(uuid: callUUID, handle: handle)
-        #endif
-
         Task {
+            guard let target = await resolveTelephonyTarget(from: destinationHash) else {
+                self.failOutgoingCall("Telephony identity unavailable")
+                return
+            }
+            await networkTransport.prepareOutboundCall(target)
+
+            self.isIncoming = false
+            self.peerName = peerDisplayName
+            self.peerHash = target.destinationHash.toHex()
+            self.callState = .calling
+            self.activeProfile = profile
+
+            let callUUID = UUID()
+            self.currentCallUUID = callUUID
+            #if os(iOS)
+            let handle = peerDisplayName ?? self.peerHash ?? "unknown"
+            self.callKitManager?.startCall(uuid: callUUID, handle: handle)
+            #endif
+
             do {
-                // The transport resolves the delivery hash → identity →
-                // telephony destination and establishes the link; if the peer
-                // isn't reachable, call() throws and we surface "Call Failed".
-                let destHex = destinationHash.map { String(format: "%02x", $0) }.joined()
-                self.logger.error("[CALL] calling Telephone.call() for dest \(destHex, privacy: .public)")
-                try await telephone.call(destinationHash: destinationHash, profile: profile)
+                // backend.openLink actively requests and awaits this exact
+                // telephony path before reporting it unreachable.
+                let destHex = target.destinationHash.toHex()
+                self.logger.error("[CALL] calling Telephone.call() for telephony dest \(destHex, privacy: .public)")
+                try await telephone.call(destinationHash: target.destinationHash, profile: profile)
             } catch {
-                await MainActor.run {
-                    self.callState = .ended("Call Failed")
-                    self.logger.error("[CALL] Call initiation failed: \(error.localizedDescription, privacy: .public)")
-                    self.endedDismissTask?.cancel()
-                    self.endedDismissTask = Task { @MainActor [weak self] in
-                        try? await Task.sleep(for: .seconds(1.5))
-                        guard !Task.isCancelled else { return }
-                        self?.resetState()
-                    }
-                }
+                self.logger.error("[CALL] Call initiation failed: \(error.localizedDescription, privacy: .public)")
+                self.failOutgoingCall("Call Failed")
             }
         }
+        #else
+        logger.warning("Cannot call: telephony is unavailable in Model B app runtime")
+        #endif
     }
+
+    #if COLUMBA_RUNTIME_PYTHON
+    /// Resolve a direct telephony announce or derive the telephony destination
+    /// from any sibling announce carrying the same 64-byte public identity.
+    /// A cached sibling telephony row is preferred but never required.
+    private func resolveTelephonyTarget(from sourceHash: Data) async -> TelephonyCallTarget? {
+        guard let pathTable,
+              let source = await pathTable.lookup(destinationHash: sourceHash),
+              source.publicKeys.count == 64,
+              let remoteIdentity = try? Identity(publicKeyBytes: source.publicKeys) else {
+            return nil
+        }
+
+        let derivedHash = Destination.hash(
+            identity: remoteIdentity,
+            appName: "lxst",
+            aspects: ["telephony"]
+        )
+
+        if source.detectedAspect == "lxst.telephony" || source.isLXSTTelephony {
+            guard sourceHash == derivedHash else { return nil }
+            return TelephonyCallTarget(destinationHash: sourceHash, publicKeys: source.publicKeys)
+        }
+
+        // Android-style cross-link: one row per destination, joined by the
+        // shared public identity. Only accept a sibling whose hash verifies.
+        if let sibling = await pathTable.allEntries().first(where: {
+            ($0.detectedAspect == "lxst.telephony" || $0.isLXSTTelephony)
+                && $0.publicKeys == source.publicKeys
+                && $0.destinationHash == derivedHash
+        }) {
+            return TelephonyCallTarget(destinationHash: sibling.destinationHash, publicKeys: sibling.publicKeys)
+        }
+
+        // Missing local telephony cache is not a reachability verdict. Stage the
+        // verified identity and let backend.openLink request the derived path.
+        return TelephonyCallTarget(destinationHash: derivedHash, publicKeys: source.publicKeys)
+    }
+
+    private func failOutgoingCall(_ reason: String) {
+        callState = .ended(reason)
+        endedDismissTask?.cancel()
+        endedDismissTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(1.5))
+            guard !Task.isCancelled else { return }
+            self?.resetState()
+        }
+    }
+    #endif
 
     /// Answer an incoming call.
     ///

--- a/Sources/ColumbaApp/Services/PythonNetworkTransport.swift
+++ b/Sources/ColumbaApp/Services/PythonNetworkTransport.swift
@@ -12,11 +12,11 @@ import os.log
 /// encryption, packetization, identify, and path resolution — so the library
 /// stays transport-agnostic. Mirrors LXST-kt's `PythonNetworkTransport`.
 ///
-/// The seam speaks in the app's universal contact key: the peer's
-/// **lxmf.delivery destination hash**. `openOutboundCall` takes it and resolves
-/// the identity → telephony destination; `remoteIdentified` reports it
-/// (computed from the verified caller identity). No RNS types cross into
-/// `Telephone`.
+/// Outbound calls are always addressed to an **lxst.telephony destination
+/// hash**. CallManager resolves either a direct telephony announce or a chat's
+/// delivery announce into `TelephonyCallTarget`, then stages the public identity
+/// here before invoking LXSTSwift. `remoteIdentified` still reports the caller's
+/// delivery hash because that is the app's conversation/contact key.
 public actor PythonNetworkTransport: NetworkTransport {
 
     // LXST telephony destination aspect: <identity>.lxst.telephony
@@ -33,6 +33,11 @@ public actor PythonNetworkTransport: NetworkTransport {
 
     /// The active call link (outbound or accepted inbound), if any.
     private var activeLink: Link?
+
+    /// Public-key hints keyed by the exact telephony destination that
+    /// LXSTSwift will pass back to `openOutboundCall`. The hint lets us build a
+    /// verified Destination before the active path request completes.
+    private var outboundIdentityHints: [Data: Data] = [:]
 
     // Seam handlers (installed by Telephone).
     private var incomingCallHandler: (@Sendable () async -> Void)?
@@ -82,20 +87,23 @@ public actor PythonNetworkTransport: NetworkTransport {
 
     // MARK: - NetworkTransport (outbound)
 
-    public func openOutboundCall(to deliveryHash: Data) async -> Bool {
-        guard let pathTable else {
-            logger.error("[PNT] openOutboundCall: no path table")
-            return false
-        }
-        // Resolve the peer's delivery hash → identity (public key from announce).
-        guard let entry = await pathTable.lookup(destinationHash: deliveryHash),
-              entry.publicKeys.count == 64,
-              let remoteIdentity = try? Identity(publicKeyBytes: entry.publicKeys) else {
-            logger.error("[PNT] openOutboundCall: peer not resolvable from path table")
+    /// Stage the canonical target before `Telephone.call` invokes the neutral
+    /// NetworkTransport seam. Verify it again when opening the Link.
+    func prepareOutboundCall(_ target: TelephonyCallTarget) {
+        outboundIdentityHints[target.destinationHash] = target.publicKeys
+    }
+
+    public func openOutboundCall(to telephonyHash: Data) async -> Bool {
+        let hintedKeys = outboundIdentityHints.removeValue(forKey: telephonyHash)
+        let cachedKeys = await pathTable?.lookup(destinationHash: telephonyHash)?.publicKeys
+        guard let publicKeys = [hintedKeys, cachedKeys].compactMap({ $0 }).first(where: { $0.count == 64 }),
+              let remoteIdentity = try? Identity(publicKeyBytes: publicKeys) else {
+            logger.error("[PNT] openOutboundCall: telephony identity unavailable")
             return false
         }
 
-        // Build the peer's telephony destination and ensure a path to it.
+        // Rebuild and verify the exact telephony destination before requesting
+        // a path or opening a Link.
         let callDest = Destination(
             identity: remoteIdentity,
             appName: Self.appName,
@@ -103,6 +111,14 @@ public actor PythonNetworkTransport: NetworkTransport {
             type: .single,
             direction: .out
         )
+        guard callDest.hash == telephonyHash else {
+            logger.error("[PNT] openOutboundCall: telephony identity mismatch")
+            return false
+        }
+
+        // The shipping backend performs the definitive active path request and
+        // bounded await inside openLink, so stale/missing cache state is probed
+        // before the call is reported unreachable.
         let pathFound = await transport.awaitPath(for: callDest.hash, timeout: 10.0)
         logger.error("[PNT] path to telephony dest found=\(pathFound, privacy: .public)")
         guard pathFound else {
@@ -251,6 +267,13 @@ public actor PythonNetworkTransport: NetworkTransport {
         )
         await remoteIdentifiedHandler?(deliveryHash)
     }
+}
+
+/// Canonical input for every outgoing call, whether selected from a chat or
+/// directly from an lxst.telephony node.
+struct TelephonyCallTarget: Sendable, Equatable {
+    let destinationHash: Data
+    let publicKeys: Data
 }
 
 /// Bridges the Compat `IdentifyCallbacks` protocol to the transport actor.

--- a/Sources/ColumbaApp/Views/Contacts/ContactsView.swift
+++ b/Sources/ColumbaApp/Views/Contacts/ContactsView.swift
@@ -74,6 +74,10 @@ public struct ContactsView: View {
     /// Contact being edited for nickname.
     @State private var editingContact: Contact?
 
+    /// Telephony node selected for an outgoing call. Selection presents the
+    /// same codec picker used by chat-originated calls.
+    @State private var callContact: Contact?
+
     /// Text field value for nickname editing.
     @State private var nicknameText: String = ""
 
@@ -130,9 +134,12 @@ public struct ContactsView: View {
                         NodeDetailsView(
                             contact: contact,
                             appServices: appServices,
-                            onStartChat: contact.badgeType == .node ? nil : { contact in
+                            onStartChat: contact.badgeType == .peer || contact.badgeType == .relay ? { contact in
                                 startChat(with: contact)
-                            },
+                            } : nil,
+                            onStartCall: contact.badgeType == .audio ? { contact in
+                                callContact = contact
+                            } : nil,
                             onBrowseSite: contact.badgeType == .node ? { contact in
                                 browseSite(for: contact)
                             } : nil,
@@ -197,6 +204,20 @@ public struct ContactsView: View {
             }
         }
         .tint(Theme.accentColor)
+        .sheet(item: $callContact) { contact in
+            CodecSelectionSheet { profile in
+                callContact = nil
+                #if os(iOS)
+                appServices.callManager?.initiateCall(
+                    destinationHash: contact.identityHash,
+                    profile: profile,
+                    peerDisplayName: contact.resolvedDisplayName
+                )
+                #endif
+            }
+            .presentationDetents([.medium])
+            .presentationDragIndicator(.visible)
+        }
         .task {
             if viewModel == nil {
                 viewModel = ContactsViewModel(

--- a/Sources/ColumbaApp/Views/Contacts/NodeDetailsView.swift
+++ b/Sources/ColumbaApp/Views/Contacts/NodeDetailsView.swift
@@ -2,7 +2,7 @@
 //  NodeDetailsView.swift
 //  Columba-iOS
 //
-//  Node details screen showing contact info cards and a Start Chat button.
+//  Node details screen showing contact info cards and a destination-type action.
 //  Navigated to by tapping a contact card in ContactsView.
 //
 
@@ -32,6 +32,9 @@ struct NodeDetailsView: View {
     /// Called when "Start Chat" is tapped; receives the contact.
     /// Only rendered for non-NomadNet contacts when this callback is non-nil.
     var onStartChat: ((Contact) -> Void)?
+
+    /// Called when "Call" is tapped for an lxst.telephony destination.
+    var onStartCall: ((Contact) -> Void)?
 
     /// Called when "Browse Site" is tapped on a NomadNet site contact.
     /// Only rendered for `.node` badge contacts when this callback is non-nil.
@@ -242,20 +245,27 @@ struct NodeDetailsView: View {
 
     // MARK: - Primary Action Button
 
-    /// Renders "Browse Site" for NomadNet sites or "Start Chat" otherwise.
-    /// Returns an `EmptyView` when no callback is provided for the contact's
-    /// badge type — the parent owns whether the action should appear.
+    /// Renders "Call" for telephony, "Browse Site" for NomadNet, or
+    /// "Start Chat" for messaging destinations. Returns an `EmptyView` when
+    /// the matching callback is absent.
     @ViewBuilder
     private var primaryActionButton: some View {
         let c = displayedContact
-        if c.badgeType == .node, let onBrowseSite {
+        if c.badgeType == .audio, let onStartCall {
+            actionButton(
+                icon: "phone.fill",
+                title: "Call"
+            ) {
+                onStartCall(c)
+            }
+        } else if c.badgeType == .node, let onBrowseSite {
             actionButton(
                 icon: "globe.americas",
                 title: "Browse Site"
             ) {
                 onBrowseSite(c)
             }
-        } else if c.badgeType != .node, let onStartChat {
+        } else if c.badgeType != .node && c.badgeType != .audio, let onStartChat {
             actionButton(
                 icon: "bubble.left.fill",
                 title: "Start Chat"

--- a/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
@@ -357,12 +357,11 @@ struct MessagingView: View {
                 let name = conversation.peerName
                 Task { @MainActor in
                     guard let cm = appServices.callManager else { return }
-                    guard let telHash = await appServices.telephonyHash(forPeerLxmfHash: dest) else {
-                        DiagLog.log("[CALL] no telephony path for \(dest.prefix(4).map { String(format: "%02x", $0) }.joined()) — peer not heard yet")
-                        callUnavailableMessage = "\(name ?? "This contact") hasn't been seen on the network recently, so a voice call can't be placed yet. Try again once they're online."
-                        return
-                    }
-                    cm.initiateCall(destinationHash: telHash, profile: profile, peerDisplayName: name)
+                    // CallManager resolves this delivery announce to the cached
+                    // sibling telephony announce when available, otherwise it
+                    // derives <identity>.lxst.telephony. The backend receives
+                    // only that telephony hash and actively requests its path.
+                    cm.initiateCall(destinationHash: dest, profile: profile, peerDisplayName: name)
                 }
                 #endif
             }

--- a/Sources/PythonBridge/PythonBridge.swift
+++ b/Sources/PythonBridge/PythonBridge.swift
@@ -805,7 +805,7 @@ public final class PythonBridge: @unchecked Sendable {
     /// Returns the Python-side `link_id` on success. A subsequent
     /// `.linkState(linkId:, state: "established")` event fires once
     /// the link is up.
-    public func openLink(destHashHex: String, aspect: String = "lxst.telephony") async throws -> (ok: Bool, linkId: Int, reason: String) {
+    public func openLink(destHashHex: String, aspect: String = "lxst.telephony", identityPublicKeyHex: String? = nil) async throws -> (ok: Bool, linkId: Int, reason: String) {
         try await runOnQueue { [self] in
             try PythonRuntime.shared.withGIL { [self] in
                 guard let module = self.module else {
@@ -815,14 +815,16 @@ public final class PythonBridge: @unchecked Sendable {
                     throw BridgeError.pythonException(currentPythonException())
                 }
                 defer { Py_DecRef(fn) }
-                guard let args = PyTuple_New(2) else { throw BridgeError.marshallingFailure("PyTuple_New") }
+                guard let args = PyTuple_New(3) else { throw BridgeError.marshallingFailure("PyTuple_New") }
                 defer { Py_DecRef(args) }
                 guard let olDest = PyUnicode_FromString(destHashHex),
-                      let olAspect = PyUnicode_FromString(aspect) else {
+                      let olAspect = PyUnicode_FromString(aspect),
+                      let olPublicKey = PyUnicode_FromString(identityPublicKeyHex ?? "") else {
                     throw BridgeError.marshallingFailure("PyUnicode_FromString")
                 }
                 PyTuple_SetItem(args, 0, olDest)
                 PyTuple_SetItem(args, 1, olAspect)
+                PyTuple_SetItem(args, 2, olPublicKey)
                 guard let result = PyObject_CallObject(fn, args) else {
                     throw BridgeError.pythonException(currentPythonException())
                 }

--- a/Sources/RNSAPI/Protocols/RnsBackend.swift
+++ b/Sources/RNSAPI/Protocols/RnsBackend.swift
@@ -257,7 +257,7 @@ public extension RnsCore {
 /// RNS.Link operations backing LXST voice (the Swift state machine drives these;
 /// the backend is the Link pipe).
 public protocol RnsTelephony: AnyObject, Sendable {
-    func openLink(destHashHex: String, aspect: String) async throws -> (ok: Bool, linkId: Int, reason: String)
+    func openLink(destHashHex: String, aspect: String, identityPublicKeyHex: String?) async throws -> (ok: Bool, linkId: Int, reason: String)
     @discardableResult func linkSend(linkId: Int, data: Data) async throws -> Bool
     @discardableResult func linkIdentify(linkId: Int) async throws -> Bool
     @discardableResult func linkTeardown(linkId: Int) async throws -> Bool
@@ -290,6 +290,6 @@ public extension RnsBackend {
 
 public extension RnsTelephony {
     func openLink(destHashHex: String) async throws -> (ok: Bool, linkId: Int, reason: String) {
-        try await openLink(destHashHex: destHashHex, aspect: "lxst.telephony")
+        try await openLink(destHashHex: destHashHex, aspect: "lxst.telephony", identityPublicKeyHex: nil)
     }
 }

--- a/Sources/RNSBackendProxy/ProxyRnsBackend.swift
+++ b/Sources/RNSBackendProxy/ProxyRnsBackend.swift
@@ -612,7 +612,7 @@ public final class ProxyRnsBackend: RnsBackend, @unchecked Sendable {
     // Each throws so a missed UI capability gate fails loud rather than silently
     // dropping audio. (Model B: runs NE-side / not proxied yet.)
 
-    public func openLink(destHashHex: String, aspect: String) async throws -> (ok: Bool, linkId: Int, reason: String) {
+    public func openLink(destHashHex: String, aspect: String, identityPublicKeyHex: String?) async throws -> (ok: Bool, linkId: Int, reason: String) {
         throw BackendError.unsupportedInProxy(feature: "openLink")
     }
 

--- a/Sources/RNSBackendPy/PythonRNSBackend.swift
+++ b/Sources/RNSBackendPy/PythonRNSBackend.swift
@@ -198,8 +198,8 @@ public final class PythonRNSBackend: RnsBackend, @unchecked Sendable {
     // Python is just the underlying Link pipe — frames marshalled over via
     // openLink + linkSend + linkPacket events.
 
-    public func openLink(destHashHex: String, aspect: String = "lxst.telephony") async throws -> (ok: Bool, linkId: Int, reason: String) {
-        try await bridge.openLink(destHashHex: destHashHex, aspect: aspect)
+    public func openLink(destHashHex: String, aspect: String = "lxst.telephony", identityPublicKeyHex: String? = nil) async throws -> (ok: Bool, linkId: Int, reason: String) {
+        try await bridge.openLink(destHashHex: destHashHex, aspect: aspect, identityPublicKeyHex: identityPublicKeyHex)
     }
 
     @discardableResult

--- a/Sources/RNSBackendSwift/SwiftRNSBackend.swift
+++ b/Sources/RNSBackendSwift/SwiftRNSBackend.swift
@@ -427,7 +427,7 @@ public final class SwiftRNSBackend: RnsBackend, @unchecked Sendable {
     // Link and bridges its inbound packets + state changes onto the neutral event
     // stream. Ported from main's CallManager identity-resolve + initiateLink path.
 
-    public func openLink(destHashHex: String, aspect: String) async throws -> (ok: Bool, linkId: Int, reason: String) {
+    public func openLink(destHashHex: String, aspect: String, identityPublicKeyHex: String?) async throws -> (ok: Bool, linkId: Int, reason: String) {
         guard let transport, let localId = identity, let pathTable else {
             return (false, 0, "not started")
         }

--- a/Tests/static/test_lxst_voice_call_routing.py
+++ b/Tests/static/test_lxst_voice_call_routing.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Contracts for first-class lxst.telephony call routing."""
+
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class LXSTVoiceCallRoutingContracts(unittest.TestCase):
+    def _read(self, relative: str) -> str:
+        return (ROOT / relative).read_text()
+
+    def test_chat_resolves_before_telephone_receives_target(self) -> None:
+        source = self._read("Sources/ColumbaApp/Services/CallManager.swift")
+        self.assertIn("resolveTelephonyTarget(from: destinationHash)", source)
+        self.assertIn("networkTransport.prepareOutboundCall(target)", source)
+        self.assertIn(
+            "telephone.call(destinationHash: target.destinationHash, profile: profile)",
+            source,
+        )
+        self.assertNotIn(
+            "telephone.call(destinationHash: destinationHash, profile: profile)",
+            source,
+        )
+
+    def test_resolver_accepts_direct_telephony_announce(self) -> None:
+        source = self._read("Sources/ColumbaApp/Services/CallManager.swift")
+        resolver = re.search(
+            r"private func resolveTelephonyTarget\(.*?\n    }\n\n    private func failOutgoingCall",
+            source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(resolver)
+        assert resolver is not None
+        body = resolver.group(0)
+        self.assertIn('source.detectedAspect == "lxst.telephony"', body)
+        self.assertIn("guard sourceHash == derivedHash", body)
+        self.assertIn(
+            "TelephonyCallTarget(destinationHash: sourceHash, publicKeys: source.publicKeys)",
+            body,
+        )
+
+    def test_resolver_prefers_linked_announce_but_derives_fallback(self) -> None:
+        source = self._read("Sources/ColumbaApp/Services/CallManager.swift")
+        self.assertIn("await pathTable.allEntries().first(where:", source)
+        self.assertIn("$0.publicKeys == source.publicKeys", source)
+        self.assertIn("$0.destinationHash == derivedHash", source)
+        self.assertIn(
+            "return TelephonyCallTarget(destinationHash: derivedHash, publicKeys: source.publicKeys)",
+            source,
+        )
+
+    def test_network_transport_accepts_only_telephony_hash(self) -> None:
+        source = self._read(
+            "Sources/ColumbaApp/Services/PythonNetworkTransport.swift"
+        )
+        outbound = re.search(
+            r"public func openOutboundCall\(.*?\n    }\n\n    public func identifySelf",
+            source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(outbound)
+        assert outbound is not None
+        body = outbound.group(0)
+        self.assertIn("to telephonyHash: Data", body)
+        self.assertIn("callDest.hash == telephonyHash", body)
+        self.assertIn("transport.initiateLink(to: callDest", body)
+        self.assertNotIn("deliveryHash", body)
+
+    def test_phone_node_details_uses_call_action_and_codec_picker(self) -> None:
+        details = self._read(
+            "Sources/ColumbaApp/Views/Contacts/NodeDetailsView.swift"
+        )
+        self.assertIn("if c.badgeType == .audio, let onStartCall", details)
+        self.assertIn('title: "Call"', details)
+        self.assertIn("onStartCall(c)", details)
+        self.assertIn(
+            "c.badgeType != .node && c.badgeType != .audio, let onStartChat",
+            details,
+        )
+
+        contacts = self._read("Sources/ColumbaApp/Views/Contacts/ContactsView.swift")
+        self.assertIn("onStartCall: contact.badgeType == .audio", contacts)
+        self.assertIn("CodecSelectionSheet { profile in", contacts)
+        self.assertIn("destinationHash: contact.identityHash", contacts)
+
+    def test_python_actively_requests_and_awaits_telephony_path(self) -> None:
+        bridge = self._read("app/rns_bridge.py")
+        open_link = re.search(r"def open_link\(.*?\n(?=\ndef )", bridge, re.DOTALL)
+        self.assertIsNotNone(open_link)
+        assert open_link is not None
+        body = open_link.group(0)
+        self.assertIn("identity_public_key_hex", body)
+        self.assertIn("candidate.load_public_key", body)
+        self.assertIn("candidate_dest.hash != dest_hash", body)
+        self.assertIn("RNS.Transport.has_path(dest_hash)", body)
+        self.assertIn("RNS.Transport.request_path(dest_hash)", body)
+        self.assertIn("deadline = time.monotonic() + 10.0", body)
+        self.assertIn('"reason": "no-path"', body)
+
+    def test_public_identity_crosses_into_python_link_open(self) -> None:
+        app_services = self._read("Sources/ColumbaApp/Services/AppServices.swift")
+        self.assertIn(
+            "identityPublicKeyHex: destination.identity?.publicKeyHex",
+            app_services,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/app/rns_bridge.py
+++ b/app/rns_bridge.py
@@ -662,7 +662,11 @@ def _wire_link_callbacks(link: Any, link_id: int) -> None:
             pass
 
 
-def open_link(dest_hash_hex: str, aspect: str = "lxst.telephony") -> dict[str, Any]:
+def open_link(
+    dest_hash_hex: str,
+    aspect: str = "lxst.telephony",
+    identity_public_key_hex: str = "",
+) -> dict[str, Any]:
     """Initiate an outbound RNS.Link to a destination with the given
     aspect (default `lxst.telephony` for voice). Returns a link_id
     Swift can use to send/teardown/identify on the link.
@@ -687,19 +691,58 @@ def open_link(dest_hash_hex: str, aspect: str = "lxst.telephony") -> dict[str, A
     except ValueError:
         return {"ok": False, "link_id": 0, "reason": "bad-hash"}
 
+    # Split the dotted aspect before resolving identity so a supplied public key
+    # can be verified against the exact destination the caller requested.
+    parts = aspect.split(".") if aspect else ["lxst", "telephony"]
+    app_name = parts[0]
+    aspects = parts[1:] if len(parts) > 1 else []
+
     peer_identity = RNS.Identity.recall(dest_hash)
-    if peer_identity is None:
+    if peer_identity is None and identity_public_key_hex:
+        try:
+            supplied_public_key = bytes.fromhex(identity_public_key_hex)
+            candidate = RNS.Identity(create_keys=False)
+            candidate.load_public_key(supplied_public_key)
+            candidate_dest = RNS.Destination(
+                candidate,
+                RNS.Destination.OUT,
+                RNS.Destination.SINGLE,
+                app_name,
+                *aspects,
+            )
+            if candidate_dest.hash != dest_hash:
+                return {"ok": False, "link_id": 0, "reason": "identity-mismatch"}
+            peer_identity = candidate
+        except Exception:
+            return {"ok": False, "link_id": 0, "reason": "bad-identity"}
+    # Identity and routing are separate concerns: a supplied public key is enough
+    # to construct and verify the destination, but it does not prove that a
+    # current path exists. Always perform a bounded path request before reporting
+    # the telephone unreachable.
+    try:
+        has_path = bool(RNS.Transport.has_path(dest_hash))
+    except Exception:
+        has_path = False
+    if not has_path:
         try:
             RNS.Transport.request_path(dest_hash)
         except Exception:
             pass
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline:
+            try:
+                if RNS.Transport.has_path(dest_hash):
+                    has_path = True
+                    break
+            except Exception:
+                pass
+            time.sleep(0.1)
+    if not has_path:
         return {"ok": False, "link_id": 0, "reason": "no-path"}
-
-    # Split the dotted aspect into app_name + remaining aspect tokens
-    # (RNS.Destination's variadic aspects parameter).
-    parts = aspect.split(".") if aspect else ["lxst", "telephony"]
-    app_name = parts[0]
-    aspects = parts[1:] if len(parts) > 1 else []
+    if peer_identity is None:
+        peer_identity = RNS.Identity.recall(dest_hash)
+    if peer_identity is None:
+        return {"ok": False, "link_id": 0, "reason": "no-identity"}
 
     peer_dest = RNS.Destination(
         peer_identity, RNS.Destination.OUT, RNS.Destination.SINGLE,


### PR DESCRIPTION
## Summary

- treat independently announced `lxst.telephony` destinations as first-class call targets
- route both chat-originated and telephony node-detail calls through the exact telephony destination hash
- associate cached delivery and telephony announces by their shared Reticulum public identity
- derive the telephony hash as a fallback without making a cached telephony announce a prerequisite
- actively request and boundedly await the telephony path before reporting it unreachable
- verify supplied public identity material derives the requested destination before opening the RNS Link
- expose a destination-type `Call` action with the existing codec/profile picker on telephony node details

## Behavior

A call started from an `lxst.telephony` node uses that announce's destination hash and public identity directly. A call started from a chat resolves the sibling telephony announce when cached, otherwise derives `<identity>.lxst.telephony`, and then performs an active path request for that exact hash.

The LXMF delivery hash never crosses the LXST transport/backend boundary as the call target.

## Validation

- 106 Python/static contracts passed
- shipping XCTest: 111 passed, 0 failed
- Model B XCTest: 11 passed, 0 failed
- signed physical-device build, install, and launch passed
- physical voice calls passed with Opus and Codec2 700C
- Python compilation and `git diff --check` passed
- publication branch tree matches the physically validated implementation tree exactly

## Risk and rollback

The primary risk is call setup against peers that publish incomplete or mismatched identity data. The implementation verifies the identity-derived destination hash and fails closed on mismatch. Path discovery is bounded to avoid indefinite setup waits.

Rollback is the single commit in this PR.

## Dependency

This PR is intentionally stacked on PR #108 and should be reviewed/merged after that PR.
