### PR TITLE
Fix chat recency ordering and unread clearing

### DIFF
--- a/Sources/ColumbaApp/Services/MessageRepository.swift
+++ b/Sources/ColumbaApp/Services/MessageRepository.swift
@@ -38,6 +38,19 @@ import LXMFSwift
 /// types so the existing ViewModels compile unchanged. All operations are
 /// serialized through the underlying GRDB actor.
 public actor MessageRepository {
+    /// Posted after a conversation's unread count has been cleared in the
+    /// canonical store. The chats list uses this to clear its in-memory badge
+    /// while a conversation is open.
+    public static let conversationReadNotification =
+        Notification.Name("network.columba.conversationRead")
+
+    /// Posted after an outbound message updates conversation activity. Inbound
+    /// messages already use `IncomingMessageHandler.messageReceivedNotification`.
+    public static let conversationActivityNotification =
+        Notification.Name("network.columba.conversationActivity")
+
+    public static let conversationHashUserInfoKey = "conversationHash"
+
     // MARK: - Properties
 
     /// The GRDB-backed canonical store written by the Swift / NE backend.
@@ -73,6 +86,11 @@ public actor MessageRepository {
     /// Mark conversation as read (reset unread count).
     public func markConversationRead(_ conversationHash: Data) async throws {
         try await database.markConversationRead(hash: conversationHash)
+        NotificationCenter.default.post(
+            name: Self.conversationReadNotification,
+            object: nil,
+            userInfo: [Self.conversationHashUserInfoKey: conversationHash]
+        )
     }
 
     /// Set the unread count for a conversation (e.g. mark as unread with count=1).
@@ -176,6 +194,13 @@ public actor MessageRepository {
     /// map so the chat UI's `LxmfFieldCodec.unpack` can recover attachments.
     public func saveMessage(_ message: RNSAPI.LXMessage) async throws {
         try await database.saveMessage(Self.mapToGRDBMessage(message))
+        if !message.incoming {
+            NotificationCenter.default.post(
+                name: Self.conversationActivityNotification,
+                object: nil,
+                userInfo: [Self.conversationHashUserInfoKey: message.destinationHash]
+            )
+        }
     }
 
     /// Get message by ID (LXMessage form), rebuilt from the GRDB record.

--- a/Sources/ColumbaApp/ViewModels/ChatsViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/ChatsViewModel.swift
@@ -149,6 +149,8 @@ public final class ChatsViewModel {
     private let notificationObserver: NotificationObserver
     private let pathTable: PathTable?
     private var inProcessObserver: NSObjectProtocol?
+    private var conversationReadObserver: NSObjectProtocol?
+    private var conversationActivityObserver: NSObjectProtocol?
 
     // MARK: - Initialization
 
@@ -174,10 +176,39 @@ public final class ChatsViewModel {
                 await self?.loadConversations()
             }
         }
+
+        conversationReadObserver = NotificationCenter.default.addObserver(
+            forName: MessageRepository.conversationReadNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let hash = notification.userInfo?[MessageRepository.conversationHashUserInfoKey] as? Data else {
+                return
+            }
+            Task { @MainActor in
+                self?.clearUnreadBadge(for: hash)
+            }
+        }
+
+        conversationActivityObserver = NotificationCenter.default.addObserver(
+            forName: MessageRepository.conversationActivityNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                await self?.loadConversations()
+            }
+        }
     }
 
     deinit {
         if let observer = inProcessObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        if let observer = conversationReadObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        if let observer = conversationActivityObserver {
             NotificationCenter.default.removeObserver(observer)
         }
     }
@@ -192,9 +223,7 @@ public final class ChatsViewModel {
 
         do {
             let records = try await repository.fetchConversations()
-            var convos = records
-                .filter { !$0.lastMessagePreview.isEmpty }
-                .map { Conversation(from: $0) }
+            var convos = Self.prepareConversations(records)
 
             // Backfill display names from path table for conversations that have none
             if let pathTable {
@@ -223,9 +252,7 @@ public final class ChatsViewModel {
 
         do {
             let records = try await repository.fetchConversations()
-            var convos = records
-                .filter { !$0.lastMessagePreview.isEmpty }
-                .map { Conversation(from: $0) }
+            var convos = Self.prepareConversations(records)
 
             // Backfill display names from path table for conversations that have none
             if let pathTable {
@@ -268,6 +295,30 @@ public final class ChatsViewModel {
         Task {
             try? await repository.setUnreadCount(conversation.destinationHash, count: 1)
         }
+    }
+
+    /// Convert persisted records to the visible chat list and enforce newest
+    /// activity first at the UI boundary, independent of database ordering.
+    static func prepareConversations(_ records: [ConversationRecord]) -> [Conversation] {
+        records
+            .filter { !$0.lastMessagePreview.isEmpty }
+            .map { Conversation(from: $0) }
+            .sorted {
+                if $0.lastMessageTimestamp != $1.lastMessageTimestamp {
+                    return $0.lastMessageTimestamp > $1.lastMessageTimestamp
+                }
+                return $0.id < $1.id
+            }
+    }
+
+    /// Clear the list's cached badge after the repository confirms the read
+    /// state was persisted. This avoids showing stale unread counts on return.
+    @MainActor
+    private func clearUnreadBadge(for conversationHash: Data) {
+        guard let index = conversations.firstIndex(where: { $0.destinationHash == conversationHash }) else {
+            return
+        }
+        conversations[index].unreadCount = 0
     }
 
     /// Delete a conversation.

--- a/Sources/ColumbaApp/ViewModels/ChatsViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/ChatsViewModel.swift
@@ -151,6 +151,7 @@ public final class ChatsViewModel {
     private var inProcessObserver: NSObjectProtocol?
     private var conversationReadObserver: NSObjectProtocol?
     private var conversationActivityObserver: NSObjectProtocol?
+    private var conversationLoadGeneration: UInt64 = 0
 
     // MARK: - Initialization
 
@@ -218,6 +219,7 @@ public final class ChatsViewModel {
     /// Load conversations from storage.
     @MainActor
     public func loadConversations() async {
+        let generation = beginConversationLoad()
         isLoading = true
         defer { isLoading = false }
 
@@ -237,16 +239,18 @@ public final class ChatsViewModel {
                 }
             }
 
-            conversations = convos
-            errorMessage = nil
+            applyLoadedConversations(convos, generation: generation)
         } catch {
-            errorMessage = error.localizedDescription
+            if generation == conversationLoadGeneration {
+                errorMessage = error.localizedDescription
+            }
         }
     }
 
     /// Refresh conversations from storage.
     @MainActor
     public func refreshConversations() async {
+        let generation = beginConversationLoad()
         isRefreshing = true
         defer { isRefreshing = false }
 
@@ -265,10 +269,11 @@ public final class ChatsViewModel {
                 }
             }
 
-            conversations = convos
-            errorMessage = nil
+            applyLoadedConversations(convos, generation: generation)
         } catch {
-            errorMessage = error.localizedDescription
+            if generation == conversationLoadGeneration {
+                errorMessage = error.localizedDescription
+            }
         }
     }
 
@@ -311,10 +316,31 @@ public final class ChatsViewModel {
             }
     }
 
+    /// Start a list refresh. Only the latest generation may replace the
+    /// visible list, preventing slower notification-driven loads from winning.
+    @MainActor
+    func beginConversationLoad() -> UInt64 {
+        conversationLoadGeneration &+= 1
+        return conversationLoadGeneration
+    }
+
+    /// Apply a loaded snapshot only if no newer activity or read-state change
+    /// has invalidated it.
+    @MainActor
+    func applyLoadedConversations(_ loaded: [Conversation], generation: UInt64) {
+        guard generation == conversationLoadGeneration else { return }
+        conversations = loaded
+        errorMessage = nil
+    }
+
     /// Clear the list's cached badge after the repository confirms the read
     /// state was persisted. This avoids showing stale unread counts on return.
     @MainActor
     private func clearUnreadBadge(for conversationHash: Data) {
+        // A load may already hold a snapshot captured before the database read
+        // completed. Invalidate it before clearing the visible badge so that
+        // stale snapshot cannot restore the unread count afterward.
+        conversationLoadGeneration &+= 1
         guard let index = conversations.firstIndex(where: { $0.destinationHash == conversationHash }) else {
             return
         }

--- a/Sources/ColumbaApp/ViewModels/ChatsViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/ChatsViewModel.swift
@@ -152,6 +152,8 @@ public final class ChatsViewModel {
     private var conversationReadObserver: NSObjectProtocol?
     private var conversationActivityObserver: NSObjectProtocol?
     private var conversationLoadGeneration: UInt64 = 0
+    private var activeConversationLoadCount: Int = 0
+    private var activeConversationRefreshCount: Int = 0
 
     // MARK: - Initialization
 
@@ -224,13 +226,8 @@ public final class ChatsViewModel {
     /// Load conversations from storage.
     @MainActor
     public func loadConversations() async {
-        let generation = beginConversationLoad()
-        isLoading = true
-        defer {
-            if generation == conversationLoadGeneration {
-                isLoading = false
-            }
-        }
+        let generation = beginLoadingConversations()
+        defer { endLoadingConversations() }
 
         do {
             let records = try await repository.fetchConversations()
@@ -259,13 +256,8 @@ public final class ChatsViewModel {
     /// Refresh conversations from storage.
     @MainActor
     public func refreshConversations() async {
-        let generation = beginConversationLoad()
-        isRefreshing = true
-        defer {
-            if generation == conversationLoadGeneration {
-                isRefreshing = false
-            }
-        }
+        let generation = beginRefreshingConversations()
+        defer { endRefreshingConversations() }
 
         do {
             let records = try await repository.fetchConversations()
@@ -335,6 +327,35 @@ public final class ChatsViewModel {
     func beginConversationLoad() -> UInt64 {
         conversationLoadGeneration &+= 1
         return conversationLoadGeneration
+    }
+
+    /// Track overlapping ordinary loads independently from refresh operations.
+    @MainActor
+    func beginLoadingConversations() -> UInt64 {
+        activeConversationLoadCount += 1
+        isLoading = true
+        return beginConversationLoad()
+    }
+
+    @MainActor
+    func endLoadingConversations() {
+        activeConversationLoadCount = max(0, activeConversationLoadCount - 1)
+        isLoading = activeConversationLoadCount > 0
+    }
+
+    /// Track pull-to-refresh/tool-bar refreshes separately so a newer ordinary
+    /// load cannot strand or prematurely clear the refresh indicator.
+    @MainActor
+    func beginRefreshingConversations() -> UInt64 {
+        activeConversationRefreshCount += 1
+        isRefreshing = true
+        return beginConversationLoad()
+    }
+
+    @MainActor
+    func endRefreshingConversations() {
+        activeConversationRefreshCount = max(0, activeConversationRefreshCount - 1)
+        isRefreshing = activeConversationRefreshCount > 0
     }
 
     /// Apply a loaded snapshot only if no newer activity or read-state change

--- a/Sources/ColumbaApp/ViewModels/ChatsViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/ChatsViewModel.swift
@@ -187,7 +187,12 @@ public final class ChatsViewModel {
                 return
             }
             Task { @MainActor in
-                self?.clearUnreadBadge(for: hash)
+                guard let self else { return }
+                self.clearUnreadBadge(for: hash)
+                // Replace any invalidated in-flight snapshot with a fresh one
+                // captured after the read transaction committed. This keeps the
+                // newest preview/timestamp/order while clearing the badge.
+                await self.loadConversations()
             }
         }
 

--- a/Sources/ColumbaApp/ViewModels/ChatsViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/ChatsViewModel.swift
@@ -226,7 +226,11 @@ public final class ChatsViewModel {
     public func loadConversations() async {
         let generation = beginConversationLoad()
         isLoading = true
-        defer { isLoading = false }
+        defer {
+            if generation == conversationLoadGeneration {
+                isLoading = false
+            }
+        }
 
         do {
             let records = try await repository.fetchConversations()
@@ -257,7 +261,11 @@ public final class ChatsViewModel {
     public func refreshConversations() async {
         let generation = beginConversationLoad()
         isRefreshing = true
-        defer { isRefreshing = false }
+        defer {
+            if generation == conversationLoadGeneration {
+                isRefreshing = false
+            }
+        }
 
         do {
             let records = try await repository.fetchConversations()

--- a/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
@@ -158,6 +158,10 @@ public final class MessagingViewModel {
             messages = resolvedMessages
             allMessagesLoaded = records.count < Self.pageSize
 
+            // Reconcile messages that arrived after the initial read reset but
+            // were included in the page we just displayed.
+            try await repository.markConversationRead(conversationHash)
+
             errorMessage = nil
         } catch {
             errorMessage = error.localizedDescription

--- a/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
@@ -128,8 +128,11 @@ public final class MessagingViewModel {
         defer { isLoading = false }
 
         do {
-            // Ensure conversation exists
+            // Ensure conversation exists, then clear unread state as soon as the
+            // user opens it. Message decoding or reply-preview failures must not
+            // leave a stale badge behind after the conversation was viewed.
             try await repository.ensureConversation(conversationHash, displayName: displayName)
+            try await repository.markConversationRead(conversationHash)
 
             // Fetch most recent page
             let records = try await repository.fetchMessageRecords(
@@ -154,9 +157,6 @@ public final class MessagingViewModel {
 
             messages = resolvedMessages
             allMessagesLoaded = records.count < Self.pageSize
-
-            // Mark as read
-            try await repository.markConversationRead(conversationHash)
 
             errorMessage = nil
         } catch {

--- a/Tests/ColumbaAppTests/MicronParserTests.swift
+++ b/Tests/ColumbaAppTests/MicronParserTests.swift
@@ -673,9 +673,20 @@ final class MessageRepositoryAdapterTests: XCTestCase {
             unreadCount: 0
         )
 
-        let conversations = ChatsViewModel.prepareConversations([older, newer])
+        let sameTimestampLowerID = RNSAPI.ConversationRecord(
+            hash: Data([0x00]),
+            displayName: "Same timestamp",
+            lastMessageAt: Date(timeIntervalSince1970: 200),
+            lastMessage: "same timestamp message",
+            unreadCount: 0
+        )
 
-        XCTAssertEqual(conversations.map(\.destinationHash), [newer.hash, older.hash])
+        let conversations = ChatsViewModel.prepareConversations([older, newer, sameTimestampLowerID])
+
+        XCTAssertEqual(
+            conversations.map(\.destinationHash),
+            [sameTimestampLowerID.hash, newer.hash, older.hash]
+        )
     }
 
     @MainActor
@@ -743,20 +754,28 @@ final class MessageRepositoryAdapterTests: XCTestCase {
             notificationObserver: NotificationObserver()
         )
         let hash = Data([0xAA, 0xBB])
-        viewModel.conversations = [Conversation(
+        let staleConversation = Conversation(
             destinationHash: hash,
             displayName: "Peer",
             lastMessageTimestamp: Date(),
             lastMessagePreview: "message",
             unreadCount: 3
-        )]
+        )
+        viewModel.conversations = [staleConversation]
 
         try await repository.ensureConversation(hash, displayName: "Peer")
         try await repository.setUnreadCount(hash, count: 3)
+        let staleGeneration = viewModel.beginConversationLoad()
         try await repository.markConversationRead(hash)
 
-        await Task.yield()
-        await Task.yield()
+        for _ in 0..<100 where viewModel.conversations.first?.unreadCount != 0 {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        // Simulate a slower load attempting to apply the snapshot it captured
+        // before markConversationRead completed. The read notification must have
+        // invalidated that generation so the stale unread count cannot return.
+        viewModel.applyLoadedConversations([staleConversation], generation: staleGeneration)
 
         let persistedConversation = try await repository.fetchConversation(hash)
         XCTAssertEqual(viewModel.conversations.first?.unreadCount, 0)

--- a/Tests/ColumbaAppTests/MicronParserTests.swift
+++ b/Tests/ColumbaAppTests/MicronParserTests.swift
@@ -690,6 +690,40 @@ final class MessageRepositoryAdapterTests: XCTestCase {
     }
 
     @MainActor
+    func testOverlappingLoadsKeepOperationSpecificIndicatorsAccurate() throws {
+        let databaseURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("columba-chat-loading-\(UUID().uuidString).sqlite")
+        defer {
+            try? FileManager.default.removeItem(at: databaseURL)
+            try? FileManager.default.removeItem(atPath: databaseURL.path + "-shm")
+            try? FileManager.default.removeItem(atPath: databaseURL.path + "-wal")
+        }
+
+        let repository = try MessageRepository(grdbPath: databaseURL.path)
+        let viewModel = ChatsViewModel(
+            repository: repository,
+            notificationObserver: NotificationObserver()
+        )
+
+        _ = viewModel.beginLoadingConversations()
+        _ = viewModel.beginLoadingConversations()
+        _ = viewModel.beginRefreshingConversations()
+        XCTAssertTrue(viewModel.isLoading)
+        XCTAssertTrue(viewModel.isRefreshing)
+
+        viewModel.endLoadingConversations()
+        XCTAssertTrue(viewModel.isLoading, "one ordinary load is still active")
+        XCTAssertTrue(viewModel.isRefreshing, "ordinary load completion must not clear refresh state")
+
+        viewModel.endRefreshingConversations()
+        XCTAssertFalse(viewModel.isRefreshing)
+        XCTAssertTrue(viewModel.isLoading, "refresh completion must not clear ordinary loading state")
+
+        viewModel.endLoadingConversations()
+        XCTAssertFalse(viewModel.isLoading)
+    }
+
+    @MainActor
     func testOutboundActivityRefreshesAndReordersChatList() async throws {
         let databaseURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("columba-chat-order-\(UUID().uuidString).sqlite")

--- a/Tests/ColumbaAppTests/MicronParserTests.swift
+++ b/Tests/ColumbaAppTests/MicronParserTests.swift
@@ -655,6 +655,114 @@ final class MicronParserTests: XCTestCase {
 /// A0: Date<-Double, RNSAPI-enum<-LXMFSwift-UInt8, String<-String?.
 final class MessageRepositoryAdapterTests: XCTestCase {
 
+    // MARK: Conversation list behavior
+
+    func testConversationListSortsMostRecentActivityFirst() {
+        let older = RNSAPI.ConversationRecord(
+            hash: Data([0x01]),
+            displayName: "Older",
+            lastMessageAt: Date(timeIntervalSince1970: 100),
+            lastMessage: "older message",
+            unreadCount: 0
+        )
+        let newer = RNSAPI.ConversationRecord(
+            hash: Data([0x02]),
+            displayName: "Newer",
+            lastMessageAt: Date(timeIntervalSince1970: 200),
+            lastMessage: "newer message",
+            unreadCount: 0
+        )
+
+        let conversations = ChatsViewModel.prepareConversations([older, newer])
+
+        XCTAssertEqual(conversations.map(\.destinationHash), [newer.hash, older.hash])
+    }
+
+    @MainActor
+    func testOutboundActivityRefreshesAndReordersChatList() async throws {
+        let databaseURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("columba-chat-order-\(UUID().uuidString).sqlite")
+        defer {
+            try? FileManager.default.removeItem(at: databaseURL)
+            try? FileManager.default.removeItem(atPath: databaseURL.path + "-shm")
+            try? FileManager.default.removeItem(atPath: databaseURL.path + "-wal")
+        }
+
+        let repository = try MessageRepository(grdbPath: databaseURL.path)
+        let viewModel = ChatsViewModel(
+            repository: repository,
+            notificationObserver: NotificationObserver()
+        )
+        let olderHash = Data([0x01])
+        let newerHash = Data([0x02])
+
+        let olderMessage = RNSAPI.LXMessage(
+            destinationHash: olderHash,
+            sourceIdentity: nil,
+            content: Data("older".utf8)
+        )
+        olderMessage.hash = Data([0xA1])
+        olderMessage.timestamp = 100
+        olderMessage.state = .sent
+        olderMessage.method = .opportunistic
+        try await repository.saveMessage(olderMessage)
+        await viewModel.loadConversations()
+        XCTAssertEqual(viewModel.conversations.first?.destinationHash, olderHash)
+
+        let newerMessage = RNSAPI.LXMessage(
+            destinationHash: newerHash,
+            sourceIdentity: nil,
+            content: Data("newer".utf8)
+        )
+        newerMessage.hash = Data([0xA2])
+        newerMessage.timestamp = 200
+        newerMessage.state = .sent
+        newerMessage.method = .opportunistic
+        try await repository.saveMessage(newerMessage)
+
+        for _ in 0..<100 where viewModel.conversations.first?.destinationHash != newerHash {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        XCTAssertEqual(viewModel.conversations.map(\.destinationHash), [newerHash, olderHash])
+    }
+
+    @MainActor
+    func testConversationReadNotificationClearsVisibleUnreadBadge() async throws {
+        let databaseURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("columba-chat-read-\(UUID().uuidString).sqlite")
+        defer {
+            try? FileManager.default.removeItem(at: databaseURL)
+            try? FileManager.default.removeItem(atPath: databaseURL.path + "-shm")
+            try? FileManager.default.removeItem(atPath: databaseURL.path + "-wal")
+        }
+
+        let repository = try MessageRepository(grdbPath: databaseURL.path)
+        let viewModel = ChatsViewModel(
+            repository: repository,
+            notificationObserver: NotificationObserver()
+        )
+        let hash = Data([0xAA, 0xBB])
+        viewModel.conversations = [Conversation(
+            destinationHash: hash,
+            displayName: "Peer",
+            lastMessageTimestamp: Date(),
+            lastMessagePreview: "message",
+            unreadCount: 3
+        )]
+
+        try await repository.ensureConversation(hash, displayName: "Peer")
+        try await repository.setUnreadCount(hash, count: 3)
+        try await repository.markConversationRead(hash)
+
+        await Task.yield()
+        await Task.yield()
+
+        let persistedConversation = try await repository.fetchConversation(hash)
+        XCTAssertEqual(viewModel.conversations.first?.unreadCount, 0)
+        XCTAssertEqual(persistedConversation?.unreadCount, 0)
+    }
+
     // MARK: Conversation mapping (Date<-Double, String<-String?)
 
     func testMapConversationFullFields() {

--- a/Tests/ColumbaAppTests/MicronParserTests.swift
+++ b/Tests/ColumbaAppTests/MicronParserTests.swift
@@ -757,28 +757,45 @@ final class MessageRepositoryAdapterTests: XCTestCase {
         let staleConversation = Conversation(
             destinationHash: hash,
             displayName: "Peer",
-            lastMessageTimestamp: Date(),
-            lastMessagePreview: "message",
+            lastMessageTimestamp: Date(timeIntervalSince1970: 100),
+            lastMessagePreview: "old message",
             unreadCount: 3
         )
         viewModel.conversations = [staleConversation]
 
-        try await repository.ensureConversation(hash, displayName: "Peer")
+        let incomingMessage = RNSAPI.LXMessage(
+            destinationHash: Data([0xDD]),
+            sourceIdentity: nil,
+            content: Data("new message".utf8)
+        )
+        incomingMessage.sourceHash = hash
+        incomingMessage.hash = Data([0xA3])
+        incomingMessage.timestamp = 200
+        incomingMessage.incoming = true
+        incomingMessage.state = .received
+        incomingMessage.method = .opportunistic
+        try await repository.saveMessage(incomingMessage)
         try await repository.setUnreadCount(hash, count: 3)
+
         let staleGeneration = viewModel.beginConversationLoad()
         try await repository.markConversationRead(hash)
 
-        for _ in 0..<100 where viewModel.conversations.first?.unreadCount != 0 {
+        for _ in 0..<100 where
+            viewModel.conversations.first?.unreadCount != 0 ||
+            viewModel.conversations.first?.lastMessagePreview != "new message" {
             try await Task.sleep(for: .milliseconds(10))
         }
 
         // Simulate a slower load attempting to apply the snapshot it captured
         // before markConversationRead completed. The read notification must have
-        // invalidated that generation so the stale unread count cannot return.
+        // invalidated that generation, while its replacement load must preserve
+        // the new preview/timestamp and cleared unread state.
         viewModel.applyLoadedConversations([staleConversation], generation: staleGeneration)
 
         let persistedConversation = try await repository.fetchConversation(hash)
         XCTAssertEqual(viewModel.conversations.first?.unreadCount, 0)
+        XCTAssertEqual(viewModel.conversations.first?.lastMessagePreview, "new message")
+        XCTAssertEqual(viewModel.conversations.first?.lastMessageTimestamp, Date(timeIntervalSince1970: 200))
         XCTAssertEqual(persistedConversation?.unreadCount, 0)
     }
 


### PR DESCRIPTION
## Summary

- sort chats deterministically by most recent message activity
- refresh the chats list after outbound messages so active conversations move to the top
- clear persisted and visible unread counts as soon as a conversation is opened
- reject stale list snapshots and reload after read invalidation so newer previews, timestamps, and ordering are preserved
- add regression coverage for ordering, outbound refresh, read persistence, and overlapping refresh/read races

## Test plan

- [x] Shipping iOS XCTest: 114 passed
- [x] Model B XCTest: 11 passed
- [x] Focused chat/repository XCTest: 18 passed
- [x] Static contract suite: 128 passed
- [x] `git diff --check`
- [x] Signed physical-device build, strict signature verification, install, and launch

## Risk and rollback

The change is limited to conversation-list refresh notifications, read-state timing, stale-load generation handling, and tests. Roll back the three commits in this branch to restore the prior behavior.
