### PR TITLE
fix: preserve opted-in Bluetooth upgrades

### DIFF
--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -1156,8 +1156,9 @@ public final class AppServices {
         #if COLUMBA_RUNTIME_MODEL_B
         // Model B: CoreBluetooth lives in the app process, but it is optional. Do not
         // construct the driver (and trigger iOS authorization) unless onboarding's
-        // Bluetooth Enable action recorded an explicit opt-in.
-        if ModelBBLEService.isUserOptedIn {
+        // Bluetooth Enable action recorded an explicit opt-in or a prior authorization
+        // proves that an existing user had already opted in before this key existed.
+        if ModelBBLEService.shouldStart {
             ModelBBLEService.shared.start(identityHash: identity.hash)
         } else {
             DiagLog.log("[BLE] Model B BLE service skipped — no explicit user opt-in")

--- a/Sources/ColumbaApp/Services/ModelBBLEService.swift
+++ b/Sources/ColumbaApp/Services/ModelBBLEService.swift
@@ -20,6 +20,7 @@
 //
 
 import Foundation
+import CoreBluetooth
 import ReticulumSwift
 
 public final class ModelBBLEService: @unchecked Sendable {
@@ -38,6 +39,27 @@ public final class ModelBBLEService: @unchecked Sendable {
 
     static func recordUserOptIn(in defaults: UserDefaults = .standard) {
         defaults.set(true, forKey: userOptInKey)
+    }
+
+    /// Decide whether the app-side Model B CoreBluetooth host may start without
+    /// constructing a manager. Existing users who already granted Bluetooth are
+    /// migrated to the explicit opt-in key so an upgrade does not silently disable BLE.
+    static var shouldStart: Bool {
+        shouldStart(isBluetoothAuthorized: CBCentralManager.authorization == .allowedAlways)
+    }
+
+    static func shouldStart(
+        isBluetoothAuthorized: Bool,
+        defaults: UserDefaults = .standard
+    ) -> Bool {
+        if isUserOptedIn(in: defaults) {
+            return true
+        }
+        guard isBluetoothAuthorized else {
+            return false
+        }
+        recordUserOptIn(in: defaults)
+        return true
     }
 
     private init() {}

--- a/Sources/ColumbaApp/ViewModels/OnboardingViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/OnboardingViewModel.swift
@@ -193,20 +193,10 @@ final class OnboardingViewModel {
 
         await settingsRepository.setDisplayName("Anonymous Peer")
 
-        // Model B: the NE node delivers over the first enabled tcpClient relay, so a
-        // skipped setup must still seed one — otherwise the node comes up with no
-        // reachable path and the user can't message anyone. (An AutoInterface-only
-        // seed is a no-op the NE ignores.)
-        let interfaceRepo = InterfaceRepository()
-        let server = TcpCommunityServer.defaultServer
-        interfaceRepo.addInterface(InterfaceEntity(
-            name: server.name,
-            type: .tcpClient,
-            config: .tcpClient(TCPClientConfig(
-                targetHost: server.host,
-                targetPort: server.port
-            ))
-        ))
+        // A skipped setup still needs the default relay, but must use the same
+        // idempotent path as normal completion. Restore can enter this method after
+        // importing interfaces, and repeated actions must not append duplicates.
+        seedInterfaces(in: InterfaceRepository())
 
         UserDefaults.standard.set(true, forKey: "has_completed_onboarding")
         UserDefaults.standard.set(true, forKey: "settings_initialized")
@@ -246,21 +236,14 @@ final class OnboardingViewModel {
         // Model B's Network Extension owns its local transports and reads one TCP relay
         // from the shared store. Seed only that relay and keep the operation idempotent.
         let server = selectedTcpServer ?? TcpCommunityServer.defaultServer
-        let alreadySeeded = repo.getEnabledInterfaces().contains { entity in
-            if case .tcpClient(let cfg) = entity.config {
-                return cfg.targetHost == server.host && cfg.targetPort == server.port
-            }
-            return false
-        }
-        guard !alreadySeeded else { return }
-        repo.addInterface(InterfaceEntity(
+        ensureInterfaceEnabled(InterfaceEntity(
             name: server.name,
             type: .tcpClient,
             config: .tcpClient(TCPClientConfig(
                 targetHost: server.host,
                 targetPort: server.port
             ))
-        ))
+        ), in: repo)
         #else
         // The shipping runtime owns these interfaces in the app process. Build a
         // canonical candidate for each selection and add it only if an equivalent
@@ -299,27 +282,42 @@ final class OnboardingViewModel {
             }
 
             guard let candidate else { continue }
-            guard !shippingInterfaceAlreadyExists(candidate, in: repo) else { continue }
-            repo.addInterface(candidate)
+            ensureInterfaceEnabled(candidate, in: repo)
         }
         #endif
     }
 
-    private func shippingInterfaceAlreadyExists(
+    /// Preserve one equivalent configuration and make sure it is enabled. Restore may
+    /// import a disabled matching record; skip/completion must reactivate that record
+    /// instead of appending a duplicate or leaving the app without a usable path.
+    private func ensureInterfaceEnabled(
         _ candidate: InterfaceEntity,
         in repo: InterfaceRepository
+    ) {
+        if repo.interfaces.contains(where: { $0.enabled && interfacesAreEquivalent($0, candidate) }) {
+            return
+        }
+        if var disabled = repo.interfaces.first(where: { !$0.enabled && interfacesAreEquivalent($0, candidate) }) {
+            disabled.enabled = true
+            repo.updateInterface(disabled)
+            return
+        }
+        repo.addInterface(candidate)
+    }
+
+    private func interfacesAreEquivalent(
+        _ existing: InterfaceEntity,
+        _ candidate: InterfaceEntity
     ) -> Bool {
-        repo.interfaces.contains { existing in
-            switch (existing.config, candidate.config) {
-            case (.autoInterface, .autoInterface),
-                 (.ble, .ble):
-                return true
-            case let (.tcpClient(existingConfig), .tcpClient(candidateConfig)):
-                return existingConfig.targetHost == candidateConfig.targetHost
-                    && existingConfig.targetPort == candidateConfig.targetPort
-            default:
-                return false
-            }
+        switch (existing.config, candidate.config) {
+        case (.autoInterface, .autoInterface),
+             (.ble, .ble):
+            return true
+        case let (.tcpClient(existingConfig), .tcpClient(candidateConfig)):
+            return existingConfig.targetHost == candidateConfig.targetHost
+                && existingConfig.targetPort == candidateConfig.targetPort
+        default:
+            return false
         }
     }
 }

--- a/Tests/ColumbaAppTests/BLESeamDriverTests.swift
+++ b/Tests/ColumbaAppTests/BLESeamDriverTests.swift
@@ -38,8 +38,46 @@ final class BLESeamDriverTests: XCTestCase {
         defer { defaults.removePersistentDomain(forName: suiteName) }
 
         XCTAssertFalse(ModelBBLEService.isUserOptedIn(in: defaults))
-        ModelBBLEService.recordUserOptIn(in: defaults)
+        XCTAssertFalse(ModelBBLEService.shouldStart(isBluetoothAuthorized: false, defaults: defaults))
+
+        // Upgrade migration: an existing authorization is prior user consent. Preserve
+        // BLE and persist the new opt-in key without constructing a manager.
+        XCTAssertTrue(ModelBBLEService.shouldStart(isBluetoothAuthorized: true, defaults: defaults))
         XCTAssertTrue(ModelBBLEService.isUserOptedIn(in: defaults))
+
+        defaults.removeObject(forKey: ModelBBLEService.userOptInKey)
+        ModelBBLEService.recordUserOptIn(in: defaults)
+        XCTAssertTrue(ModelBBLEService.shouldStart(isBluetoothAuthorized: false, defaults: defaults))
+    }
+
+    @MainActor
+    func testModelBSeedingReenablesDisabledRelayWithoutDuplicate() throws {
+        let suiteName = "test.ModelBOnboardingInterfaces.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            return XCTFail("Could not create isolated UserDefaults suite")
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(try JSONEncoder().encode([InterfaceEntity]()), forKey: "com.columba.interfaces")
+        let repository = InterfaceRepository(userDefaults: defaults)
+        let server = TcpCommunityServer.defaultServer
+        repository.addInterface(InterfaceEntity(
+            name: server.name,
+            type: .tcpClient,
+            enabled: false,
+            config: .tcpClient(TCPClientConfig(
+                targetHost: server.host,
+                targetPort: server.port
+            ))
+        ))
+        let viewModel = OnboardingViewModel()
+        viewModel.selectedTcpServer = server
+
+        viewModel.seedInterfaces(in: repository)
+        viewModel.seedInterfaces(in: repository)
+
+        XCTAssertEqual(repository.interfaces.count, 1)
+        XCTAssertTrue(repository.interfaces[0].enabled)
     }
 
     func testDiscoveredEventFeedsStream() async throws {

--- a/Tests/ColumbaAppTests/RuntimeFlavorTests.swift
+++ b/Tests/ColumbaAppTests/RuntimeFlavorTests.swift
@@ -69,9 +69,19 @@ final class RuntimeFlavorTests: XCTestCase {
         // defaults into this isolated suite.
         defaults.set(try JSONEncoder().encode([InterfaceEntity]()), forKey: "com.columba.interfaces")
         let repository = InterfaceRepository(userDefaults: defaults)
+        let server = TcpCommunityServer.defaultServer
+        repository.addInterface(InterfaceEntity(
+            name: server.name,
+            type: .tcpClient,
+            enabled: false,
+            config: .tcpClient(TCPClientConfig(
+                targetHost: server.host,
+                targetPort: server.port
+            ))
+        ))
         let viewModel = OnboardingViewModel()
         viewModel.selectedInterfaces = [.auto, .ble, .tcp]
-        viewModel.selectedTcpServer = .defaultServer
+        viewModel.selectedTcpServer = server
 
         viewModel.seedInterfaces(in: repository)
         viewModel.seedInterfaces(in: repository)
@@ -79,7 +89,9 @@ final class RuntimeFlavorTests: XCTestCase {
         XCTAssertEqual(repository.interfaces.count, 3)
         XCTAssertEqual(repository.interfaces.filter { $0.type == .autoInterface }.count, 1)
         XCTAssertEqual(repository.interfaces.filter { $0.type == .ble }.count, 1)
-        XCTAssertEqual(repository.interfaces.filter { $0.type == .tcpClient }.count, 1)
+        let tcpInterfaces = repository.interfaces.filter { $0.type == .tcpClient }
+        XCTAssertEqual(tcpInterfaces.count, 1)
+        XCTAssertTrue(tcpInterfaces[0].enabled)
     }
     #endif
 }

--- a/Tests/static/test_onboarding_interface_selection.py
+++ b/Tests/static/test_onboarding_interface_selection.py
@@ -93,19 +93,27 @@ class OnboardingInterfaceSelectionContracts(unittest.TestCase):
 
         self.assertIn('userOptInKey = "model_b_ble_user_opt_in"', service)
         self.assertIn("recordUserOptIn()", view_model)
+        self.assertIn("shouldStart(isBluetoothAuthorized:", service)
         start = "ModelBBLEService.shared.start(identityHash: identity.hash)"
         self.assertEqual(1, app_services.count(start))
         start_offset = app_services.index(start)
         guard_offset = app_services.rfind("if ", 0, start_offset)
         guard = app_services[guard_offset:start_offset]
-        self.assertIn("ModelBBLEService.isUserOptedIn", guard)
+        self.assertIn("ModelBBLEService.shouldStart", guard)
 
     def test_shipping_interface_creation_is_idempotent(self) -> None:
         view_model = source(VIEW_MODEL)
         method = view_model.split("private func createInterfaces(in repo: InterfaceRepository) {", 1)[1]
         shipping = method.split("#else", 1)[1].split("#endif", 1)[0]
-        self.assertIn("shippingInterfaceAlreadyExists", shipping)
-        self.assertIn("guard !shippingInterfaceAlreadyExists", shipping)
+        self.assertIn("ensureInterfaceEnabled(candidate, in: repo)", shipping)
+        self.assertIn("disabled.enabled = true", view_model)
+        self.assertIn("repo.updateInterface(disabled)", view_model)
+
+    def test_skip_and_restore_use_idempotent_interface_seeding(self) -> None:
+        view_model = source(VIEW_MODEL)
+        skip = view_model.split("func skipOnboarding(", 1)[1].split("// MARK: - Onboarding Check", 1)[0]
+        self.assertIn("seedInterfaces(in: InterfaceRepository())", skip)
+        self.assertNotIn("addInterface", skip)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- preserve Model B BLE for existing users who already granted Bluetooth permission
- keep fresh non-opted users from initializing CoreBluetooth
- make skip/restore interface seeding idempotent
- re-enable equivalent disabled default interfaces instead of duplicating them

## Validation
- shipping native tests passed
- Model B native tests passed
- portable static suite: 135 tests and 233 subtests passed
- target/isolation contracts: 43 runs and 1,167 assertions passed

Follow-up to merged PR #112. This PR contains only commit `233bb3bc50b58c955cb7ebeaa0c58145c211e8b0`.