### PR TITLE
ci: retry Xcode Cloud Python runtime download

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,7 +72,8 @@ jobs:
           set -euo pipefail
           python3 -B -m unittest \
             Tests.static.test_host_entitlements_contract \
-            Tests.static.test_ci_artifact_isolation
+            Tests.static.test_ci_artifact_isolation \
+            Tests.static.test_fetch_python_resilience
 
       - name: Build shipping artifact (embedded Python)
         run: |

--- a/Tests/static/test_fetch_python_resilience.py
+++ b/Tests/static/test_fetch_python_resilience.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Static contract for the Xcode Cloud Python runtime download."""
+
+from pathlib import Path
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "support" / "fetch-python.sh"
+
+
+class FetchPythonResilienceTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.source = SCRIPT.read_text(encoding="utf-8")
+
+    def test_transient_network_failures_are_retried(self) -> None:
+        for option in (
+            "--retry 5",
+            "--retry-all-errors",
+            "--retry-delay 2",
+            "--connect-timeout 30",
+            "--retry-max-time 600",
+        ):
+            with self.subTest(option=option):
+                self.assertIn(option, self.source)
+
+    def test_partial_download_is_cleaned_up(self) -> None:
+        self.assertIn('DOWNLOAD_PATH="$FW_DIR/${TARBALL}.part"', self.source)
+        self.assertIn("trap cleanup EXIT", self.source)
+        self.assertIn('rm -f "$DOWNLOAD_PATH"', self.source)
+
+    def test_archive_is_validated_before_stale_framework_is_removed(self) -> None:
+        validation = self.source.index('tar -tzf "$DOWNLOAD_PATH"')
+        destructive_cleanup = self.source.index('rm -rf "$FW_DIR/Python.xcframework"')
+        self.assertLess(validation, destructive_cleanup)
+
+    def test_corrupt_download_preserves_existing_framework(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            support = root / "support"
+            framework = root / "Frameworks" / "Python.xcframework"
+            fake_bin = root / "bin"
+            support.mkdir()
+            framework.mkdir(parents=True)
+            fake_bin.mkdir()
+
+            shutil.copy2(SCRIPT, support / "fetch-python.sh")
+            sentinel = framework / "existing-runtime"
+            sentinel.write_text("keep", encoding="utf-8")
+            (root / "Frameworks" / "VERSIONS").write_text("Build: old\n", encoding="utf-8")
+
+            fake_curl = fake_bin / "curl"
+            fake_curl.write_text(
+                """#!/bin/bash
+set -eu
+output=""
+while [ "$#" -gt 0 ]; do
+    if [ "$1" = "--output" ]; then
+        shift
+        output="$1"
+    fi
+    shift
+done
+printf 'not a gzip archive' > "$output"
+""",
+                encoding="utf-8",
+            )
+            fake_curl.chmod(0o755)
+
+            environment = os.environ.copy()
+            environment["PATH"] = f"{fake_bin}:{environment['PATH']}"
+            result = subprocess.run(
+                [str(support / "fetch-python.sh")],
+                cwd=root,
+                env=environment,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertEqual(sentinel.read_text(encoding="utf-8"), "keep")
+            self.assertFalse(any((root / "Frameworks").glob("*.part")))
+            self.assertFalse(any((root / "Frameworks").glob(".python-stage.*")))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/support/fetch-python.sh
+++ b/support/fetch-python.sh
@@ -18,7 +18,15 @@ URL="https://github.com/beeware/Python-Apple-support/releases/download/${RELEASE
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 FW_DIR="$ROOT/Frameworks"
+DOWNLOAD_PATH="$FW_DIR/${TARBALL}.part"
+STAGE_DIR="$FW_DIR/.python-stage.$$"
 mkdir -p "$FW_DIR"
+
+cleanup() {
+    rm -f "$DOWNLOAD_PATH"
+    rm -rf "$STAGE_DIR"
+}
+trap cleanup EXIT
 
 # Bail early if the right version is already installed.
 if [ -f "$FW_DIR/VERSIONS" ] && grep -q "Build: ${PY_BUILD}" "$FW_DIR/VERSIONS"; then
@@ -26,18 +34,42 @@ if [ -f "$FW_DIR/VERSIONS" ] && grep -q "Build: ${PY_BUILD}" "$FW_DIR/VERSIONS";
     exit 0
 fi
 
+# Xcode Cloud occasionally resets long GitHub release-asset connections. Retry
+# every curl-class failure, including exit 35 (TLS/connection reset), while
+# bounding both connection setup and the total retry window.
+rm -f "$DOWNLOAD_PATH"
 echo "==> Fetching $TARBALL"
-curl -fL --progress-bar -o "$FW_DIR/$TARBALL" "$URL"
+curl --fail --location --progress-bar \
+    --retry 5 \
+    --retry-all-errors \
+    --retry-delay 2 \
+    --retry-max-time 600 \
+    --connect-timeout 30 \
+    --output "$DOWNLOAD_PATH" \
+    "$URL"
 
-echo "==> Removing stale Python.xcframework (if any)"
-rm -rf "$FW_DIR/Python.xcframework" "$FW_DIR/testbed" "$FW_DIR/VERSIONS"
+# Validate and fully extract into staging before touching an existing runtime.
+# A truncated 2xx response must not destroy a previously valid framework.
+echo "==> Validating archive"
+tar -tzf "$DOWNLOAD_PATH" >/dev/null
 
+rm -rf "$STAGE_DIR"
+mkdir -p "$STAGE_DIR"
 echo "==> Extracting"
-tar -xzf "$FW_DIR/$TARBALL" -C "$FW_DIR"
-rm "$FW_DIR/$TARBALL"
-# The testbed/ directory is a BeeWare reference Xcode project — we don't need it
-# in this repo. Saves ~5 MB on a fresh checkout.
-rm -rf "$FW_DIR/testbed"
+tar -xzf "$DOWNLOAD_PATH" -C "$STAGE_DIR"
+
+if [ ! -d "$STAGE_DIR/Python.xcframework" ] || [ ! -f "$STAGE_DIR/VERSIONS" ]; then
+    echo "error: downloaded archive is missing Python.xcframework or VERSIONS" >&2
+    exit 1
+fi
+
+echo "==> Replacing stale Python.xcframework (if any)"
+rm -rf "$FW_DIR/Python.xcframework" "$FW_DIR/testbed" "$FW_DIR/VERSIONS"
+mv "$STAGE_DIR/Python.xcframework" "$FW_DIR/Python.xcframework"
+mv "$STAGE_DIR/VERSIONS" "$FW_DIR/VERSIONS"
+
+# The testbed/ directory is a BeeWare reference Xcode project — we don't need it.
+rm -rf "$STAGE_DIR/testbed"
 
 echo "==> Done. Python.xcframework installed:"
 cat "$FW_DIR/VERSIONS"


### PR DESCRIPTION
## Summary
- retry transient GitHub release-asset failures, including curl exit 35
- validate and stage the Python runtime archive before replacing an existing framework
- clean partial downloads and add regression coverage for corrupt archives

## Verification
- downloaded, validated, and extracted Python-Apple-support 3.13-b13 successfully
- verified an idempotent rerun skips the installed framework
- `python3 -B -m unittest discover -s Tests/static -p "test_*.py"` (138 passed)
- `bash -n support/fetch-python.sh ci_scripts/ci_post_clone.sh`
- `git diff --check`

## Risk / rollback
Low risk: this changes only the CI dependency-fetch path. Revert commit 82c5033 to restore the previous single-attempt download behavior.