### PR TITLE
fix: harden Bluetooth opt-in and interface seeding

### DIFF
--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -1155,9 +1155,9 @@ public final class AppServices {
 
         #if COLUMBA_RUNTIME_MODEL_B
         // Model B: CoreBluetooth lives in the app process, but it is optional. Do not
-        // construct the driver (and trigger iOS authorization) unless onboarding's
-        // Bluetooth Enable action recorded an explicit opt-in.
-        if ModelBBLEService.isUserOptedIn {
+        // construct the driver (and trigger iOS authorization) unless onboarding or
+        // Settings recorded an explicit transport opt-in.
+        if ModelBBLEService.shouldStart {
             ModelBBLEService.shared.start(identityHash: identity.hash)
         } else {
             DiagLog.log("[BLE] Model B BLE service skipped — no explicit user opt-in")

--- a/Sources/ColumbaApp/Services/ModelBBLEService.swift
+++ b/Sources/ColumbaApp/Services/ModelBBLEService.swift
@@ -40,6 +40,20 @@ public final class ModelBBLEService: @unchecked Sendable {
         defaults.set(true, forKey: userOptInKey)
     }
 
+    static func clearUserOptIn(in defaults: UserDefaults = .standard) {
+        defaults.removeObject(forKey: userOptInKey)
+    }
+
+    /// App-wide Bluetooth authorization is not transport-specific consent. Only the
+    /// explicit onboarding or Settings action may enable the Model B BLE host.
+    static var shouldStart: Bool {
+        shouldStart(in: .standard)
+    }
+
+    static func shouldStart(in defaults: UserDefaults) -> Bool {
+        isUserOptedIn(in: defaults)
+    }
+
     private init() {}
 
     private let lock = NSLock()

--- a/Sources/ColumbaApp/ViewModels/OnboardingViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/OnboardingViewModel.swift
@@ -29,7 +29,13 @@ final class OnboardingViewModel {
     /// onboarding when `ModelBBLEService` starts — surfacing it on the Permissions page
     /// keeps it inside the flow.
     var bluetoothAuthorization: CBManagerAuthorization = CBCentralManager.authorization
-    var bluetoothGranted: Bool { bluetoothAuthorization == .allowedAlways }
+    var bluetoothGranted: Bool {
+        #if COLUMBA_RUNTIME_MODEL_B
+        bluetoothAuthorization == .allowedAlways && ModelBBLEService.isUserOptedIn
+        #else
+        bluetoothAuthorization == .allowedAlways
+        #endif
+    }
     @ObservationIgnored private var bluetoothProbe: BluetoothPermissionProbe?
     var isSaving: Bool = false
 
@@ -193,20 +199,10 @@ final class OnboardingViewModel {
 
         await settingsRepository.setDisplayName("Anonymous Peer")
 
-        // Model B: the NE node delivers over the first enabled tcpClient relay, so a
-        // skipped setup must still seed one — otherwise the node comes up with no
-        // reachable path and the user can't message anyone. (An AutoInterface-only
-        // seed is a no-op the NE ignores.)
-        let interfaceRepo = InterfaceRepository()
-        let server = TcpCommunityServer.defaultServer
-        interfaceRepo.addInterface(InterfaceEntity(
-            name: server.name,
-            type: .tcpClient,
-            config: .tcpClient(TCPClientConfig(
-                targetHost: server.host,
-                targetPort: server.port
-            ))
-        ))
+        // A skipped setup still needs the default relay, but must use the same
+        // idempotent path as normal completion. Restore can enter this method after
+        // importing interfaces, and repeated actions must not append duplicates.
+        seedInterfaces(in: InterfaceRepository())
 
         UserDefaults.standard.set(true, forKey: "has_completed_onboarding")
         UserDefaults.standard.set(true, forKey: "settings_initialized")
@@ -246,21 +242,14 @@ final class OnboardingViewModel {
         // Model B's Network Extension owns its local transports and reads one TCP relay
         // from the shared store. Seed only that relay and keep the operation idempotent.
         let server = selectedTcpServer ?? TcpCommunityServer.defaultServer
-        let alreadySeeded = repo.getEnabledInterfaces().contains { entity in
-            if case .tcpClient(let cfg) = entity.config {
-                return cfg.targetHost == server.host && cfg.targetPort == server.port
-            }
-            return false
-        }
-        guard !alreadySeeded else { return }
-        repo.addInterface(InterfaceEntity(
+        ensureInterfaceEnabled(InterfaceEntity(
             name: server.name,
             type: .tcpClient,
             config: .tcpClient(TCPClientConfig(
                 targetHost: server.host,
                 targetPort: server.port
             ))
-        ))
+        ), in: repo)
         #else
         // The shipping runtime owns these interfaces in the app process. Build a
         // canonical candidate for each selection and add it only if an equivalent
@@ -299,28 +288,34 @@ final class OnboardingViewModel {
             }
 
             guard let candidate else { continue }
-            guard !shippingInterfaceAlreadyExists(candidate, in: repo) else { continue }
-            repo.addInterface(candidate)
+            ensureInterfaceEnabled(candidate, in: repo)
         }
         #endif
     }
 
-    private func shippingInterfaceAlreadyExists(
+    /// Preserve one equivalent configuration and make sure it is enabled. Restore may
+    /// import a disabled matching record; skip/completion must reactivate that record
+    /// instead of appending a duplicate or leaving the app without a usable path.
+    private func ensureInterfaceEnabled(
         _ candidate: InterfaceEntity,
         in repo: InterfaceRepository
-    ) -> Bool {
-        repo.interfaces.contains { existing in
-            switch (existing.config, candidate.config) {
-            case (.autoInterface, .autoInterface),
-                 (.ble, .ble):
-                return true
-            case let (.tcpClient(existingConfig), .tcpClient(candidateConfig)):
-                return existingConfig.targetHost == candidateConfig.targetHost
-                    && existingConfig.targetPort == candidateConfig.targetPort
-            default:
-                return false
-            }
+    ) {
+        if repo.interfaces.contains(where: { $0.enabled && interfacesAreEquivalent($0, candidate) }) {
+            return
         }
+        if var disabled = repo.interfaces.first(where: { !$0.enabled && interfacesAreEquivalent($0, candidate) }) {
+            disabled.enabled = true
+            repo.updateInterface(disabled)
+            return
+        }
+        repo.addInterface(candidate)
+    }
+
+    private func interfacesAreEquivalent(
+        _ existing: InterfaceEntity,
+        _ candidate: InterfaceEntity
+    ) -> Bool {
+        existing.type == candidate.type && existing.config == candidate.config
     }
 }
 
@@ -389,7 +384,7 @@ enum OnboardingInterfaceType: String, CaseIterable, Hashable {
 /// (iOS prompts on first creation when authorization is `.notDetermined`) and reports
 /// the resulting authorization. Used by onboarding's Permissions page so the Model-B
 /// app-side CoreBluetooth host doesn't surprise-prompt after setup.
-private final class BluetoothPermissionProbe: NSObject, CBCentralManagerDelegate {
+final class BluetoothPermissionProbe: NSObject, CBCentralManagerDelegate {
     private var manager: CBCentralManager?
     private let onAuthorizationChange: (CBManagerAuthorization) -> Void
 

--- a/Sources/ColumbaApp/Views/Settings/SettingsView.swift
+++ b/Sources/ColumbaApp/Views/Settings/SettingsView.swift
@@ -51,6 +51,9 @@ struct SettingsView: View {
     #if COLUMBA_RUNTIME_MODEL_B
     /// Presents the background-transport explainer / enable sheet.
     @State private var showBackgroundTransport = false
+    /// Model B BLE is transport-specific consent, separate from app-wide permission.
+    @State private var modelBBLEOptedIn = ModelBBLEService.isUserOptedIn
+    @State private var modelBBLEPermissionProbe: BluetoothPermissionProbe?
     #endif
     @State private var interfaceRepository: InterfaceRepository?
     /// Persisted across body re-evaluations so showRNodeWizard=true is not lost
@@ -311,8 +314,49 @@ struct SettingsView: View {
                     .clipShape(RoundedRectangle(cornerRadius: Theme.cornerRadiusMedium))
                 }
 
+                #if COLUMBA_RUNTIME_MODEL_B
+                Divider()
+                    .padding(.vertical, 4)
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Bluetooth Mesh")
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(Theme.textPrimary)
+                    Text(modelBBLEOptedIn
+                         ? "Enabled for Model B. Changes take effect on the next app launch."
+                         : "Off. Enable only if you want Model B to scan and advertise over Bluetooth.")
+                        .font(.caption)
+                        .foregroundStyle(Theme.textSecondary)
+
+                    Button {
+                        if modelBBLEOptedIn {
+                            ModelBBLEService.clearUserOptIn()
+                            ModelBBLEService.shared.stop()
+                            modelBBLEOptedIn = false
+                        } else {
+                            ModelBBLEService.recordUserOptIn()
+                            modelBBLEOptedIn = true
+                            // Construct a permission-only probe after the explicit action;
+                            // the transport itself starts on the next app launch.
+                            modelBBLEPermissionProbe = BluetoothPermissionProbe { _ in }
+                        }
+                    } label: {
+                        Text(modelBBLEOptedIn ? "Disable Bluetooth Mesh" : "Enable Bluetooth Mesh")
+                            .font(.system(size: 15, weight: .medium))
+                            .foregroundStyle(.white)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 12)
+                            .background(modelBBLEOptedIn ? Theme.error : Theme.accentColor)
+                            .clipShape(RoundedRectangle(cornerRadius: Theme.cornerRadiusMedium))
+                    }
+                }
+                #endif
+
                 // BLE Connections Button
                 Button(action: {
+                    #if COLUMBA_RUNTIME_MODEL_B
+                    guard modelBBLEOptedIn else { return }
+                    #endif
                     showBLEConnections = true
                 }) {
                     HStack(spacing: 8) {

--- a/Tests/ColumbaAppTests/BLESeamDriverTests.swift
+++ b/Tests/ColumbaAppTests/BLESeamDriverTests.swift
@@ -38,8 +38,79 @@ final class BLESeamDriverTests: XCTestCase {
         defer { defaults.removePersistentDomain(forName: suiteName) }
 
         XCTAssertFalse(ModelBBLEService.isUserOptedIn(in: defaults))
+        XCTAssertFalse(ModelBBLEService.shouldStart(in: defaults))
+
         ModelBBLEService.recordUserOptIn(in: defaults)
         XCTAssertTrue(ModelBBLEService.isUserOptedIn(in: defaults))
+        XCTAssertTrue(ModelBBLEService.shouldStart(in: defaults))
+
+        ModelBBLEService.clearUserOptIn(in: defaults)
+        XCTAssertFalse(ModelBBLEService.isUserOptedIn(in: defaults))
+        XCTAssertFalse(ModelBBLEService.shouldStart(in: defaults))
+    }
+
+    @MainActor
+    func testModelBSeedingReenablesDisabledRelayWithoutDuplicate() throws {
+        let suiteName = "test.ModelBOnboardingInterfaces.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            return XCTFail("Could not create isolated UserDefaults suite")
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(try JSONEncoder().encode([InterfaceEntity]()), forKey: "com.columba.interfaces")
+        let repository = InterfaceRepository(userDefaults: defaults)
+        let server = TcpCommunityServer.defaultServer
+        repository.addInterface(InterfaceEntity(
+            name: server.name,
+            type: .tcpClient,
+            enabled: false,
+            config: .tcpClient(TCPClientConfig(
+                targetHost: server.host,
+                targetPort: server.port
+            ))
+        ))
+        let viewModel = OnboardingViewModel()
+        viewModel.selectedTcpServer = server
+
+        viewModel.seedInterfaces(in: repository)
+        viewModel.seedInterfaces(in: repository)
+
+        XCTAssertEqual(repository.interfaces.count, 1)
+        XCTAssertTrue(repository.interfaces[0].enabled)
+    }
+
+    @MainActor
+    func testModelBSeedingKeepsDifferentIFACRelayDisabled() throws {
+        let suiteName = "test.ModelBOnboardingIFAC.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            return XCTFail("Could not create isolated UserDefaults suite")
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(try JSONEncoder().encode([InterfaceEntity]()), forKey: "com.columba.interfaces")
+        let repository = InterfaceRepository(userDefaults: defaults)
+        let server = TcpCommunityServer.defaultServer
+        let privateRelay = InterfaceEntity(
+            name: "Private IFAC relay",
+            type: .tcpClient,
+            enabled: false,
+            config: .tcpClient(TCPClientConfig(
+                targetHost: server.host,
+                targetPort: server.port,
+                networkName: "private-network",
+                passphrase: "private-passphrase"
+            ))
+        )
+        repository.addInterface(privateRelay)
+        let viewModel = OnboardingViewModel()
+        viewModel.selectedTcpServer = server
+
+        viewModel.seedInterfaces(in: repository)
+        viewModel.seedInterfaces(in: repository)
+
+        XCTAssertEqual(repository.interfaces.count, 2)
+        XCTAssertEqual(repository.interfaces.filter(\.enabled).count, 1)
+        XCTAssertFalse(try XCTUnwrap(repository.interfaces.first { $0.id == privateRelay.id }).enabled)
     }
 
     func testDiscoveredEventFeedsStream() async throws {

--- a/Tests/ColumbaAppTests/RuntimeFlavorTests.swift
+++ b/Tests/ColumbaAppTests/RuntimeFlavorTests.swift
@@ -69,17 +69,45 @@ final class RuntimeFlavorTests: XCTestCase {
         // defaults into this isolated suite.
         defaults.set(try JSONEncoder().encode([InterfaceEntity]()), forKey: "com.columba.interfaces")
         let repository = InterfaceRepository(userDefaults: defaults)
+        let server = TcpCommunityServer.defaultServer
+        repository.addInterface(InterfaceEntity(
+            name: server.name,
+            type: .tcpClient,
+            enabled: false,
+            config: .tcpClient(TCPClientConfig(
+                targetHost: server.host,
+                targetPort: server.port
+            ))
+        ))
+        let privateAuto = InterfaceEntity(
+            name: "Private Auto",
+            type: .autoInterface,
+            enabled: false,
+            config: .autoInterface(AutoInterfaceConfig(groupId: "private-group"))
+        )
+        let scanOnlyBLE = InterfaceEntity(
+            name: "Scan-only BLE",
+            type: .ble,
+            enabled: false,
+            config: .ble(BLEConfig(advertise: false, scan: true))
+        )
+        repository.addInterface(privateAuto)
+        repository.addInterface(scanOnlyBLE)
         let viewModel = OnboardingViewModel()
         viewModel.selectedInterfaces = [.auto, .ble, .tcp]
-        viewModel.selectedTcpServer = .defaultServer
+        viewModel.selectedTcpServer = server
 
         viewModel.seedInterfaces(in: repository)
         viewModel.seedInterfaces(in: repository)
 
-        XCTAssertEqual(repository.interfaces.count, 3)
-        XCTAssertEqual(repository.interfaces.filter { $0.type == .autoInterface }.count, 1)
-        XCTAssertEqual(repository.interfaces.filter { $0.type == .ble }.count, 1)
-        XCTAssertEqual(repository.interfaces.filter { $0.type == .tcpClient }.count, 1)
+        XCTAssertEqual(repository.interfaces.count, 5)
+        XCTAssertEqual(repository.interfaces.filter { $0.type == .autoInterface }.count, 2)
+        XCTAssertEqual(repository.interfaces.filter { $0.type == .ble }.count, 2)
+        XCTAssertFalse(try XCTUnwrap(repository.interfaces.first { $0.id == privateAuto.id }).enabled)
+        XCTAssertFalse(try XCTUnwrap(repository.interfaces.first { $0.id == scanOnlyBLE.id }).enabled)
+        let tcpInterfaces = repository.interfaces.filter { $0.type == .tcpClient }
+        XCTAssertEqual(tcpInterfaces.count, 1)
+        XCTAssertTrue(tcpInterfaces[0].enabled)
     }
     #endif
 }

--- a/Tests/static/test_onboarding_interface_selection.py
+++ b/Tests/static/test_onboarding_interface_selection.py
@@ -11,6 +11,7 @@ VIEW_MODEL = ROOT / "Sources/ColumbaApp/ViewModels/OnboardingViewModel.swift"
 APP_ENTRY = ROOT / "Sources/ColumbaApp/App/ColumbaApp.swift"
 APP_SERVICES = ROOT / "Sources/ColumbaApp/Services/AppServices.swift"
 MODEL_B_BLE_SERVICE = ROOT / "Sources/ColumbaApp/Services/ModelBBLEService.swift"
+SETTINGS_VIEW = ROOT / "Sources/ColumbaApp/Views/Settings/SettingsView.swift"
 
 
 def source(path: Path) -> str:
@@ -90,22 +91,37 @@ class OnboardingInterfaceSelectionContracts(unittest.TestCase):
         service = source(MODEL_B_BLE_SERVICE)
         view_model = source(VIEW_MODEL)
         app_services = source(APP_SERVICES)
+        settings = source(SETTINGS_VIEW)
 
         self.assertIn('userOptInKey = "model_b_ble_user_opt_in"', service)
         self.assertIn("recordUserOptIn()", view_model)
+        self.assertIn("ModelBBLEService.isUserOptedIn", view_model)
+        self.assertIn("shouldStart(in:", service)
+        self.assertNotIn("CBCentralManager.authorization", service)
+        self.assertIn("ModelBBLEService.recordUserOptIn()", settings)
+        self.assertIn("ModelBBLEService.clearUserOptIn()", settings)
+        self.assertIn('Text("Bluetooth Mesh")', settings)
         start = "ModelBBLEService.shared.start(identityHash: identity.hash)"
         self.assertEqual(1, app_services.count(start))
         start_offset = app_services.index(start)
         guard_offset = app_services.rfind("if ", 0, start_offset)
         guard = app_services[guard_offset:start_offset]
-        self.assertIn("ModelBBLEService.isUserOptedIn", guard)
+        self.assertIn("ModelBBLEService.shouldStart", guard)
 
     def test_shipping_interface_creation_is_idempotent(self) -> None:
         view_model = source(VIEW_MODEL)
         method = view_model.split("private func createInterfaces(in repo: InterfaceRepository) {", 1)[1]
         shipping = method.split("#else", 1)[1].split("#endif", 1)[0]
-        self.assertIn("shippingInterfaceAlreadyExists", shipping)
-        self.assertIn("guard !shippingInterfaceAlreadyExists", shipping)
+        self.assertIn("ensureInterfaceEnabled(candidate, in: repo)", shipping)
+        self.assertIn("disabled.enabled = true", view_model)
+        self.assertIn("repo.updateInterface(disabled)", view_model)
+        self.assertIn("existing.type == candidate.type && existing.config == candidate.config", view_model)
+
+    def test_skip_and_restore_use_idempotent_interface_seeding(self) -> None:
+        view_model = source(VIEW_MODEL)
+        skip = view_model.split("func skipOnboarding(", 1)[1].split("// MARK: - Onboarding Check", 1)[0]
+        self.assertIn("seedInterfaces(in: InterfaceRepository())", skip)
+        self.assertNotIn("addInterface", skip)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- require explicit Model B transport consent from onboarding or Settings before BLE scanning/advertising
- never treat app-wide Bluetooth authorization as Model B transport consent
- provide a post-upgrade Settings control to enable or disable Bluetooth Mesh
- make skip/restore interface seeding idempotent
- re-enable only interfaces whose declared type and complete configuration match

## Validation
- shipping native tests: 116/116 passed
- Model B native tests: 14/14 passed
- portable suite: 135 tests and 233 subtests passed
- target/isolation contracts: 43 runs and 1,167 assertions passed

Supersedes PR #114. This PR contains exactly one commit: `2b4be59dfaaf9f2ef982d39a9b7b641c6948a1dd`.