### PR TITLE
fix: harden Bluetooth opt-in and interface seeding

### DIFF
--- a/Sources/ColumbaApp/Models/MigrationData.swift
+++ b/Sources/ColumbaApp/Models/MigrationData.swift
@@ -179,6 +179,9 @@ struct InterfaceExport: Codable {
     /// Interface type raw value (e.g., "TCPClient").
     let type: String
 
+    /// Interface mode raw value. Backups created before this field existed default to full.
+    let mode: String?
+
     /// Whether the interface is enabled.
     let enabled: Bool
 
@@ -187,6 +190,22 @@ struct InterfaceExport: Codable {
 
     /// Display order in the list.
     let displayOrder: Int
+
+    init(
+        name: String,
+        type: String,
+        mode: String? = nil,
+        enabled: Bool,
+        configJson: String,
+        displayOrder: Int
+    ) {
+        self.name = name
+        self.type = type
+        self.mode = mode
+        self.enabled = enabled
+        self.configJson = configJson
+        self.displayOrder = displayOrder
+    }
 }
 
 // MARK: - Settings Export
@@ -253,6 +272,7 @@ struct MigrationPreview {
 
 /// Counts of imported items after a successful import.
 struct ImportResult {
+    let preferredIdentityHash: String?
     let identitiesImported: Int
     let identitiesSkipped: Int
     let conversationsImported: Int

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -1155,9 +1155,9 @@ public final class AppServices {
 
         #if COLUMBA_RUNTIME_MODEL_B
         // Model B: CoreBluetooth lives in the app process, but it is optional. Do not
-        // construct the driver (and trigger iOS authorization) unless onboarding's
-        // Bluetooth Enable action recorded an explicit opt-in.
-        if ModelBBLEService.isUserOptedIn {
+        // construct the driver (and trigger iOS authorization) unless onboarding or
+        // Settings recorded an explicit transport opt-in.
+        if ModelBBLEService.shouldStart {
             ModelBBLEService.shared.start(identityHash: identity.hash)
         } else {
             DiagLog.log("[BLE] Model B BLE service skipped — no explicit user opt-in")
@@ -3599,6 +3599,13 @@ public final class AppServices {
 
         stateObserverTask?.cancel()
         stateObserverTask = nil
+
+        #if COLUMBA_RUNTIME_MODEL_B
+        // The BLE driver's identity hash is fixed at construction. Tear it down on every
+        // backend shutdown so identity switching cannot keep advertising the old identity;
+        // the subsequent initialize() starts a fresh driver with the new identity hash.
+        ModelBBLEService.shared.stop()
+        #endif
 
         #if os(iOS)
         // Stop call manager: ends any active CallKit call and tears down the

--- a/Sources/ColumbaApp/Services/IdentityManager.swift
+++ b/Sources/ColumbaApp/Services/IdentityManager.swift
@@ -16,6 +16,7 @@ actor IdentityManager {
     // MARK: - Constants
 
     private static let storageKey = "localIdentities"
+    private static let metadataFilename = "local-identities.json"
     static let keychainService = "com.columba.identity"
 
     private let logger = Logger(subsystem: "network.columba.Columba", category: "IdentityManager")
@@ -73,11 +74,60 @@ actor IdentityManager {
             isActive: false
         )
 
+        let previous = identities
         identities.append(local)
-        saveIdentities()
+        do {
+            try saveIdentitiesVerified()
+        } catch {
+            identities = previous
+            do {
+                try persistIdentitiesVerified(previous)
+            } catch {
+                // Keep the key if durable rollback failed: persisted metadata may still
+                // reference this identity and must never point to missing key material.
+                throw error
+            }
+            let query: [String: Any] = [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrService as String: Self.keychainService,
+                kSecAttrAccount as String: account
+            ]
+            let deleteStatus = SecItemDelete(query as CFDictionary)
+            guard deleteStatus == errSecSuccess || deleteStatus == errSecItemNotFound else {
+                throw IdentityManagerError.keychainDeleteFailed(deleteStatus)
+            }
+            throw error
+        }
 
         logger.info("Created identity '\(displayName)': \(identityHash)")
         return local
+    }
+
+    /// Register restored identity metadata through the actor that owns the live cache.
+    /// Merge storage first to preserve records written by an older importer or another
+    /// actor instance, then persist the union without replacing restored identities.
+    func importIdentityRecord(_ local: LocalIdentity) throws {
+        let previous = identities
+        var merged = Self.loadIdentities()
+        for existing in identities where !merged.contains(where: { $0.identityHash == existing.identityHash }) {
+            merged.append(existing)
+        }
+        if !merged.contains(where: { $0.identityHash == local.identityHash }) {
+            merged.append(local)
+        }
+        identities = merged
+        do {
+            try saveIdentitiesVerified()
+        } catch {
+            identities = previous
+            do {
+                try persistIdentitiesVerified(previous)
+            } catch {
+                throw error
+            }
+            throw error
+        }
+        logger.info("Registered imported identity: \(local.identityHash)")
     }
 
     // MARK: - Load Keys
@@ -113,13 +163,24 @@ actor IdentityManager {
         let identity = try loadIdentityKeys(for: hash)
 
         // Deactivate all, activate target
+        let previous = identities
         for i in identities.indices {
             identities[i].isActive = false
         }
         identities[idx].isActive = true
         identities[idx].lastUsedAt = Date().timeIntervalSince1970
 
-        saveIdentities()
+        do {
+            try saveIdentitiesVerified()
+        } catch {
+            identities = previous
+            do {
+                try persistIdentitiesVerified(previous)
+            } catch {
+                throw error
+            }
+            throw error
+        }
 
         logger.info("Switched to identity: \(hash)")
         return (identities[idx], identity)
@@ -243,13 +304,38 @@ actor IdentityManager {
     // MARK: - Persistence
 
     private static func loadIdentities() -> [LocalIdentity] {
+        let url = identityMetadataURL
+        if let data = try? Data(contentsOf: url),
+           let decoded = try? JSONDecoder().decode([LocalIdentity].self, from: data) {
+            return decoded
+        }
         guard let data = UserDefaults.standard.data(forKey: storageKey) else { return [] }
         return (try? JSONDecoder().decode([LocalIdentity].self, from: data)) ?? []
     }
 
     private func saveIdentities() {
-        guard let data = try? JSONEncoder().encode(identities) else { return }
+        try? saveIdentitiesVerified()
+    }
+
+    private func saveIdentitiesVerified() throws {
+        try persistIdentitiesVerified(identities)
+    }
+
+    private func persistIdentitiesVerified(_ snapshot: [LocalIdentity]) throws {
+        let data = try JSONEncoder().encode(snapshot)
+        let url = Self.identityMetadataURL
+        try data.write(to: url, options: .atomic)
+        let persisted = try Data(contentsOf: url)
+        guard persisted == data else {
+            throw IdentityManagerError.metadataPersistenceFailed
+        }
+        // Compatibility mirror for older builds; the atomic file is authoritative.
         UserDefaults.standard.set(data, forKey: Self.storageKey)
+    }
+
+    private static var identityMetadataURL: URL {
+        URL(fileURLWithPath: columbaDirectory, isDirectory: true)
+            .appendingPathComponent(metadataFilename, isDirectory: false)
     }
 
     // MARK: - File Paths
@@ -272,6 +358,8 @@ enum IdentityManagerError: Error, LocalizedError {
     case identityNotFound(String)
     case keychainLoadFailed(String)
     case cannotDeleteActive
+    case metadataPersistenceFailed
+    case keychainDeleteFailed(OSStatus)
 
     var errorDescription: String? {
         switch self {
@@ -281,6 +369,10 @@ enum IdentityManagerError: Error, LocalizedError {
             return "Failed to load identity keys from Keychain: \(hash)"
         case .cannotDeleteActive:
             return "Cannot delete the active identity. Switch to another identity first."
+        case .metadataPersistenceFailed:
+            return "Failed to persist restored identity metadata."
+        case .keychainDeleteFailed(let status):
+            return "Failed to roll back identity key material (Keychain status \(status))."
         }
     }
 }

--- a/Sources/ColumbaApp/Services/MigrationExporter.swift
+++ b/Sources/ColumbaApp/Services/MigrationExporter.swift
@@ -179,6 +179,7 @@ actor MigrationExporter {
             bundle.interfaces.append(InterfaceExport(
                 name: iface.name,
                 type: iface.type.rawValue,
+                mode: iface.mode.rawValue,
                 enabled: iface.enabled,
                 configJson: configJson,
                 displayOrder: iface.displayOrder

--- a/Sources/ColumbaApp/Services/MigrationImporter.swift
+++ b/Sources/ColumbaApp/Services/MigrationImporter.swift
@@ -11,6 +11,50 @@ import Foundation
 import RNSAPI
 import os.log
 
+struct ValidatedIdentityImport {
+    let export: IdentityExport
+    let identity: Identity
+    let identityHash: String
+    let destinationHash: String
+}
+
+enum MigrationIdentityValidationError: Error, LocalizedError {
+    case invalidKeyData
+    case identityHashMismatch
+    case destinationHashMismatch
+    case duplicateIdentity(String)
+    case nonCanonicalIdentityOwner(String)
+    case unknownIdentityOwner(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidKeyData:
+            return "Backup identity contains invalid private key data."
+        case .identityHashMismatch:
+            return "Backup identity hash does not match its private keys."
+        case .destinationHashMismatch:
+            return "Backup destination hash does not match its private keys."
+        case .duplicateIdentity(let hash):
+            return "Backup contains duplicate identity \(hash)."
+        case .nonCanonicalIdentityOwner(let hash):
+            return "Backup history uses a non-canonical identity hash: \(hash)."
+        case .unknownIdentityOwner(let hash):
+            return "Backup history references an identity not contained in the backup: \(hash)."
+        }
+    }
+}
+
+enum MigrationInterfaceValidationError: Error, LocalizedError {
+    case unsupportedMode(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .unsupportedMode(let mode):
+            return "Backup interface uses an unsupported mode: \(mode)."
+        }
+    }
+}
+
 /// Imports data from an encrypted .columba backup file.
 @available(macOS 14.0, iOS 17.0, *)
 actor MigrationImporter {
@@ -21,6 +65,68 @@ actor MigrationImporter {
     init(identityManager: IdentityManager, settingsRepository: SettingsRepository) {
         self.identityManager = identityManager
         self.settingsRepository = settingsRepository
+    }
+
+    /// Validate every restored identity before the importer performs any durable write.
+    /// Supplied metadata is never authoritative: hashes must be derived from key material.
+    static func validateIdentityExports(_ exports: [IdentityExport]) throws -> [ValidatedIdentityImport] {
+        var seenHashes = Set<String>()
+        return try exports.map { export in
+            guard let keyData = Data(base64Encoded: export.keyData), keyData.count == 64 else {
+                throw MigrationIdentityValidationError.invalidKeyData
+            }
+            let identity = try Identity(privateKeyBytes: keyData)
+            let identityHash = identity.hexHash.lowercased()
+            let destinationHash = Destination.hash(
+                identity: identity,
+                appName: "lxmf",
+                aspects: ["delivery"]
+            ).map { String(format: "%02x", $0) }.joined()
+
+            guard export.identityHash.lowercased() == identityHash else {
+                throw MigrationIdentityValidationError.identityHashMismatch
+            }
+            guard export.destinationHash.lowercased() == destinationHash else {
+                throw MigrationIdentityValidationError.destinationHashMismatch
+            }
+            guard seenHashes.insert(identityHash).inserted else {
+                throw MigrationIdentityValidationError.duplicateIdentity(identityHash)
+            }
+            return ValidatedIdentityImport(
+                export: export,
+                identity: identity,
+                identityHash: identityHash,
+                destinationHash: destinationHash
+            )
+        }
+    }
+
+    static func preferredIdentityHash(from identities: [ValidatedIdentityImport]) -> String? {
+        identities.first(where: { $0.export.isActive })?.identityHash
+            ?? identities.first?.identityHash
+    }
+
+    static func validateRecordOwnerHashes(
+        _ ownerHashes: [String],
+        canonicalIdentityHashes: Set<String>
+    ) throws {
+        for ownerHash in ownerHashes {
+            let canonical = ownerHash.lowercased()
+            guard ownerHash == canonical else {
+                throw MigrationIdentityValidationError.nonCanonicalIdentityOwner(ownerHash)
+            }
+            guard canonicalIdentityHashes.contains(canonical) else {
+                throw MigrationIdentityValidationError.unknownIdentityOwner(ownerHash)
+            }
+        }
+    }
+
+    static func validatedInterfaceMode(_ rawMode: String?) throws -> InterfaceMode {
+        guard let rawMode else { return .full }
+        guard let mode = InterfaceMode(rawValue: rawMode) else {
+            throw MigrationInterfaceValidationError.unsupportedMode(rawMode)
+        }
+        return mode
     }
 
     // MARK: - Format Detection
@@ -65,6 +171,13 @@ actor MigrationImporter {
     /// - Returns: Summary of imported items
     func importData(data: Data, password: String?, onProgress: @Sendable (Float) -> Void) async throws -> ImportResult {
         let bundle = try decryptAndParse(data: data, password: password)
+        let validatedIdentities = try Self.validateIdentityExports(bundle.identities)
+        let canonicalIdentityHashes = Set(validatedIdentities.map(\.identityHash))
+        try Self.validateRecordOwnerHashes(
+            bundle.conversations.map(\.identityHash) + bundle.messages.map(\.identityHash),
+            canonicalIdentityHashes: canonicalIdentityHashes
+        )
+        let validatedInterfaceModes = try bundle.interfaces.map { try Self.validatedInterfaceMode($0.mode) }
         onProgress(0.1)
 
         var identitiesImported = 0
@@ -77,50 +190,42 @@ actor MigrationImporter {
 
         // 1. Import identities
         let existingIdentities = await identityManager.getAllIdentities()
-        let existingHashes = Set(existingIdentities.map { $0.identityHash })
+        let existingHashes = Set(existingIdentities.map { $0.identityHash.lowercased() })
 
-        for export in bundle.identities {
-            if existingHashes.contains(export.identityHash) {
-                logger.info("Skipping existing identity: \(export.identityHash)")
+        for validated in validatedIdentities {
+            let export = validated.export
+            if existingHashes.contains(validated.identityHash) {
+                logger.info("Skipping existing identity: \(validated.identityHash)")
                 identitiesSkipped += 1
                 continue
             }
 
             do {
-                // Decode private key data
-                guard let keyData = Data(base64Encoded: export.keyData), keyData.count == 64 else {
-                    logger.warning("Invalid key data for identity \(export.identityHash)")
-                    continue
-                }
-
-                // Create Identity from private keys
-                let identity = try Identity(privateKeyBytes: keyData)
-
-                // Save to Keychain
-                let account = "identity-\(export.identityHash)"
-                try identity.saveToKeychain(
+                // Store and register only canonical hashes derived from private keys.
+                let account = "identity-\(validated.identityHash)"
+                try validated.identity.saveToKeychain(
                     service: IdentityManager.keychainService,
                     account: account
                 )
 
-                // Create LocalIdentity record
-                // We don't go through IdentityManager.createIdentity() because
-                // we already have the keys and don't want new ones generated
                 let local = LocalIdentity(
-                    identityHash: export.identityHash,
+                    identityHash: validated.identityHash,
                     displayName: export.displayName,
-                    destinationHash: export.destinationHash,
+                    destinationHash: validated.destinationHash,
                     createdAt: export.createdTimestamp,
                     lastUsedAt: export.lastUsedTimestamp,
                     isActive: false // Don't auto-activate imported identities
                 )
 
-                // Add to the identity manager's storage directly
-                await addIdentityRecord(local)
+                // Register through the actor-owned cache so a subsequent create/switch
+                // cannot overwrite freshly restored metadata from stale in-memory state.
+                try await identityManager.importIdentityRecord(local)
                 identitiesImported += 1
-                logger.info("Imported identity: \(export.identityHash) (\(export.displayName))")
+                logger.info("Imported identity: \(validated.identityHash) (\(export.displayName))")
             } catch {
-                logger.warning("Failed to import identity \(export.identityHash): \(error)")
+                logger.error("Failed to persist restored identity \(validated.identityHash): \(error)")
+                // History import must not continue without accessible key material and metadata.
+                throw error
             }
         }
         onProgress(0.3)
@@ -230,18 +335,14 @@ actor MigrationImporter {
         // 3. Import interfaces
         onProgress(0.7)
         let repo = InterfaceRepository()
-        let existingInterfaceNames = Set(repo.interfaces.map { "\($0.name)_\($0.type.rawValue)" })
+        var seenInterfaces = repo.interfaces
         let decoder = JSONDecoder()
 
-        for export in bundle.interfaces {
-            let key = "\(export.name)_\(export.type)"
-            if existingInterfaceNames.contains(key) {
-                continue
-            }
-
+        for (export, mode) in zip(bundle.interfaces, validatedInterfaceModes) {
             guard let ifaceType = InterfaceType(rawValue: export.type) else { continue }
 
-            // Decode config from JSON
+            // Mode was added after the initial backup format; validated legacy
+            // records default to full while explicit unsupported values fail preflight.
             guard let configData = export.configJson.data(using: .utf8),
                   let config = try? decoder.decode(InterfaceTypeConfig.self, from: configData) else {
                 continue
@@ -251,10 +352,17 @@ actor MigrationImporter {
                 name: export.name,
                 type: ifaceType,
                 enabled: export.enabled,
+                mode: mode,
                 config: config,
                 displayOrder: export.displayOrder
             )
+            if seenInterfaces.contains(where: {
+                $0.type == entity.type && $0.mode == entity.mode && $0.config == entity.config
+            }) {
+                continue
+            }
             repo.addInterface(entity)
+            seenInterfaces.append(entity)
             interfacesImported += 1
         }
         onProgress(0.8)
@@ -311,7 +419,9 @@ actor MigrationImporter {
         }
         onProgress(1.0)
 
+        let preferredIdentityHash = Self.preferredIdentityHash(from: validatedIdentities)
         let result = ImportResult(
+            preferredIdentityHash: preferredIdentityHash,
             identitiesImported: identitiesImported,
             identitiesSkipped: identitiesSkipped,
             conversationsImported: conversationsImported,
@@ -355,29 +465,6 @@ actor MigrationImporter {
         return bundle
     }
 
-    /// Add an identity record to IdentityManager's stored list.
-    ///
-    /// This bypasses the normal createIdentity flow since we already have keys.
-    private func addIdentityRecord(_ local: LocalIdentity) async {
-        // Load current identities from UserDefaults, append, and save
-        let storageKey = "localIdentities"
-        var identities: [LocalIdentity] = []
-
-        if let data = UserDefaults.standard.data(forKey: storageKey) {
-            identities = (try? JSONDecoder().decode([LocalIdentity].self, from: data)) ?? []
-        }
-
-        // Don't add duplicates
-        if identities.contains(where: { $0.identityHash == local.identityHash }) {
-            return
-        }
-
-        identities.append(local)
-
-        if let data = try? JSONEncoder().encode(identities) {
-            UserDefaults.standard.set(data, forKey: storageKey)
-        }
-    }
 }
 
 // Note: Data(hexString:) extension is defined in PropagationNodeManager.swift

--- a/Sources/ColumbaApp/Services/ModelBBLEService.swift
+++ b/Sources/ColumbaApp/Services/ModelBBLEService.swift
@@ -40,6 +40,20 @@ public final class ModelBBLEService: @unchecked Sendable {
         defaults.set(true, forKey: userOptInKey)
     }
 
+    static func clearUserOptIn(in defaults: UserDefaults = .standard) {
+        defaults.removeObject(forKey: userOptInKey)
+    }
+
+    /// App-wide Bluetooth authorization is not transport-specific consent. Only the
+    /// explicit onboarding or Settings action may enable the Model B BLE host.
+    static var shouldStart: Bool {
+        shouldStart(in: .standard)
+    }
+
+    static func shouldStart(in defaults: UserDefaults) -> Bool {
+        isUserOptedIn(in: defaults)
+    }
+
     private init() {}
 
     private let lock = NSLock()

--- a/Sources/ColumbaApp/ViewModels/MigrationViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/MigrationViewModel.swift
@@ -48,6 +48,9 @@ final class MigrationViewModel {
     }
 
     var state: MigrationState = .idle
+    private(set) var isImporting = false
+    private var activeImportGeneration: UUID?
+    private var activeExportGeneration: UUID?
 
     /// Export preview stats (loaded on appear).
     var exportPreview: ExportPreview?
@@ -103,7 +106,14 @@ final class MigrationViewModel {
 
     /// Start the export process.
     func startExport() async {
-        guard isExportPasswordValid else { return }
+        guard isExportPasswordValid, activeExportGeneration == nil else { return }
+        let generation = UUID()
+        activeExportGeneration = generation
+        defer {
+            if activeExportGeneration == generation {
+                activeExportGeneration = nil
+            }
+        }
         let password = exportPassword
         showExportPasswordSheet = false
         state = .exporting(progress: 0)
@@ -111,12 +121,15 @@ final class MigrationViewModel {
         do {
             let url = try await exporter.exportData(password: password) { [weak self] progress in
                 Task { @MainActor in
+                    guard self?.activeExportGeneration == generation else { return }
                     self?.state = .exporting(progress: progress)
                 }
             }
+            activeExportGeneration = nil
             state = .exportComplete(url: url)
             logger.info("Export complete: \(url.lastPathComponent)")
         } catch {
+            activeExportGeneration = nil
             state = .error(message: "Export failed: \(error.localizedDescription)")
             logger.error("Export failed: \(error)")
         }
@@ -176,18 +189,32 @@ final class MigrationViewModel {
     /// Confirm and execute the import.
     func confirmImport() async {
         guard let data = pendingImportData else { return }
+        guard !isImporting else { return }
+        isImporting = true
+        let generation = UUID()
+        activeImportGeneration = generation
+        defer {
+            if activeImportGeneration == generation {
+                activeImportGeneration = nil
+            }
+            isImporting = false
+        }
         let password = pendingImportPassword
         state = .importing(progress: 0)
 
         do {
             let result = try await importer.importData(data: data, password: password) { [weak self] progress in
                 Task { @MainActor in
+                    guard self?.activeImportGeneration == generation else { return }
                     self?.state = .importing(progress: progress)
                 }
             }
+            // Invalidate queued progress jobs before publishing terminal state.
+            activeImportGeneration = nil
             state = .importComplete(result: result)
             logger.info("Import complete")
         } catch {
+            activeImportGeneration = nil
             state = .error(message: "Import failed: \(error.localizedDescription)")
             logger.error("Import failed: \(error)")
         }
@@ -199,6 +226,8 @@ final class MigrationViewModel {
 
     /// Reset state back to idle.
     func reset() {
+        activeImportGeneration = nil
+        activeExportGeneration = nil
         state = .idle
         pendingImportData = nil
         pendingImportPassword = nil

--- a/Sources/ColumbaApp/ViewModels/OnboardingViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/OnboardingViewModel.swift
@@ -12,6 +12,20 @@ import Observation
 import UserNotifications
 import CoreBluetooth
 
+private enum OnboardingFlowError: LocalizedError {
+    case operationInProgress
+    case noRestoredIdentity
+
+    var errorDescription: String? {
+        switch self {
+        case .operationInProgress:
+            return "Setup is already in progress. Please wait and try again."
+        case .noRestoredIdentity:
+            return "The backup did not contain an identity that can be activated."
+        }
+    }
+}
+
 /// Manages onboarding flow state and persists selections on completion.
 @available(iOS 17.0, macOS 14.0, *)
 @Observable
@@ -29,7 +43,13 @@ final class OnboardingViewModel {
     /// onboarding when `ModelBBLEService` starts — surfacing it on the Permissions page
     /// keeps it inside the flow.
     var bluetoothAuthorization: CBManagerAuthorization = CBCentralManager.authorization
-    var bluetoothGranted: Bool { bluetoothAuthorization == .allowedAlways }
+    var bluetoothGranted: Bool {
+        #if COLUMBA_RUNTIME_MODEL_B
+        bluetoothAuthorization == .allowedAlways && ModelBBLEService.isUserOptedIn
+        #else
+        bluetoothAuthorization == .allowedAlways
+        #endif
+    }
     @ObservationIgnored private var bluetoothProbe: BluetoothPermissionProbe?
     var isSaving: Bool = false
 
@@ -115,11 +135,15 @@ final class OnboardingViewModel {
 
     /// Create the identity eagerly so the QR code is available on the complete page.
     func prepareIdentity(identityManager: IdentityManager) async {
-        guard createdIdentity == nil else { return }
+        guard qrCodeString.isEmpty else { return }
         do {
-            let local = try await identityManager.createIdentity(displayName: effectiveDisplayName)
+            try beginSaving()
+            defer { isSaving = false }
+            let local = try await createOrResumeIdentity(
+                displayName: effectiveDisplayName,
+                identityManager: identityManager
+            )
             let identity = try await identityManager.loadIdentityKeys(for: local.identityHash)
-            createdIdentity = local
 
             // Build QR string: lxma://<dest_hash>:<public_key_hex>
             let pubKeyHex = identity.publicKeys.map { String(format: "%02x", $0) }.joined()
@@ -138,16 +162,15 @@ final class OnboardingViewModel {
         identityManager: IdentityManager,
         settingsRepository: SettingsRepository
     ) async throws {
-        isSaving = true
+        try beginSaving()
         defer { isSaving = false }
 
-        // 1. Use existing identity or create one
-        let local: LocalIdentity
-        if let existing = createdIdentity {
-            local = existing
-        } else {
-            local = try await identityManager.createIdentity(displayName: effectiveDisplayName)
-        }
+        // 1. Resume the identity persisted by preparation/a prior failed activation,
+        // or create and retain one before any subsequent throwing operation.
+        let local = try await createOrResumeIdentity(
+            displayName: effectiveDisplayName,
+            identityManager: identityManager
+        )
         let _ = try await identityManager.switchToIdentity(local.identityHash)
 
         // 2. Save display name to settings
@@ -185,29 +208,47 @@ final class OnboardingViewModel {
         identityManager: IdentityManager,
         settingsRepository: SettingsRepository
     ) async throws {
-        isSaving = true
+        try beginSaving()
         defer { isSaving = false }
 
-        let local = try await identityManager.createIdentity(displayName: "Anonymous Peer")
+        let requestedName = createdIdentity?.displayName ?? "Anonymous Peer"
+        let local = try await createOrResumeIdentity(
+            displayName: requestedName,
+            identityManager: identityManager
+        )
         let _ = try await identityManager.switchToIdentity(local.identityHash)
 
-        await settingsRepository.setDisplayName("Anonymous Peer")
+        await settingsRepository.setDisplayName(local.displayName)
 
-        // Model B: the NE node delivers over the first enabled tcpClient relay, so a
-        // skipped setup must still seed one — otherwise the node comes up with no
-        // reachable path and the user can't message anyone. (An AutoInterface-only
-        // seed is a no-op the NE ignores.)
-        let interfaceRepo = InterfaceRepository()
-        let server = TcpCommunityServer.defaultServer
-        interfaceRepo.addInterface(InterfaceEntity(
-            name: server.name,
-            type: .tcpClient,
-            config: .tcpClient(TCPClientConfig(
-                targetHost: server.host,
-                targetPort: server.port
-            ))
-        ))
+        // A skipped setup always needs the canonical default relay, regardless of
+        // Connectivity-page selections. Use the shared idempotent path so repeated
+        // Skip/restore actions do not append duplicates.
+        seedDefaultTcpInterface(in: InterfaceRepository())
 
+        UserDefaults.standard.set(true, forKey: "has_completed_onboarding")
+        UserDefaults.standard.set(true, forKey: "settings_initialized")
+    }
+
+    /// Finish a restore by activating a cryptographically validated identity from the backup.
+    /// Never creates a replacement identity: a missing restored identity remains a retryable error.
+    func completeRestoredOnboarding(
+        preferredIdentityHash: String?,
+        identityManager: IdentityManager,
+        settingsRepository: SettingsRepository
+    ) async throws {
+        try beginSaving()
+        defer { isSaving = false }
+
+        guard let preferredIdentityHash,
+              let local = await identityManager.getAllIdentities().first(where: {
+                  $0.identityHash == preferredIdentityHash
+              }) else {
+            throw OnboardingFlowError.noRestoredIdentity
+        }
+        createdIdentity = local
+        let _ = try await identityManager.switchToIdentity(local.identityHash)
+        await settingsRepository.setDisplayName(local.displayName)
+        seedDefaultTcpInterface(in: InterfaceRepository())
         UserDefaults.standard.set(true, forKey: "has_completed_onboarding")
         UserDefaults.standard.set(true, forKey: "settings_initialized")
     }
@@ -232,6 +273,25 @@ final class OnboardingViewModel {
 
     // MARK: - Private
 
+    /// MainActor isolation makes this check-and-set atomic before either operation's
+    /// first suspension point, preventing duplicate identities from concurrent taps.
+    private func beginSaving() throws {
+        guard !isSaving else { throw OnboardingFlowError.operationInProgress }
+        isSaving = true
+    }
+
+    /// Identity creation persists immediately. Retain that record before key loading or
+    /// activation can throw so retries resume it rather than creating orphan duplicates.
+    private func createOrResumeIdentity(
+        displayName: String,
+        identityManager: IdentityManager
+    ) async throws -> LocalIdentity {
+        if let createdIdentity { return createdIdentity }
+        let local = try await identityManager.createIdentity(displayName: displayName)
+        createdIdentity = local
+        return local
+    }
+
     /// Seed the chosen TCP relay into the SHARED interface store. MUST run before the
     /// NE is started (on the Background-Delivery step) — the in-NE node reads its relay
     /// from this store ONCE at start (`loadTCPRelayConfig`) and has no observer to pick
@@ -241,26 +301,33 @@ final class OnboardingViewModel {
         createInterfaces(in: repo)
     }
 
-    private func createInterfaces(in repo: InterfaceRepository) {
-        #if COLUMBA_RUNTIME_MODEL_B
-        // Model B's Network Extension owns its local transports and reads one TCP relay
-        // from the shared store. Seed only that relay and keep the operation idempotent.
-        let server = selectedTcpServer ?? TcpCommunityServer.defaultServer
-        let alreadySeeded = repo.getEnabledInterfaces().contains { entity in
-            if case .tcpClient(let cfg) = entity.config {
-                return cfg.targetHost == server.host && cfg.targetPort == server.port
-            }
-            return false
-        }
-        guard !alreadySeeded else { return }
-        repo.addInterface(InterfaceEntity(
+    /// Skip is deliberately independent of mutable Connectivity-page state: it always
+    /// provides the canonical public relay and remains safe to invoke repeatedly.
+    func seedDefaultTcpInterface(in repo: InterfaceRepository = InterfaceRepository()) {
+        let server = TcpCommunityServer.defaultServer
+        ensureInterfaceEnabled(InterfaceEntity(
             name: server.name,
             type: .tcpClient,
             config: .tcpClient(TCPClientConfig(
                 targetHost: server.host,
                 targetPort: server.port
             ))
-        ))
+        ), in: repo)
+    }
+
+    private func createInterfaces(in repo: InterfaceRepository) {
+        #if COLUMBA_RUNTIME_MODEL_B
+        // Model B's Network Extension owns its local transports and reads one TCP relay
+        // from the shared store. Seed only that relay and keep the operation idempotent.
+        let server = selectedTcpServer ?? TcpCommunityServer.defaultServer
+        ensureInterfaceEnabled(InterfaceEntity(
+            name: server.name,
+            type: .tcpClient,
+            config: .tcpClient(TCPClientConfig(
+                targetHost: server.host,
+                targetPort: server.port
+            ))
+        ), in: repo)
         #else
         // The shipping runtime owns these interfaces in the app process. Build a
         // canonical candidate for each selection and add it only if an equivalent
@@ -299,28 +366,36 @@ final class OnboardingViewModel {
             }
 
             guard let candidate else { continue }
-            guard !shippingInterfaceAlreadyExists(candidate, in: repo) else { continue }
-            repo.addInterface(candidate)
+            ensureInterfaceEnabled(candidate, in: repo)
         }
         #endif
     }
 
-    private func shippingInterfaceAlreadyExists(
+    /// Preserve one equivalent configuration and make sure it is enabled. Restore may
+    /// import a disabled matching record; skip/completion must reactivate that record
+    /// instead of appending a duplicate or leaving the app without a usable path.
+    private func ensureInterfaceEnabled(
         _ candidate: InterfaceEntity,
         in repo: InterfaceRepository
-    ) -> Bool {
-        repo.interfaces.contains { existing in
-            switch (existing.config, candidate.config) {
-            case (.autoInterface, .autoInterface),
-                 (.ble, .ble):
-                return true
-            case let (.tcpClient(existingConfig), .tcpClient(candidateConfig)):
-                return existingConfig.targetHost == candidateConfig.targetHost
-                    && existingConfig.targetPort == candidateConfig.targetPort
-            default:
-                return false
-            }
+    ) {
+        if repo.interfaces.contains(where: { $0.enabled && interfacesAreEquivalent($0, candidate) }) {
+            return
         }
+        if var disabled = repo.interfaces.first(where: { !$0.enabled && interfacesAreEquivalent($0, candidate) }) {
+            disabled.enabled = true
+            repo.updateInterface(disabled)
+            return
+        }
+        repo.addInterface(candidate)
+    }
+
+    private func interfacesAreEquivalent(
+        _ existing: InterfaceEntity,
+        _ candidate: InterfaceEntity
+    ) -> Bool {
+        existing.type == candidate.type
+            && existing.mode == candidate.mode
+            && existing.config == candidate.config
     }
 }
 
@@ -389,7 +464,7 @@ enum OnboardingInterfaceType: String, CaseIterable, Hashable {
 /// (iOS prompts on first creation when authorization is `.notDetermined`) and reports
 /// the resulting authorization. Used by onboarding's Permissions page so the Model-B
 /// app-side CoreBluetooth host doesn't surprise-prompt after setup.
-private final class BluetoothPermissionProbe: NSObject, CBCentralManagerDelegate {
+final class BluetoothPermissionProbe: NSObject, CBCentralManagerDelegate {
     private var manager: CBCentralManager?
     private let onAuthorizationChange: (CBManagerAuthorization) -> Void
 

--- a/Sources/ColumbaApp/Views/Onboarding/OnboardingRestoreSheet.swift
+++ b/Sources/ColumbaApp/Views/Onboarding/OnboardingRestoreSheet.swift
@@ -13,9 +13,11 @@ import RNSAPI
 @available(iOS 17.0, macOS 14.0, *)
 struct OnboardingRestoreSheet: View {
     @Bindable var viewModel: MigrationViewModel
-    let onComplete: () -> Void
+    let onComplete: (ImportResult) async throws -> Void
 
     @Environment(\.dismiss) private var dismiss
+    @State private var isFinishing = false
+    @State private var finishErrorMessage: String?
 
     var body: some View {
         NavigationStack {
@@ -83,10 +85,29 @@ struct OnboardingRestoreSheet: View {
                         viewModel.reset()
                         dismiss()
                     }
+                    .disabled(isOperationLocked)
                 }
             }
         }
         .presentationDetents([.medium, .large])
+        .interactiveDismissDisabled(isOperationLocked)
+        .alert(
+            "Unable to Finish Setup",
+            isPresented: Binding(
+                get: { finishErrorMessage != nil },
+                set: { if !$0 { finishErrorMessage = nil } }
+            )
+        ) {
+            Button("OK", role: .cancel) {
+                finishErrorMessage = nil
+            }
+        } message: {
+            Text(finishErrorMessage ?? "Please try again.")
+        }
+    }
+
+    private var isOperationLocked: Bool {
+        isFinishing || viewModel.isImporting
     }
 
     // MARK: - Password Entry
@@ -229,16 +250,33 @@ struct OnboardingRestoreSheet: View {
             Spacer()
 
             Button {
-                onComplete()
+                guard !isFinishing else { return }
+                isFinishing = true
+                Task {
+                    defer { isFinishing = false }
+                    do {
+                        try await onComplete(result)
+                    } catch {
+                        finishErrorMessage = error.localizedDescription
+                    }
+                }
             } label: {
-                Text("Continue")
-                    .font(.headline)
+                Group {
+                    if isFinishing {
+                        ProgressView()
+                            .tint(.white)
+                    } else {
+                        Text("Continue")
+                            .font(.headline)
+                    }
+                }
                     .foregroundStyle(.white)
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 16)
                     .background(Theme.accentGradient)
                     .clipShape(RoundedRectangle(cornerRadius: 14))
             }
+            .disabled(isOperationLocked)
         }
     }
 

--- a/Sources/ColumbaApp/Views/Onboarding/OnboardingView.swift
+++ b/Sources/ColumbaApp/Views/Onboarding/OnboardingView.swift
@@ -18,6 +18,7 @@ struct OnboardingView: View {
     let onComplete: () -> Void
 
     @State private var viewModel = OnboardingViewModel()
+    @State private var skipErrorMessage: String?
     #if COLUMBA_MIGRATION_ENABLED
     @State private var showRestoreSheet = false
     @State private var migrationVM: MigrationViewModel?
@@ -31,14 +32,19 @@ struct OnboardingView: View {
                 // Skip button (pages 0-3)
                 HStack {
                     Spacer()
-                    if viewModel.currentPage < OnboardingViewModel.pageCount - 1 {
+                    if viewModel.currentPage < 4 {
                         Button {
+                            guard !viewModel.isSaving else { return }
                             Task {
-                                try? await viewModel.skipOnboarding(
-                                    identityManager: identityManager,
-                                    settingsRepository: settingsRepository
-                                )
-                                onComplete()
+                                do {
+                                    try await viewModel.skipOnboarding(
+                                        identityManager: identityManager,
+                                        settingsRepository: settingsRepository
+                                    )
+                                    onComplete()
+                                } catch {
+                                    skipErrorMessage = error.localizedDescription
+                                }
                             }
                         } label: {
                             Text("Skip")
@@ -47,6 +53,7 @@ struct OnboardingView: View {
                                 .padding(.horizontal, 16)
                                 .padding(.vertical, 8)
                         }
+                        .disabled(viewModel.isSaving)
                     }
                 }
                 .frame(height: 44)
@@ -142,6 +149,19 @@ struct OnboardingView: View {
             }
         }
         .animation(.easeInOut(duration: 0.25), value: viewModel.currentPage)
+        .alert(
+            "Unable to Skip Setup",
+            isPresented: Binding(
+                get: { skipErrorMessage != nil },
+                set: { if !$0 { skipErrorMessage = nil } }
+            )
+        ) {
+            Button("OK", role: .cancel) {
+                skipErrorMessage = nil
+            }
+        } message: {
+            Text(skipErrorMessage ?? "Please try again.")
+        }
         .task {
             await viewModel.checkNotificationStatus()
             viewModel.checkBluetoothStatus()
@@ -149,16 +169,14 @@ struct OnboardingView: View {
         #if COLUMBA_MIGRATION_ENABLED
         .sheet(isPresented: $showRestoreSheet) {
             if let vm = migrationVM {
-                OnboardingRestoreSheet(viewModel: vm) {
+                OnboardingRestoreSheet(viewModel: vm) { result in
+                    try await viewModel.completeRestoredOnboarding(
+                        preferredIdentityHash: result.preferredIdentityHash,
+                        identityManager: identityManager,
+                        settingsRepository: settingsRepository
+                    )
                     showRestoreSheet = false
-                    // Restore complete — skip onboarding and finish
-                    Task {
-                        try? await viewModel.skipOnboarding(
-                            identityManager: identityManager,
-                            settingsRepository: settingsRepository
-                        )
-                        onComplete()
-                    }
+                    onComplete()
                 }
             }
         }
@@ -179,11 +197,15 @@ struct OnboardingView: View {
             },
             onFinish: {
                 Task {
-                    try? await viewModel.completeOnboarding(
-                        identityManager: identityManager,
-                        settingsRepository: settingsRepository
-                    )
-                    onComplete()
+                    do {
+                        try await viewModel.completeOnboarding(
+                            identityManager: identityManager,
+                            settingsRepository: settingsRepository
+                        )
+                        onComplete()
+                    } catch {
+                        skipErrorMessage = error.localizedDescription
+                    }
                 }
             }
         )

--- a/Sources/ColumbaApp/Views/Settings/SettingsView.swift
+++ b/Sources/ColumbaApp/Views/Settings/SettingsView.swift
@@ -51,6 +51,9 @@ struct SettingsView: View {
     #if COLUMBA_RUNTIME_MODEL_B
     /// Presents the background-transport explainer / enable sheet.
     @State private var showBackgroundTransport = false
+    /// Model B BLE is transport-specific consent, separate from app-wide permission.
+    @State private var modelBBLEOptedIn = ModelBBLEService.isUserOptedIn
+    @State private var modelBBLEPermissionProbe: BluetoothPermissionProbe?
     #endif
     @State private var interfaceRepository: InterfaceRepository?
     /// Persisted across body re-evaluations so showRNodeWizard=true is not lost
@@ -311,8 +314,49 @@ struct SettingsView: View {
                     .clipShape(RoundedRectangle(cornerRadius: Theme.cornerRadiusMedium))
                 }
 
+                #if COLUMBA_RUNTIME_MODEL_B
+                Divider()
+                    .padding(.vertical, 4)
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Bluetooth Mesh")
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(Theme.textPrimary)
+                    Text(modelBBLEOptedIn
+                         ? "Enabled for Model B. Changes take effect on the next app launch."
+                         : "Off. Enable only if you want Model B to scan and advertise over Bluetooth.")
+                        .font(.caption)
+                        .foregroundStyle(Theme.textSecondary)
+
+                    Button {
+                        if modelBBLEOptedIn {
+                            ModelBBLEService.clearUserOptIn()
+                            ModelBBLEService.shared.stop()
+                            modelBBLEOptedIn = false
+                        } else {
+                            ModelBBLEService.recordUserOptIn()
+                            modelBBLEOptedIn = true
+                            // Construct a permission-only probe after the explicit action;
+                            // the transport itself starts on the next app launch.
+                            modelBBLEPermissionProbe = BluetoothPermissionProbe { _ in }
+                        }
+                    } label: {
+                        Text(modelBBLEOptedIn ? "Disable Bluetooth Mesh" : "Enable Bluetooth Mesh")
+                            .font(.system(size: 15, weight: .medium))
+                            .foregroundStyle(.white)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 12)
+                            .background(modelBBLEOptedIn ? Theme.error : Theme.accentColor)
+                            .clipShape(RoundedRectangle(cornerRadius: Theme.cornerRadiusMedium))
+                    }
+                }
+                #endif
+
                 // BLE Connections Button
                 Button(action: {
+                    #if COLUMBA_RUNTIME_MODEL_B
+                    guard modelBBLEOptedIn else { return }
+                    #endif
                     showBLEConnections = true
                 }) {
                     HStack(spacing: 8) {

--- a/Tests/ColumbaAppTests/BLESeamDriverTests.swift
+++ b/Tests/ColumbaAppTests/BLESeamDriverTests.swift
@@ -38,8 +38,91 @@ final class BLESeamDriverTests: XCTestCase {
         defer { defaults.removePersistentDomain(forName: suiteName) }
 
         XCTAssertFalse(ModelBBLEService.isUserOptedIn(in: defaults))
+        XCTAssertFalse(ModelBBLEService.shouldStart(in: defaults))
+
         ModelBBLEService.recordUserOptIn(in: defaults)
         XCTAssertTrue(ModelBBLEService.isUserOptedIn(in: defaults))
+        XCTAssertTrue(ModelBBLEService.shouldStart(in: defaults))
+
+        ModelBBLEService.clearUserOptIn(in: defaults)
+        XCTAssertFalse(ModelBBLEService.isUserOptedIn(in: defaults))
+        XCTAssertFalse(ModelBBLEService.shouldStart(in: defaults))
+    }
+
+    @MainActor
+    func testModelBSeedingReenablesDisabledRelayWithoutDuplicate() throws {
+        let suiteName = "test.ModelBOnboardingInterfaces.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            return XCTFail("Could not create isolated UserDefaults suite")
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(try JSONEncoder().encode([InterfaceEntity]()), forKey: "com.columba.interfaces")
+        let repository = InterfaceRepository(userDefaults: defaults)
+        let server = TcpCommunityServer.defaultServer
+        repository.addInterface(InterfaceEntity(
+            name: server.name,
+            type: .tcpClient,
+            enabled: false,
+            config: .tcpClient(TCPClientConfig(
+                targetHost: server.host,
+                targetPort: server.port
+            ))
+        ))
+        let viewModel = OnboardingViewModel()
+        viewModel.selectedTcpServer = server
+
+        viewModel.seedInterfaces(in: repository)
+        viewModel.seedInterfaces(in: repository)
+
+        XCTAssertEqual(repository.interfaces.count, 1)
+        XCTAssertTrue(repository.interfaces[0].enabled)
+    }
+
+    @MainActor
+    func testModelBSeedingKeepsDifferentIFACRelayDisabled() throws {
+        let suiteName = "test.ModelBOnboardingIFAC.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            return XCTFail("Could not create isolated UserDefaults suite")
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(try JSONEncoder().encode([InterfaceEntity]()), forKey: "com.columba.interfaces")
+        let repository = InterfaceRepository(userDefaults: defaults)
+        let server = TcpCommunityServer.defaultServer
+        let privateRelay = InterfaceEntity(
+            name: "Private IFAC relay",
+            type: .tcpClient,
+            enabled: false,
+            config: .tcpClient(TCPClientConfig(
+                targetHost: server.host,
+                targetPort: server.port,
+                networkName: "private-network",
+                passphrase: "private-passphrase"
+            ))
+        )
+        repository.addInterface(privateRelay)
+        let gatewayRelay = InterfaceEntity(
+            name: "Gateway-mode public relay",
+            type: .tcpClient,
+            enabled: false,
+            mode: .gateway,
+            config: .tcpClient(TCPClientConfig(
+                targetHost: server.host,
+                targetPort: server.port
+            ))
+        )
+        repository.addInterface(gatewayRelay)
+        let viewModel = OnboardingViewModel()
+        viewModel.selectedTcpServer = server
+
+        viewModel.seedInterfaces(in: repository)
+        viewModel.seedInterfaces(in: repository)
+
+        XCTAssertEqual(repository.interfaces.count, 3)
+        XCTAssertEqual(repository.interfaces.filter(\.enabled).count, 1)
+        XCTAssertFalse(try XCTUnwrap(repository.interfaces.first { $0.id == privateRelay.id }).enabled)
+        XCTAssertFalse(try XCTUnwrap(repository.interfaces.first { $0.id == gatewayRelay.id }).enabled)
     }
 
     func testDiscoveredEventFeedsStream() async throws {

--- a/Tests/ColumbaAppTests/MigrationRoundTripTests.swift
+++ b/Tests/ColumbaAppTests/MigrationRoundTripTests.swift
@@ -83,6 +83,7 @@ final class MigrationRoundTripTests: XCTestCase {
         let interface = InterfaceExport(
             name: "TCP Hub",
             type: "tcp_client",
+            mode: InterfaceMode.full.rawValue,
             enabled: true,
             configJson: "{\"host\":\"example\"}",
             displayOrder: 0
@@ -102,6 +103,153 @@ final class MigrationRoundTripTests: XCTestCase {
             interfaces: [interface],
             settings: settings
         )
+    }
+
+    private func makeValidatedIdentityExport(
+        identity: Identity = Identity(),
+        identityHash: String? = nil,
+        destinationHash: String? = nil,
+        isActive: Bool = false
+    ) throws -> IdentityExport {
+        let canonicalDestination = Destination.hash(
+            identity: identity,
+            appName: "lxmf",
+            aspects: ["delivery"]
+        ).map { String(format: "%02x", $0) }.joined()
+        return IdentityExport(
+            identityHash: identityHash ?? identity.hexHash,
+            displayName: "Validated Identity",
+            destinationHash: destinationHash ?? canonicalDestination,
+            keyData: try identity.exportPrivateKeys().base64EncodedString(),
+            createdTimestamp: 1_699_000_000,
+            lastUsedTimestamp: 1_700_000_000,
+            isActive: isActive,
+            iconName: nil,
+            iconForegroundColor: nil,
+            iconBackgroundColor: nil
+        )
+    }
+
+    func testIdentityRestoreValidationBindsMetadataToPrivateKeys() throws {
+        let export = try makeValidatedIdentityExport()
+        let validated = try MigrationImporter.validateIdentityExports([export])
+        XCTAssertEqual(validated.count, 1)
+        XCTAssertEqual(validated[0].identityHash, export.identityHash.lowercased())
+        XCTAssertEqual(validated[0].destinationHash, export.destinationHash.lowercased())
+    }
+
+    func testIdentityRestoreValidationRejectsIdentityHashMismatch() throws {
+        let export = try makeValidatedIdentityExport(identityHash: "00")
+        XCTAssertThrowsError(try MigrationImporter.validateIdentityExports([export])) { error in
+            guard case MigrationIdentityValidationError.identityHashMismatch = error else {
+                return XCTFail("Expected identityHashMismatch, got \(error)")
+            }
+        }
+    }
+
+    func testIdentityRestoreValidationRejectsDestinationHashMismatch() throws {
+        let export = try makeValidatedIdentityExport(destinationHash: "00")
+        XCTAssertThrowsError(try MigrationImporter.validateIdentityExports([export])) { error in
+            guard case MigrationIdentityValidationError.destinationHashMismatch = error else {
+                return XCTFail("Expected destinationHashMismatch, got \(error)")
+            }
+        }
+    }
+
+    func testIdentityRestoreValidationRejectsDuplicateHashes() throws {
+        let export = try makeValidatedIdentityExport()
+        XCTAssertThrowsError(try MigrationImporter.validateIdentityExports([export, export])) { error in
+            guard case MigrationIdentityValidationError.duplicateIdentity = error else {
+                return XCTFail("Expected duplicateIdentity, got \(error)")
+            }
+        }
+    }
+
+    func testIdentityRestoreValidationRejectsDuplicateClaimWithDifferentKeys() throws {
+        let first = try makeValidatedIdentityExport()
+        let second = try makeValidatedIdentityExport(identityHash: first.identityHash)
+        XCTAssertThrowsError(try MigrationImporter.validateIdentityExports([first, second]))
+    }
+
+    func testImportedIdentityMetadataPersistsAcrossManagerInstances() async throws {
+        let hash = "test-restore-\(UUID().uuidString.lowercased())"
+        let local = LocalIdentity(
+            identityHash: hash,
+            displayName: "Restore Persistence Test",
+            destinationHash: "destination-\(hash)",
+            createdAt: Date().timeIntervalSince1970,
+            lastUsedAt: Date().timeIntervalSince1970,
+            isActive: false
+        )
+        let manager = IdentityManager()
+        try await manager.importIdentityRecord(local)
+
+        let reloaded = IdentityManager()
+        let persisted = await reloaded.getAllIdentities()
+        XCTAssertTrue(persisted.contains(where: { $0.identityHash == hash }))
+
+        try await manager.deleteIdentity(hash)
+    }
+
+    func testRestorePrefersBackupActiveIdentityAndFallsBackToFirst() throws {
+        let first = try makeValidatedIdentityExport()
+        let active = try makeValidatedIdentityExport(isActive: true)
+        let validated = try MigrationImporter.validateIdentityExports([first, active])
+        XCTAssertEqual(
+            MigrationImporter.preferredIdentityHash(from: validated),
+            validated[1].identityHash
+        )
+        XCTAssertEqual(
+            MigrationImporter.preferredIdentityHash(from: [validated[0]]),
+            validated[0].identityHash
+        )
+        XCTAssertNil(MigrationImporter.preferredIdentityHash(from: []))
+    }
+
+    func testHistoryOwnerValidationRejectsMissingOrForeignIdentity() {
+        XCTAssertThrowsError(try MigrationImporter.validateRecordOwnerHashes(
+            ["aabbccdd"],
+            canonicalIdentityHashes: []
+        )) { error in
+            guard case MigrationIdentityValidationError.unknownIdentityOwner = error else {
+                return XCTFail("Expected unknownIdentityOwner, got \(error)")
+            }
+        }
+        XCTAssertThrowsError(try MigrationImporter.validateRecordOwnerHashes(
+            ["aabbccdd"],
+            canonicalIdentityHashes: ["11223344"]
+        ))
+    }
+
+    func testHistoryOwnerValidationRejectsUppercaseReference() {
+        XCTAssertThrowsError(try MigrationImporter.validateRecordOwnerHashes(
+            ["AABBCCDD"],
+            canonicalIdentityHashes: ["aabbccdd"]
+        )) { error in
+            guard case MigrationIdentityValidationError.nonCanonicalIdentityOwner = error else {
+                return XCTFail("Expected nonCanonicalIdentityOwner, got \(error)")
+            }
+        }
+    }
+
+    func testHistoryOwnerValidationAcceptsCanonicalBackupIdentity() throws {
+        try MigrationImporter.validateRecordOwnerHashes(
+            ["aabbccdd", "aabbccdd"],
+            canonicalIdentityHashes: ["aabbccdd"]
+        )
+    }
+
+    func testInterfaceModeValidationDefaultsOnlyMissingLegacyMode() throws {
+        XCTAssertEqual(try MigrationImporter.validatedInterfaceMode(nil), .full)
+        XCTAssertEqual(
+            try MigrationImporter.validatedInterfaceMode(InterfaceMode.gateway.rawValue),
+            .gateway
+        )
+        XCTAssertThrowsError(try MigrationImporter.validatedInterfaceMode("future-unsupported-mode")) { error in
+            guard case MigrationInterfaceValidationError.unsupportedMode = error else {
+                return XCTFail("Expected unsupportedMode, got \(error)")
+            }
+        }
     }
 
     /// Encode → encrypt → decrypt → decode must preserve every field, with
@@ -126,6 +274,7 @@ final class MigrationRoundTripTests: XCTestCase {
         XCTAssertEqual(restored.conversations.count, 1)
         XCTAssertEqual(restored.messages.count, 2)
         XCTAssertEqual(restored.interfaces.count, 1)
+        XCTAssertEqual(restored.interfaces.first?.mode, InterfaceMode.full.rawValue)
 
         // Identity survives with key material intact.
         let id = try XCTUnwrap(restored.identities.first)

--- a/Tests/ColumbaAppTests/RuntimeFlavorTests.swift
+++ b/Tests/ColumbaAppTests/RuntimeFlavorTests.swift
@@ -69,17 +69,77 @@ final class RuntimeFlavorTests: XCTestCase {
         // defaults into this isolated suite.
         defaults.set(try JSONEncoder().encode([InterfaceEntity]()), forKey: "com.columba.interfaces")
         let repository = InterfaceRepository(userDefaults: defaults)
+        let server = TcpCommunityServer.defaultServer
+        repository.addInterface(InterfaceEntity(
+            name: server.name,
+            type: .tcpClient,
+            enabled: false,
+            config: .tcpClient(TCPClientConfig(
+                targetHost: server.host,
+                targetPort: server.port
+            ))
+        ))
+        let privateAuto = InterfaceEntity(
+            name: "Private Auto",
+            type: .autoInterface,
+            enabled: false,
+            config: .autoInterface(AutoInterfaceConfig(groupId: "private-group"))
+        )
+        let scanOnlyBLE = InterfaceEntity(
+            name: "Scan-only BLE",
+            type: .ble,
+            enabled: false,
+            config: .ble(BLEConfig(advertise: false, scan: true))
+        )
+        repository.addInterface(privateAuto)
+        repository.addInterface(scanOnlyBLE)
         let viewModel = OnboardingViewModel()
         viewModel.selectedInterfaces = [.auto, .ble, .tcp]
-        viewModel.selectedTcpServer = .defaultServer
+        viewModel.selectedTcpServer = server
 
         viewModel.seedInterfaces(in: repository)
         viewModel.seedInterfaces(in: repository)
 
-        XCTAssertEqual(repository.interfaces.count, 3)
-        XCTAssertEqual(repository.interfaces.filter { $0.type == .autoInterface }.count, 1)
-        XCTAssertEqual(repository.interfaces.filter { $0.type == .ble }.count, 1)
-        XCTAssertEqual(repository.interfaces.filter { $0.type == .tcpClient }.count, 1)
+        XCTAssertEqual(repository.interfaces.count, 5)
+        XCTAssertEqual(repository.interfaces.filter { $0.type == .autoInterface }.count, 2)
+        XCTAssertEqual(repository.interfaces.filter { $0.type == .ble }.count, 2)
+        XCTAssertFalse(try XCTUnwrap(repository.interfaces.first { $0.id == privateAuto.id }).enabled)
+        XCTAssertFalse(try XCTUnwrap(repository.interfaces.first { $0.id == scanOnlyBLE.id }).enabled)
+        let tcpInterfaces = repository.interfaces.filter { $0.type == .tcpClient }
+        XCTAssertEqual(tcpInterfaces.count, 1)
+        XCTAssertTrue(tcpInterfaces[0].enabled)
+    }
+
+    @MainActor
+    func testShippingSkipAlwaysSeedsCanonicalDefaultRelay() throws {
+        let suiteName = "test.OnboardingSkipDefault.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            return XCTFail("Could not create isolated UserDefaults suite")
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(try JSONEncoder().encode([InterfaceEntity]()), forKey: "com.columba.interfaces")
+        let repository = InterfaceRepository(userDefaults: defaults)
+        let viewModel = OnboardingViewModel()
+        viewModel.selectedInterfaces = []
+        viewModel.selectedTcpServer = TcpCommunityServer(
+            name: "Custom relay",
+            host: "custom.invalid",
+            port: 4242,
+            isBootstrap: false
+        )
+
+        viewModel.seedDefaultTcpInterface(in: repository)
+        viewModel.seedDefaultTcpInterface(in: repository)
+
+        let interfaces = repository.interfaces
+        XCTAssertEqual(interfaces.count, 1)
+        guard case let .tcpClient(config) = interfaces[0].config else {
+            return XCTFail("Skip must seed a TCP client")
+        }
+        XCTAssertTrue(interfaces[0].enabled)
+        XCTAssertEqual(config.targetHost, TcpCommunityServer.defaultServer.host)
+        XCTAssertEqual(config.targetPort, TcpCommunityServer.defaultServer.port)
     }
     #endif
 }

--- a/Tests/static/test_onboarding_interface_selection.py
+++ b/Tests/static/test_onboarding_interface_selection.py
@@ -5,12 +5,19 @@ import unittest
 
 ROOT = Path(__file__).resolve().parents[2]
 ONBOARDING_VIEW = ROOT / "Sources/ColumbaApp/Views/Onboarding/OnboardingView.swift"
+RESTORE_SHEET = ROOT / "Sources/ColumbaApp/Views/Onboarding/OnboardingRestoreSheet.swift"
 CONNECTIVITY_PAGE = ROOT / "Sources/ColumbaApp/Views/Onboarding/ConnectivityPage.swift"
 PERMISSIONS_PAGE = ROOT / "Sources/ColumbaApp/Views/Onboarding/PermissionsPage.swift"
 VIEW_MODEL = ROOT / "Sources/ColumbaApp/ViewModels/OnboardingViewModel.swift"
+MIGRATION_VIEW_MODEL = ROOT / "Sources/ColumbaApp/ViewModels/MigrationViewModel.swift"
+IDENTITY_MANAGER = ROOT / "Sources/ColumbaApp/Services/IdentityManager.swift"
+MIGRATION_IMPORTER = ROOT / "Sources/ColumbaApp/Services/MigrationImporter.swift"
+MIGRATION_EXPORTER = ROOT / "Sources/ColumbaApp/Services/MigrationExporter.swift"
+MIGRATION_DATA = ROOT / "Sources/ColumbaApp/Models/MigrationData.swift"
 APP_ENTRY = ROOT / "Sources/ColumbaApp/App/ColumbaApp.swift"
 APP_SERVICES = ROOT / "Sources/ColumbaApp/Services/AppServices.swift"
 MODEL_B_BLE_SERVICE = ROOT / "Sources/ColumbaApp/Services/ModelBBLEService.swift"
+SETTINGS_VIEW = ROOT / "Sources/ColumbaApp/Views/Settings/SettingsView.swift"
 
 
 def source(path: Path) -> str:
@@ -46,6 +53,138 @@ class OnboardingInterfaceSelectionContracts(unittest.TestCase):
         text = source(ONBOARDING_VIEW)
         self.assertIn("selectedInterfaces: $viewModel.selectedInterfaces", text)
         self.assertNotIn("if viewModel.bluetoothAuthorization == .notDetermined", text)
+
+    def test_skip_completes_only_after_success_and_surfaces_failures(self) -> None:
+        text = source(ONBOARDING_VIEW)
+        skip_ui = text.split("// Skip button", 1)[1].split("// Page content", 1)[0]
+        self.assertNotIn("try?", skip_ui)
+        self.assertIn("do {", skip_ui)
+        self.assertIn("catch {", skip_ui)
+        self.assertIn("skipErrorMessage = error.localizedDescription", skip_ui)
+        self.assertIn(".disabled(viewModel.isSaving)", skip_ui)
+        self.assertLess(skip_ui.index("try await viewModel.skipOnboarding"), skip_ui.index("onComplete()"))
+        self.assertIn('"Unable to Skip Setup"', text)
+
+        restore_parent = text.split("OnboardingRestoreSheet(viewModel: vm)", 1)[1].split(
+            "#endif", 1
+        )[0]
+        self.assertNotIn("try?", restore_parent)
+        self.assertLess(
+            restore_parent.index("try await viewModel.completeRestoredOnboarding"),
+            restore_parent.index("showRestoreSheet = false"),
+        )
+        self.assertLess(
+            restore_parent.index("showRestoreSheet = false"),
+            restore_parent.index("onComplete()"),
+        )
+
+        restore_sheet = source(RESTORE_SHEET)
+        self.assertIn("let onComplete: (ImportResult) async throws -> Void", restore_sheet)
+        self.assertIn("try await onComplete(result)", restore_sheet)
+        self.assertIn("finishErrorMessage = error.localizedDescription", restore_sheet)
+        self.assertIn(".disabled(isOperationLocked)", restore_sheet)
+        self.assertIn(".interactiveDismissDisabled(isOperationLocked)", restore_sheet)
+        self.assertIn("isFinishing || viewModel.isImporting", restore_sheet)
+
+        view_model = source(VIEW_MODEL)
+        self.assertIn("guard qrCodeString.isEmpty else { return }", view_model)
+        self.assertIn("guard !isSaving else { throw OnboardingFlowError.operationInProgress }", view_model)
+        self.assertGreaterEqual(view_model.count("try beginSaving()"), 3)
+        self.assertGreaterEqual(view_model.count("createOrResumeIdentity("), 4)
+        resume = view_model.split("private func createOrResumeIdentity(", 1)[1].split(
+            "/// Seed the chosen TCP relay", 1
+        )[0]
+        self.assertLess(
+            resume.index("identityManager.createIdentity"),
+            resume.index("createdIdentity = local"),
+        )
+        self.assertLess(resume.index("createdIdentity = local"), resume.index("return local"))
+
+        finish = text.split("onFinish: {", 1)[1].split("}\n        )", 1)[0]
+        self.assertNotIn("try?", finish)
+        self.assertIn("catch {", finish)
+        self.assertIn("if viewModel.currentPage < 4", text)
+
+        migration_view_model = source(MIGRATION_VIEW_MODEL)
+        self.assertIn("guard !isImporting else { return }", migration_view_model)
+        self.assertIn("isImporting = true", migration_view_model)
+        self.assertIn("defer {", migration_view_model)
+        self.assertIn("activeImportGeneration = generation", migration_view_model)
+        self.assertIn("guard self?.activeImportGeneration == generation else { return }", migration_view_model)
+        self.assertIn("activeExportGeneration = generation", migration_view_model)
+        self.assertIn("guard self?.activeExportGeneration == generation else { return }", migration_view_model)
+        self.assertLess(
+            migration_view_model.index("activeExportGeneration = nil\n            state = .exportComplete"),
+            migration_view_model.index("state = .exportComplete"),
+        )
+        self.assertLess(
+            migration_view_model.index("activeImportGeneration = nil\n            state = .importComplete"),
+            migration_view_model.index("state = .importComplete"),
+        )
+
+        identity_manager = source(IDENTITY_MANAGER)
+        migration_importer = source(MIGRATION_IMPORTER)
+        self.assertIn("func importIdentityRecord(_ local: LocalIdentity) throws", identity_manager)
+        self.assertIn("var merged = Self.loadIdentities()", identity_manager)
+        self.assertIn("try saveIdentitiesVerified()", identity_manager)
+        self.assertIn("try persistIdentitiesVerified(previous)", identity_manager)
+        create_body = identity_manager.split("func createIdentity(displayName: String) throws", 1)[1].split(
+            "/// Register restored identity metadata", 1
+        )[0]
+        self.assertLess(
+            create_body.index("try persistIdentitiesVerified(previous)"),
+            create_body.index("SecItemDelete(query as CFDictionary)"),
+        )
+        switch_body = identity_manager.split("func switchToIdentity(_ hash: String) throws", 1)[1].split(
+            "// MARK: - Rename", 1
+        )[0]
+        self.assertIn("let previous = identities", switch_body)
+        self.assertIn("try saveIdentitiesVerified()", switch_body)
+        self.assertIn("identities = previous", switch_body)
+        self.assertIn("try data.write(to: url, options: .atomic)", identity_manager)
+        self.assertIn("let persisted = try Data(contentsOf: url)", identity_manager)
+        self.assertIn("guard persisted == data", identity_manager)
+        self.assertIn("try await identityManager.importIdentityRecord(local)", migration_importer)
+        self.assertNotIn("addIdentityRecord", migration_importer)
+        self.assertIn("identity.hexHash.lowercased()", migration_importer)
+        self.assertIn('appName: "lxmf"', migration_importer)
+        self.assertIn('aspects: ["delivery"]', migration_importer)
+        self.assertIn("seenHashes.insert(identityHash).inserted", migration_importer)
+        self.assertLess(
+            migration_importer.index("validateIdentityExports(bundle.identities)"),
+            migration_importer.index("onProgress(0.1)"),
+        )
+        self.assertIn('let account = "identity-\\(validated.identityHash)"', migration_importer)
+        self.assertLess(
+            migration_importer.index("throw error"),
+            migration_importer.index("let conversationsByIdentity"),
+        )
+        self.assertIn("first(where: { $0.export.isActive })?.identityHash", migration_importer)
+        self.assertIn("preferredIdentityHash: preferredIdentityHash", migration_importer)
+        self.assertIn("completeRestoredOnboarding(", view_model)
+        restored_completion = view_model.split("func completeRestoredOnboarding(", 1)[1].split(
+            "// MARK: - Onboarding Check", 1
+        )[0]
+        self.assertNotIn("createOrResumeIdentity", restored_completion)
+        self.assertIn("identityManager.switchToIdentity(local.identityHash)", restored_completion)
+        self.assertIn("validateRecordOwnerHashes(", migration_importer)
+        self.assertIn("canonicalIdentityHashes: canonicalIdentityHashes", migration_importer)
+        self.assertIn("var seenInterfaces = repo.interfaces", migration_importer)
+        self.assertIn("seenInterfaces.append(entity)", migration_importer)
+        self.assertIn("$0.type == entity.type && $0.mode == entity.mode && $0.config == entity.config", migration_importer)
+        self.assertIn("validatedInterfaceMode(_ rawMode: String?)", migration_importer)
+        self.assertIn("guard let rawMode else { return .full }", migration_importer)
+        self.assertIn("throw MigrationInterfaceValidationError.unsupportedMode(rawMode)", migration_importer)
+        self.assertLess(
+            migration_importer.index("let validatedInterfaceModes"),
+            migration_importer.index("onProgress(0.1)"),
+        )
+
+        migration_exporter = source(MIGRATION_EXPORTER)
+        migration_data = source(MIGRATION_DATA)
+        self.assertIn("mode: iface.mode.rawValue", migration_exporter)
+        self.assertIn("let mode: String?", migration_data)
+        self.assertIn("mode: String? = nil", migration_data)
 
     def test_shipping_interfaces_are_persisted_but_model_b_only_seeds_relay(self) -> None:
         text = source(VIEW_MODEL)
@@ -90,22 +229,49 @@ class OnboardingInterfaceSelectionContracts(unittest.TestCase):
         service = source(MODEL_B_BLE_SERVICE)
         view_model = source(VIEW_MODEL)
         app_services = source(APP_SERVICES)
+        settings = source(SETTINGS_VIEW)
 
         self.assertIn('userOptInKey = "model_b_ble_user_opt_in"', service)
         self.assertIn("recordUserOptIn()", view_model)
+        self.assertIn("ModelBBLEService.isUserOptedIn", view_model)
+        self.assertIn("shouldStart(in:", service)
+        self.assertNotIn("CBCentralManager.authorization", service)
+        self.assertIn("ModelBBLEService.recordUserOptIn()", settings)
+        self.assertIn("ModelBBLEService.clearUserOptIn()", settings)
+        self.assertIn('Text("Bluetooth Mesh")', settings)
         start = "ModelBBLEService.shared.start(identityHash: identity.hash)"
         self.assertEqual(1, app_services.count(start))
         start_offset = app_services.index(start)
         guard_offset = app_services.rfind("if ", 0, start_offset)
         guard = app_services[guard_offset:start_offset]
-        self.assertIn("ModelBBLEService.isUserOptedIn", guard)
+        self.assertIn("ModelBBLEService.shouldStart", guard)
+        shutdown = app_services.split("public func shutdown() async {", 1)[1].split(
+            "// MARK:", 1
+        )[0]
+        self.assertIn("ModelBBLEService.shared.stop()", shutdown)
 
     def test_shipping_interface_creation_is_idempotent(self) -> None:
         view_model = source(VIEW_MODEL)
         method = view_model.split("private func createInterfaces(in repo: InterfaceRepository) {", 1)[1]
         shipping = method.split("#else", 1)[1].split("#endif", 1)[0]
-        self.assertIn("shippingInterfaceAlreadyExists", shipping)
-        self.assertIn("guard !shippingInterfaceAlreadyExists", shipping)
+        self.assertIn("ensureInterfaceEnabled(candidate, in: repo)", shipping)
+        self.assertIn("disabled.enabled = true", view_model)
+        self.assertIn("repo.updateInterface(disabled)", view_model)
+        self.assertIn("existing.mode == candidate.mode", view_model)
+        self.assertIn("existing.config == candidate.config", view_model)
+
+    def test_skip_and_restore_use_idempotent_interface_seeding(self) -> None:
+        view_model = source(VIEW_MODEL)
+        skip = view_model.split("func skipOnboarding(", 1)[1].split("// MARK: - Onboarding Check", 1)[0]
+        self.assertIn("seedDefaultTcpInterface(in: InterfaceRepository())", skip)
+        self.assertNotIn("seedInterfaces(in: InterfaceRepository())", skip)
+        self.assertNotIn("addInterface", skip)
+        default_seed = view_model.split("func seedDefaultTcpInterface(", 1)[1].split(
+            "private func createInterfaces", 1
+        )[0]
+        self.assertIn("TcpCommunityServer.defaultServer", default_seed)
+        self.assertNotIn("selectedInterfaces", default_seed)
+        self.assertNotIn("selectedTcpServer", default_seed)
 
 
 if __name__ == "__main__":

--- a/Tests/static/test_task10_modelb_vpn_isolation_contract.py
+++ b/Tests/static/test_task10_modelb_vpn_isolation_contract.py
@@ -597,7 +597,7 @@ class Task10ModelBVPNIsolationContractTests(unittest.TestCase):
         self.assertEqual(1, view.count("CompletePage("), "completion UI must remain shared")
         for required_flow in (
             "await viewModel.prepareIdentity(identityManager: identityManager)",
-            "try? await viewModel.completeOnboarding(",
+            "try await viewModel.completeOnboarding(",
             "onComplete()",
         ):
             self.assertIn(required_flow, view)


### PR DESCRIPTION
## Summary
- expose only shipping-supported onboarding transports while preserving Model B isolation and explicit BLE consent
- make identity and interface setup idempotent, retry-safe, and success-only across normal, skip, and restore flows
- harden backup restore identity ownership, interface equivalence, destructive-operation locking, and progress terminal states

## Verification
- Shipping native tests: 126/126 passed
- Model B native tests: 14/14 passed
- Portable contracts: 136 tests and 233 subtests passed
- Exact immutable review: No findings
- `git diff --check` passed

## Risk / rollback
- Changes onboarding, BLE startup lifecycle, and migration restore validation.
- Roll back by reverting this single commit.