### PR TITLE
feat: improve onboarding education and setup review

### DIFF
--- a/Columba.xcodeproj/project.pbxproj
+++ b/Columba.xcodeproj/project.pbxproj
@@ -31,6 +31,8 @@
 		020 /* IdenticonGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F020 /* IdenticonGenerator.swift */; };
 		021 /* MapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F021 /* MapView.swift */; platformFilter = ios; };
 		022 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F022 /* Assets.xcassets */; };
+		C01110CA1100000000000002 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = C01110CA1100000000000001 /* Localizable.xcstrings */; };
+		C01110CA1100000000000003 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = C01110CA1100000000000001 /* Localizable.xcstrings */; };
 		0229B2C848210EE825D13B8E /* PythonBLECallbackBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF4DCA18506B96230721ACC /* PythonBLECallbackBridge.swift */; };
 		024 /* AppServices.swift in Sources */ = {isa = PBXBuildFile; fileRef = F024 /* AppServices.swift */; };
 		025 /* MessageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = F025 /* MessageRepository.swift */; };
@@ -466,6 +468,7 @@
 		F020 /* IdenticonGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdenticonGenerator.swift; sourceTree = "<group>"; };
 		F021 /* MapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapView.swift; sourceTree = "<group>"; };
 		F022 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		C01110CA1100000000000001 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		F023 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F024 /* AppServices.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppServices.swift; sourceTree = "<group>"; };
 		F025 /* MessageRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageRepository.swift; sourceTree = "<group>"; };
@@ -867,6 +870,7 @@
 			isa = PBXGroup;
 			children = (
 				F022 /* Assets.xcassets */,
+				C01110CA1100000000000001 /* Localizable.xcstrings */,
 				F023 /* Info.plist */,
 				F039 /* materialdesignicons.ttf */,
 				F075 /* ColumbaApp.entitlements */,
@@ -1274,6 +1278,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D116F7C8ADEB284C5AF41963 /* Assets.xcassets in Resources */,
+				C01110CA1100000000000003 /* Localizable.xcstrings in Resources */,
 				485B8EFF327C28C1A5F0727B /* materialdesignicons.ttf in Resources */,
 				AF6FBB2A1A52C48C0FF27494 /* JetBrainsMono-Regular.ttf in Resources */,
 				C17B4B4AD850DBC3CD27AEC0 /* JetBrainsMono-Bold.ttf in Resources */,
@@ -1293,6 +1298,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				022 /* Assets.xcassets in Resources */,
+				C01110CA1100000000000002 /* Localizable.xcstrings in Resources */,
 				039 /* materialdesignicons.ttf in Resources */,
 				67079BBC2E8309A43DF576E5 /* app in Resources */,
 				DE9220E1D4ABF9A4C2CBA761 /* JetBrainsMono-Regular.ttf in Resources */,

--- a/Sources/ColumbaApp/Resources/Localizable.xcstrings
+++ b/Sources/ColumbaApp/Resources/Localizable.xcstrings
@@ -1,0 +1,926 @@
+{
+  "sourceLanguage": "en",
+  "strings": {
+    "A relay helps your device reach Reticulum peers over the internet. It transports encrypted Reticulum traffic — it does not create an account or hold your identity. We've selected a recommended default.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A relay helps your device reach Reticulum peers over the internet. It transports encrypted Reticulum traffic — it does not create an account or hold your identity. We've selected a recommended default."
+          }
+        }
+      }
+    },
+    "Allow Columba to alert you after it receives:": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow Columba to alert you after it receives:"
+          }
+        }
+      }
+    },
+    "Allow notifications to stay informed": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow notifications to stay informed"
+          }
+        }
+      }
+    },
+    "Another Columba user can scan this public contact code to add you. It does not contain your private identity keys.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Another Columba user can scan this public contact code to add you. It does not contain your private identity keys."
+          }
+        }
+      }
+    },
+    "Apple devices only, no Wi-Fi needed": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apple devices only, no Wi-Fi needed"
+          }
+        }
+      }
+    },
+    "BLE": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BLE"
+          }
+        }
+      }
+    },
+    "Back": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Back"
+          }
+        }
+      }
+    },
+    "Background Delivery": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Background Delivery"
+          }
+        }
+      }
+    },
+    "Backup Contents": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Backup Contents"
+          }
+        }
+      }
+    },
+    "Bluetooth": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bluetooth"
+          }
+        }
+      }
+    },
+    "Bluetooth LE": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bluetooth LE"
+          }
+        }
+      }
+    },
+    "Bluetooth access is requested only if you select Bluetooth LE. RNode access is requested later during radio setup.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bluetooth access is requested only if you select Bluetooth LE. RNode access is requested later during radio setup."
+          }
+        }
+      }
+    },
+    "Cancel": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
+          }
+        }
+      }
+    },
+    "Choose a Display Name": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose a Display Name"
+          }
+        }
+      }
+    },
+    "Choose a relay": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose a relay"
+          }
+        }
+      }
+    },
+    "Close": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        }
+      }
+    },
+    "Columba creates a private cryptographic identity on your device. You control it — and can protect it with an encrypted backup.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Columba creates a private cryptographic identity on your device. You control it — and can protect it with an encrypted backup."
+          }
+        }
+      }
+    },
+    "Columba generates the private cryptographic identity. This name does not need to be unique, and you can change it anytime.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Columba generates the private cryptographic identity. This name does not need to be unique, and you can change it anytime."
+          }
+        }
+      }
+    },
+    "Columba uses Apple's VPN system to keep its own network component available in the background. It is not a commercial VPN service.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Columba uses Apple's VPN system to keep its own network component available in the background. It is not a commercial VPN service."
+          }
+        }
+      }
+    },
+    "Configure in Settings after setup": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configure in Settings after setup"
+          }
+        }
+      }
+    },
+    "Connect directly to nearby Columba devices": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connect directly to nearby Columba devices"
+          }
+        }
+      }
+    },
+    "Connect directly with nearby Apple devices": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connect directly with nearby Apple devices"
+          }
+        }
+      }
+    },
+    "Continue": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continue"
+          }
+        }
+      }
+    },
+    "Decrypt": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Decrypt"
+          }
+        }
+      }
+    },
+    "Disabled": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disabled"
+          }
+        }
+      }
+    },
+    "Done": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Done"
+          }
+        }
+      }
+    },
+    "Enable": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable"
+          }
+        }
+      }
+    },
+    "Enable Background Delivery": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable Background Delivery"
+          }
+        }
+      }
+    },
+    "Enabled": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enabled"
+          }
+        }
+      }
+    },
+    "Enter Backup Password": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter Backup Password"
+          }
+        }
+      }
+    },
+    "Existing identities and messages will not be duplicated. Conversation details and app settings may be updated from this backup.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Existing identities and messages will not be duplicated. Conversation details and app settings may be updated from this backup."
+          }
+        }
+      }
+    },
+    "Generating identity...": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Generating identity..."
+          }
+        }
+      }
+    },
+    "Get Started": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Get Started"
+          }
+        }
+      }
+    },
+    "How will you connect?": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "How will you connect?"
+          }
+        }
+      }
+    },
+    "Incorrect password. Please try again.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Incorrect password. Please try again."
+          }
+        }
+      }
+    },
+    "Internet Relay": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Internet Relay"
+          }
+        }
+      }
+    },
+    "Internet relay": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Internet relay"
+          }
+        }
+      }
+    },
+    "Internet, local, Bluetooth, and radio connections": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Internet, local, Bluetooth, and radio connections"
+          }
+        }
+      }
+    },
+    "Local Wi-Fi": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Local Wi-Fi"
+          }
+        }
+      }
+    },
+    "Long-range mesh via RNode hardware": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Long-range mesh via RNode hardware"
+          }
+        }
+      }
+    },
+    "Message Alerts": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Message Alerts"
+          }
+        }
+      }
+    },
+    "Nearby": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nearby"
+          }
+        }
+      }
+    },
+    "New messages": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New messages"
+          }
+        }
+      }
+    },
+    "No Wi-Fi required; iOS will request Bluetooth access": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Wi-Fi required; iOS will request Bluetooth access"
+          }
+        }
+      }
+    },
+    "No active identity is available.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No active identity is available."
+          }
+        }
+      }
+    },
+    "No central account or sign-up": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No central account or sign-up"
+          }
+        }
+      }
+    },
+    "No internet required; iOS may request Local Network access": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No internet required; iOS may request Local Network access"
+          }
+        }
+      }
+    },
+    "No phone number or email": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No phone number or email"
+          }
+        }
+      }
+    },
+    "Notification permission does not keep Columba connected in the background. You can change access anytime in iOS Settings.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notification permission does not keep Columba connected in the background. You can change access anytime in iOS Settings."
+          }
+        }
+      }
+    },
+    "Notifications": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notifications"
+          }
+        }
+      }
+    },
+    "OK": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        }
+      }
+    },
+    "Optional network and Bluetooth events": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Optional network and Bluetooth events"
+          }
+        }
+      }
+    },
+    "Other Public Relays": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Other Public Relays"
+          }
+        }
+      }
+    },
+    "Please try again.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Please try again."
+          }
+        }
+      }
+    },
+    "Private messaging without a central account": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Private messaging without a central account"
+          }
+        }
+      }
+    },
+    "RNode": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RNode"
+          }
+        }
+      }
+    },
+    "RNode Radio": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RNode Radio"
+          }
+        }
+      }
+    },
+    "Reach Reticulum devices on the same network": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reach Reticulum devices on the same network"
+          }
+        }
+      }
+    },
+    "Reach Reticulum peers through a public relay": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reach Reticulum peers through a public relay"
+          }
+        }
+      }
+    },
+    "Reading backup...": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reading backup..."
+          }
+        }
+      }
+    },
+    "Recommended Relays": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recommended Relays"
+          }
+        }
+      }
+    },
+    "Recommended for getting started; requires internet": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recommended for getting started; requires internet"
+          }
+        }
+      }
+    },
+    "Relay server": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relay server"
+          }
+        }
+      }
+    },
+    "Reopen onboarding without deleting your identity or messages.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reopen onboarding without deleting your identity or messages."
+          }
+        }
+      }
+    },
+    "Restore Backup": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restore Backup"
+          }
+        }
+      }
+    },
+    "Restore Complete!": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restore Complete!"
+          }
+        }
+      }
+    },
+    "Restore Data": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restore Data"
+          }
+        }
+      }
+    },
+    "Restore from backup": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restore from backup"
+          }
+        }
+      }
+    },
+    "Review Setup Guide": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Review Setup Guide"
+          }
+        }
+      }
+    },
+    "Select Server": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select Server"
+          }
+        }
+      }
+    },
+    "Select at least one connection method to continue.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select at least one connection method to continue."
+          }
+        }
+      }
+    },
+    "Select one or more. You can change these later.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select one or more. You can change these later."
+          }
+        }
+      }
+    },
+    "Share Your Identity": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share Your Identity"
+          }
+        }
+      }
+    },
+    "Share your QR code with another Columba user, then create an encrypted backup from Settings.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share your QR code with another Columba user, then create an encrypted backup from Settings."
+          }
+        }
+      }
+    },
+    "Show QR Code": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show QR Code"
+          }
+        }
+      }
+    },
+    "Show alerts for received messages and events": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show alerts for received messages and events"
+          }
+        }
+      }
+    },
+    "The indicator means iOS has an active network extension. It stays visible while Background Delivery is enabled.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The indicator means iOS has an active network extension. It stays visible while Background Delivery is enabled."
+          }
+        }
+      }
+    },
+    "The indicator means iOS has an active network extension. It stays visible while Background Transport is enabled.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The indicator means iOS has an active network extension. It stays visible while Background Transport is enabled."
+          }
+        }
+      }
+    },
+    "This backup is encrypted. Enter the password used when creating it.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This backup is encrypted. Enter the password used when creating it."
+          }
+        }
+      }
+    },
+    "This is the changeable name other people will see.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This is the changeable name other people will see."
+          }
+        }
+      }
+    },
+    "Try Again": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Try Again"
+          }
+        }
+      }
+    },
+    "Unable to Open Setup": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to Open Setup"
+          }
+        }
+      }
+    },
+    "Use Defaults": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use Defaults"
+          }
+        }
+      }
+    },
+    "VPN": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VPN"
+          }
+        }
+      }
+    },
+    "Welcome to Columba": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Welcome to Columba"
+          }
+        }
+      }
+    },
+    "While this is on, iOS shows a VPN indicator.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "While this is on, iOS shows a VPN indicator."
+          }
+        }
+      }
+    },
+    "Wi-Fi": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wi-Fi"
+          }
+        }
+      }
+    },
+    "You can choose another relay later in Settings.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You can choose another relay later in Settings."
+          }
+        }
+      }
+    },
+    "You're all set!": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You're all set!"
+          }
+        }
+      }
+    },
+    "iOS Notifications": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iOS Notifications"
+          }
+        }
+      }
+    },
+    "iOS uses its VPN system to let Columba's network component continue running when the app is not open. Only traffic from Columba and Reticulum uses this component; your other apps and web traffic are not routed through Columba.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iOS uses its VPN system to let Columba's network component continue running when the app is not open. Only traffic from Columba and Reticulum uses this component; your other apps and web traffic are not routed through Columba."
+          }
+        }
+      }
+    },
+    "iOS will ask you to allow the configuration and will show a VPN indicator while Background Delivery is enabled. Delivery still depends on available Reticulum connections.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iOS will ask you to allow the configuration and will show a VPN indicator while Background Delivery is enabled. Delivery still depends on available Reticulum connections."
+          }
+        }
+      }
+    }
+  },
+  "version": "1.0"
+}

--- a/Sources/ColumbaApp/Resources/Localizable.xcstrings
+++ b/Sources/ColumbaApp/Resources/Localizable.xcstrings
@@ -920,6 +920,33 @@
           }
         }
       }
+    },
+    "Your Display Name": {
+      "comment": "Read-only heading shown while reviewing an existing setup."
+    },
+    "Current relay": {
+      "comment": "Read-only heading for the relay shown during setup review."
+    },
+    "This is the relay currently configured for Columba. You can change it later in Settings.": {
+      "comment": "Explains that setup review does not edit the relay."
+    },
+    "Current connections": {
+      "comment": "Read-only heading for connection methods shown during setup review."
+    },
+    "This setup review is read-only. Change connection methods in Settings.": {
+      "comment": "Explains where connection methods can be edited."
+    },
+    "Setup Guide Reviewed": {
+      "comment": "Heading after completing a read-only setup review."
+    },
+    "iOS Notification Permission": {
+      "comment": "Label for the operating-system notification authorization status."
+    },
+    "Allowed": {
+      "comment": "Status indicating an iOS permission is allowed."
+    },
+    "Not Allowed": {
+      "comment": "Status indicating an iOS permission is not allowed."
     }
   },
   "version": "1.0"

--- a/Sources/ColumbaApp/ViewModels/OnboardingViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/OnboardingViewModel.swift
@@ -199,6 +199,11 @@ final class OnboardingViewModel {
         try beginSaving()
         defer { isSaving = false }
 
+        // Settings exposes this flow as a non-destructive setup review. The pages
+        // are read-only in that mode, and finishing must not rewrite identity,
+        // notification, or interface preferences from presentation state.
+        guard !isReviewingExistingSetup else { return }
+
         // 1. Resume the identity persisted by preparation/a prior failed activation,
         // or create and retain one before any subsequent throwing operation.
         let local = try await createOrResumeIdentity(
@@ -206,10 +211,6 @@ final class OnboardingViewModel {
             identityManager: identityManager
         )
         let _ = try await identityManager.switchToIdentity(local.identityHash)
-
-        if isReviewingExistingSetup && local.displayName != effectiveDisplayName {
-            await identityManager.renameIdentity(local.identityHash, newName: effectiveDisplayName)
-        }
 
         // 2. Save display name to settings
         await settingsRepository.setDisplayName(effectiveDisplayName)

--- a/Sources/ColumbaApp/ViewModels/OnboardingViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/OnboardingViewModel.swift
@@ -52,11 +52,45 @@ final class OnboardingViewModel {
     }
     @ObservationIgnored private var bluetoothProbe: BluetoothPermissionProbe?
     var isSaving: Bool = false
+    /// True when Settings reopens onboarding around the already-active identity.
+    /// Review mode must never create a second identity merely to preview the flow.
+    let isReviewingExistingSetup: Bool
 
     /// Identity created during onboarding (set by prepareIdentity).
     var createdIdentity: LocalIdentity?
     /// QR code string for the created identity.
     var qrCodeString: String = ""
+
+    init(existingIdentity: LocalIdentity? = nil, interfaceRepository: InterfaceRepository? = nil) {
+        isReviewingExistingSetup = existingIdentity != nil
+        if let existingIdentity {
+            displayName = existingIdentity.displayName
+            createdIdentity = existingIdentity
+
+            let repo = interfaceRepository ?? InterfaceRepository()
+            let enabled = repo.getEnabledInterfaces()
+            selectedInterfaces = Set(enabled.compactMap { entity -> OnboardingInterfaceType? in
+                switch entity.type {
+                case .autoInterface: return .auto
+                case .ble: return .ble
+                case .tcpClient: return .tcp
+                case .rnode: return .rnode
+                default: return nil
+                }
+            })
+            if let tcp = enabled.first(where: { $0.type == .tcpClient }),
+               case .tcpClient(let config) = tcp.config {
+                selectedTcpServer = TcpCommunityServer.servers.first {
+                    $0.host == config.targetHost && $0.port == config.targetPort
+                } ?? TcpCommunityServer(
+                    name: tcp.name,
+                    host: config.targetHost,
+                    port: config.targetPort,
+                    isBootstrap: false
+                )
+            }
+        }
+    }
 
     /// Total number of onboarding pages.
     #if COLUMBA_RUNTIME_MODEL_B
@@ -172,6 +206,10 @@ final class OnboardingViewModel {
             identityManager: identityManager
         )
         let _ = try await identityManager.switchToIdentity(local.identityHash)
+
+        if isReviewingExistingSetup && local.displayName != effectiveDisplayName {
+            await identityManager.renameIdentity(local.identityHash, newName: effectiveDisplayName)
+        }
 
         // 2. Save display name to settings
         await settingsRepository.setDisplayName(effectiveDisplayName)
@@ -441,20 +479,20 @@ enum OnboardingInterfaceType: String, CaseIterable, Hashable {
 
     var description: String {
         switch self {
-        case .auto: return "Discover peers on your local network"
+        case .auto: return "Reach Reticulum devices on the same network"
         case .nearby: return "Connect directly with nearby Apple devices"
-        case .ble: return "Connect directly to nearby devices"
-        case .tcp: return "Connect to the global Reticulum network"
+        case .ble: return "Connect directly to nearby Columba devices"
+        case .tcp: return "Reach Reticulum peers through a public relay"
         case .rnode: return "Long-range mesh via RNode hardware"
         }
     }
 
     var subtitle: String {
         switch self {
-        case .auto: return "No internet required"
+        case .auto: return "No internet required; iOS may request Local Network access"
         case .nearby: return "Apple devices only, no WiFi needed"
-        case .ble: return "Requires Bluetooth permissions"
-        case .tcp: return "Requires internet connection"
+        case .ble: return "No Wi-Fi required; iOS will request Bluetooth access"
+        case .tcp: return "Recommended for getting started; requires internet"
         case .rnode: return "Configure in Settings after setup"
         }
     }

--- a/Sources/ColumbaApp/ViewModels/OnboardingViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/OnboardingViewModel.swift
@@ -449,21 +449,21 @@ enum OnboardingInterfaceType: String, CaseIterable, Hashable {
 
     var title: String {
         switch self {
-        case .auto: return "Local WiFi"
-        case .nearby: return "Nearby"
-        case .ble: return "Bluetooth LE"
-        case .tcp: return "Internet (TCP)"
-        case .rnode: return "LoRa Radio"
+        case .auto: return String(localized: "Local Wi-Fi")
+        case .nearby: return String(localized: "Nearby")
+        case .ble: return String(localized: "Bluetooth LE")
+        case .tcp: return String(localized: "Internet Relay")
+        case .rnode: return String(localized: "RNode Radio")
         }
     }
 
     var shortName: String {
         switch self {
-        case .auto: return "WiFi"
-        case .nearby: return "Nearby"
-        case .ble: return "BLE"
-        case .tcp: return "TCP"
-        case .rnode: return "LoRa"
+        case .auto: return String(localized: "Wi-Fi")
+        case .nearby: return String(localized: "Nearby")
+        case .ble: return String(localized: "BLE")
+        case .tcp: return String(localized: "Internet relay")
+        case .rnode: return String(localized: "RNode")
         }
     }
 
@@ -479,21 +479,21 @@ enum OnboardingInterfaceType: String, CaseIterable, Hashable {
 
     var description: String {
         switch self {
-        case .auto: return "Reach Reticulum devices on the same network"
-        case .nearby: return "Connect directly with nearby Apple devices"
-        case .ble: return "Connect directly to nearby Columba devices"
-        case .tcp: return "Reach Reticulum peers through a public relay"
-        case .rnode: return "Long-range mesh via RNode hardware"
+        case .auto: return String(localized: "Reach Reticulum devices on the same network")
+        case .nearby: return String(localized: "Connect directly with nearby Apple devices")
+        case .ble: return String(localized: "Connect directly to nearby Columba devices")
+        case .tcp: return String(localized: "Reach Reticulum peers through a public relay")
+        case .rnode: return String(localized: "Long-range mesh via RNode hardware")
         }
     }
 
     var subtitle: String {
         switch self {
-        case .auto: return "No internet required; iOS may request Local Network access"
-        case .nearby: return "Apple devices only, no WiFi needed"
-        case .ble: return "No Wi-Fi required; iOS will request Bluetooth access"
-        case .tcp: return "Recommended for getting started; requires internet"
-        case .rnode: return "Configure in Settings after setup"
+        case .auto: return String(localized: "No internet required; iOS may request Local Network access")
+        case .nearby: return String(localized: "Apple devices only, no Wi-Fi needed")
+        case .ble: return String(localized: "No Wi-Fi required; iOS will request Bluetooth access")
+        case .tcp: return String(localized: "Recommended for getting started; requires internet")
+        case .rnode: return String(localized: "Configure in Settings after setup")
         }
     }
 }

--- a/Sources/ColumbaApp/Views/Components/BackgroundVPNExplainer.swift
+++ b/Sources/ColumbaApp/Views/Components/BackgroundVPNExplainer.swift
@@ -81,7 +81,7 @@ struct VPNBadgeExplainer: View {
 @available(iOS 17.0, macOS 14.0, *)
 @MainActor
 enum VPNExplainerUI {
-    static func sectionHeader(icon: String, title: String) -> some View {
+    static func sectionHeader(icon: String, title: LocalizedStringKey) -> some View {
         HStack(spacing: 8) {
             Image(systemName: icon)
                 .font(.system(size: 16, weight: .semibold))
@@ -93,7 +93,7 @@ enum VPNExplainerUI {
         }
     }
 
-    static func explainerRow(icon: String, text: String) -> some View {
+    static func explainerRow(icon: String, text: LocalizedStringKey) -> some View {
         HStack(alignment: .top, spacing: 12) {
             Image(systemName: icon)
                 .font(.system(size: 16))

--- a/Sources/ColumbaApp/Views/Components/BackgroundVPNExplainer.swift
+++ b/Sources/ColumbaApp/Views/Components/BackgroundVPNExplainer.swift
@@ -24,18 +24,18 @@ struct VPNNotCommercialExplainer: View {
         VStack(alignment: .leading, spacing: 10) {
             VPNExplainerUI.sectionHeader(icon: "lock.shield.fill", title: "Not a commercial VPN")
 
-            Text("Columba uses Apple's VPN mechanism only as the way to run a background packet tunnel for the mesh. It is not a commercial VPN service.")
+            Text("Columba uses Apple's VPN system to keep its own network component available in the background. It is not a commercial VPN service.")
                 .font(.caption)
                 .foregroundStyle(Theme.textSecondary)
                 .fixedSize(horizontal: false, vertical: true)
 
             VPNExplainerUI.explainerRow(
                 icon: "checkmark.shield.fill",
-                text: "Your internet traffic is not proxied, routed through, or monetized by Columba."
+                text: "Your other apps and web traffic are not proxied or routed through Columba."
             )
             VPNExplainerUI.explainerRow(
                 icon: "iphone",
-                text: "The tunnel runs entirely on your device to carry Reticulum traffic. Nothing else is intercepted."
+                text: "The component carries Columba and Reticulum traffic, which may use the relay and interfaces you configured."
             )
         }
     }
@@ -50,7 +50,7 @@ struct VPNBadgeExplainer: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
-            VPNExplainerUI.sectionHeader(icon: "rectangle.topthird.inset.filled", title: "The VPN badge")
+            VPNExplainerUI.sectionHeader(icon: "rectangle.topthird.inset.filled", title: "The VPN indicator")
 
             HStack(spacing: 10) {
                 Text("VPN")
@@ -61,13 +61,13 @@ struct VPNBadgeExplainer: View {
                     .background(Theme.accentColor)
                     .clipShape(RoundedRectangle(cornerRadius: 4))
 
-                Text("While this is on, iOS shows a VPN badge in your status bar.")
+                Text("While this is on, iOS shows a VPN indicator.")
                     .font(.subheadline)
                     .foregroundStyle(Theme.textPrimary)
                     .fixedSize(horizontal: false, vertical: true)
             }
 
-            Text("The badge is iOS telling you a packet tunnel is active. It stays visible the whole time \(featureName) is enabled.")
+            Text("The indicator means iOS has an active network extension. It stays visible while \(featureName) is enabled.")
                 .font(.caption)
                 .foregroundStyle(Theme.textSecondary)
                 .fixedSize(horizontal: false, vertical: true)

--- a/Sources/ColumbaApp/Views/Onboarding/BackgroundDeliveryGateView.swift
+++ b/Sources/ColumbaApp/Views/Onboarding/BackgroundDeliveryGateView.swift
@@ -48,7 +48,7 @@ struct BackgroundDeliveryGateView: View {
                         .foregroundStyle(Theme.textPrimary)
                         .multilineTextAlignment(.center)
 
-                    Text("Columba runs a small on-device VPN so it can keep delivering and receiving your messages in the background — even when the app is closed. Your traffic isn't sent to any server; the tunnel only powers Columba's own network node on your device.")
+                    Text("iOS uses its VPN system to let Columba's network component continue running when the app is not open. Only traffic from Columba and Reticulum uses this component; your other apps and web traffic are not routed through Columba.")
                         .font(.subheadline)
                         .foregroundStyle(Theme.textSecondary)
                         .multilineTextAlignment(.center)
@@ -87,7 +87,7 @@ struct BackgroundDeliveryGateView: View {
                 .disabled(isWorking)
                 .padding(.horizontal, 24)
 
-                Text("iOS will ask you to allow the VPN configuration. Columba can't deliver messages in the background without it.")
+                Text("iOS will ask you to allow the configuration and will show a VPN indicator while Background Delivery is enabled. Delivery still depends on available Reticulum connections.")
                     .font(.caption2)
                     .foregroundStyle(Theme.textSecondary)
                     .multilineTextAlignment(.center)

--- a/Sources/ColumbaApp/Views/Onboarding/BackgroundDeliveryPage.swift
+++ b/Sources/ColumbaApp/Views/Onboarding/BackgroundDeliveryPage.swift
@@ -53,7 +53,7 @@ struct BackgroundDeliveryPage: View {
                         .foregroundStyle(.white)
                         .padding(.bottom, 8)
 
-                    Text("Columba runs a small on-device VPN so it can keep delivering and receiving your messages in the background — even when the app is closed. Your traffic isn't sent to any server; the tunnel only powers Columba's own network node on your device.")
+                    Text("iOS uses its VPN system to let Columba's network component continue running when the app is not open. Only traffic from Columba and Reticulum uses this component; your other apps and web traffic are not routed through Columba.")
                         .font(.subheadline)
                         .foregroundStyle(Theme.textSecondary)
                         .multilineTextAlignment(.center)
@@ -73,7 +73,7 @@ struct BackgroundDeliveryPage: View {
                             .padding(.bottom, 8)
                     }
 
-                    Text("iOS will ask you to allow the VPN configuration. Columba can't deliver messages in the background without it.")
+                    Text("iOS will ask you to allow the configuration and will show a VPN indicator while Background Delivery is enabled. Delivery still depends on available Reticulum connections.")
                         .font(.caption2)
                         .foregroundStyle(Theme.textSecondary)
                         .multilineTextAlignment(.center)

--- a/Sources/ColumbaApp/Views/Onboarding/BackgroundDeliveryPage.swift
+++ b/Sources/ColumbaApp/Views/Onboarding/BackgroundDeliveryPage.swift
@@ -23,6 +23,8 @@ import SwiftUI
 
 @available(iOS 17.0, macOS 14.0, *)
 struct BackgroundDeliveryPage: View {
+    /// Setup review is educational only and must not install or restart the tunnel.
+    let isReadOnly: Bool
     /// Performs the enable (create+share identity, install+start tunnel, wait for
     /// connect). Returns success; advancing to the next page is the caller's job on
     /// `true`.
@@ -106,7 +108,15 @@ struct BackgroundDeliveryPage: View {
                             ProgressView()
                                 .progressViewStyle(CircularProgressViewStyle(tint: .white))
                         }
-                        Text(isWorking ? "Connecting…" : (errorMessage == nil ? "Enable" : "Try Again"))
+                        if isReadOnly {
+                            Text("Continue")
+                        } else if isWorking {
+                            Text("Connecting…")
+                        } else if errorMessage == nil {
+                            Text("Enable")
+                        } else {
+                            Text("Try Again")
+                        }
                     }
                     .font(.headline)
                     .foregroundStyle(.white)

--- a/Sources/ColumbaApp/Views/Onboarding/CompletePage.swift
+++ b/Sources/ColumbaApp/Views/Onboarding/CompletePage.swift
@@ -92,6 +92,12 @@ struct CompletePage: View {
             }
             .padding(.bottom, 8)
 
+            Text("Share your QR code with another Columba user, then create an encrypted backup from Settings.")
+                .font(.footnote)
+                .foregroundStyle(Theme.textSecondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
+
             Spacer()
 
             // Finish buttons
@@ -174,7 +180,7 @@ struct CompletePage: View {
                             .clipShape(RoundedRectangle(cornerRadius: 8))
                     }
 
-                    Text("Scan this code to add you as a contact")
+                    Text("Another Columba user can scan this public contact code to add you. It does not contain your private identity keys.")
                         .font(.subheadline)
                         .foregroundStyle(Theme.textSecondary)
                         .multilineTextAlignment(.center)

--- a/Sources/ColumbaApp/Views/Onboarding/CompletePage.swift
+++ b/Sources/ColumbaApp/Views/Onboarding/CompletePage.swift
@@ -15,6 +15,7 @@ struct CompletePage: View {
     let displayName: String
     let interfaceNames: String
     let notificationsGranted: Bool
+    let isReviewOnly: Bool
     let isSaving: Bool
     let selectedRNode: Bool
     let identityManager: IdentityManager
@@ -33,7 +34,13 @@ struct CompletePage: View {
                 .foregroundStyle(Theme.success)
                 .padding(.bottom, 24)
 
-            Text("You're all set!")
+            Group {
+                if isReviewOnly {
+                    Text("Setup Guide Reviewed")
+                } else {
+                    Text("You're all set!")
+                }
+            }
                 .font(.system(size: 28, weight: .bold))
                 .foregroundStyle(.white)
                 .padding(.bottom, 24)
@@ -50,7 +57,13 @@ struct CompletePage: View {
                         .foregroundStyle(Theme.accentColor)
                         .frame(width: 24)
 
-                    Text("Notifications")
+                    Group {
+                        if isReviewOnly {
+                            Text("iOS Notification Permission")
+                        } else {
+                            Text("Notifications")
+                        }
+                    }
                         .font(.subheadline)
                         .foregroundStyle(Theme.textSecondary)
 
@@ -60,12 +73,22 @@ struct CompletePage: View {
                         HStack(spacing: 4) {
                             Image(systemName: "checkmark")
                                 .font(.caption2.bold())
-                            Text("Enabled")
+                            if isReviewOnly {
+                                Text("Allowed")
+                            } else {
+                                Text("Enabled")
+                            }
                         }
                         .font(.subheadline)
                         .foregroundStyle(Theme.success)
                     } else {
-                        Text("Disabled")
+                        Group {
+                            if isReviewOnly {
+                                Text("Not Allowed")
+                            } else {
+                                Text("Disabled")
+                            }
+                        }
                             .font(.subheadline)
                             .foregroundStyle(Theme.textDisabled)
                     }
@@ -108,7 +131,13 @@ struct CompletePage: View {
                             ProgressView()
                                 .tint(.white)
                         } else {
-                            Text(selectedRNode ? "Configure LoRa Radio" : "Start Messaging")
+                            if isReviewOnly {
+                                Text("Done")
+                            } else if selectedRNode {
+                                Text("Configure LoRa Radio")
+                            } else {
+                                Text("Start Messaging")
+                            }
                         }
                     }
                     .font(.headline)

--- a/Sources/ColumbaApp/Views/Onboarding/CompletePage.swift
+++ b/Sources/ColumbaApp/Views/Onboarding/CompletePage.swift
@@ -157,39 +157,39 @@ struct CompletePage: View {
 
     private var qrCodeSheet: some View {
         NavigationStack {
-            VStack(spacing: 20) {
-                Spacer()
+            ScrollView {
+                VStack(spacing: 20) {
+                    Text("Share Your Identity")
+                        .font(.title2.bold())
+                        .foregroundStyle(.white)
 
-                Text("Share Your Identity")
-                    .font(.title2.bold())
-                    .foregroundStyle(.white)
+                    if qrCodeString.isEmpty {
+                        ProgressView()
+                            .tint(Theme.accentColor)
+                        Text("Generating identity...")
+                            .font(.subheadline)
+                            .foregroundStyle(Theme.textSecondary)
+                    } else {
+                        if let cgImage = Self.generateQRCode(from: qrCodeString) {
+                            Image(decorative: cgImage, scale: 1)
+                                .interpolation(.none)
+                                .resizable()
+                                .scaledToFit()
+                                .frame(width: 200, height: 200)
+                                .clipShape(RoundedRectangle(cornerRadius: 8))
+                        }
 
-                if qrCodeString.isEmpty {
-                    ProgressView()
-                        .tint(Theme.accentColor)
-                    Text("Generating identity...")
-                        .font(.subheadline)
-                        .foregroundStyle(Theme.textSecondary)
-                } else {
-                    if let cgImage = Self.generateQRCode(from: qrCodeString) {
-                        Image(decorative: cgImage, scale: 1)
-                            .interpolation(.none)
-                            .resizable()
-                            .scaledToFit()
-                            .frame(width: 200, height: 200)
-                            .clipShape(RoundedRectangle(cornerRadius: 8))
+                        Text("Another Columba user can scan this public contact code to add you. It does not contain your private identity keys.")
+                            .font(.subheadline)
+                            .foregroundStyle(Theme.textSecondary)
+                            .multilineTextAlignment(.center)
+                            .fixedSize(horizontal: false, vertical: true)
                     }
-
-                    Text("Another Columba user can scan this public contact code to add you. It does not contain your private identity keys.")
-                        .font(.subheadline)
-                        .foregroundStyle(Theme.textSecondary)
-                        .multilineTextAlignment(.center)
-                        .padding(.horizontal, 40)
                 }
-
-                Spacer()
+                .frame(maxWidth: .infinity)
+                .padding(.horizontal, 32)
+                .padding(.vertical, 24)
             }
-            .frame(maxWidth: .infinity)
             .background(Theme.backgroundPrimary)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -198,7 +198,7 @@ struct CompletePage: View {
                 }
             }
         }
-        .presentationDetents([.medium])
+        .presentationDetents([.large])
     }
 
     // MARK: - QR Code Generation

--- a/Sources/ColumbaApp/Views/Onboarding/ConnectivityPage.swift
+++ b/Sources/ColumbaApp/Views/Onboarding/ConnectivityPage.swift
@@ -13,6 +13,7 @@ import RNSAPI
 struct ConnectivityPage: View {
     @Binding var selectedInterfaces: Set<OnboardingInterfaceType>
     @Binding var selectedTcpServer: TcpCommunityServer?
+    let isReadOnly: Bool
     let onRequestBluetooth: () -> Void
     let onBack: () -> Void
     let onContinue: () -> Void
@@ -31,12 +32,24 @@ struct ConnectivityPage: View {
                         .foregroundStyle(Theme.accentColor)
                         .padding(.bottom, 24)
 
-                    Text("Choose a relay")
+                    Group {
+                        if isReadOnly {
+                            Text("Current relay")
+                        } else {
+                            Text("Choose a relay")
+                        }
+                    }
                         .font(.system(size: 28, weight: .bold))
                         .foregroundStyle(.white)
                         .padding(.bottom, 8)
 
-                    Text("A relay helps your device reach Reticulum peers over the internet. It transports encrypted Reticulum traffic — it does not create an account or hold your identity. We've selected a recommended default.")
+                    Group {
+                        if isReadOnly {
+                            Text("This is the relay currently configured for Columba. You can change it later in Settings.")
+                        } else {
+                            Text("A relay helps your device reach Reticulum peers over the internet. It transports encrypted Reticulum traffic — it does not create an account or hold your identity. We've selected a recommended default.")
+                        }
+                    }
                         .font(.subheadline)
                         .foregroundStyle(Theme.textSecondary)
                         .multilineTextAlignment(.center)
@@ -61,7 +74,7 @@ struct ConnectivityPage: View {
             serverPickerSheet
         }
         .onAppear {
-            if selectedTcpServer == nil {
+            if !isReadOnly && selectedTcpServer == nil {
                 selectedTcpServer = TcpCommunityServer.defaultServer
             }
         }
@@ -76,12 +89,24 @@ struct ConnectivityPage: View {
                         .foregroundStyle(Theme.accentColor)
                         .padding(.bottom, 24)
 
-                    Text("How will you connect?")
+                    Group {
+                        if isReadOnly {
+                            Text("Current connections")
+                        } else {
+                            Text("How will you connect?")
+                        }
+                    }
                         .font(.system(size: 28, weight: .bold))
                         .foregroundStyle(.white)
                         .padding(.bottom, 8)
 
-                    Text("Select one or more. You can change these later.")
+                    Group {
+                        if isReadOnly {
+                            Text("This setup review is read-only. Change connection methods in Settings.")
+                        } else {
+                            Text("Select one or more. You can change these later.")
+                        }
+                    }
                         .font(.subheadline)
                         .foregroundStyle(Theme.textSecondary)
                         .padding(.bottom, 24)
@@ -103,7 +128,7 @@ struct ConnectivityPage: View {
                             .padding(.bottom, 12)
                     }
 
-                    if selectedInterfaces.isEmpty {
+                    if !isReadOnly && selectedInterfaces.isEmpty {
                         Text("Select at least one connection method to continue.")
                             .font(.footnote.weight(.medium))
                             .foregroundStyle(Theme.warning)
@@ -127,7 +152,7 @@ struct ConnectivityPage: View {
             serverPickerSheet
         }
         .onAppear {
-            if selectedInterfaces.contains(.tcp) && selectedTcpServer == nil {
+            if !isReadOnly && selectedInterfaces.contains(.tcp) && selectedTcpServer == nil {
                 selectedTcpServer = TcpCommunityServer.defaultServer
             }
         }
@@ -190,6 +215,7 @@ struct ConnectivityPage: View {
             )
         }
         .buttonStyle(.plain)
+        .disabled(isReadOnly)
     }
 
     // MARK: - Navigation
@@ -221,8 +247,8 @@ struct ConnectivityPage: View {
                 .background(Theme.accentGradient)
                 .clipShape(RoundedRectangle(cornerRadius: 14))
             }
-            .disabled(selectedInterfaces.isEmpty)
-            .opacity(selectedInterfaces.isEmpty ? 0.5 : 1)
+            .disabled(!isReadOnly && selectedInterfaces.isEmpty)
+            .opacity(!isReadOnly && selectedInterfaces.isEmpty ? 0.5 : 1)
         }
         .padding(.horizontal, 24)
         .padding(.bottom, 16)
@@ -260,6 +286,7 @@ struct ConnectivityPage: View {
             )
         }
         .buttonStyle(.plain)
+        .disabled(isReadOnly)
     }
 
     private var serverPickerSheet: some View {

--- a/Sources/ColumbaApp/Views/Onboarding/ConnectivityPage.swift
+++ b/Sources/ColumbaApp/Views/Onboarding/ConnectivityPage.swift
@@ -36,7 +36,7 @@ struct ConnectivityPage: View {
                         .foregroundStyle(.white)
                         .padding(.bottom, 8)
 
-                    Text("Columba reaches the wider network through a community relay server. We've picked a good default — you can change it anytime in Settings.")
+                    Text("A relay helps your device reach Reticulum peers over the internet. It transports encrypted Reticulum traffic — it does not create an account or hold your identity. We've selected a recommended default.")
                         .font(.subheadline)
                         .foregroundStyle(Theme.textSecondary)
                         .multilineTextAlignment(.center)
@@ -48,7 +48,7 @@ struct ConnectivityPage: View {
                         .padding(.horizontal, 24)
                         .padding(.bottom, 12)
 
-                    Text("You can configure connectivity later in Settings")
+                    Text("You can choose another relay later in Settings.")
                         .font(.footnote)
                         .foregroundStyle(Theme.textSecondary)
                         .padding(.bottom, 16)
@@ -81,7 +81,7 @@ struct ConnectivityPage: View {
                         .foregroundStyle(.white)
                         .padding(.bottom, 8)
 
-                    Text("Select the networks you'd like to use:")
+                    Text("Select one or more. You can change these later.")
                         .font(.subheadline)
                         .foregroundStyle(Theme.textSecondary)
                         .padding(.bottom, 24)
@@ -103,7 +103,16 @@ struct ConnectivityPage: View {
                             .padding(.bottom, 12)
                     }
 
-                    Text("Bluetooth permission is requested only when you enable Bluetooth LE. RNode permission is requested later during radio setup.")
+                    if selectedInterfaces.isEmpty {
+                        Text("Select at least one connection method to continue.")
+                            .font(.footnote.weight(.medium))
+                            .foregroundStyle(Theme.warning)
+                            .multilineTextAlignment(.center)
+                            .padding(.horizontal, 32)
+                            .padding(.bottom, 8)
+                    }
+
+                    Text("Bluetooth access is requested only if you select Bluetooth LE. RNode access is requested later during radio setup.")
                         .font(.footnote)
                         .foregroundStyle(Theme.textSecondary)
                         .multilineTextAlignment(.center)
@@ -212,6 +221,8 @@ struct ConnectivityPage: View {
                 .background(Theme.accentGradient)
                 .clipShape(RoundedRectangle(cornerRadius: 14))
             }
+            .disabled(selectedInterfaces.isEmpty)
+            .opacity(selectedInterfaces.isEmpty ? 0.5 : 1)
         }
         .padding(.horizontal, 24)
         .padding(.bottom, 16)
@@ -254,12 +265,12 @@ struct ConnectivityPage: View {
     private var serverPickerSheet: some View {
         NavigationStack {
             List {
-                Section("Bootstrap Servers") {
+                Section("Recommended Relays") {
                     ForEach(TcpCommunityServer.servers.filter { $0.isBootstrap }) { server in
                         serverRow(server)
                     }
                 }
-                Section("Community Servers") {
+                Section("Other Public Relays") {
                     ForEach(TcpCommunityServer.servers.filter { !$0.isBootstrap }) { server in
                         serverRow(server)
                     }

--- a/Sources/ColumbaApp/Views/Onboarding/IdentityPage.swift
+++ b/Sources/ColumbaApp/Views/Onboarding/IdentityPage.swift
@@ -26,12 +26,12 @@ struct IdentityPage: View {
                 .foregroundStyle(Theme.accentColor)
                 .padding(.bottom, 24)
 
-            Text("Your Identity")
+            Text("Choose a Display Name")
                 .font(.system(size: 28, weight: .bold))
                 .foregroundStyle(.white)
                 .padding(.bottom, 8)
 
-            Text("Choose a display name others will see:")
+            Text("This is the changeable name other people will see.")
                 .font(.subheadline)
                 .foregroundStyle(Theme.textSecondary)
                 .padding(.bottom, 32)
@@ -52,7 +52,7 @@ struct IdentityPage: View {
                 .padding(.horizontal, 24)
                 .padding(.bottom, 12)
 
-            Text("You can change this anytime, or create multiple identities for different contexts.")
+            Text("Columba generates the private cryptographic identity. This name does not need to be unique, and you can change it anytime.")
                 .font(.footnote)
                 .foregroundStyle(Theme.textSecondary)
                 .multilineTextAlignment(.center)

--- a/Sources/ColumbaApp/Views/Onboarding/IdentityPage.swift
+++ b/Sources/ColumbaApp/Views/Onboarding/IdentityPage.swift
@@ -12,6 +12,7 @@ import RNSAPI
 @available(iOS 17.0, macOS 14.0, *)
 struct IdentityPage: View {
     @Binding var displayName: String
+    let isReadOnly: Bool
     let onBack: () -> Void
     let onContinue: () -> Void
 
@@ -26,7 +27,13 @@ struct IdentityPage: View {
                 .foregroundStyle(Theme.accentColor)
                 .padding(.bottom, 24)
 
-            Text("Choose a Display Name")
+            Group {
+                if isReadOnly {
+                    Text("Your Display Name")
+                } else {
+                    Text("Choose a Display Name")
+                }
+            }
                 .font(.system(size: 28, weight: .bold))
                 .foregroundStyle(.white)
                 .padding(.bottom, 8)
@@ -49,6 +56,7 @@ struct IdentityPage: View {
                         .stroke(isNameFocused ? Theme.accentColor : Theme.divider, lineWidth: 1)
                 )
                 .focused($isNameFocused)
+                .disabled(isReadOnly)
                 .padding(.horizontal, 24)
                 .padding(.bottom, 12)
 

--- a/Sources/ColumbaApp/Views/Onboarding/OnboardingRestoreSheet.swift
+++ b/Sources/ColumbaApp/Views/Onboarding/OnboardingRestoreSheet.swift
@@ -189,7 +189,7 @@ struct OnboardingRestoreSheet: View {
                 Image(systemName: "info.circle.fill")
                     .font(.caption)
                     .foregroundStyle(Theme.warning)
-                Text("Existing data will be preserved. Only new items will be added.")
+                Text("Existing identities and messages will not be duplicated. Conversation details and app settings may be updated from this backup.")
                     .font(.caption2)
                     .foregroundStyle(Theme.textSecondary)
             }

--- a/Sources/ColumbaApp/Views/Onboarding/OnboardingView.swift
+++ b/Sources/ColumbaApp/Views/Onboarding/OnboardingView.swift
@@ -16,23 +16,48 @@ struct OnboardingView: View {
     let settingsRepository: SettingsRepository
     let appServices: AppServices
     let onComplete: () -> Void
+    let onCancel: (() -> Void)?
 
-    @State private var viewModel = OnboardingViewModel()
+    @State private var viewModel: OnboardingViewModel
     @State private var skipErrorMessage: String?
     #if COLUMBA_MIGRATION_ENABLED
     @State private var showRestoreSheet = false
     @State private var migrationVM: MigrationViewModel?
     #endif
 
+    init(
+        identityManager: IdentityManager,
+        settingsRepository: SettingsRepository,
+        appServices: AppServices,
+        existingIdentity: LocalIdentity? = nil,
+        onCancel: (() -> Void)? = nil,
+        onComplete: @escaping () -> Void
+    ) {
+        self.identityManager = identityManager
+        self.settingsRepository = settingsRepository
+        self.appServices = appServices
+        self.onCancel = onCancel
+        self.onComplete = onComplete
+        _viewModel = State(initialValue: OnboardingViewModel(existingIdentity: existingIdentity))
+    }
+
     var body: some View {
         ZStack {
             Theme.backgroundPrimary.ignoresSafeArea()
 
             VStack(spacing: 0) {
-                // Skip button (pages 0-3)
+                // First-run setup offers explicit safe defaults. Settings review mode
+                // instead offers a mutation-free Close action on every page.
                 HStack {
                     Spacer()
-                    if viewModel.currentPage < 4 {
+                    if let onCancel {
+                        Button("Close", action: onCancel)
+                            .font(.subheadline)
+                            .foregroundStyle(Theme.textSecondary)
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 8)
+                            .disabled(viewModel.isSaving)
+                    } else if viewModel.currentPage < 4 {
                         Button {
                             guard !viewModel.isSaving else { return }
                             Task {
@@ -47,7 +72,7 @@ struct OnboardingView: View {
                                 }
                             }
                         } label: {
-                            Text("Skip")
+                            Text("Use Defaults")
                                 .font(.subheadline)
                                 .foregroundStyle(Theme.textSecondary)
                                 .padding(.horizontal, 16)
@@ -145,6 +170,11 @@ struct OnboardingView: View {
                             .frame(width: 8, height: 8)
                     }
                 }
+                .accessibilityLabel("Step \(viewModel.currentPage + 1) of \(OnboardingViewModel.pageCount)")
+                Text("Step \(viewModel.currentPage + 1) of \(OnboardingViewModel.pageCount)")
+                    .font(.caption2)
+                    .foregroundStyle(Theme.textDisabled)
+                    .padding(.top, 6)
                 .padding(.bottom, 12)
             }
         }

--- a/Sources/ColumbaApp/Views/Onboarding/OnboardingView.swift
+++ b/Sources/ColumbaApp/Views/Onboarding/OnboardingView.swift
@@ -21,8 +21,7 @@ struct OnboardingView: View {
     @State private var viewModel: OnboardingViewModel
     @State private var skipErrorMessage: String?
     #if COLUMBA_MIGRATION_ENABLED
-    @State private var showRestoreSheet = false
-    @State private var migrationVM: MigrationViewModel?
+    @State private var restoreSession: RestoreSession?
     #endif
 
     init(
@@ -96,8 +95,7 @@ struct OnboardingView: View {
                                     identityManager: identityManager,
                                     settingsRepository: settingsRepository
                                 )
-                                migrationVM = vm
-                                showRestoreSheet = true
+                                restoreSession = RestoreSession(viewModel: vm)
                                 Task { await vm.handleImportFile(data: data) }
                             }
                         )
@@ -197,21 +195,26 @@ struct OnboardingView: View {
             viewModel.checkBluetoothStatus()
         }
         #if COLUMBA_MIGRATION_ENABLED
-        .sheet(isPresented: $showRestoreSheet) {
-            if let vm = migrationVM {
-                OnboardingRestoreSheet(viewModel: vm) { result in
-                    try await viewModel.completeRestoredOnboarding(
-                        preferredIdentityHash: result.preferredIdentityHash,
-                        identityManager: identityManager,
-                        settingsRepository: settingsRepository
-                    )
-                    showRestoreSheet = false
-                    onComplete()
-                }
+        .sheet(item: $restoreSession) { session in
+            OnboardingRestoreSheet(viewModel: session.viewModel) { result in
+                try await viewModel.completeRestoredOnboarding(
+                    preferredIdentityHash: result.preferredIdentityHash,
+                    identityManager: identityManager,
+                    settingsRepository: settingsRepository
+                )
+                restoreSession = nil
+                onComplete()
             }
         }
         #endif
     }
+
+    #if COLUMBA_MIGRATION_ENABLED
+    private struct RestoreSession: Identifiable {
+        let id = UUID()
+        let viewModel: MigrationViewModel
+    }
+    #endif
 
     private var completePage: some View {
         CompletePage(

--- a/Sources/ColumbaApp/Views/Onboarding/OnboardingView.swift
+++ b/Sources/ColumbaApp/Views/Onboarding/OnboardingView.swift
@@ -88,23 +88,28 @@ struct OnboardingView: View {
                     switch viewModel.currentPage {
                     case 0:
                         #if COLUMBA_MIGRATION_ENABLED
-                        WelcomePage(
-                            onContinue: { viewModel.nextPage() },
-                            onRestoreFile: { data in
-                                let vm = MigrationViewModel(
-                                    identityManager: identityManager,
-                                    settingsRepository: settingsRepository
-                                )
-                                restoreSession = RestoreSession(viewModel: vm)
-                                Task { await vm.handleImportFile(data: data) }
-                            }
-                        )
+                        if viewModel.isReviewingExistingSetup {
+                            WelcomePage(onContinue: { viewModel.nextPage() })
+                        } else {
+                            WelcomePage(
+                                onContinue: { viewModel.nextPage() },
+                                onRestoreFile: { data in
+                                    let vm = MigrationViewModel(
+                                        identityManager: identityManager,
+                                        settingsRepository: settingsRepository
+                                    )
+                                    restoreSession = RestoreSession(viewModel: vm)
+                                    Task { await vm.handleImportFile(data: data) }
+                                }
+                            )
+                        }
                         #else
                         WelcomePage(onContinue: { viewModel.nextPage() })
                         #endif
                     case 1:
                         IdentityPage(
                             displayName: $viewModel.displayName,
+                            isReadOnly: viewModel.isReviewingExistingSetup,
                             onBack: { viewModel.previousPage() },
                             onContinue: { viewModel.nextPage() }
                         )
@@ -112,6 +117,7 @@ struct OnboardingView: View {
                         ConnectivityPage(
                             selectedInterfaces: $viewModel.selectedInterfaces,
                             selectedTcpServer: $viewModel.selectedTcpServer,
+                            isReadOnly: viewModel.isReviewingExistingSetup,
                             onRequestBluetooth: { viewModel.requestBluetoothPermission() },
                             onBack: { viewModel.previousPage() },
                             onContinue: { viewModel.nextPage() }
@@ -119,6 +125,7 @@ struct OnboardingView: View {
                     case 3:
                         PermissionsPage(
                             notificationsGranted: viewModel.notificationsGranted,
+                            isReadOnly: viewModel.isReviewingExistingSetup,
                             onRequestNotifications: {
                                 Task { await viewModel.requestNotificationPermission() }
                             },
@@ -130,7 +137,12 @@ struct OnboardingView: View {
                     #if COLUMBA_RUNTIME_MODEL_B
                     case 4:
                         BackgroundDeliveryPage(
+                            isReadOnly: viewModel.isReviewingExistingSetup,
                             onEnable: {
+                                if viewModel.isReviewingExistingSetup {
+                                    viewModel.nextPage()
+                                    return true
+                                }
                                 // Create the identity now (idempotent) so the NE can
                                 // load it from the shared keychain, activate it, then
                                 // bring the tunnel up. Only advance on success.
@@ -221,6 +233,7 @@ struct OnboardingView: View {
             displayName: viewModel.effectiveDisplayName,
             interfaceNames: viewModel.selectedInterfaceNames,
             notificationsGranted: viewModel.notificationsGranted,
+            isReviewOnly: viewModel.isReviewingExistingSetup,
             isSaving: viewModel.isSaving,
             selectedRNode: viewModel.selectedInterfaces.contains(.rnode),
             identityManager: identityManager,
@@ -229,6 +242,10 @@ struct OnboardingView: View {
                 await viewModel.prepareIdentity(identityManager: identityManager)
             },
             onFinish: {
+                if viewModel.isReviewingExistingSetup {
+                    onCancel?()
+                    return
+                }
                 Task {
                     do {
                         try await viewModel.completeOnboarding(

--- a/Sources/ColumbaApp/Views/Onboarding/PermissionsPage.swift
+++ b/Sources/ColumbaApp/Views/Onboarding/PermissionsPage.swift
@@ -12,6 +12,7 @@ import RNSAPI
 @available(iOS 17.0, macOS 14.0, *)
 struct PermissionsPage: View {
     let notificationsGranted: Bool
+    let isReadOnly: Bool
     let onRequestNotifications: () -> Void
     let bluetoothGranted: Bool
     let onRequestBluetooth: () -> Void
@@ -67,14 +68,20 @@ struct PermissionsPage: View {
                         .font(.system(size: 24))
                         .foregroundStyle(Theme.success)
                 } else {
-                    Button(action: onRequestNotifications) {
-                        Text("Enable")
+                    if isReadOnly {
+                        Text("Not Allowed")
                             .font(.subheadline.bold())
-                            .foregroundStyle(.white)
-                            .padding(.horizontal, 16)
-                            .padding(.vertical, 8)
-                            .background(Theme.accentColor)
-                            .clipShape(RoundedRectangle(cornerRadius: 8))
+                            .foregroundStyle(Theme.textDisabled)
+                    } else {
+                        Button(action: onRequestNotifications) {
+                            Text("Enable")
+                                .font(.subheadline.bold())
+                                .foregroundStyle(.white)
+                                .padding(.horizontal, 16)
+                                .padding(.vertical, 8)
+                                .background(Theme.accentColor)
+                                .clipShape(RoundedRectangle(cornerRadius: 8))
+                        }
                     }
                 }
             }
@@ -112,14 +119,20 @@ struct PermissionsPage: View {
                         .font(.system(size: 24))
                         .foregroundStyle(Theme.success)
                 } else {
-                    Button(action: onRequestBluetooth) {
-                        Text("Enable")
+                    if isReadOnly {
+                        Text("Not Allowed")
                             .font(.subheadline.bold())
-                            .foregroundStyle(.white)
-                            .padding(.horizontal, 16)
-                            .padding(.vertical, 8)
-                            .background(Theme.accentColor)
-                            .clipShape(RoundedRectangle(cornerRadius: 8))
+                            .foregroundStyle(Theme.textDisabled)
+                    } else {
+                        Button(action: onRequestBluetooth) {
+                            Text("Enable")
+                                .font(.subheadline.bold())
+                                .foregroundStyle(.white)
+                                .padding(.horizontal, 16)
+                                .padding(.vertical, 8)
+                                .background(Theme.accentColor)
+                                .clipShape(RoundedRectangle(cornerRadius: 8))
+                        }
                     }
                 }
             }

--- a/Sources/ColumbaApp/Views/Onboarding/PermissionsPage.swift
+++ b/Sources/ColumbaApp/Views/Onboarding/PermissionsPage.swift
@@ -27,20 +27,20 @@ struct PermissionsPage: View {
                 .foregroundStyle(Theme.accentColor)
                 .padding(.bottom, 24)
 
-            Text("Stay Connected")
+            Text("Message Alerts")
                 .font(.system(size: 28, weight: .bold))
                 .foregroundStyle(.white)
                 .padding(.bottom, 8)
 
-            Text("Columba can notify you when:")
+            Text("Allow Columba to alert you after it receives:")
                 .font(.subheadline)
                 .foregroundStyle(Theme.textSecondary)
                 .padding(.bottom, 24)
 
             // Notification features
             VStack(alignment: .leading, spacing: 14) {
-                notificationRow("New messages arrive")
-                notificationRow("Someone you know comes online")
+                notificationRow("New messages")
+                notificationRow("Optional network and Bluetooth events")
             }
             .padding(.horizontal, 40)
             .padding(.bottom, 32)
@@ -52,10 +52,10 @@ struct PermissionsPage: View {
                     .foregroundStyle(notificationsGranted ? Theme.success : Theme.accentColor)
 
                 VStack(alignment: .leading, spacing: 2) {
-                    Text("Push Notifications")
+                    Text("iOS Notifications")
                         .font(.system(size: 16, weight: .medium))
                         .foregroundStyle(Theme.textPrimary)
-                    Text(notificationsGranted ? "Enabled" : "Allow notifications to stay informed")
+                    Text(notificationsGranted ? "Enabled" : "Show alerts for received messages and events")
                         .font(.caption)
                         .foregroundStyle(Theme.textSecondary)
                 }
@@ -100,7 +100,7 @@ struct PermissionsPage: View {
                     Text("Bluetooth")
                         .font(.system(size: 16, weight: .medium))
                         .foregroundStyle(Theme.textPrimary)
-                    Text(bluetoothGranted ? "Enabled" : "Optional — for nearby / offline mesh")
+                    Text(bluetoothGranted ? "Enabled" : "Optional — connect to nearby devices without internet")
                         .font(.caption)
                         .foregroundStyle(Theme.textSecondary)
                 }
@@ -134,7 +134,7 @@ struct PermissionsPage: View {
             .padding(.bottom, 12)
             #endif
 
-            Text("You can change these anytime in iOS Settings")
+            Text("Notification permission does not keep Columba connected in the background. You can change access anytime in iOS Settings.")
                 .font(.footnote)
                 .foregroundStyle(Theme.textSecondary)
                 .multilineTextAlignment(.center)

--- a/Sources/ColumbaApp/Views/Onboarding/PermissionsPage.swift
+++ b/Sources/ColumbaApp/Views/Onboarding/PermissionsPage.swift
@@ -175,7 +175,7 @@ struct PermissionsPage: View {
         }
     }
 
-    private func notificationRow(_ text: String) -> some View {
+    private func notificationRow(_ text: LocalizedStringKey) -> some View {
         HStack(spacing: 12) {
             Image(systemName: "checkmark.circle")
                 .font(.system(size: 18))

--- a/Sources/ColumbaApp/Views/Onboarding/WelcomePage.swift
+++ b/Sources/ColumbaApp/Views/Onboarding/WelcomePage.swift
@@ -109,7 +109,7 @@ struct WelcomePage: View {
         #endif
     }
 
-    private func privacyRow(_ text: String, icon: String) -> some View {
+    private func privacyRow(_ text: LocalizedStringKey, icon: String) -> some View {
         HStack(spacing: 12) {
             Image(systemName: icon)
                 .font(.system(size: 20))

--- a/Sources/ColumbaApp/Views/Onboarding/WelcomePage.swift
+++ b/Sources/ColumbaApp/Views/Onboarding/WelcomePage.swift
@@ -40,21 +40,21 @@ struct WelcomePage: View {
                 .foregroundStyle(.white)
                 .padding(.bottom, 8)
 
-            Text("A private messenger that requires:")
+            Text("Private messaging without a central account")
                 .font(.subheadline)
                 .foregroundStyle(Theme.textSecondary)
                 .padding(.bottom, 24)
 
             // Privacy bullet points
             VStack(alignment: .leading, spacing: 16) {
-                privacyRow("No phone number")
-                privacyRow("No email address")
-                privacyRow("No sign-up or accounts")
+                privacyRow("No phone number or email", icon: "xmark.circle")
+                privacyRow("No central account or sign-up", icon: "xmark.circle")
+                privacyRow("Internet, local, Bluetooth, and radio connections", icon: "antenna.radiowaves.left.and.right")
             }
             .padding(.horizontal, 40)
             .padding(.bottom, 32)
 
-            Text("Your identity is generated and stored securely on your device. You control it completely.")
+            Text("Columba creates a private cryptographic identity on your device. You control it — and can protect it with an encrypted backup.")
                 .font(.footnote)
                 .foregroundStyle(Theme.textSecondary)
                 .multilineTextAlignment(.center)
@@ -109,9 +109,9 @@ struct WelcomePage: View {
         #endif
     }
 
-    private func privacyRow(_ text: String) -> some View {
+    private func privacyRow(_ text: String, icon: String) -> some View {
         HStack(spacing: 12) {
-            Image(systemName: "xmark.circle")
+            Image(systemName: icon)
                 .font(.system(size: 20))
                 .foregroundStyle(Theme.accentColor)
                 .frame(width: 24)

--- a/Sources/ColumbaApp/Views/Settings/SettingsView.swift
+++ b/Sources/ColumbaApp/Views/Settings/SettingsView.swift
@@ -48,7 +48,6 @@ struct SettingsView: View {
     @State private var showNetworkStatus = false
     @State private var showBLEConnections = false
     @State private var showDataMigration = false
-    @State private var showOnboardingReview = false
     @State private var onboardingReviewIdentity: LocalIdentity?
     @State private var onboardingReviewError: String?
     #if COLUMBA_RUNTIME_MODEL_B
@@ -200,23 +199,19 @@ struct SettingsView: View {
         .onAppear {
             viewModel?.refreshSyncState()
         }
-        .fullScreenCover(isPresented: $showOnboardingReview, onDismiss: {
-            onboardingReviewIdentity = nil
-        }) {
+        .fullScreenCover(item: $onboardingReviewIdentity) { existingIdentity in
             #if COLUMBA_ONBOARDING_ENABLED
-            if let existingIdentity = onboardingReviewIdentity {
-                OnboardingView(
-                    identityManager: identityManager,
-                    settingsRepository: settingsRepository,
-                    appServices: appServices,
-                    existingIdentity: existingIdentity,
-                    onCancel: { showOnboardingReview = false },
-                    onComplete: {
-                        showOnboardingReview = false
-                        Task { await appServices.restartPythonBackend() }
-                    }
-                )
-            }
+            OnboardingView(
+                identityManager: identityManager,
+                settingsRepository: settingsRepository,
+                appServices: appServices,
+                existingIdentity: existingIdentity,
+                onCancel: { onboardingReviewIdentity = nil },
+                onComplete: {
+                    onboardingReviewIdentity = nil
+                    Task { await appServices.restartPythonBackend() }
+                }
+            )
             #else
             EmptyView()
             #endif
@@ -1405,7 +1400,6 @@ struct SettingsView: View {
                     return
                 }
                 onboardingReviewIdentity = active
-                showOnboardingReview = true
             }
         } label: {
             HStack(spacing: 12) {

--- a/Sources/ColumbaApp/Views/Settings/SettingsView.swift
+++ b/Sources/ColumbaApp/Views/Settings/SettingsView.swift
@@ -48,6 +48,9 @@ struct SettingsView: View {
     @State private var showNetworkStatus = false
     @State private var showBLEConnections = false
     @State private var showDataMigration = false
+    @State private var showOnboardingReview = false
+    @State private var onboardingReviewIdentity: LocalIdentity?
+    @State private var onboardingReviewError: String?
     #if COLUMBA_RUNTIME_MODEL_B
     /// Presents the background-transport explainer / enable sheet.
     @State private var showBackgroundTransport = false
@@ -111,6 +114,11 @@ struct SettingsView: View {
 
                         // Data Migration
                         dataMigrationCard(vm)
+
+                        // Safe, non-destructive entry point for reviewing onboarding.
+                        #if COLUMBA_ONBOARDING_ENABLED
+                        onboardingReviewCard
+                        #endif
 
                         // Advanced section anchor — separates Transport
                         // Mode (and future advanced settings) from the
@@ -191,6 +199,38 @@ struct SettingsView: View {
         #endif
         .onAppear {
             viewModel?.refreshSyncState()
+        }
+        .fullScreenCover(isPresented: $showOnboardingReview, onDismiss: {
+            onboardingReviewIdentity = nil
+        }) {
+            #if COLUMBA_ONBOARDING_ENABLED
+            if let existingIdentity = onboardingReviewIdentity {
+                OnboardingView(
+                    identityManager: identityManager,
+                    settingsRepository: settingsRepository,
+                    appServices: appServices,
+                    existingIdentity: existingIdentity,
+                    onCancel: { showOnboardingReview = false },
+                    onComplete: {
+                        showOnboardingReview = false
+                        Task { await appServices.restartPythonBackend() }
+                    }
+                )
+            }
+            #else
+            EmptyView()
+            #endif
+        }
+        .alert(
+            "Unable to Open Setup",
+            isPresented: Binding(
+                get: { onboardingReviewError != nil },
+                set: { if !$0 { onboardingReviewError = nil } }
+            )
+        ) {
+            Button("OK", role: .cancel) { onboardingReviewError = nil }
+        } message: {
+            Text(onboardingReviewError ?? "Please try again.")
         }
         .task {
             if viewModel == nil {
@@ -1353,6 +1393,47 @@ struct SettingsView: View {
                 }
             }
         }
+    }
+
+    // MARK: - Onboarding Review
+
+    private var onboardingReviewCard: some View {
+        Button {
+            Task {
+                guard let active = await identityManager.getActiveIdentity() else {
+                    onboardingReviewError = "No active identity is available."
+                    return
+                }
+                onboardingReviewIdentity = active
+                showOnboardingReview = true
+            }
+        } label: {
+            HStack(spacing: 12) {
+                Image(systemName: "rectangle.stack.badge.play")
+                    .font(.system(size: 18, weight: .medium))
+                    .foregroundStyle(Theme.accentColor)
+                    .frame(width: 24, height: 24)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Review Setup Guide")
+                        .font(.system(size: 16, weight: .medium))
+                        .foregroundStyle(Theme.textPrimary)
+                    Text("Reopen onboarding without deleting your identity or messages.")
+                        .font(.caption)
+                        .foregroundStyle(Theme.textSecondary)
+                        .multilineTextAlignment(.leading)
+                }
+
+                Spacer()
+
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(Theme.textSecondary)
+            }
+        }
+        .buttonStyle(.plain)
+        .padding(16)
+        .glassCard()
     }
 
     // MARK: - Data Migration Card

--- a/Tests/ColumbaAppTests/RuntimeFlavorTests.swift
+++ b/Tests/ColumbaAppTests/RuntimeFlavorTests.swift
@@ -141,5 +141,42 @@ final class RuntimeFlavorTests: XCTestCase {
         XCTAssertEqual(config.targetHost, TcpCommunityServer.defaultServer.host)
         XCTAssertEqual(config.targetPort, TcpCommunityServer.defaultServer.port)
     }
+
+    @MainActor
+    func testSettingsReviewReusesActiveIdentityAndCurrentCustomRelay() throws {
+        let suiteName = "test.OnboardingReview.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            return XCTFail("Could not create isolated UserDefaults suite")
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(try JSONEncoder().encode([InterfaceEntity]()), forKey: "com.columba.interfaces")
+        let repository = InterfaceRepository(userDefaults: defaults)
+        repository.addInterface(InterfaceEntity(
+            name: "Private relay",
+            type: .tcpClient,
+            config: .tcpClient(TCPClientConfig(targetHost: "relay.example", targetPort: 4242))
+        ))
+        let existing = LocalIdentity(
+            identityHash: "identity-hash",
+            displayName: "Existing Peer",
+            destinationHash: "destination-hash",
+            createdAt: 1,
+            lastUsedAt: 2,
+            isActive: true
+        )
+
+        let viewModel = OnboardingViewModel(
+            existingIdentity: existing,
+            interfaceRepository: repository
+        )
+
+        XCTAssertTrue(viewModel.isReviewingExistingSetup)
+        XCTAssertEqual(viewModel.createdIdentity?.identityHash, existing.identityHash)
+        XCTAssertEqual(viewModel.displayName, existing.displayName)
+        XCTAssertEqual(viewModel.selectedInterfaces, [.tcp])
+        XCTAssertEqual(viewModel.selectedTcpServer?.host, "relay.example")
+        XCTAssertEqual(viewModel.selectedTcpServer?.name, "Private relay")
+    }
     #endif
 }

--- a/Tests/static/test_onboarding_interface_selection.py
+++ b/Tests/static/test_onboarding_interface_selection.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import re
 import unittest
+import json
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -137,6 +138,38 @@ class OnboardingInterfaceSelectionContracts(unittest.TestCase):
         self.assertIn("let isReviewingExistingSetup: Bool", view_model)
         self.assertIn("createdIdentity = existingIdentity", view_model)
         self.assertIn("identityManager.renameIdentity", view_model)
+
+    def test_onboarding_copy_is_translation_ready(self) -> None:
+        catalog_path = ROOT / "Sources/ColumbaApp/Resources/Localizable.xcstrings"
+        catalog = json.loads(catalog_path.read_text(encoding="utf-8"))
+        strings = catalog["strings"]
+
+        required = {
+            "Private messaging without a central account",
+            "Choose a Display Name",
+            "Select one or more. You can change these later.",
+            "Message Alerts",
+            "Existing identities and messages will not be duplicated. Conversation details and app settings may be updated from this backup.",
+            "Review Setup Guide",
+            "Reopen onboarding without deleting your identity or messages.",
+            "Internet Relay",
+            "RNode Radio",
+        }
+        self.assertTrue(required.issubset(strings))
+        self.assertEqual(catalog["sourceLanguage"], "en")
+
+        project = source(ROOT / "Columba.xcodeproj/project.pbxproj")
+        self.assertEqual(project.count("Localizable.xcstrings in Resources"), 4)
+        self.assertIn("Localizable.xcstrings */ = {isa = PBXFileReference", project)
+
+        welcome = source(ROOT / "Sources/ColumbaApp/Views/Onboarding/WelcomePage.swift")
+        permissions = source(PERMISSIONS_PAGE)
+        explainer = source(ROOT / "Sources/ColumbaApp/Views/Components/BackgroundVPNExplainer.swift")
+        view_model = source(VIEW_MODEL)
+        self.assertIn("LocalizedStringKey, icon: String", welcome)
+        self.assertIn("notificationRow(_ text: LocalizedStringKey)", permissions)
+        self.assertIn("text: LocalizedStringKey", explainer)
+        self.assertIn('String(localized: "Internet Relay")', view_model)
 
         migration_view_model = source(MIGRATION_VIEW_MODEL)
         self.assertIn("guard !isImporting else { return }", migration_view_model)

--- a/Tests/static/test_onboarding_interface_selection.py
+++ b/Tests/static/test_onboarding_interface_selection.py
@@ -129,6 +129,10 @@ class OnboardingInterfaceSelectionContracts(unittest.TestCase):
         self.assertNotIn("Push Notifications", permissions)
         self.assertNotIn("Someone you know comes online", permissions)
         self.assertIn("encrypted backup from Settings", complete)
+        self.assertIn("ScrollView", complete)
+        self.assertIn(".fixedSize(horizontal: false, vertical: true)", complete)
+        self.assertIn(".presentationDetents([.large])", complete)
+        self.assertNotIn(".presentationDetents([.medium])", complete)
         self.assertIn("app settings may be updated", restore)
         self.assertNotIn("Your traffic isn't sent to any server", background)
 

--- a/Tests/static/test_onboarding_interface_selection.py
+++ b/Tests/static/test_onboarding_interface_selection.py
@@ -56,7 +56,7 @@ class OnboardingInterfaceSelectionContracts(unittest.TestCase):
 
     def test_skip_completes_only_after_success_and_surfaces_failures(self) -> None:
         text = source(ONBOARDING_VIEW)
-        skip_ui = text.split("// Skip button", 1)[1].split("// Page content", 1)[0]
+        skip_ui = text.split("// First-run setup offers", 1)[1].split("// Page content", 1)[0]
         self.assertNotIn("try?", skip_ui)
         self.assertIn("do {", skip_ui)
         self.assertIn("catch {", skip_ui)
@@ -64,6 +64,8 @@ class OnboardingInterfaceSelectionContracts(unittest.TestCase):
         self.assertIn(".disabled(viewModel.isSaving)", skip_ui)
         self.assertLess(skip_ui.index("try await viewModel.skipOnboarding"), skip_ui.index("onComplete()"))
         self.assertIn('"Unable to Skip Setup"', text)
+        self.assertIn('Text("Use Defaults")', skip_ui)
+        self.assertIn('Button("Close", action: onCancel)', skip_ui)
 
         restore_parent = text.split("OnboardingRestoreSheet(viewModel: vm)", 1)[1].split(
             "#endif", 1
@@ -104,6 +106,37 @@ class OnboardingInterfaceSelectionContracts(unittest.TestCase):
         self.assertNotIn("try?", finish)
         self.assertIn("catch {", finish)
         self.assertIn("if viewModel.currentPage < 4", text)
+
+    def test_educational_copy_and_safe_settings_review(self) -> None:
+        welcome = source(ROOT / "Sources/ColumbaApp/Views/Onboarding/WelcomePage.swift")
+        identity = source(ROOT / "Sources/ColumbaApp/Views/Onboarding/IdentityPage.swift")
+        connectivity = source(CONNECTIVITY_PAGE)
+        permissions = source(PERMISSIONS_PAGE)
+        complete = source(ROOT / "Sources/ColumbaApp/Views/Onboarding/CompletePage.swift")
+        restore = source(RESTORE_SHEET)
+        background = source(ROOT / "Sources/ColumbaApp/Views/Onboarding/BackgroundDeliveryPage.swift")
+        settings = source(SETTINGS_VIEW)
+        view_model = source(VIEW_MODEL)
+
+        self.assertIn("Private messaging without a central account", welcome)
+        self.assertIn("private cryptographic identity", welcome)
+        self.assertIn("Choose a Display Name", identity)
+        self.assertIn("Select one or more", connectivity)
+        self.assertIn("Select at least one connection method", connectivity)
+        self.assertIn("Recommended Relays", connectivity)
+        self.assertIn("iOS Notifications", permissions)
+        self.assertNotIn("Push Notifications", permissions)
+        self.assertNotIn("Someone you know comes online", permissions)
+        self.assertIn("encrypted backup from Settings", complete)
+        self.assertIn("app settings may be updated", restore)
+        self.assertNotIn("Your traffic isn't sent to any server", background)
+
+        self.assertIn("Review Setup Guide", settings)
+        self.assertIn("existingIdentity: existingIdentity", settings)
+        self.assertIn("onCancel: { showOnboardingReview = false }", settings)
+        self.assertIn("let isReviewingExistingSetup: Bool", view_model)
+        self.assertIn("createdIdentity = existingIdentity", view_model)
+        self.assertIn("identityManager.renameIdentity", view_model)
 
         migration_view_model = source(MIGRATION_VIEW_MODEL)
         self.assertIn("guard !isImporting else { return }", migration_view_model)

--- a/Tests/static/test_onboarding_interface_selection.py
+++ b/Tests/static/test_onboarding_interface_selection.py
@@ -134,7 +134,9 @@ class OnboardingInterfaceSelectionContracts(unittest.TestCase):
 
         self.assertIn("Review Setup Guide", settings)
         self.assertIn("existingIdentity: existingIdentity", settings)
-        self.assertIn("onCancel: { showOnboardingReview = false }", settings)
+        self.assertIn("fullScreenCover(item: $onboardingReviewIdentity)", settings)
+        self.assertIn("onCancel: { onboardingReviewIdentity = nil }", settings)
+        self.assertNotIn("showOnboardingReview", settings)
         self.assertIn("let isReviewingExistingSetup: Bool", view_model)
         self.assertIn("createdIdentity = existingIdentity", view_model)
         self.assertIn("identityManager.renameIdentity", view_model)

--- a/Tests/static/test_onboarding_interface_selection.py
+++ b/Tests/static/test_onboarding_interface_selection.py
@@ -147,7 +147,26 @@ class OnboardingInterfaceSelectionContracts(unittest.TestCase):
         self.assertNotIn("showOnboardingReview", settings)
         self.assertIn("let isReviewingExistingSetup: Bool", view_model)
         self.assertIn("createdIdentity = existingIdentity", view_model)
-        self.assertIn("identityManager.renameIdentity", view_model)
+        self.assertIn("guard !isReviewingExistingSetup else { return }", view_model)
+        self.assertNotIn("identityManager.renameIdentity", view_model)
+        onboarding_view = source(ONBOARDING_VIEW)
+        self.assertGreaterEqual(
+            onboarding_view.count("isReadOnly: viewModel.isReviewingExistingSetup"),
+            2,
+        )
+        self.assertIn(".disabled(isReadOnly)", identity)
+        self.assertGreaterEqual(connectivity.count(".disabled(isReadOnly)"), 2)
+        self.assertIn("if viewModel.isReviewingExistingSetup", onboarding_view)
+        self.assertIn("isReadOnly: viewModel.isReviewingExistingSetup", onboarding_view)
+        background = source(
+            ROOT / "Sources/ColumbaApp/Views/Onboarding/BackgroundDeliveryPage.swift"
+        )
+        self.assertIn('Text("Continue")', background)
+        self.assertIn("WelcomePage(onContinue: { viewModel.nextPage() })", onboarding_view)
+        self.assertIn("onCancel?()", onboarding_view)
+        self.assertIn('Text("Done")', complete)
+        self.assertIn('Text("iOS Notification Permission")', complete)
+        self.assertIn('Text("Not Allowed")', permissions)
 
     def test_onboarding_copy_is_translation_ready(self) -> None:
         catalog_path = ROOT / "Sources/ColumbaApp/Resources/Localizable.xcstrings"

--- a/Tests/static/test_onboarding_interface_selection.py
+++ b/Tests/static/test_onboarding_interface_selection.py
@@ -68,16 +68,16 @@ class OnboardingInterfaceSelectionContracts(unittest.TestCase):
         self.assertIn('Text("Use Defaults")', skip_ui)
         self.assertIn('Button("Close", action: onCancel)', skip_ui)
 
-        restore_parent = text.split("OnboardingRestoreSheet(viewModel: vm)", 1)[1].split(
+        restore_parent = text.split("OnboardingRestoreSheet(viewModel: session.viewModel)", 1)[1].split(
             "#endif", 1
         )[0]
         self.assertNotIn("try?", restore_parent)
         self.assertLess(
             restore_parent.index("try await viewModel.completeRestoredOnboarding"),
-            restore_parent.index("showRestoreSheet = false"),
+            restore_parent.index("restoreSession = nil"),
         )
         self.assertLess(
-            restore_parent.index("showRestoreSheet = false"),
+            restore_parent.index("restoreSession = nil"),
             restore_parent.index("onComplete()"),
         )
 
@@ -107,6 +107,10 @@ class OnboardingInterfaceSelectionContracts(unittest.TestCase):
         self.assertNotIn("try?", finish)
         self.assertIn("catch {", finish)
         self.assertIn("if viewModel.currentPage < 4", text)
+        self.assertIn("sheet(item: $restoreSession)", text)
+        self.assertIn("RestoreSession(viewModel: vm)", text)
+        self.assertNotIn("showRestoreSheet", text)
+        self.assertNotIn("migrationVM", text)
 
     def test_educational_copy_and_safe_settings_review(self) -> None:
         welcome = source(ROOT / "Sources/ColumbaApp/Views/Onboarding/WelcomePage.swift")


### PR DESCRIPTION
## Summary

- simplify and correct the onboarding explanations for identity, connectivity, notifications, background delivery, completion, and backup restore
- add an English string catalog and route dynamic onboarding labels through localization-aware APIs
- add a non-destructive Settings entry point for reviewing onboarding with the active identity and current interfaces
- make QR guidance fully visible in a large, scrollable sheet
- drive setup-review and restore presentations from loaded item state to prevent empty black/gray sheets

## Verification

- `python3 -m unittest discover -s Tests/static -p "test_*.py"` — 142 passed
- shipping XCTest suite — 129 passed
- Model B XCTest suite — 14 passed
- signed physical-device build succeeded
- strict code-sign verification passed
- shipping artifact-isolation verification passed
- installed and exercised on a physical iPhone

## Risk / rollback

The changes are confined to onboarding/setup-review presentation, educational copy, localization resources, and focused state initialization. Reverting this PR restores the previous onboarding flow.