### PR TITLE
fix: optimize iOS Network tab performance

### DIFF
--- a/Columba.xcodeproj/project.pbxproj
+++ b/Columba.xcodeproj/project.pbxproj
@@ -335,6 +335,8 @@
 		PNT001 /* PythonNetworkTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = PNT002 /* PythonNetworkTransport.swift */; };
 		PXI2B /* ProxyIPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = PXIF /* ProxyIPC.swift */; };
 		RFT002 /* RuntimeFlavorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = RFT001 /* RuntimeFlavorTests.swift */; };
+		RMLT002 /* RuntimeActivityMonitorLeaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = RMLT001 /* RuntimeActivityMonitorLeaseTests.swift */; };
+		RMLT003 /* RuntimeActivityMonitorLeaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = RMLT001 /* RuntimeActivityMonitorLeaseTests.swift */; };
 		T003 /* MicronParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FT03 /* MicronParserTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -569,6 +571,7 @@
 		PROD /* ColumbaApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ColumbaApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		PXIF /* ProxyIPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyIPC.swift; sourceTree = "<group>"; };
 		RFT001 /* RuntimeFlavorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RuntimeFlavorTests.swift; sourceTree = "<group>"; };
+		RMLT001 /* RuntimeActivityMonitorLeaseTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RuntimeActivityMonitorLeaseTests.swift; sourceTree = "<group>"; };
 		SRB002 /* SwiftRNSBackend.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SwiftRNSBackend.swift; path = Sources/RNSBackendSwift/SwiftRNSBackend.swift; sourceTree = SOURCE_ROOT; };
 		TPROD /* ColumbaAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ColumbaAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -996,6 +999,7 @@
 				853F1E1C2B6E5305277FCB2A /* MigrationRoundTripTests.swift */,
 				6C8CFC274AF9EF63E9A75238 /* PythonConfigWriterTests.swift */,
 				RFT001 /* RuntimeFlavorTests.swift */,
+				RMLT001 /* RuntimeActivityMonitorLeaseTests.swift */,
 			);
 			path = Tests/ColumbaAppTests;
 			sourceTree = "<group>";
@@ -1485,6 +1489,7 @@
 			files = (
 				3AD864B112B2E1810E510599 /* BLESeamDriverTests.swift in Sources */,
 				5A782C77CC09D0601E7D945C /* RNodeSeamTests.swift in Sources */,
+				RMLT003 /* RuntimeActivityMonitorLeaseTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1657,6 +1662,7 @@
 				0FF6A5C5596A39C092AADA29 /* MigrationRoundTripTests.swift in Sources */,
 				26D564FAEE8E3C750E8E2442 /* PythonConfigWriterTests.swift in Sources */,
 				RFT002 /* RuntimeFlavorTests.swift in Sources */,
+				RMLT002 /* RuntimeActivityMonitorLeaseTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -17,7 +17,8 @@ import CryptoKit
 #if canImport(UIKit)
 import UIKit
 #endif
-#if os(iOS)
+#if canImport(Darwin)
+import Darwin
 #endif
 import os.log
 
@@ -85,6 +86,184 @@ enum DiagLog {
     }
     #endif
     #endif
+}
+
+/// Low-overhead, privacy-safe runtime instrumentation for physical-device soak tests.
+///
+/// Samples cumulative process CPU every 15 seconds, observes thermal-state changes,
+/// and aggregates announce and path-table persistence activity. Diagnostic output
+/// contains counts and interface classes only: no endpoints, hashes, names, or content.
+final class RuntimeActivityMonitor: @unchecked Sendable {
+    static let shared = RuntimeActivityMonitor()
+
+    private enum AnnounceSource {
+        case tcp
+        case ble
+        case auto
+        case other
+    }
+
+    private struct Counters {
+        var announceTCP = 0
+        var announceBLE = 0
+        var announceAuto = 0
+        var announceOther = 0
+        var pathWrites = 0
+        var pathWriteMilliseconds = 0.0
+        var pathWriteMaxMilliseconds = 0.0
+
+        var announceTotal: Int {
+            announceTCP + announceBLE + announceAuto + announceOther
+        }
+    }
+
+    private let lock = NSLock()
+    private let queue = DispatchQueue(label: "network.columba.runtime-activity", qos: .utility)
+    private var timer: DispatchSourceTimer?
+    private var thermalObserver: NSObjectProtocol?
+    private var counters = Counters()
+    private var lastSampleUptime = ProcessInfo.processInfo.systemUptime
+    private var lastCPUSeconds = 0.0
+
+    private init() {}
+
+    func start() {
+        lock.lock()
+        guard timer == nil else {
+            lock.unlock()
+            return
+        }
+        counters = Counters()
+        lastSampleUptime = ProcessInfo.processInfo.systemUptime
+        lastCPUSeconds = Self.processCPUSeconds()
+
+        let timer = DispatchSource.makeTimerSource(queue: queue)
+        timer.schedule(deadline: .now() + 15, repeating: 15)
+        timer.setEventHandler { [weak self] in
+            self?.emitSample(reason: "periodic")
+        }
+        self.timer = timer
+        thermalObserver = NotificationCenter.default.addObserver(
+            forName: ProcessInfo.thermalStateDidChangeNotification,
+            object: nil,
+            queue: nil
+        ) { [weak self] _ in
+            self?.emitSample(reason: "thermal_change")
+        }
+        lock.unlock()
+
+        timer.activate()
+        emitSample(reason: "start")
+    }
+
+    func stop() {
+        lock.lock()
+        guard let timer else {
+            lock.unlock()
+            return
+        }
+        let observer = thermalObserver
+        self.timer = nil
+        thermalObserver = nil
+        lock.unlock()
+
+        emitSample(reason: "stop")
+        timer.cancel()
+        if let observer {
+            NotificationCenter.default.removeObserver(observer)
+        }
+    }
+
+    func recordAnnounce(interfaceName: String, configuredType: InterfaceType?) {
+        let source = Self.classify(
+            interfaceName: interfaceName,
+            configuredType: configuredType
+        )
+        lock.lock()
+        switch source {
+        case .tcp: counters.announceTCP += 1
+        case .ble: counters.announceBLE += 1
+        case .auto: counters.announceAuto += 1
+        case .other: counters.announceOther += 1
+        }
+        lock.unlock()
+    }
+
+    func recordPathTableWrite(durationMilliseconds: Double) {
+        lock.lock()
+        counters.pathWrites += 1
+        counters.pathWriteMilliseconds += durationMilliseconds
+        counters.pathWriteMaxMilliseconds = max(
+            counters.pathWriteMaxMilliseconds,
+            durationMilliseconds
+        )
+        lock.unlock()
+    }
+
+    private static func classify(
+        interfaceName: String,
+        configuredType: InterfaceType?
+    ) -> AnnounceSource {
+        if let configuredType {
+            switch configuredType {
+            case .tcpClient, .tcpServer: return .tcp
+            case .ble: return .ble
+            case .autoInterface, .multipeer: return .auto
+            case .rnode: return .other
+            }
+        }
+
+        // Dynamically spawned Auto/BLE peer interfaces do not have a matching
+        // InterfaceEntity, so retain a class-name fallback for those children.
+        let normalized = interfaceName.lowercased()
+        if normalized.contains("tcp") { return .tcp }
+        if normalized.contains("bluetooth") || normalized.contains("ble") { return .ble }
+        if normalized.contains("auto") || normalized.contains("multipeer") { return .auto }
+        return .other
+    }
+
+    private func emitSample(reason: String) {
+        let now = ProcessInfo.processInfo.systemUptime
+        let cpuNow = Self.processCPUSeconds()
+
+        lock.lock()
+        let elapsed = max(0.001, now - lastSampleUptime)
+        let cpuPercent = max(0, cpuNow - lastCPUSeconds) / elapsed * 100
+        let snapshot = counters
+        counters = Counters()
+        lastSampleUptime = now
+        lastCPUSeconds = cpuNow
+        lock.unlock()
+
+        let announceRate = Double(snapshot.announceTotal) / elapsed * 60
+        let pathAverage = snapshot.pathWrites == 0
+            ? 0
+            : snapshot.pathWriteMilliseconds / Double(snapshot.pathWrites)
+        let line = "[PERF] reason=\(reason) thermal=\(Self.thermalStateName()) sample_seconds=\(String(format: "%.1f", elapsed)) cpu_pct=\(String(format: "%.1f", cpuPercent)) announce_total=\(snapshot.announceTotal) announce_per_min=\(String(format: "%.1f", announceRate)) announce_tcp=\(snapshot.announceTCP) announce_ble=\(snapshot.announceBLE) announce_auto=\(snapshot.announceAuto) announce_other=\(snapshot.announceOther) path_writes=\(snapshot.pathWrites) path_write_ms_avg=\(String(format: "%.3f", pathAverage)) path_write_ms_max=\(String(format: "%.3f", snapshot.pathWriteMaxMilliseconds))"
+        DiagLog.log(line)
+    }
+
+    private static func thermalStateName() -> String {
+        switch ProcessInfo.processInfo.thermalState {
+        case .nominal: return "nominal"
+        case .fair: return "fair"
+        case .serious: return "serious"
+        case .critical: return "critical"
+        @unknown default: return "unknown"
+        }
+    }
+
+    private static func processCPUSeconds() -> Double {
+        #if canImport(Darwin)
+        var usage = rusage()
+        guard getrusage(RUSAGE_SELF, &usage) == 0 else { return 0 }
+        let user = Double(usage.ru_utime.tv_sec) + Double(usage.ru_utime.tv_usec) / 1_000_000
+        let system = Double(usage.ru_stime.tv_sec) + Double(usage.ru_stime.tv_usec) / 1_000_000
+        return user + system
+        #else
+        return 0
+        #endif
+    }
 }
 
 /// Central LXMF service layer for the SwiftUI application.
@@ -818,6 +997,7 @@ public final class AppServices {
     /// - Throws: InterfaceError, DatabaseError, or other initialization errors
     public func initialize(tcpServerAddress: String) async throws {
         DiagLog.clear()
+        RuntimeActivityMonitor.shared.start()
         DiagLog.log("[INIT] Starting with TCP server: \(tcpServerAddress)")
 
         // 1. Load identity from persistent storage (try Keychain first, then file)
@@ -2413,6 +2593,13 @@ public final class AppServices {
             // NodeDetailsView) can parse limits + stamp cost from it.
             let appData = Data(hexString: appDataHex) ?? Data()
             let displayName = AppDataParser.displayName(from: appData, aspect: aspect)
+            let configuredType = pythonInterfaceEntities.values.first {
+                expectedSectionName(for: $0) == interfaceName
+            }?.type
+            RuntimeActivityMonitor.shared.recordAnnounce(
+                interfaceName: interfaceName,
+                configuredType: configuredType
+            )
             DiagLog.log("[RNS] announce dest=\(destHash) aspect=\(aspect) name=\"\(displayName)\" iface=\"\(interfaceName)\" hops=\(hops)")
 
             // Aspect is now the SOLE signal Contact.init uses to type an
@@ -2454,7 +2641,10 @@ public final class AppServices {
                     isLXSTTelephony: aspect == "lxst.telephony",
                     isKnownDestination: true
                 )
-                await pathTable.insert(entry)
+                let metrics = await pathTable.insert(entry)
+                RuntimeActivityMonitor.shared.recordPathTableWrite(
+                    durationMilliseconds: metrics.persistenceDurationMilliseconds
+                )
             }
 
             NotificationCenter.default.post(
@@ -2588,6 +2778,7 @@ public final class AppServices {
     ///   - tcpServerAddress: TCP server address (e.g., "10.0.0.1:4242")
     public func initialize(identity: Identity, identityHash: String, tcpServerAddress: String) async throws {
         DiagLog.clear()
+        RuntimeActivityMonitor.shared.start()
         DiagLog.log("[INIT2] Starting with identity: \(identityHash), tcp: \(tcpServerAddress)")
 
         self.identity = identity
@@ -3677,6 +3868,7 @@ public final class AppServices {
         await stopAutoInterface()
 
         isConnected = false
+        RuntimeActivityMonitor.shared.stop()
         logger.info("AppServices shutdown complete")
     }
 

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -96,6 +96,11 @@ enum DiagLog {
 final class RuntimeActivityMonitor: @unchecked Sendable {
     static let shared = RuntimeActivityMonitor()
 
+    struct Lease: Hashable, Sendable {
+        fileprivate let generation: UInt64
+        fileprivate let identifier: UInt64
+    }
+
     private enum AnnounceSource {
         case tcp
         case ble
@@ -124,15 +129,48 @@ final class RuntimeActivityMonitor: @unchecked Sendable {
     private var counters = Counters()
     private var lastSampleUptime = ProcessInfo.processInfo.systemUptime
     private var lastCPUSeconds = 0.0
+    private var generationCounter: UInt64 = 0
+    private var activeGeneration: UInt64?
+    private var nextLeaseIdentifier: UInt64 = 0
+    private var activeLeases: Set<Lease> = []
 
-    private init() {}
+    init() {}
 
-    func start() {
+    var activeLeaseCountForTesting: Int {
         lock.lock()
-        guard timer == nil else {
+        defer { lock.unlock() }
+        return activeLeases.count
+    }
+
+    var isRunningForTesting: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return activeGeneration != nil
+    }
+
+    func acquire() -> Lease {
+        lock.lock()
+        nextLeaseIdentifier &+= 1
+
+        if let generation = activeGeneration {
+            let lease = Lease(
+                generation: generation,
+                identifier: nextLeaseIdentifier
+            )
+            activeLeases.insert(lease)
             lock.unlock()
-            return
+            return lease
         }
+
+        precondition(timer == nil && activeLeases.isEmpty)
+        generationCounter &+= 1
+        let generation = generationCounter
+        activeGeneration = generation
+        let lease = Lease(
+            generation: generation,
+            identifier: nextLeaseIdentifier
+        )
+        activeLeases.insert(lease)
         counters = Counters()
         lastSampleUptime = ProcessInfo.processInfo.systemUptime
         lastCPUSeconds = Self.processCPUSeconds()
@@ -140,7 +178,7 @@ final class RuntimeActivityMonitor: @unchecked Sendable {
         let timer = DispatchSource.makeTimerSource(queue: queue)
         timer.schedule(deadline: .now() + 15, repeating: 15)
         timer.setEventHandler { [weak self] in
-            self?.emitSample(reason: "periodic")
+            self?.emitSample(reason: "periodic", generation: generation)
         }
         self.timer = timer
         thermalObserver = NotificationCenter.default.addObserver(
@@ -148,30 +186,47 @@ final class RuntimeActivityMonitor: @unchecked Sendable {
             object: nil,
             queue: nil
         ) { [weak self] _ in
-            self?.emitSample(reason: "thermal_change")
+            self?.emitSample(reason: "thermal_change", generation: generation)
         }
         lock.unlock()
 
         timer.activate()
-        emitSample(reason: "start")
+        emitSample(reason: "start", generation: generation)
+        return lease
     }
 
-    func stop() {
+    func release(_ lease: Lease) {
         lock.lock()
-        guard let timer else {
+        guard activeGeneration == lease.generation,
+              activeLeases.remove(lease) != nil else {
             lock.unlock()
             return
         }
-        let observer = thermalObserver
-        self.timer = nil
-        thermalObserver = nil
-        lock.unlock()
+        guard activeLeases.isEmpty else {
+            lock.unlock()
+            return
+        }
+        guard let timer else {
+            activeGeneration = nil
+            lock.unlock()
+            return
+        }
 
-        emitSample(reason: "stop")
+        let observer = thermalObserver
+        let finalLine = makeSampleLineLocked(reason: "stop")
+        activeGeneration = nil
+
+        // The last release owns teardown while holding the monitor lock. New
+        // acquisitions and accepted callbacks cannot cross the final sample.
+        timer.setEventHandler {}
         timer.cancel()
         if let observer {
             NotificationCenter.default.removeObserver(observer)
         }
+        DiagLog.log(finalLine)
+        self.timer = nil
+        thermalObserver = nil
+        lock.unlock()
     }
 
     func recordAnnounce(interfaceName: String, configuredType: InterfaceType?) {
@@ -180,6 +235,10 @@ final class RuntimeActivityMonitor: @unchecked Sendable {
             configuredType: configuredType
         )
         lock.lock()
+        guard activeGeneration != nil else {
+            lock.unlock()
+            return
+        }
         switch source {
         case .tcp: counters.announceTCP += 1
         case .ble: counters.announceBLE += 1
@@ -191,6 +250,10 @@ final class RuntimeActivityMonitor: @unchecked Sendable {
 
     func recordPathTableWrite(durationMilliseconds: Double) {
         lock.lock()
+        guard activeGeneration != nil else {
+            lock.unlock()
+            return
+        }
         counters.pathWrites += 1
         counters.pathWriteMilliseconds += durationMilliseconds
         counters.pathWriteMaxMilliseconds = max(
@@ -222,25 +285,36 @@ final class RuntimeActivityMonitor: @unchecked Sendable {
         return .other
     }
 
-    private func emitSample(reason: String) {
+    private func emitSample(reason: String, generation: UInt64) {
+        lock.lock()
+        guard activeGeneration == generation else {
+            lock.unlock()
+            return
+        }
+        let line = makeSampleLineLocked(reason: reason)
+        // Publication is part of the generation's critical section. Teardown
+        // cannot capture its final sample until every accepted callback line
+        // has reached the diagnostic stream.
+        DiagLog.log(line)
+        lock.unlock()
+    }
+
+    /// Build and reset one interval while the caller holds `lock`.
+    private func makeSampleLineLocked(reason: String) -> String {
         let now = ProcessInfo.processInfo.systemUptime
         let cpuNow = Self.processCPUSeconds()
-
-        lock.lock()
         let elapsed = max(0.001, now - lastSampleUptime)
         let cpuPercent = max(0, cpuNow - lastCPUSeconds) / elapsed * 100
         let snapshot = counters
         counters = Counters()
         lastSampleUptime = now
         lastCPUSeconds = cpuNow
-        lock.unlock()
 
         let announceRate = Double(snapshot.announceTotal) / elapsed * 60
         let pathAverage = snapshot.pathWrites == 0
             ? 0
             : snapshot.pathWriteMilliseconds / Double(snapshot.pathWrites)
-        let line = "[PERF] reason=\(reason) thermal=\(Self.thermalStateName()) sample_seconds=\(String(format: "%.1f", elapsed)) cpu_pct=\(String(format: "%.1f", cpuPercent)) announce_total=\(snapshot.announceTotal) announce_per_min=\(String(format: "%.1f", announceRate)) announce_tcp=\(snapshot.announceTCP) announce_ble=\(snapshot.announceBLE) announce_auto=\(snapshot.announceAuto) announce_other=\(snapshot.announceOther) path_writes=\(snapshot.pathWrites) path_write_ms_avg=\(String(format: "%.3f", pathAverage)) path_write_ms_max=\(String(format: "%.3f", snapshot.pathWriteMaxMilliseconds))"
-        DiagLog.log(line)
+        return "[PERF] reason=\(reason) thermal=\(Self.thermalStateName()) sample_seconds=\(String(format: "%.1f", elapsed)) cpu_pct=\(String(format: "%.1f", cpuPercent)) announce_total=\(snapshot.announceTotal) announce_per_min=\(String(format: "%.1f", announceRate)) announce_tcp=\(snapshot.announceTCP) announce_ble=\(snapshot.announceBLE) announce_auto=\(snapshot.announceAuto) announce_other=\(snapshot.announceOther) path_writes=\(snapshot.pathWrites) path_write_ms_avg=\(String(format: "%.3f", pathAverage)) path_write_ms_max=\(String(format: "%.3f", snapshot.pathWriteMaxMilliseconds))"
     }
 
     private static func thermalStateName() -> String {
@@ -263,6 +337,19 @@ final class RuntimeActivityMonitor: @unchecked Sendable {
         #else
         return 0
         #endif
+    }
+}
+
+/// RAII fallback for callers that fail to invoke AppServices.shutdown().
+/// Normal mutation is main-actor confined by AppServices; holder destruction
+/// releases any remaining generation-bound lease without actor-isolated access.
+private final class RuntimeActivityMonitorLeaseHolder {
+    var lease: RuntimeActivityMonitor.Lease?
+
+    deinit {
+        if let lease {
+            RuntimeActivityMonitor.shared.release(lease)
+        }
     }
 }
 
@@ -406,6 +493,65 @@ public final class AppServices {
     /// `LXMRouter` and `ReticulumTransport` stubs delegate real work
     /// (announce listening, opportunistic LXMF send/receive) through this.
     public private(set) var backend: (any RnsBackend)?
+
+    /// Generation-bound retain on the process-global activity monitor. Each
+    /// active AppServices instance holds one lease; only the last release stops
+    /// instrumentation.
+    private let runtimeActivityMonitorLeaseHolder = RuntimeActivityMonitorLeaseHolder()
+
+    /// Retain a successful operation's lease for this service instance. If a
+    /// prior successful operation already retained one, the operation's extra
+    /// lease is released rather than accumulated.
+    private func retainRuntimeActivityMonitorLease(_ lease: RuntimeActivityMonitor.Lease) {
+        guard runtimeActivityMonitorLeaseHolder.lease == nil else {
+            RuntimeActivityMonitor.shared.release(lease)
+            return
+        }
+        runtimeActivityMonitorLeaseHolder.lease = lease
+    }
+
+    private func releaseRuntimeActivityMonitorLease() {
+        guard let lease = runtimeActivityMonitorLeaseHolder.lease else { return }
+        runtimeActivityMonitorLeaseHolder.lease = nil
+        RuntimeActivityMonitor.shared.release(lease)
+    }
+
+    private func requireActiveRuntimeForInterfaceMutation() throws {
+        guard runtimeActivityMonitorLeaseHolder.lease != nil else {
+            throw AppServicesError.transportNotConnected
+        }
+    }
+
+    /// MainActor methods are reentrant at each await. This FIFO gate prevents
+    /// initialize, shutdown, and reconnect from committing through one another.
+    private var lifecycleOperationActive = false
+    private var lifecycleOperationWaiters: [CheckedContinuation<Void, Never>] = []
+
+    private func acquireLifecycleOperation() async {
+        guard lifecycleOperationActive else {
+            lifecycleOperationActive = true
+            return
+        }
+        await withCheckedContinuation { continuation in
+            lifecycleOperationWaiters.append(continuation)
+        }
+    }
+
+    private func releaseLifecycleOperation() {
+        guard !lifecycleOperationWaiters.isEmpty else {
+            lifecycleOperationActive = false
+            return
+        }
+        lifecycleOperationWaiters.removeFirst().resume()
+    }
+
+    func withLifecycleOperation<T>(
+        _ operation: () async throws -> T
+    ) async rethrows -> T {
+        await acquireLifecycleOperation()
+        defer { releaseLifecycleOperation() }
+        return try await operation()
+    }
 
     /// The bound backend downcast to the Python impl — for Python-only wiring
     /// (BLE callback bridge and diagnose_* deep links). This API is compiled
@@ -974,12 +1120,6 @@ public final class AppServices {
     /// Call `initialize(tcpServerAddress:)` to set up all components.
     public init() {}
 
-    // Note: No deinit needed - stateObserverTask is automatically cancelled
-    // when the Task reference is deallocated, and shutdown() should be
-    // called explicitly for clean teardown.
-
-    // MARK: - Service Initialization
-
     /// Initialize all LXMF components.
     ///
     /// This async method sets up the complete LXMF stack:
@@ -996,8 +1136,22 @@ public final class AppServices {
     /// - Parameter tcpServerAddress: TCP server address (e.g., "tcp://10.0.0.1:4242" or "10.0.0.1:4242")
     /// - Throws: InterfaceError, DatabaseError, or other initialization errors
     public func initialize(tcpServerAddress: String) async throws {
+        try await withLifecycleOperation {
+            try await initializeUnlocked(tcpServerAddress: tcpServerAddress)
+        }
+    }
+
+    private func initializeUnlocked(tcpServerAddress: String) async throws {
         DiagLog.clear()
-        RuntimeActivityMonitor.shared.start()
+        let monitorLease = RuntimeActivityMonitor.shared.acquire()
+        var initializationSucceeded = false
+        defer {
+            if initializationSucceeded {
+                retainRuntimeActivityMonitorLease(monitorLease)
+            } else {
+                RuntimeActivityMonitor.shared.release(monitorLease)
+            }
+        }
         DiagLog.log("[INIT] Starting with TCP server: \(tcpServerAddress)")
 
         // 1. Load identity from persistent storage (try Keychain first, then file)
@@ -1138,6 +1292,7 @@ public final class AppServices {
         // notification now that the backend is up (see helper docs). Idempotent.
         registerTestAnnounceObserver()
 
+        initializationSucceeded = true
         logger.info("Initialization complete")
     }
 
@@ -2258,6 +2413,12 @@ public final class AppServices {
     /// TCP is unaffected.
     @MainActor
     public func applyInterfaceChanges() async {
+        await withLifecycleOperation {
+            await applyInterfaceChangesUnlocked()
+        }
+    }
+
+    private func applyInterfaceChangesUnlocked() async {
         // Model B: the NE owns the RNS node + all interfaces; the app's `backend` here is
         // the thin `ProxyRnsBackend`, whose `addInterface` throws `unsupportedInProxy`. The
         // python-shaped hot-add/-remove path below is therefore both wrong (it would error
@@ -2384,13 +2545,13 @@ public final class AppServices {
                 }
             }
         case .autoInterface(let cfg):
-            try? await startAutoInterface(groupId: cfg.groupId ?? "reticulum")
+            try? await startAutoInterfaceUnlocked(groupId: cfg.groupId ?? "reticulum")
         case .ble:
             #if canImport(CoreBluetooth)
-            try? await startBLEInterface()
+            try? await startBLEInterfaceUnlocked()
             #endif
         case .rnode(let cfg):
-            try? await startRNodeInterface(config: cfg, name: entity.name)
+            try? await startRNodeInterfaceUnlocked(config: cfg, name: entity.name)
         case .multipeer:
             break // Multipeer status mirror not wired for hot-add yet.
         }
@@ -2409,13 +2570,13 @@ public final class AppServices {
                 tcpInterfaces.removeValue(forKey: entity.id)
             }
         case .autoInterface:
-            await stopAutoInterface()
+            await stopAutoInterfaceUnlocked()
         case .ble:
             #if canImport(CoreBluetooth)
-            await stopBLEInterface()
+            await stopBLEInterfaceUnlocked()
             #endif
         case .rnode:
-            await stopRNodeInterface()
+            await stopRNodeInterfaceUnlocked()
         case .multipeer:
             break
         }
@@ -2430,7 +2591,7 @@ public final class AppServices {
             case .tcpClient(let config):
                 let entityId = entity.id
                 do {
-                    try await connectTCPInterface(entityId: entityId, host: config.targetHost, port: config.targetPort)
+                    try await connectTCPInterfaceUnlocked(entityId: entityId, host: config.targetHost, port: config.targetPort)
                     DiagLog.log("[RESPAWN] TCP \(entityId) connected")
                 } catch {
                     DiagLog.log("[RESPAWN] TCP \(entityId) failed: \(error)")
@@ -2438,7 +2599,7 @@ public final class AppServices {
             case .autoInterface(let config):
                 let groupId = config.groupId ?? "reticulum"
                 do {
-                    try await startAutoInterface(groupId: groupId)
+                    try await startAutoInterfaceUnlocked(groupId: groupId)
                     DiagLog.log("[RESPAWN] AutoInterface started groupId=\(groupId)")
                 } catch {
                     DiagLog.log("[RESPAWN] AutoInterface failed: \(error)")
@@ -2446,7 +2607,7 @@ public final class AppServices {
             case .ble:
                 #if canImport(CoreBluetooth)
                 do {
-                    try await startBLEInterface()
+                    try await startBLEInterfaceUnlocked()
                     DiagLog.log("[RESPAWN] BLEInterface started")
                 } catch {
                     DiagLog.log("[RESPAWN] BLEInterface failed: \(error)")
@@ -2777,8 +2938,30 @@ public final class AppServices {
     ///   - identityHash: Hex hash of the identity (used for DB filename)
     ///   - tcpServerAddress: TCP server address (e.g., "10.0.0.1:4242")
     public func initialize(identity: Identity, identityHash: String, tcpServerAddress: String) async throws {
+        try await withLifecycleOperation {
+            try await initializeUnlocked(
+                identity: identity,
+                identityHash: identityHash,
+                tcpServerAddress: tcpServerAddress
+            )
+        }
+    }
+
+    private func initializeUnlocked(
+        identity: Identity,
+        identityHash: String,
+        tcpServerAddress: String
+    ) async throws {
         DiagLog.clear()
-        RuntimeActivityMonitor.shared.start()
+        let monitorLease = RuntimeActivityMonitor.shared.acquire()
+        var initializationSucceeded = false
+        defer {
+            if initializationSucceeded {
+                retainRuntimeActivityMonitorLease(monitorLease)
+            } else {
+                RuntimeActivityMonitor.shared.release(monitorLease)
+            }
+        }
         DiagLog.log("[INIT2] Starting with identity: \(identityHash), tcp: \(tcpServerAddress)")
 
         self.identity = identity
@@ -2952,6 +3135,7 @@ public final class AppServices {
         // notification now that the backend is up (see helper docs). Idempotent.
         registerTestAnnounceObserver()
 
+        initializationSucceeded = true
         DiagLog.log("[INIT2] Initialization complete (identity: \(identityHash))")
     }
 
@@ -3015,10 +3199,24 @@ public final class AppServices {
     ///   - identityHash: Hex hash of the new identity
     ///   - tcpServerAddress: TCP server address to reconnect to
     public func switchIdentity(to newIdentity: Identity, identityHash: String, tcpServerAddress: String) async throws {
+        try await withLifecycleOperation {
+            try await switchIdentityUnlocked(
+                to: newIdentity,
+                identityHash: identityHash,
+                tcpServerAddress: tcpServerAddress
+            )
+        }
+    }
+
+    private func switchIdentityUnlocked(
+        to newIdentity: Identity,
+        identityHash: String,
+        tcpServerAddress: String
+    ) async throws {
         logger.info("Switching identity to: \(identityHash)")
 
         // Tear down current stack
-        await shutdown()
+        await shutdownUnlocked()
 
         // NOTE: Path table is NOT cleared here — path entries (announce routes)
         // are identity-agnostic and remain valid across identity switches.
@@ -3028,7 +3226,11 @@ public final class AppServices {
         try? await Task.sleep(for: .milliseconds(200))
 
         // Re-initialize with new identity
-        try await initialize(identity: newIdentity, identityHash: identityHash, tcpServerAddress: tcpServerAddress)
+        try await initializeUnlocked(
+            identity: newIdentity,
+            identityHash: identityHash,
+            tcpServerAddress: tcpServerAddress
+        )
 
         logger.info("Identity switch complete: \(identityHash)")
     }
@@ -3195,8 +3397,15 @@ public final class AppServices {
     ///
     /// - Parameter groupId: Group ID for peer discovery (default: "reticulum")
     public func startAutoInterface(groupId: String = "reticulum") async throws {
+        try await withLifecycleOperation {
+            try requireActiveRuntimeForInterfaceMutation()
+            try await startAutoInterfaceUnlocked(groupId: groupId)
+        }
+    }
+
+    private func startAutoInterfaceUnlocked(groupId: String = "reticulum") async throws {
         // Stop existing auto interface if any
-        await stopAutoInterface()
+        await stopAutoInterfaceUnlocked()
 
         // Ensure we have base stack (identity, transport, router)
         if transport == nil {
@@ -3232,6 +3441,12 @@ public final class AppServices {
 
     /// Stop the AutoInterface.
     public func stopAutoInterface() async {
+        await withLifecycleOperation {
+            await stopAutoInterfaceUnlocked()
+        }
+    }
+
+    private func stopAutoInterfaceUnlocked() async {
         guard let auto = autoInterface else { return }
         await auto.disconnect()
         if let transport = transport {
@@ -3256,10 +3471,17 @@ public final class AppServices {
     ///      are how `IOSBLEDriver` actually calls into Swift.)
     ///   4. Update Compat-layer BLEInterface stub for the UI.
     public func startBLEInterface() async throws {
+        try await withLifecycleOperation {
+            try requireActiveRuntimeForInterfaceMutation()
+            try await startBLEInterfaceUnlocked()
+        }
+    }
+
+    private func startBLEInterfaceUnlocked() async throws {
         logger.info("[BLE_DIAG] startBLEInterface() called")
 
         if bleInterface != nil {
-            await stopBLEInterface()
+            await stopBLEInterfaceUnlocked()
             try? await Task.sleep(for: .milliseconds(500))
         }
 
@@ -3362,6 +3584,12 @@ public final class AppServices {
 
     /// Stop the BLE interface.
     public func stopBLEInterface() async {
+        await withLifecycleOperation {
+            await stopBLEInterfaceUnlocked()
+        }
+    }
+
+    private func stopBLEInterfaceUnlocked() async {
         guard let ble = bleInterface else { return }
         await ble.disconnect()
         if let transport = transport {
@@ -3384,7 +3612,14 @@ public final class AppServices {
     /// and establishes direct peer-to-peer WiFi connections without
     /// requiring shared infrastructure.
     public func startMPCInterface() async throws {
-        await stopMPCInterface()
+        try await withLifecycleOperation {
+            try requireActiveRuntimeForInterfaceMutation()
+            try await startMPCInterfaceUnlocked()
+        }
+    }
+
+    private func startMPCInterfaceUnlocked() async throws {
+        await stopMPCInterfaceUnlocked()
 
         if transport == nil {
             try await initializeBaseStack()
@@ -3414,6 +3649,12 @@ public final class AppServices {
 
     /// Stop the Multipeer Connectivity interface.
     public func stopMPCInterface() async {
+        await withLifecycleOperation {
+            await stopMPCInterfaceUnlocked()
+        }
+    }
+
+    private func stopMPCInterfaceUnlocked() async {
         guard let mpc = mpcInterface else { return }
         await mpc.disconnect()
         if let transport = transport {
@@ -3434,6 +3675,13 @@ public final class AppServices {
     ///   - config: RNode radio configuration (device name, frequency, etc.)
     ///   - name: Display name for the interface
     public func startRNodeInterface(config rnodeConfig: RNodeConfig, name: String) async throws {
+        try await withLifecycleOperation {
+            try requireActiveRuntimeForInterfaceMutation()
+            try await startRNodeInterfaceUnlocked(config: rnodeConfig, name: name)
+        }
+    }
+
+    private func startRNodeInterfaceUnlocked(config rnodeConfig: RNodeConfig, name: String) async throws {
         #if COLUMBA_RUNTIME_MODEL_B
         // Model B: the RNode protocol stack (RNodeInterface + KISS framing) runs in the
         // Network Extension — the app hosts ONLY the CoreBluetooth NUS radio. Start the
@@ -3514,6 +3762,12 @@ public final class AppServices {
 
     /// Stop or clear the runtime's RNode interface state.
     public func stopRNodeInterface() async {
+        await withLifecycleOperation {
+            await stopRNodeInterfaceUnlocked()
+        }
+    }
+
+    private func stopRNodeInterfaceUnlocked() async {
         #if COLUMBA_RUNTIME_MODEL_B
         rnodeConnectWatchdog?.cancel()
         rnodeConnectWatchdog = nil
@@ -3765,6 +4019,12 @@ public final class AppServices {
 
     /// Disconnect a specific BLE peer.
     public func disconnectBLEPeer(identityHex: String) async {
+        await withLifecycleOperation {
+            await disconnectBLEPeerUnlocked(identityHex: identityHex)
+        }
+    }
+
+    private func disconnectBLEPeerUnlocked(identityHex: String) async {
         // Resolve identity → address via the bridge; if found, ask the
         // bridge to drop the GATT connection. The Compat stub's
         // disconnectPeer was a no-op, so this is the path that actually
@@ -3786,6 +4046,12 @@ public final class AppServices {
     ///
     /// Disconnects the TCP interface, shuts down the router, and cleans up resources.
     public func shutdown() async {
+        await withLifecycleOperation {
+            await shutdownUnlocked()
+        }
+    }
+
+    private func shutdownUnlocked() async {
         logger.info("Shutting down AppServices")
 
         stateObserverTask?.cancel()
@@ -3854,21 +4120,21 @@ public final class AppServices {
         await router?.shutdown()
 
         // Disconnect all TCP interfaces
-        await stopTCPInterface()
+        await stopTCPInterfaceUnlocked()
 
         // Stop RNode interface
-        await stopRNodeInterface()
+        await stopRNodeInterfaceUnlocked()
 
         // Stop BLE interface
         #if canImport(CoreBluetooth)
-        await stopBLEInterface()
+        await stopBLEInterfaceUnlocked()
         #endif
 
         // Stop auto interface
-        await stopAutoInterface()
+        await stopAutoInterfaceUnlocked()
 
         isConnected = false
-        RuntimeActivityMonitor.shared.stop()
+        releaseRuntimeActivityMonitorLease()
         logger.info("AppServices shutdown complete")
     }
 
@@ -3878,6 +4144,13 @@ public final class AppServices {
     /// Idempotent: if an interface is already running for `entityId` with the same
     /// `host:port`, returns without disturbing it.
     public func connectTCPInterface(entityId: String, host: String, port: UInt16) async throws {
+        try await withLifecycleOperation {
+            try requireActiveRuntimeForInterfaceMutation()
+            try await connectTCPInterfaceUnlocked(entityId: entityId, host: host, port: port)
+        }
+    }
+
+    private func connectTCPInterfaceUnlocked(entityId: String, host: String, port: UInt16) async throws {
         let endpoint = TCPEndpoint(host: host, port: port)
 
         // Already running with the same endpoint — leave it alone.
@@ -3961,6 +4234,12 @@ public final class AppServices {
 
     /// Stop a specific TCP interface by entity ID.
     public func stopTCPInterface(entityId: String) async {
+        await withLifecycleOperation {
+            await stopTCPInterfaceUnlocked(entityId: entityId)
+        }
+    }
+
+    private func stopTCPInterfaceUnlocked(entityId: String) async {
         guard let interface = tcpInterfaces[entityId] else { return }
         await interface.disconnect()
         await transport?.removeInterface(id: entityId)
@@ -3970,6 +4249,12 @@ public final class AppServices {
 
     /// Stop all TCP interfaces.
     public func stopTCPInterface() async {
+        await withLifecycleOperation {
+            await stopTCPInterfaceUnlocked()
+        }
+    }
+
+    private func stopTCPInterfaceUnlocked() async {
         for (entityId, interface) in tcpInterfaces {
             await interface.disconnect()
             await transport?.removeInterface(id: entityId)
@@ -3982,7 +4267,10 @@ public final class AppServices {
     /// Reconnect only the TCP interface without tearing down BLE/Auto/RNode.
     /// Uses the legacy "tcp-server" entity ID for backward compatibility.
     public func reconnectTCPOnly(host: String, port: UInt16) async throws {
-        try await connectTCPInterface(entityId: "tcp-server", host: host, port: port)
+        try await withLifecycleOperation {
+            try requireActiveRuntimeForInterfaceMutation()
+            try await connectTCPInterfaceUnlocked(entityId: "tcp-server", host: host, port: port)
+        }
     }
 
     // MARK: - Reconnection
@@ -3997,10 +4285,16 @@ public final class AppServices {
     /// - Parameter tcpServerAddress: New TCP server address (e.g., "tcp://10.0.0.1:4242")
     /// - Throws: InterfaceError or other initialization errors
     public func reconnect(tcpServerAddress: String) async throws {
+        try await withLifecycleOperation {
+            try await reconnectUnlocked(tcpServerAddress: tcpServerAddress)
+        }
+    }
+
+    private func reconnectUnlocked(tcpServerAddress: String) async throws {
         logger.info("Reconnecting to new TCP server: \(tcpServerAddress)")
 
         // 1. Shutdown existing connection
-        await shutdown()
+        await shutdownUnlocked()
 
         // 2. Clear path table (old paths may not be valid for new network)
         if let pathTable = pathTable {
@@ -4022,6 +4316,16 @@ public final class AppServices {
     private func reinitializeConnection(tcpServerAddress: String) async throws {
         guard let existingIdentity = identity else {
             throw AppServicesError.identityNotInitialized
+        }
+
+        let monitorLease = RuntimeActivityMonitor.shared.acquire()
+        var reinitializationSucceeded = false
+        defer {
+            if reinitializationSucceeded {
+                retainRuntimeActivityMonitorLease(monitorLease)
+            } else {
+                RuntimeActivityMonitor.shared.release(monitorLease)
+            }
         }
 
         // Parse server address
@@ -4097,6 +4401,7 @@ public final class AppServices {
         // Restart state observer
         startStateObserver()
 
+        reinitializationSucceeded = true
         logger.info("Connection re-initialized to \(host):\(port)")
     }
 

--- a/Sources/ColumbaApp/Services/MessageRepository.swift
+++ b/Sources/ColumbaApp/Services/MessageRepository.swift
@@ -113,9 +113,18 @@ public actor MessageRepository {
         try await database.ensureConversation(hash: conversationHash, displayName: displayName)
     }
 
+    /// Posted after persisted favorite/contact membership changes.
+    public static let favoriteStatusChangedNotification =
+        Notification.Name("network.columba.favoriteStatusChanged")
+
     /// Set favorite status for a conversation.
     public func setFavorite(_ conversationHash: Data, isFavorite: Bool) async throws {
         try await database.setFavorite(hash: conversationHash, isFavorite: isFavorite)
+        NotificationCenter.default.post(
+            name: Self.favoriteStatusChangedNotification,
+            object: nil,
+            userInfo: [Self.conversationHashUserInfoKey: conversationHash]
+        )
     }
 
     /// Set pinned status for a conversation.

--- a/Sources/ColumbaApp/ViewModels/ContactsViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/ContactsViewModel.swift
@@ -386,10 +386,18 @@ public final class ContactsViewModel {
     /// Task for streaming path updates.
     private var updateTask: Task<Void, Never>?
 
+    /// One-shot task for lightweight saved-contact reconciliation.
+    private var favoriteRefreshTask: Task<Void, Never>?
+
+    /// Synchronously registered before reconciliation so a favorite mutation
+    /// cannot land in a refresh/subscribe gap.
+    private var favoriteObserver: NSObjectProtocol?
+
     /// Avoid rebuilding thousands of contacts whenever the SwiftUI task
     /// reappears. Explicit pull-to-refresh passes `force: true`.
     private var hasLoadedContacts = false
     private var isContactsLoadInFlight = false
+    private var savedContactsGeneration: UInt64 = 0
 
     // MARK: - Computed Properties
 
@@ -527,6 +535,10 @@ public final class ContactsViewModel {
 
     deinit {
         updateTask?.cancel()
+        favoriteRefreshTask?.cancel()
+        if let favoriteObserver {
+            NotificationCenter.default.removeObserver(favoriteObserver)
+        }
     }
 
     // MARK: - Real-Time Updates
@@ -543,12 +555,58 @@ public final class ContactsViewModel {
                 handleNewPathEntry(entry)
             }
         }
+
+        if let favoriteObserver {
+            NotificationCenter.default.removeObserver(favoriteObserver)
+        }
+        favoriteObserver = NotificationCenter.default.addObserver(
+            forName: MessageRepository.favoriteStatusChangedNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.scheduleSavedContactsRefresh()
+            }
+        }
+
+        // Register first, then reconcile anything changed while Contacts was
+        // hidden. A mutation during this refresh posts to the already-live
+        // observer and replaces this task with a newer authoritative refresh.
+        if hasLoadedContacts {
+            scheduleSavedContactsRefresh()
+        }
     }
 
     /// Stop listening for updates.
     public func stopListening() {
         updateTask?.cancel()
         updateTask = nil
+        if let favoriteObserver {
+            NotificationCenter.default.removeObserver(favoriteObserver)
+            self.favoriteObserver = nil
+        }
+        favoriteRefreshTask?.cancel()
+        favoriteRefreshTask = nil
+    }
+
+    /// Cancel any in-flight snapshot before starting a newer authoritative one.
+    /// `refreshSavedContacts` checks cancellation after its repository await, so
+    /// an older fetch cannot overwrite a newer favorite mutation.
+    @MainActor
+    private func scheduleSavedContactsRefresh() {
+        favoriteRefreshTask?.cancel()
+        favoriteRefreshTask = Task { [weak self] in
+            guard let self else { return }
+            do {
+                try await self.refreshSavedContacts()
+                self.syncRelayState()
+                self.errorMessage = nil
+            } catch is CancellationError {
+                // Superseded by a newer favorite mutation or listener teardown.
+            } catch {
+                self.errorMessage = error.localizedDescription
+            }
+        }
     }
 
     /// Handle a new path entry from the stream.
@@ -624,12 +682,11 @@ public final class ContactsViewModel {
 
     // MARK: - Public Methods
 
-    /// Load contacts from storage once per view-model lifetime. Pull-to-refresh
-    /// passes `force: true`; ordinary SwiftUI task reappearances reuse the live
-    /// snapshot maintained by the path-update stream.
+    /// Load contacts from storage. After the first full path snapshot, ordinary
+    /// SwiftUI task reappearances refresh only saved-contact state; path updates
+    /// remain live through the stream. Pull-to-refresh passes `force: true`.
     @MainActor
     public func loadContacts(force: Bool = false) async {
-        guard force || !hasLoadedContacts else { return }
         guard !isContactsLoadInFlight else { return }
 
         isContactsLoadInFlight = true
@@ -641,11 +698,15 @@ public final class ContactsViewModel {
         }
 
         do {
-            // Load my contacts from favorited conversations only.
-            let conversations = try await messageRepository.fetchConversations()
-            myContacts = conversations
-                .filter { $0.isFavorite != 0 }
-                .map { Contact(from: $0) }
+            if hasLoadedContacts && !force {
+                try await refreshSavedContacts()
+                syncRelayState()
+                return
+            }
+
+            // Load saved contacts without publishing a second Network snapshot;
+            // the full path snapshot below will reconcile favorite markers once.
+            try await refreshSavedContacts(reconcileNetwork: false)
 
             // Build and mark the network snapshot off to the side, then publish
             // it once. This avoids repeatedly filtering thousands of contacts.
@@ -677,6 +738,8 @@ public final class ContactsViewModel {
 
             hasLoadedContacts = true
             errorMessage = nil
+        } catch is CancellationError {
+            // View/task teardown is not a user-visible load failure.
         } catch {
             errorMessage = error.localizedDescription
         }
@@ -854,7 +917,12 @@ public final class ContactsViewModel {
                 displayName: contact.displayName
             )
             try await messageRepository.setFavorite(contact.identityHash, isFavorite: true)
-            myContacts.append(contact.copy(isFavorite: true))
+            let savedContact = contact.copy(isFavorite: true)
+            if let existingIndex = myContacts.firstIndex(where: { $0.id == contact.id }) {
+                myContacts[existingIndex] = savedContact
+            } else {
+                myContacts.append(savedContact)
+            }
 
             // Mark this contact as saved in network announces
             if let index = networkAnnounces.firstIndex(where: { $0.id == contact.id }) {
@@ -930,7 +998,11 @@ public final class ContactsViewModel {
                 isFavorite: true,
                 isRelay: false
             )
-            myContacts.append(contact)
+            if let existingIndex = myContacts.firstIndex(where: { $0.id == hex }) {
+                myContacts[existingIndex] = contact
+            } else {
+                myContacts.append(contact)
+            }
         } catch {
             errorMessage = "Failed to add contact: \(error.localizedDescription)"
         }
@@ -949,6 +1021,30 @@ public final class ContactsViewModel {
             data.append(byte)
         }
         return data
+    }
+
+    /// Refresh favorites from the conversation store. Reappearance uses this
+    /// lightweight path so changes made in Messaging are reflected without
+    /// rebuilding every path-table contact.
+    @MainActor @discardableResult
+    private func refreshSavedContacts(reconcileNetwork: Bool = true) async throws -> Bool {
+        savedContactsGeneration &+= 1
+        let generation = savedContactsGeneration
+        let conversations = try await messageRepository.fetchConversations()
+        try Task.checkCancellation()
+        guard generation == savedContactsGeneration else {
+            return false
+        }
+        myContacts = conversations
+            .filter { $0.isFavorite != 0 }
+            .map { Contact(from: $0) }
+
+        if reconcileNetwork {
+            networkAnnounces = markingSavedContacts(in: networkAnnounces)
+            pendingAnnounces = markingSavedContacts(in: pendingAnnounces)
+            enrichMyContactBadges()
+        }
+        return true
     }
 
     /// Enrich myContacts from network announces.
@@ -985,10 +1081,16 @@ public final class ContactsViewModel {
     private func markingSavedContacts(in contacts: [Contact]) -> [Contact] {
         let savedById = Dictionary(myContacts.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
         return contacts.map { contact in
-            if let saved = savedById[contact.id], !contact.isFavorite {
-                return contact.copy(isFavorite: true, isPinned: saved.isPinned)
+            let saved = savedById[contact.id]
+            let shouldBeFavorite = saved != nil
+            let shouldBePinned = saved?.isPinned ?? false
+            guard contact.isFavorite != shouldBeFavorite || contact.isPinned != shouldBePinned else {
+                return contact
             }
-            return contact
+            return contact.copy(
+                isFavorite: saved != nil,
+                isPinned: shouldBePinned
+            )
         }
     }
 }

--- a/Sources/ColumbaApp/ViewModels/ContactsViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/ContactsViewModel.swift
@@ -148,7 +148,7 @@ public struct Contact: Identifiable, Sendable, Hashable {
     ///
     /// Detects propagation nodes by parsing appData with PropagationNodeInfo.
     public init(from entry: PathEntry) {
-        let hex = entry.destinationHash.map { String(format: "%02x", $0) }.joined()
+        let hex = Self.hexString(for: entry.destinationHash)
         self.id = hex
         self.displayName = entry.displayName
         self.identityHash = entry.destinationHash
@@ -199,7 +199,7 @@ public struct Contact: Identifiable, Sendable, Hashable {
 
     /// Create from ConversationRecord.
     public init(from record: ConversationRecord) {
-        let hex = record.destinationHash.map { String(format: "%02x", $0) }.joined()
+        let hex = Self.hexString(for: record.destinationHash)
         self.id = hex
         self.displayName = record.displayName
         self.identityHash = record.destinationHash
@@ -256,6 +256,20 @@ public struct Contact: Identifiable, Sendable, Hashable {
         self.interfaceId = interfaceId
         self.aspect = aspect
     }
+
+    private static let lowercaseHex = Array("0123456789abcdef".utf8)
+
+    /// Avoid `String(format:)` allocation for every byte while materializing
+    /// thousands of path-table rows on the main actor.
+    private static func hexString(for data: Data) -> String {
+        var output = [UInt8]()
+        output.reserveCapacity(data.count * 2)
+        for byte in data {
+            output.append(lowercaseHex[Int(byte >> 4)])
+            output.append(lowercaseHex[Int(byte & 0x0f)])
+        }
+        return String(decoding: output, as: UTF8.self)
+    }
 }
 
 // MARK: - Tab Selection
@@ -296,13 +310,24 @@ public final class ContactsViewModel {
     public var myContacts: [Contact] = []
 
     /// Network announces from the mesh (from path table).
-    public var networkAnnounces: [Contact] = []
+    public var networkAnnounces: [Contact] = [] {
+        didSet { rebuildFilteredNetworkAnnounces() }
+    }
+
+    /// Cached visible result. Rebuilt only when source data or filters change,
+    /// never merely because SwiftUI reevaluates the Network tab while scrolling.
+    public private(set) var filteredNetworkAnnounces: [Contact] = []
 
     /// Buffered new announces that haven't been merged into the visible
     /// list yet. The Network tab pushes incoming announces here instead
     /// of inserting them inline so the rendered order stays stable while
     /// the user is scrolling — a "show N new" pill at the top flushes.
-    public var pendingAnnounces: [Contact] = []
+    public var pendingAnnounces: [Contact] = [] {
+        didSet { rebuildFilteredPendingAnnounces() }
+    }
+
+    /// Cached banner result for the same reason as the visible Network list.
+    public private(set) var filteredPendingAnnounces: [Contact] = []
 
     /// Currently selected tab.
     public var selectedTab: ContactsTab = .myContacts
@@ -320,13 +345,28 @@ public final class ContactsViewModel {
     public var errorMessage: String?
 
     /// Search text.
-    public var searchText: String = ""
+    public var searchText: String = "" {
+        didSet {
+            rebuildFilteredNetworkAnnounces()
+            rebuildFilteredPendingAnnounces()
+        }
+    }
 
     /// Network announces aspect filter.
-    public var announceFilter: AnnounceFilter = .peers
+    public var announceFilter: AnnounceFilter = .peers {
+        didSet {
+            rebuildFilteredNetworkAnnounces()
+            rebuildFilteredPendingAnnounces()
+        }
+    }
 
     /// Network announces interface filter.
-    public var interfaceFilter: InterfaceFilter = .all
+    public var interfaceFilter: InterfaceFilter = .all {
+        didSet {
+            rebuildFilteredNetworkAnnounces()
+            rebuildFilteredPendingAnnounces()
+        }
+    }
 
     /// Currently selected relay node hash (lxmf.propagation aspect, from PropagationNodeManager).
     public var selectedRelayHash: Data?
@@ -346,6 +386,11 @@ public final class ContactsViewModel {
     /// Task for streaming path updates.
     private var updateTask: Task<Void, Never>?
 
+    /// Avoid rebuilding thousands of contacts whenever the SwiftUI task
+    /// reappears. Explicit pull-to-refresh passes `force: true`.
+    private var hasLoadedContacts = false
+    private var isContactsLoadInFlight = false
+
     // MARK: - Computed Properties
 
     /// Filtered my contacts based on search.
@@ -358,19 +403,14 @@ public final class ContactsViewModel {
         }
     }
 
-    /// Filtered network announces based on search, aspect filter, and interface filter.
-    public var filteredNetworkAnnounces: [Contact] {
-        applyAnnounceFilters(to: networkAnnounces)
+    /// Recompute the cached Network-tab result after a source/filter mutation.
+    private func rebuildFilteredNetworkAnnounces() {
+        filteredNetworkAnnounces = applyAnnounceFilters(to: networkAnnounces)
     }
 
-    /// `pendingAnnounces` filtered by the currently-active announce
-    /// filters. Used to drive the "Show N new" pill so the count
-    /// reflects how many will actually appear in the visible list
-    /// after a flush, not the raw buffer size — otherwise an active
-    /// filter (peers / audio / sites / relays / interface / search)
-    /// could overstate the pill and surprise the user.
-    public var filteredPendingAnnounces: [Contact] {
-        applyAnnounceFilters(to: pendingAnnounces)
+    /// Recompute the cached pending-banner result after source/filter changes.
+    private func rebuildFilteredPendingAnnounces() {
+        filteredPendingAnnounces = applyAnnounceFilters(to: pendingAnnounces)
     }
 
     /// Apply the active aspect / interface / search filters to a
@@ -576,76 +616,70 @@ public final class ContactsViewModel {
     @MainActor
     public func flushPendingAnnounces() {
         guard !pendingAnnounces.isEmpty else { return }
-        networkAnnounces.append(contentsOf: pendingAnnounces)
-        pendingAnnounces.removeAll()
-        networkAnnounces.sort { $0.timestamp > $1.timestamp }
+        let merged = (networkAnnounces + pendingAnnounces)
+            .sorted { $0.timestamp > $1.timestamp }
+        pendingAnnounces.removeAll(keepingCapacity: true)
+        networkAnnounces = merged
     }
 
     // MARK: - Public Methods
 
-    /// Load contacts from storage.
+    /// Load contacts from storage once per view-model lifetime. Pull-to-refresh
+    /// passes `force: true`; ordinary SwiftUI task reappearances reuse the live
+    /// snapshot maintained by the path-update stream.
     @MainActor
-    public func loadContacts() async {
+    public func loadContacts(force: Bool = false) async {
+        guard force || !hasLoadedContacts else { return }
+        guard !isContactsLoadInFlight else { return }
+
+        isContactsLoadInFlight = true
         isLoading = true
         errorMessage = nil
+        defer {
+            isContactsLoadInFlight = false
+            isLoading = false
+        }
 
         do {
-            // Load my contacts from favorited conversations only
+            // Load my contacts from favorited conversations only.
             let conversations = try await messageRepository.fetchConversations()
             myContacts = conversations
                 .filter { $0.isFavorite != 0 }
                 .map { Contact(from: $0) }
 
-            // Load network announces from path table (known destinations)
+            // Build and mark the network snapshot off to the side, then publish
+            // it once. This avoids repeatedly filtering thousands of contacts.
             if let pathTable = appServices.pathTable {
                 let entries = await pathTable.allEntries()
-                networkAnnounces = entries
+                let loaded = entries
                     .filter { $0.isKnownDestination }
                     .map { Contact(from: $0) }
                     .sorted { $0.timestamp > $1.timestamp }
+                networkAnnounces = markingSavedContacts(in: loaded)
             }
-            // Drop only the pending entries that the fresh path-table
-            // snapshot already covers. `handleNewPathEntry` is also
-            // @MainActor and can interleave with the await above, so a
-            // blanket `removeAll()` would silently delete announces
-            // that arrived *during* the suspension and aren't in the
-            // snapshot yet. Filtering by id keeps those late arrivals
-            // queued for the next flush.
+
+            // Drop only pending entries that the fresh snapshot covers. Keep
+            // announces that arrived while the path-table await was suspended.
             let visibleIds = Set(networkAnnounces.map(\.id))
             pendingAnnounces.removeAll { visibleIds.contains($0.id) }
 
-            // Mark network announces that are already saved contacts
-            markSavedContacts()
-
-            // Enrich myContacts badges from network announces (ConversationRecord
-            // always creates contacts with .peer badge — cross-reference with path
-            // table data so relays keep their .relay badge after restart)
             enrichMyContactBadges()
-
-            // Sync relay state from PropagationNodeManager
             syncRelayState()
 
-            // DEBUG: Log relay state for diagnosing badge bug
-            let relayHex = selectedRelayHash.map { $0.map { String(format: "%02x", $0) }.joined() } ?? "nil"
-            let relayContacts = networkAnnounces.filter { $0.isRelay }
-            let myRelayMatches = myContacts.filter { $0.identityHash == selectedRelayHash }
-            let netRelayMatches = networkAnnounces.filter { $0.identityHash == selectedRelayHash }
-            DiagLog.log("[CONTACTS] selectedRelayHash=\(relayHex)")
-            DiagLog.log("[CONTACTS] networkAnnounces=\(networkAnnounces.count), relays=\(relayContacts.count): \(relayContacts.map { "\($0.resolvedDisplayName)=\($0.identityHashHex.prefix(16))" })")
-            DiagLog.log("[CONTACTS] myContacts=\(myContacts.count): \(myContacts.map { "\($0.resolvedDisplayName)=\($0.identityHashHex.prefix(16))(\($0.badgeType.rawValue))" })")
-            DiagLog.log("[CONTACTS] relay match in network=\(netRelayMatches.count), in myContacts=\(myRelayMatches.count)")
-            if let relay = currentRelayContact {
-                DiagLog.log("[CONTACTS] currentRelayContact=\(relay.resolvedDisplayName) badge=\(relay.badgeType.rawValue)")
-            } else {
-                DiagLog.log("[CONTACTS] currentRelayContact=nil")
-            }
+            // Aggregate-only diagnostics: never stringify contact arrays,
+            // display names, or hashes on this hot path.
+            let relayCount = networkAnnounces.lazy.filter(\.isRelay).count
+            DiagLog.log(
+                "[CONTACTS] loaded network=\(networkAnnounces.count) "
+                + "relays=\(relayCount) saved=\(myContacts.count) "
+                + "selected_relay_present=\(currentRelayContact != nil)"
+            )
 
+            hasLoadedContacts = true
             errorMessage = nil
         } catch {
             errorMessage = error.localizedDescription
         }
-
-        isLoading = false
     }
 
     /// Refresh announces from the network.
@@ -656,21 +690,19 @@ public final class ContactsViewModel {
 
         if let pathTable = appServices.pathTable {
             let entries = await pathTable.allEntries()
-            networkAnnounces = entries
+            let loaded = entries
                 .filter { $0.isKnownDestination }
                 .map { Contact(from: $0) }
                 .sorted { $0.timestamp > $1.timestamp }
+            networkAnnounces = markingSavedContacts(in: loaded)
         }
         // Drop only the pending entries the fresh path-table snapshot
         // already covers — see `loadContacts` for the same race
         // (handleNewPathEntry can interleave with the await above and
         // queue announces that aren't in the snapshot yet; a blanket
-        // removeAll() would silently lose them).
+        // `removeAll()` would silently lose them).
         let visibleIds = Set(networkAnnounces.map(\.id))
         pendingAnnounces.removeAll { visibleIds.contains($0.id) }
-
-        // Mark network announces that are already saved contacts
-        markSavedContacts()
 
         // Enrich myContacts badges from network announces
         enrichMyContactBadges()
@@ -947,11 +979,12 @@ public final class ContactsViewModel {
         }
     }
 
-    /// Mark network announces that already exist in my contacts.
+    /// Mark network announces that already exist in my contacts without
+    /// publishing an intermediate array (which would rebuild all filters).
     @MainActor
-    private func markSavedContacts() {
+    private func markingSavedContacts(in contacts: [Contact]) -> [Contact] {
         let savedById = Dictionary(myContacts.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
-        networkAnnounces = networkAnnounces.map { contact in
+        return contacts.map { contact in
             if let saved = savedById[contact.id], !contact.isFavorite {
                 return contact.copy(isFavorite: true, isPinned: saved.isPinned)
             }

--- a/Sources/ColumbaApp/Views/Components/Identicon.swift
+++ b/Sources/ColumbaApp/Views/Components/Identicon.swift
@@ -57,7 +57,7 @@ public struct Identicon: View {
         dotScale: CGFloat = 0.7,
         dotSpacing: CGFloat = 1.0
     ) {
-        self.pattern = IdenticonGenerator.generate(from: hash, gridSize: gridSize)
+        self.pattern = IdenticonGenerator.cachedPattern(from: hash, gridSize: gridSize)
         self.dotScale = dotScale
         self.dotSpacing = dotSpacing
     }
@@ -75,7 +75,7 @@ public struct Identicon: View {
         dotScale: CGFloat = 0.7,
         dotSpacing: CGFloat = 1.0
     ) {
-        self.pattern = IdenticonGenerator.generate(fromHex: hexHash, gridSize: gridSize)
+        self.pattern = IdenticonGenerator.cachedPattern(fromHex: hexHash, gridSize: gridSize)
         self.dotScale = dotScale
         self.dotSpacing = dotSpacing
     }

--- a/Sources/ColumbaApp/Views/Components/IdenticonGenerator.swift
+++ b/Sources/ColumbaApp/Views/Components/IdenticonGenerator.swift
@@ -8,6 +8,7 @@
 //  Compatible with ReticulumSwift Identity.hash (16-byte Data).
 //
 
+import Foundation
 import SwiftUI
 import RNSAPI
 
@@ -44,6 +45,36 @@ public struct IdenticonGenerator {
 
         /// Grid size (number of rows/columns).
         public let gridSize: Int
+    }
+
+    private final class PatternBox: NSObject {
+        let pattern: Pattern
+        init(_ pattern: Pattern) { self.pattern = pattern }
+    }
+
+    /// `NSCache` is internally synchronized. The unsafe annotation only tells
+    /// strict concurrency checking that synchronization is owned by NSCache.
+    nonisolated(unsafe) private static let patternCache: NSCache<NSString, PatternBox> = {
+        let patternCache = NSCache<NSString, PatternBox>()
+        patternCache.countLimit = 4096
+        return patternCache
+    }()
+
+    /// Reuse deterministic pattern construction as rows enter and leave the
+    /// lazy Network list. The bound prevents a long-running node from retaining
+    /// an unbounded number of historical destination patterns.
+    public static func cachedPattern(from hash: Data, gridSize: Int = 5) -> Pattern {
+        let key = "\(gridSize):\(hash.base64EncodedString())" as NSString
+        if let cached = patternCache.object(forKey: key) {
+            return cached.pattern
+        }
+        let pattern = generate(from: hash, gridSize: gridSize)
+        patternCache.setObject(PatternBox(pattern), forKey: key)
+        return pattern
+    }
+
+    public static func cachedPattern(fromHex hexHash: String, gridSize: Int = 5) -> Pattern {
+        cachedPattern(from: hexToData(hexHash), gridSize: gridSize)
     }
 
     // MARK: - Color Palette

--- a/Sources/ColumbaApp/Views/Contacts/ContactsView.swift
+++ b/Sources/ColumbaApp/Views/Contacts/ContactsView.swift
@@ -423,7 +423,7 @@ public struct ContactsView: View {
             .padding(.vertical, 12)
         }
         .refreshable {
-            await vm.loadContacts()
+            await vm.loadContacts(force: true)
         }
     }
 

--- a/Sources/ColumbaApp/Views/Contacts/NetworkAnnouncesTab.swift
+++ b/Sources/ColumbaApp/Views/Contacts/NetworkAnnouncesTab.swift
@@ -26,6 +26,11 @@ struct NetworkAnnouncesTab: View {
     /// Called when a contact is selected.
     var onContactSelected: ((Contact) -> Void)?
 
+    /// Keep the live SwiftUI hierarchy bounded even when the path table holds
+    /// thousands of destinations. Additional rows are appended near the end.
+    private static let pageSize = 100
+    @State private var visibleLimit = NetworkAnnouncesTab.pageSize
+
     // MARK: - Body
 
     var body: some View {
@@ -54,6 +59,9 @@ struct NetworkAnnouncesTab: View {
                 announcesList
             }
         }
+        .onChange(of: viewModel.announceFilter) { _, _ in resetVisibleWindow() }
+        .onChange(of: viewModel.interfaceFilter) { _, _ in resetVisibleWindow() }
+        .onChange(of: viewModel.searchText) { _, _ in resetVisibleWindow() }
     }
 
     // MARK: - Empty State
@@ -220,9 +228,12 @@ struct NetworkAnnouncesTab: View {
     // MARK: - Announces List
 
     private var announcesList: some View {
-        ScrollView {
+        let filtered = viewModel.filteredNetworkAnnounces
+        let visible = filtered.prefix(visibleLimit)
+
+        return ScrollView {
             LazyVStack(spacing: 12) {
-                ForEach(viewModel.filteredNetworkAnnounces) { contact in
+                ForEach(visible) { contact in
                     ContactCard(
                         contact: contact,
                         showInterfaceIcon: true,
@@ -239,6 +250,14 @@ struct NetworkAnnouncesTab: View {
                         }
                     )
                 }
+
+                if visibleLimit < filtered.count {
+                    ProgressView()
+                        .padding(.vertical, 12)
+                        .onAppear {
+                            loadNextPage(totalCount: filtered.count)
+                        }
+                }
             }
             .padding(.horizontal, 16)
             .padding(.vertical, 12)
@@ -246,6 +265,14 @@ struct NetworkAnnouncesTab: View {
         .refreshable {
             await viewModel.refreshAnnounces()
         }
+    }
+
+    private func loadNextPage(totalCount: Int) {
+        visibleLimit = min(visibleLimit + Self.pageSize, totalCount)
+    }
+
+    private func resetVisibleWindow() {
+        visibleLimit = Self.pageSize
     }
 
     /// Tappable banner shown above the list while new announces are buffered.

--- a/Sources/RNSAPI/Compat.swift
+++ b/Sources/RNSAPI/Compat.swift
@@ -1,5 +1,6 @@
 import Foundation
 import CryptoKit
+import Dispatch
 import SQLite3
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1746,6 +1747,16 @@ public struct InterfaceSnapshot: Identifiable, Equatable, Sendable {
 
 // MARK: - PathTable
 
+/// Timing returned by `PathTable.insert(_:)` for low-overhead runtime diagnostics.
+/// It contains aggregate duration only and no path or destination information.
+public struct PathInsertMetrics: Sendable {
+    public let persistenceDurationMilliseconds: Double
+
+    public init(persistenceDurationMilliseconds: Double) {
+        self.persistenceDurationMilliseconds = persistenceDurationMilliseconds
+    }
+}
+
 /// In-memory path table. Python's RNS.Transport.path_table is the source of
 /// truth for the network state; AppServices.handlePythonEvent mirrors each
 /// `announce` event into this Compat-layer table via `insert(_:)`. The
@@ -1853,15 +1864,21 @@ public final class PathTable: @unchecked Sendable {
     /// Insert or update a path entry. Keyed by `destinationHash`; replacing
     /// an existing entry yields the new copy to all live `pathUpdates`
     /// subscribers so the UI re-renders.
-    public func insert(_ entry: PathEntry) async {
+    public func insert(_ entry: PathEntry) async -> PathInsertMetrics {
         lock.lock()
         entries[entry.destinationHash] = entry
+        let persistStart = DispatchTime.now().uptimeNanoseconds
         persist(entry)
+        let persistEnd = DispatchTime.now().uptimeNanoseconds
         let continuationsCopy = continuations.values
         lock.unlock()
         for continuation in continuationsCopy {
             continuation.yield(entry)
         }
+        let persistenceDurationMilliseconds = Double(persistEnd - persistStart) / 1_000_000
+        return PathInsertMetrics(
+            persistenceDurationMilliseconds: persistenceDurationMilliseconds
+        )
     }
 
     /// Stream of path-table updates. Each subscriber gets its own continuation;

--- a/Tests/ColumbaAppTests/RuntimeActivityMonitorLeaseTests.swift
+++ b/Tests/ColumbaAppTests/RuntimeActivityMonitorLeaseTests.swift
@@ -1,0 +1,116 @@
+import XCTest
+#if COLUMBA_RUNTIME_MODEL_B
+@testable import ColumbaModelBApp
+#else
+@testable import ColumbaApp
+#endif
+
+final class RuntimeActivityMonitorLeaseTests: XCTestCase {
+    func testMonitorRunsUntilLastLeaseIsReleased() {
+        let monitor = RuntimeActivityMonitor()
+
+        let first = monitor.acquire()
+        let second = monitor.acquire()
+        XCTAssertTrue(monitor.isRunningForTesting)
+        XCTAssertEqual(monitor.activeLeaseCountForTesting, 2)
+
+        monitor.release(first)
+        XCTAssertTrue(monitor.isRunningForTesting)
+        XCTAssertEqual(monitor.activeLeaseCountForTesting, 1)
+
+        monitor.release(second)
+        XCTAssertFalse(monitor.isRunningForTesting)
+        XCTAssertEqual(monitor.activeLeaseCountForTesting, 0)
+    }
+
+    func testStaleLeaseCannotStopNewGeneration() {
+        let monitor = RuntimeActivityMonitor()
+
+        let stale = monitor.acquire()
+        monitor.release(stale)
+        let current = monitor.acquire()
+
+        monitor.release(stale)
+        XCTAssertTrue(monitor.isRunningForTesting)
+        XCTAssertEqual(monitor.activeLeaseCountForTesting, 1)
+
+        monitor.release(current)
+        XCTAssertFalse(monitor.isRunningForTesting)
+    }
+
+    func testLeaseReleaseIsIdempotent() {
+        let monitor = RuntimeActivityMonitor()
+        let first = monitor.acquire()
+        let second = monitor.acquire()
+
+        monitor.release(first)
+        monitor.release(first)
+        XCTAssertTrue(monitor.isRunningForTesting)
+        XCTAssertEqual(monitor.activeLeaseCountForTesting, 1)
+
+        monitor.release(second)
+        XCTAssertFalse(monitor.isRunningForTesting)
+    }
+}
+
+final class AppServicesLifecycleGateTests: XCTestCase {
+    private enum ExpectedError: Error {
+        case failure
+    }
+
+    @MainActor
+    func testSuspendedOperationBlocksItsSuccessor() async {
+        let services = AppServices()
+        let firstEntered = expectation(description: "first operation entered")
+        var releaseFirst: CheckedContinuation<Void, Never>?
+        var events: [String] = []
+
+        let firstTask = Task { @MainActor in
+            await services.withLifecycleOperation {
+                events.append("first-start")
+                firstEntered.fulfill()
+                await withCheckedContinuation { continuation in
+                    releaseFirst = continuation
+                }
+                events.append("first-end")
+            }
+        }
+
+        await fulfillment(of: [firstEntered], timeout: 1)
+        let secondTask = Task { @MainActor in
+            await services.withLifecycleOperation {
+                events.append("second")
+            }
+        }
+
+        try? await Task.sleep(for: .milliseconds(50))
+        XCTAssertEqual(events, ["first-start"])
+        XCTAssertNotNil(releaseFirst)
+        releaseFirst?.resume()
+        await firstTask.value
+        await secondTask.value
+        XCTAssertEqual(events, ["first-start", "first-end", "second"])
+    }
+
+    @MainActor
+    func testThrownOperationReleasesGate() async {
+        let services = AppServices()
+
+        do {
+            try await services.withLifecycleOperation {
+                throw ExpectedError.failure
+            }
+            XCTFail("Expected lifecycle operation to throw")
+        } catch ExpectedError.failure {
+            // Expected.
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        var successorRan = false
+        await services.withLifecycleOperation {
+            successorRan = true
+        }
+        XCTAssertTrue(successorRan)
+    }
+}

--- a/Tests/static/test_contacts_network_performance.py
+++ b/Tests/static/test_contacts_network_performance.py
@@ -9,6 +9,7 @@ NETWORK_TAB = ROOT / "Sources/ColumbaApp/Views/Contacts/NetworkAnnouncesTab.swif
 IDENTICON = ROOT / "Sources/ColumbaApp/Views/Components/Identicon.swift"
 GENERATOR = ROOT / "Sources/ColumbaApp/Views/Components/IdenticonGenerator.swift"
 CONTACTS_VIEW = ROOT / "Sources/ColumbaApp/Views/Contacts/ContactsView.swift"
+MESSAGE_REPOSITORY = ROOT / "Sources/ColumbaApp/Services/MessageRepository.swift"
 
 
 class ContactsNetworkPerformanceContractTests(unittest.TestCase):
@@ -19,6 +20,7 @@ class ContactsNetworkPerformanceContractTests(unittest.TestCase):
         cls.identicon = IDENTICON.read_text()
         cls.generator = GENERATOR.read_text()
         cls.view = CONTACTS_VIEW.read_text()
+        cls.repository = MESSAGE_REPOSITORY.read_text()
 
     def test_contact_diagnostics_are_aggregate_only(self):
         self.assertNotIn("relayContacts.map", self.vm)
@@ -54,10 +56,32 @@ class ContactsNetworkPerformanceContractTests(unittest.TestCase):
         self.assertIn("patternCache.countLimit = 4096", self.generator)
         self.assertIn("public static func cachedPattern", self.generator)
 
-    def test_contacts_view_does_not_reload_unchanged_data_on_reappearance(self):
+    def test_reappearance_refreshes_saved_state_without_rebuilding_paths(self):
         self.assertIn("private var hasLoadedContacts = false", self.vm)
         self.assertIn("public func loadContacts(force: Bool = false)", self.vm)
-        self.assertIn("guard force || !hasLoadedContacts else { return }", self.vm)
+        self.assertIn("if hasLoadedContacts && !force", self.vm)
+        self.assertIn("try await refreshSavedContacts()", self.vm)
+        self.assertIn("private func refreshSavedContacts(", self.vm)
+        self.assertIn("MessageRepository.favoriteStatusChangedNotification", self.vm)
+        self.assertIn("favoriteObserver = NotificationCenter.default.addObserver", self.vm)
+        self.assertIn("scheduleSavedContactsRefresh()", self.vm)
+        start_listening = self.vm.index("public func startListening()")
+        stop_listening = self.vm.index("public func stopListening()", start_listening)
+        listener = self.vm[start_listening:stop_listening]
+        self.assertLess(
+            listener.index("favoriteObserver = NotificationCenter.default.addObserver"),
+            listener.index("scheduleSavedContactsRefresh()"),
+        )
+        self.assertIn("try Task.checkCancellation()", self.vm)
+        self.assertIn("private var savedContactsGeneration: UInt64 = 0", self.vm)
+        self.assertIn("guard generation == savedContactsGeneration", self.vm)
+        self.assertIn("return false", self.vm)
+        self.assertGreaterEqual(
+            self.vm.count("if let existingIndex = myContacts.firstIndex"), 2
+        )
+        self.assertIn("favoriteStatusChangedNotification", self.repository)
+        self.assertIn("pendingAnnounces = markingSavedContacts", self.vm)
+        self.assertIn("isFavorite: saved != nil", self.vm)
         self.assertIn("await vm.loadContacts(force: true)", self.view)
 
 

--- a/Tests/static/test_contacts_network_performance.py
+++ b/Tests/static/test_contacts_network_performance.py
@@ -1,0 +1,65 @@
+import pathlib
+import re
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+VIEW_MODEL = ROOT / "Sources/ColumbaApp/ViewModels/ContactsViewModel.swift"
+NETWORK_TAB = ROOT / "Sources/ColumbaApp/Views/Contacts/NetworkAnnouncesTab.swift"
+IDENTICON = ROOT / "Sources/ColumbaApp/Views/Components/Identicon.swift"
+GENERATOR = ROOT / "Sources/ColumbaApp/Views/Components/IdenticonGenerator.swift"
+CONTACTS_VIEW = ROOT / "Sources/ColumbaApp/Views/Contacts/ContactsView.swift"
+
+
+class ContactsNetworkPerformanceContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.vm = VIEW_MODEL.read_text()
+        cls.tab = NETWORK_TAB.read_text()
+        cls.identicon = IDENTICON.read_text()
+        cls.generator = GENERATOR.read_text()
+        cls.view = CONTACTS_VIEW.read_text()
+
+    def test_contact_diagnostics_are_aggregate_only(self):
+        self.assertNotIn("relayContacts.map", self.vm)
+        self.assertNotIn("myContacts.map { \"\\($0.resolvedDisplayName)", self.vm)
+        self.assertIn("[CONTACTS] loaded network=", self.vm)
+        self.assertIn("relays=", self.vm)
+
+    def test_filtered_network_results_are_stored_not_computed_per_body(self):
+        self.assertRegex(
+            self.vm,
+            r"public private\(set\) var filteredNetworkAnnounces: \[Contact\] = \[\]",
+        )
+        self.assertIn("rebuildFilteredNetworkAnnounces()", self.vm)
+        self.assertIn(
+            "public private(set) var filteredPendingAnnounces: [Contact] = []",
+            self.vm,
+        )
+        self.assertIn("rebuildFilteredPendingAnnounces()", self.vm)
+        self.assertNotRegex(
+            self.vm,
+            r"public var filteredNetworkAnnounces: \[Contact\] \{\s*applyAnnounceFilters",
+        )
+
+    def test_network_rows_are_incrementally_windowed(self):
+        self.assertIn("private static let pageSize = 100", self.tab)
+        self.assertIn("@State private var visibleLimit = NetworkAnnouncesTab.pageSize", self.tab)
+        self.assertIn("prefix(visibleLimit)", self.tab)
+        self.assertIn("loadNextPage", self.tab)
+        self.assertIn("visibleLimit = Self.pageSize", self.tab)
+
+    def test_identicon_patterns_are_cached_with_a_bound(self):
+        self.assertIn("cachedPattern(from:", self.identicon)
+        self.assertIn("patternCache.countLimit = 4096", self.generator)
+        self.assertIn("public static func cachedPattern", self.generator)
+
+    def test_contacts_view_does_not_reload_unchanged_data_on_reappearance(self):
+        self.assertIn("private var hasLoadedContacts = false", self.vm)
+        self.assertIn("public func loadContacts(force: Bool = false)", self.vm)
+        self.assertIn("guard force || !hasLoadedContacts else { return }", self.vm)
+        self.assertIn("await vm.loadContacts(force: true)", self.view)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tests/static/test_runtime_thermal_instrumentation.py
+++ b/Tests/static/test_runtime_thermal_instrumentation.py
@@ -1,0 +1,72 @@
+import pathlib
+import re
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+APP_SERVICES = ROOT / "Sources/ColumbaApp/Services/AppServices.swift"
+COMPAT = ROOT / "Sources/RNSAPI/Compat.swift"
+
+
+class RuntimeThermalInstrumentationContractTests(unittest.TestCase):
+    def setUp(self):
+        self.app = APP_SERVICES.read_text(encoding="utf-8")
+        self.compat = COMPAT.read_text(encoding="utf-8")
+
+    def test_monitor_samples_cpu_and_thermal_state_at_low_frequency(self):
+        self.assertIn("final class RuntimeActivityMonitor", self.app)
+        self.assertIn("ProcessInfo.thermalStateDidChangeNotification", self.app)
+        self.assertIn("getrusage(RUSAGE_SELF", self.app)
+        self.assertIn("timer.schedule(deadline: .now() + 15, repeating: 15)", self.app)
+        self.assertRegex(
+            self.app,
+            r'\[PERF\].*thermal=.*cpu_pct=.*announce_total=.*path_writes=',
+        )
+
+    def test_monitor_lifecycle_tracks_runtime_lifecycle(self):
+        # Both initialization entry points clear the diagnostic log and must start
+        # a fresh monitoring generation; shutdown must emit a final sample and stop.
+        self.assertEqual(
+            self.app.count("RuntimeActivityMonitor.shared.start()"),
+            2,
+        )
+        shutdown = self.app.index("public func shutdown() async")
+        self.assertIn(
+            "RuntimeActivityMonitor.shared.stop()",
+            self.app[shutdown:],
+        )
+
+    def test_announce_sources_are_aggregated_without_raw_interface_logging(self):
+        self.assertRegex(
+            self.app,
+            r"recordAnnounce\(\s*interfaceName: interfaceName,\s*"
+            r"configuredType: configuredType\s*\)",
+        )
+        self.assertIn("expectedSectionName(for: $0) == interfaceName", self.app)
+        monitor_start = self.app.index("final class RuntimeActivityMonitor")
+        monitor_end = self.app.index("// MARK: -", monitor_start)
+        monitor = self.app[monitor_start:monitor_end]
+        for category in ("announce_tcp", "announce_ble", "announce_auto", "announce_other"):
+            self.assertIn(category, monitor)
+        perf_line = re.search(r'let line = "\[PERF\].*?\n', monitor)
+        self.assertIsNotNone(perf_line)
+        assert perf_line is not None
+        self.assertNotIn("interfaceName", perf_line.group(0))
+
+    def test_path_table_reports_exact_sqlite_persistence_duration(self):
+        insert_start = self.compat.index("public func insert(_ entry: PathEntry)")
+        insert_end = self.compat.index("/// Stream of path-table updates", insert_start)
+        insert = self.compat[insert_start:insert_end]
+        self.assertIn("PathInsertMetrics", insert)
+        self.assertIn("persistStart", insert)
+        self.assertIn("persist(entry)", insert)
+        self.assertIn("persistenceDurationMilliseconds", insert)
+        self.assertRegex(
+            self.app,
+            r"recordPathTableWrite\(\s*durationMilliseconds:\s*"
+            r"metrics\.persistenceDurationMilliseconds\s*\)",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tests/static/test_runtime_thermal_instrumentation.py
+++ b/Tests/static/test_runtime_thermal_instrumentation.py
@@ -6,12 +6,14 @@ import unittest
 ROOT = pathlib.Path(__file__).resolve().parents[2]
 APP_SERVICES = ROOT / "Sources/ColumbaApp/Services/AppServices.swift"
 COMPAT = ROOT / "Sources/RNSAPI/Compat.swift"
+PROJECT = ROOT / "Columba.xcodeproj/project.pbxproj"
 
 
 class RuntimeThermalInstrumentationContractTests(unittest.TestCase):
     def setUp(self):
         self.app = APP_SERVICES.read_text(encoding="utf-8")
         self.compat = COMPAT.read_text(encoding="utf-8")
+        self.project = PROJECT.read_text(encoding="utf-8")
 
     def test_monitor_samples_cpu_and_thermal_state_at_low_frequency(self):
         self.assertIn("final class RuntimeActivityMonitor", self.app)
@@ -24,17 +26,142 @@ class RuntimeThermalInstrumentationContractTests(unittest.TestCase):
         )
 
     def test_monitor_lifecycle_tracks_runtime_lifecycle(self):
-        # Both initialization entry points clear the diagnostic log and must start
-        # a fresh monitoring generation; shutdown must emit a final sample and stop.
+        # Every initialization/reconnect operation gets an independent lease.
+        # Failure releases only the operation lease; success retains at most one
+        # instance lease, shutdown releases it, and reconnect reacquires.
+        self.assertIn("func acquire() -> Lease", self.app)
+        self.assertIn("func release(_ lease: Lease)", self.app)
+        self.assertIn("private let runtimeActivityMonitorLeaseHolder = RuntimeActivityMonitorLeaseHolder()", self.app)
+        self.assertIn("private func retainRuntimeActivityMonitorLease", self.app)
         self.assertEqual(
-            self.app.count("RuntimeActivityMonitor.shared.start()"),
-            2,
+            self.app.count("let monitorLease = RuntimeActivityMonitor.shared.acquire()"),
+            3,
         )
+        self.assertEqual(
+            self.app.count("retainRuntimeActivityMonitorLease(monitorLease)"),
+            3,
+        )
+        self.assertEqual(
+            self.app.count("RuntimeActivityMonitor.shared.release(monitorLease)"),
+            3,
+        )
+        self.assertEqual(self.app.count("\n        initializationSucceeded = true\n"), 2)
+        self.assertIn("reinitializationSucceeded = true", self.app)
+        self.assertIn("deinit {", self.app)
+        self.assertIn("RuntimeActivityMonitor.shared.release(lease)", self.app)
+        self.assertIn("private var activeGeneration: UInt64?", self.app)
+        self.assertIn('emitSample(reason: "periodic", generation: generation)', self.app)
+        self.assertIn('emitSample(reason: "thermal_change", generation: generation)', self.app)
         shutdown = self.app.index("public func shutdown() async")
-        self.assertIn(
-            "RuntimeActivityMonitor.shared.stop()",
-            self.app[shutdown:],
+        shutdown_body = self.app[shutdown:]
+        self.assertIn("releaseRuntimeActivityMonitorLease()", shutdown_body)
+
+    def test_app_services_lifecycle_operations_are_serialized(self):
+        self.assertIn("private var lifecycleOperationActive = false", self.app)
+        self.assertIn("private var lifecycleOperationWaiters: [CheckedContinuation<Void, Never>] = []", self.app)
+        self.assertIn("func withLifecycleOperation", self.app)
+        gated_public_signatures = [
+            "public func initialize(tcpServerAddress:",
+            "public func initialize(identity:",
+            "public func switchIdentity(",
+            "public func applyInterfaceChanges()",
+            "public func startAutoInterface(",
+            "public func stopAutoInterface()",
+            "public func startBLEInterface()",
+            "public func stopBLEInterface()",
+            "public func startMPCInterface()",
+            "public func stopMPCInterface()",
+            "public func startRNodeInterface(",
+            "public func stopRNodeInterface()",
+            "public func disconnectBLEPeer(",
+            "public func shutdown()",
+            "public func connectTCPInterface(",
+            "public func stopTCPInterface(entityId:",
+            "public func stopTCPInterface()",
+            "public func reconnectTCPOnly(",
+            "public func reconnect(tcpServerAddress:",
+        ]
+        for signature in gated_public_signatures:
+            start = self.app.index(signature)
+            self.assertIn("withLifecycleOperation", self.app[start:start + 700], signature)
+
+        guarded_start_signatures = [
+            "public func startAutoInterface(",
+            "public func startBLEInterface()",
+            "public func startMPCInterface()",
+            "public func startRNodeInterface(",
+            "public func connectTCPInterface(",
+            "public func reconnectTCPOnly(",
+        ]
+        for signature in guarded_start_signatures:
+            start = self.app.index(signature)
+            self.assertIn(
+                "requireActiveRuntimeForInterfaceMutation()",
+                self.app[start:start + 700],
+                signature,
+            )
+
+        self.assertIn("private func shutdownUnlocked() async", self.app)
+        self.assertIn("private func reconnectUnlocked(tcpServerAddress: String) async throws", self.app)
+        self.assertIn("private func switchIdentityUnlocked", self.app)
+        reconnect_start = self.app.index("private func reconnectUnlocked")
+        reconnect_end = self.app.index("private func reinitializeConnection", reconnect_start)
+        reconnect = self.app[reconnect_start:reconnect_end]
+        self.assertIn("await shutdownUnlocked()", reconnect)
+        self.assertNotIn("await shutdown()", reconnect)
+        switch_start = self.app.index("private func switchIdentityUnlocked")
+        switch_end = self.app.index("// MARK: - State Observation", switch_start)
+        switch = self.app[switch_start:switch_end]
+        self.assertIn("await shutdownUnlocked()", switch)
+        self.assertIn("try await initializeUnlocked(", switch)
+        self.assertNotIn("await shutdown()", switch)
+        self.assertNotIn("try await initialize(identity:", switch)
+
+        shutdown_start = self.app.index("private func shutdownUnlocked() async")
+        shutdown_end = self.app.index("public func connectTCPInterface(", shutdown_start)
+        shutdown = self.app[shutdown_start:shutdown_end]
+        for nested_public_call in [
+            "await stopTCPInterface()",
+            "await stopRNodeInterface()",
+            "await stopBLEInterface()",
+            "await stopAutoInterface()",
+        ]:
+            self.assertNotIn(nested_public_call, shutdown)
+
+        self.assertIn("private func applyInterfaceChangesUnlocked() async", self.app)
+        self.assertIn("private func startAutoInterfaceUnlocked", self.app)
+        self.assertIn("private func startBLEInterfaceUnlocked", self.app)
+        self.assertIn("private func startMPCInterfaceUnlocked", self.app)
+        self.assertIn("private func startRNodeInterfaceUnlocked", self.app)
+        self.assertIn("private func connectTCPInterfaceUnlocked", self.app)
+
+    def test_lease_regressions_are_wired_into_both_native_test_targets(self):
+        self.assertTrue((ROOT / "Tests/ColumbaAppTests/RuntimeActivityMonitorLeaseTests.swift").is_file())
+        self.assertEqual(
+            self.project.count("RuntimeActivityMonitorLeaseTests.swift in Sources"),
+            4,
         )
+
+    def test_last_lease_release_invalidates_callbacks_before_final_sample(self):
+        stop_start = self.app.index("func release(_ lease: Lease)")
+        stop_end = self.app.index("func recordAnnounce", stop_start)
+        stop = self.app[stop_start:stop_end]
+        self.assertIn("activeLeases.remove(lease)", stop)
+        self.assertIn("guard activeLeases.isEmpty", stop)
+        self.assertIn("activeGeneration = nil", stop)
+        self.assertIn("timer.setEventHandler {}", stop)
+        self.assertIn("timer.cancel()", stop)
+        self.assertIn("NotificationCenter.default.removeObserver(observer)", stop)
+        self.assertIn("DiagLog.log(finalLine)", stop)
+        self.assertLess(stop.index("timer.cancel()"), stop.index("DiagLog.log(finalLine)"))
+        self.assertLess(
+            stop.index("NotificationCenter.default.removeObserver(observer)"),
+            stop.index("DiagLog.log(finalLine)"),
+        )
+        emit_start = self.app.index("private func emitSample(")
+        emit_end = self.app.index("private func makeSampleLineLocked", emit_start)
+        emit = self.app[emit_start:emit_end]
+        self.assertLess(emit.index("DiagLog.log(line)"), emit.rindex("lock.unlock()"))
 
     def test_announce_sources_are_aggregated_without_raw_interface_logging(self):
         self.assertRegex(
@@ -48,7 +175,7 @@ class RuntimeThermalInstrumentationContractTests(unittest.TestCase):
         monitor = self.app[monitor_start:monitor_end]
         for category in ("announce_tcp", "announce_ble", "announce_auto", "announce_other"):
             self.assertIn(category, monitor)
-        perf_line = re.search(r'let line = "\[PERF\].*?\n', monitor)
+        perf_line = re.search(r'(?:let line = |return )"\[PERF\].*?\n', monitor)
         self.assertIsNotNone(perf_line)
         assert perf_line is not None
         self.assertNotIn("interfaceName", perf_line.group(0))


### PR DESCRIPTION
## Summary

- add privacy-safe runtime CPU, thermal, announce, interface, and path-write instrumentation used to identify the Network-tab hot path
- cache Network and pending-announcement filters so SwiftUI body reevaluation does not repeatedly scan thousands of destinations
- render Network contacts in 100-row increments and reuse a bounded identicon-pattern cache
- retain the live path snapshot on reappearance while reconciling favorite state through a lightweight repository notification
- retain the process-wide runtime monitor with generation-bound leases across overlapping service instances and release only the last active lease
- serialize stack lifecycle and interface hot-reload mutations so shutdown cannot race a replacement runtime or resurrect an interface without monitoring
- replace identity-bearing multi-kilobyte contact diagnostics with one aggregate-only record
- use allocation-light destination hash formatting while materializing path-table contacts

## Verification

- `python3 -B -m unittest discover -s Tests/static -p 'test_*.py'` — 154 tests passed on the final candidate
- Shipping `Columba` simulator build — succeeded
- Shipping `ColumbaAppTests` — 134 tests passed
- Shared `Columba-ModelB` simulator build — succeeded
- `ColumbaModelBAppTests` — 19 tests passed
- monitor lease and lifecycle-gate regressions — 5 tests passed in each native target
- Signed Shipping device build at optimized commit `83935b4`, code-sign verification, installation, and process-state verification — succeeded
- Physical Network-tab test of that optimized build with approximately 3,347 known destinations:
  - scrolling CPU average: 5.6%
  - scrolling CPU maximum: 6.7%
  - thermal state: nominal throughout
  - 61 announces processed during the measured scrolling window
  - verbose contact diagnostics absent; aggregate contact record was 100 bytes

## Risk and rollback

- Network results are still complete; the UI extends the visible window by 100 rows near the end of each page.
- Identicon caching is bounded to 4,096 entries.
- Pull-to-refresh remains the explicit full-reload path.
- The branch can be rolled back as three isolated commits: instrumentation, Network-tab optimization, and review remediation.
