### PR TITLE
fix: classify announces by exact destination aspect

### DIFF
--- a/Sources/ColumbaApp/Services/CallManager.swift
+++ b/Sources/ColumbaApp/Services/CallManager.swift
@@ -345,7 +345,7 @@ public final class CallManager {
             aspects: ["telephony"]
         )
 
-        if source.detectedAspect == "lxst.telephony" || source.isLXSTTelephony {
+        if source.destinationAspect == .lxstTelephony {
             guard sourceHash == derivedHash else { return nil }
             return TelephonyCallTarget(destinationHash: sourceHash, publicKeys: source.publicKeys)
         }
@@ -353,7 +353,7 @@ public final class CallManager {
         // Android-style cross-link: one row per destination, joined by the
         // shared public identity. Only accept a sibling whose hash verifies.
         if let sibling = await pathTable.allEntries().first(where: {
-            ($0.detectedAspect == "lxst.telephony" || $0.isLXSTTelephony)
+            $0.destinationAspect == .lxstTelephony
                 && $0.publicKeys == source.publicKeys
                 && $0.destinationHash == derivedHash
         }) {

--- a/Sources/ColumbaApp/Services/PropagationNodeManager.swift
+++ b/Sources/ColumbaApp/Services/PropagationNodeManager.swift
@@ -193,6 +193,7 @@ public final class PropagationNodeManager {
 
     /// Process a path entry to check if it's a propagation node.
     private func processPathEntry(_ entry: PathEntry) async {
+        guard entry.destinationAspect == .lxmfPropagation else { return }
         guard let appData = entry.appData else { return }
         guard let info = PropagationNodeInfo.parse(from: appData) else { return }
         guard info.enabled else { return }
@@ -257,14 +258,21 @@ public final class PropagationNodeManager {
     ///
     /// Disables auto-select when called manually.
     public func selectNode(hash: Data) async {
+        guard let entry = await appServices?.pathTable?.lookup(destinationHash: hash),
+              entry.destinationAspect == .lxmfPropagation,
+              let appData = entry.appData,
+              let info = PropagationNodeInfo.parse(from: appData),
+              info.enabled else {
+            logger.warning("Rejected relay selection without exact enabled propagation aspect")
+            return
+        }
         selectedNodeHash = hash
         let node = knownNodes.first(where: { $0.hash == hash })
-        selectedNodeName = node?.resolvedDisplayName
+        selectedNodeName = node?.resolvedDisplayName ?? info.displayName ?? entry.displayName
 
         // Compute delivery hash for this identity so we can match against saved contacts.
         // Relay announces use lxmf.propagation aspect; contacts use lxmf.delivery aspect.
-        if let entry = await appServices?.pathTable?.lookup(destinationHash: hash),
-           entry.publicKeys.count >= 64 {
+        if entry.publicKeys.count >= 64 {
             let identityHash = Hashing.truncatedHash(entry.publicKeys)
             let nameHash = Hashing.destinationNameHash(appName: "lxmf", aspects: ["delivery"])
             var combined = nameHash
@@ -278,7 +286,7 @@ public final class PropagationNodeManager {
         // LXMRouter.setOutboundPropagationNode used to set a local var
         // only — Python's LXMF.LXMRouter.set_outbound_propagation_node
         // is what actually affects delivery.
-        let stampCost = node?.info.stampCost ?? 0
+        let stampCost = info.stampCost
         selectedNodeStampCost = stampCost
         #if COLUMBA_RUNTIME_PYTHON
         if let backend = appServices?.pythonBackend {

--- a/Sources/ColumbaApp/ViewModels/ContactsViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/ContactsViewModel.swift
@@ -18,6 +18,7 @@ public enum ContactBadgeType: String, Sendable, Equatable, Hashable {
     case relay = "RELAY"
     case audio = "Audio"
     case node = "Node"
+    case unsupported = "Unsupported"
 }
 
 // MARK: - Contact Model
@@ -66,8 +67,10 @@ public struct Contact: Identifiable, Sendable, Hashable {
 
     /// Whether this is an LXST telephony (audio/voice call) announce.
     public var isAudio: Bool {
-        aspect == "lxst.telephony"
+        destinationAspect == .lxstTelephony
     }
+
+    public var destinationAspect: DestinationAspect { DestinationAspect(aspect) }
 
     /// Interface filter category for this contact.
     public var interfaceFilterType: InterfaceFilter {
@@ -83,7 +86,11 @@ public struct Contact: Identifiable, Sendable, Hashable {
 
     /// Display name with fallback to "Peer <hash prefix>" (matches Android Columba).
     public var resolvedDisplayName: String {
-        displayName ?? "Peer \(String(identityHashHex.prefix(8)).uppercased())"
+        if let displayName,
+           !displayName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return displayName
+        }
+        return "Peer \(String(identityHashHex.prefix(8)).uppercased())"
     }
 
     /// Truncated hex hash for display (first 24 chars + ...).
@@ -126,7 +133,8 @@ public struct Contact: Identifiable, Sendable, Hashable {
         signalStrength: Int? = nil,
         isFavorite: Bool? = nil,
         isPinned: Bool? = nil,
-        isRelay: Bool? = nil
+        isRelay: Bool? = nil,
+        aspect: String?? = nil
     ) -> Contact {
         Contact(
             id: id,
@@ -140,7 +148,7 @@ public struct Contact: Identifiable, Sendable, Hashable {
             isPinned: isPinned ?? self.isPinned,
             isRelay: isRelay ?? self.isRelay,
             iconName: iconName, iconFgColor: iconFgColor, iconBgColor: iconBgColor,
-            interfaceId: interfaceId, aspect: aspect
+            interfaceId: interfaceId, aspect: aspect ?? self.aspect
         )
     }
 
@@ -166,33 +174,24 @@ public struct Contact: Identifiable, Sendable, Hashable {
         // reference clients exactly: Sideband types each announce by which RNS
         // aspect handler received it (aspect_filter "lxmf.propagation" vs
         // "lxmf.delivery"), and Android does the same via NodeType.fromAspect.
-        // `entry.isLXMFPropagationNode` is itself derived solely from
-        // aspect == "lxmf.propagation" (the Python bridge sets it via a
-        // cryptographic per-aspect handler match; the native backends compute
-        // detectedAspect cryptographically), so aspect is the SOLE relay
-        // signal. An unrecognized / empty aspect defaults to .peer, matching
-        // NodeType.fromAspect's default.
-        //
-        // The previous `PropagationNodeInfo.parse(app_data)` fallback was
-        // removed: it accepted any >=3-element msgpack app_data without
-        // verifying the destination was a propagation node, so a delivery /
-        // audio / site announce carrying such app_data was mis-flagged as a
-        // relay (leaking into the Peers filter). Both backends already
-        // guarantee a genuine propagation node arrives tagged
-        // "lxmf.propagation" or is dropped before reaching here, so the
-        // fallback only ever caught false positives.
-        if entry.isLXMFPropagationNode {
+        // Exact aspect is the sole type signal. Legacy boolean flags and
+        // app-data shape are retained for compatibility but never authorize a
+        // badge or action. Unknown aspects remain explicitly unsupported.
+        switch entry.destinationAspect {
+        case .lxmfPropagation:
             self.badgeType = .relay
             self.isRelay = true
-        } else if entry.isLXSTTelephony {
+        case .lxstTelephony:
             self.badgeType = .audio
             self.isRelay = false
-        } else if entry.detectedAspect == "nomadnetwork.node" {
+        case .nomadNetworkNode:
             self.badgeType = .node
             self.isRelay = false
-        } else {
-            // lxmf.delivery and any unrecognized/empty aspect → peer.
+        case .lxmfDelivery:
             self.badgeType = .peer
+            self.isRelay = false
+        case .unsupported:
+            self.badgeType = .unsupported
             self.isRelay = false
         }
     }
@@ -556,12 +555,14 @@ public final class ContactsViewModel {
             if existing.badgeType != contact.badgeType
                 || existing.hopCount != contact.hopCount
                 || existing.signalStrength != contact.signalStrength
-                || existing.isRelay != contact.isRelay {
+                || existing.isRelay != contact.isRelay
+                || existing.aspect != contact.aspect {
                 myContacts[myIndex] = existing.copy(
                     badgeType: contact.badgeType,
                     hopCount: contact.hopCount,
                     signalStrength: contact.signalStrength,
-                    isRelay: contact.isRelay
+                    isRelay: contact.isRelay,
+                    aspect: .some(contact.aspect)
                 )
             }
         }
@@ -921,7 +922,7 @@ public final class ContactsViewModel {
 
     /// Enrich myContacts from network announces.
     ///
-    /// ConversationRecord has no badge / relay / hops / signal fields, so
+    /// ConversationRecord has no badge / relay / hops / signal / aspect fields, so
     /// Contact(from: ConversationRecord) always produces `badgeType=.peer`,
     /// `hopCount=0`, `signalStrength=4`. Cross-reference with networkAnnounces
     /// (built from PathEntry which has all of these) to restore the correct
@@ -937,12 +938,14 @@ public final class ContactsViewModel {
             let badgeNeedsUpdate = announce.badgeType != contact.badgeType
             let hopsNeedUpdate = announce.hopCount != contact.hopCount
                 || announce.signalStrength != contact.signalStrength
-            guard badgeNeedsUpdate || hopsNeedUpdate else { return contact }
+            let aspectNeedsUpdate = announce.aspect != contact.aspect
+            guard badgeNeedsUpdate || hopsNeedUpdate || aspectNeedsUpdate else { return contact }
             return contact.copy(
                 badgeType: announce.badgeType,
                 hopCount: announce.hopCount,
                 signalStrength: announce.signalStrength,
-                isRelay: announce.isRelay
+                isRelay: announce.isRelay,
+                aspect: .some(announce.aspect)
             )
         }
     }

--- a/Sources/ColumbaApp/Views/Contacts/ContactCard.swift
+++ b/Sources/ColumbaApp/Views/Contacts/ContactCard.swift
@@ -212,6 +212,15 @@ struct ContactCard: View {
                     .padding(.vertical, 2)
                     .background(Color.green)
                     .cornerRadius(4)
+            case .unsupported:
+                Text("Unsupported")
+                    .font(.caption2)
+                    .fontWeight(.medium)
+                    .foregroundStyle(.white.opacity(0.8))
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(Color.orange.opacity(0.7))
+                    .cornerRadius(4)
             case .peer:
                 Text("Peer")
                     .font(.caption2)

--- a/Sources/ColumbaApp/Views/Contacts/ContactsView.swift
+++ b/Sources/ColumbaApp/Views/Contacts/ContactsView.swift
@@ -134,15 +134,15 @@ public struct ContactsView: View {
                         NodeDetailsView(
                             contact: contact,
                             appServices: appServices,
-                            onStartChat: contact.badgeType == .peer || contact.badgeType == .relay ? { contact in
+                            onStartChat: { contact in
                                 startChat(with: contact)
-                            } : nil,
-                            onStartCall: contact.badgeType == .audio ? { contact in
+                            },
+                            onStartCall: { contact in
                                 callContact = contact
-                            } : nil,
-                            onBrowseSite: contact.badgeType == .node ? { contact in
+                            },
+                            onBrowseSite: { contact in
                                 browseSite(for: contact)
-                            } : nil,
+                            },
                             // Star = add-to-contacts / favorite, mirroring
                             // Android's add (from a network announce) and remove
                             // (already a contact) semantics. The Contact-typed

--- a/Sources/ColumbaApp/Views/Contacts/NodeDetailsView.swift
+++ b/Sources/ColumbaApp/Views/Contacts/NodeDetailsView.swift
@@ -13,11 +13,9 @@ import RNSAPI
 ///
 /// Layout:
 /// - Header: Large identicon, display name, online/expired status badge
-/// - Action: "Start Chat" or "Browse Site" button (accent gradient, full width).
-///   For NomadNet sites (`badgeType == .node`), shows "Browse Site" when
-///   `onBrowseSite` is provided; otherwise shows "Start Chat" when
-///   `onStartChat` is provided. If neither callback is provided for the
-///   relevant badge type, no primary action is rendered.
+/// - Action selected from the exact destination aspect: Chat for LXMF delivery,
+///   Call for LXST telephony, Browse Site for NomadNet, and relay controls only
+///   for enabled LXMF propagation announces.
 /// - Details cards: Destination hash, hop count, last heard/expires timestamps
 @available(iOS 17.0, macOS 14.0, *)
 struct NodeDetailsView: View {
@@ -91,7 +89,8 @@ struct NodeDetailsView: View {
                 if !displayedContact.isOnline {
                     expiredHint
                 }
-                if propagationInfo != nil {
+                if displayedContact.destinationAspect == .lxmfPropagation,
+                   propagationInfo?.enabled == true {
                     setAsRelayButton
                 } else {
                     primaryActionButton
@@ -251,21 +250,21 @@ struct NodeDetailsView: View {
     @ViewBuilder
     private var primaryActionButton: some View {
         let c = displayedContact
-        if c.badgeType == .audio, let onStartCall {
+        if c.destinationAspect == .lxstTelephony, let onStartCall {
             actionButton(
                 icon: "phone.fill",
                 title: "Call"
             ) {
                 onStartCall(c)
             }
-        } else if c.badgeType == .node, let onBrowseSite {
+        } else if c.destinationAspect == .nomadNetworkNode, let onBrowseSite {
             actionButton(
                 icon: "globe.americas",
                 title: "Browse Site"
             ) {
                 onBrowseSite(c)
             }
-        } else if c.badgeType != .node && c.badgeType != .audio, let onStartChat {
+        } else if c.destinationAspect == .lxmfDelivery, let onStartChat {
             actionButton(
                 icon: "bubble.left.fill",
                 title: "Start Chat"
@@ -559,7 +558,8 @@ struct NodeDetailsView: View {
             // "Unknown" instead of pinning to a stale value.
             interfaceName = nil
         }
-        if let appData = entry.appData {
+        if entry.destinationAspect == .lxmfPropagation,
+           let appData = entry.appData {
             propagationInfo = PropagationNodeInfo.parse(from: appData)
         } else {
             // Clear stale info when a re-announce drops the propagation

--- a/Sources/RNSAPI/Compat.swift
+++ b/Sources/RNSAPI/Compat.swift
@@ -1888,6 +1888,20 @@ public final class PathTable: @unchecked Sendable {
     }
 }
 
+public enum DestinationAspect: String, Sendable, Equatable, Hashable, Codable {
+    case lxmfDelivery = "lxmf.delivery"
+    case lxmfPropagation = "lxmf.propagation"
+    case lxstTelephony = "lxst.telephony"
+    case nomadNetworkNode = "nomadnetwork.node"
+    case unsupported
+
+    public init(_ rawValue: String?) {
+        self = rawValue.flatMap(Self.init(rawValue:)) ?? .unsupported
+    }
+
+    public var isSupported: Bool { self != .unsupported }
+}
+
 public struct PathEntry: Identifiable, Equatable, Sendable, Codable {
     public let destinationHash: Data
     public var displayName: String
@@ -1905,6 +1919,7 @@ public struct PathEntry: Identifiable, Equatable, Sendable, Codable {
     public var isKnownDestination: Bool
 
     public var id: Data { destinationHash }
+    public var destinationAspect: DestinationAspect { DestinationAspect(detectedAspect) }
 
     public init(
         destinationHash: Data,
@@ -2307,21 +2322,37 @@ public struct PropagationNodeInfo: Identifiable, Equatable, Sendable, Codable {
 
     public static func parse(_ data: Data) -> PropagationNodeInfo? { parse(from: data) }
 
-    /// Parse an `lxmf.propagation` announce's app_data. Mirrors canonical
-    /// Python `LXMF.LXMRouter.get_propagation_node_app_data`:
+    /// Parse an `lxmf.propagation` announce's app_data. Supports both the
+    /// LXMF 0.4.0–0.8.0 layout:
+    ///   msgpack [node_state, timebase, per_transfer_limit, wanted_peers]
+    /// and the current LXMF 0.9.0+ layout:
     ///   msgpack [legacy_bool, timebase, node_state, per_transfer_limit,
     ///            per_sync_limit, stamp_cost, metadata_map]
-    /// `node_state` (index 2) is the enabled flag; the optional display name is
-    /// in the metadata map (index 6) at key PN_META_NAME. `destinationHash` /
-    /// `lastSeen` / `hopCount` aren't in app_data — the caller fills those from
-    /// the PathEntry. Returns nil if the data isn't a propagation announce.
+    /// In the current layout, `node_state` (index 2) is the enabled flag and
+    /// the optional display name is in the metadata map (index 6) at key
+    /// PN_META_NAME. `destinationHash` / `lastSeen` / `hopCount` aren't in
+    /// app_data — the caller fills those from the PathEntry. Returns nil if
+    /// the data isn't a propagation announce.
     public static func parse(from data: Data) -> PropagationNodeInfo? {
         guard !data.isEmpty,
               let value = try? unpackMsgPack(data),
               case .array(let arr) = value,
               arr.count >= 3 else { return nil }
 
-        let enabled = arr[2].boolValue ?? false
+        // LXMF 0.4.0–0.8.0 put node_state at index 0 and the numeric transfer
+        // limit at index 2. Distinguish it by exact length and value types so
+        // the transfer limit is never mistaken for a disabled current node.
+        if arr.count == 4,
+           let enabled = arr[0].boolValue,
+           arr[1].intValue != nil,
+           let perTransfer = arr[2].intValue {
+            return PropagationNodeInfo(
+                perTransferLimit: perTransfer,
+                enabled: enabled
+            )
+        }
+
+        guard let enabled = arr[2].boolValue else { return nil }
         let perTransfer = arr.count > 3 ? (arr[3].intValue ?? 0) : 0
         let perSync = arr.count > 4 ? (arr[4].intValue ?? 0) : 0
         // stamp_cost (index 5) is itself a list [cost, flexibility, peering] in

--- a/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
+++ b/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
@@ -11,7 +11,7 @@ import RNSAPI
 /// reference clients — Sideband types announces by which RNS aspect handler
 /// received them, and Android via NodeType.fromAspect. A propagation node is
 /// `aspect == "lxmf.propagation"` (surfaced as `entry.isLXMFPropagationNode`);
-/// every other aspect, including an unrecognized/empty one, is NOT a relay.
+/// every other aspect is NOT a relay, and unknown is not silently typed as peer.
 ///
 /// Regression target: the "Peers" filter (the default) also showed relays.
 /// The old `PropagationNodeInfo.parse(appData)` heuristic accepted ANY
@@ -101,22 +101,58 @@ final class AnnounceClassificationTests: XCTestCase {
         XCTAssertTrue(c.isRelay)
     }
 
+    func testPropagationAspectWinsWhenLegacyFlagIsFalse() {
+        let c = Contact(from: entry(
+            aspect: "lxmf.propagation",
+            appData: propagationAppData(name: "Hub"),
+            isPropagation: false
+        ))
+        XCTAssertEqual(c.badgeType, .relay)
+        XCTAssertTrue(c.isRelay)
+    }
+
+    func testDeliveryAspectWinsWhenLegacyPropagationFlagIsTrue() {
+        let c = Contact(from: entry(
+            aspect: "lxmf.delivery",
+            appData: propagationAppData(name: "Not a relay"),
+            isPropagation: true
+        ))
+        XCTAssertEqual(c.badgeType, .peer)
+        XCTAssertFalse(c.isRelay)
+    }
+
+    func testCopyCarriesExactAspectDuringSavedContactEnrichment() {
+        let saved = Contact(
+            id: "saved", displayName: "Saved", identityHash: Data(repeating: 1, count: 16),
+            identityHashHex: "01", badgeType: .peer, hopCount: 0, signalStrength: 4,
+            timestamp: Date(), isOnline: true, isFavorite: true, isPinned: false,
+            isRelay: false, aspect: nil
+        )
+
+        let enriched = saved.copy(
+            badgeType: .audio,
+            aspect: .some("lxst.telephony")
+        )
+
+        XCTAssertEqual(enriched.destinationAspect, .lxstTelephony)
+        XCTAssertEqual(enriched.badgeType, .audio)
+    }
+
     /// Aspect is the sole relay signal: an UNTAGGED announce (no aspect) whose
     /// app_data happens to be propagation-shaped is NOT promoted to a relay.
     /// (Both backends guarantee a genuine propagation node arrives tagged
     /// "lxmf.propagation" or is dropped before reaching here, so the removed
     /// app_data heuristic only ever caught false positives.)
-    func testUntaggedPropagationShapedAppDataIsPeerNotRelay() {
+    func testUntaggedPropagationShapedAppDataIsUnsupportedNotRelay() {
         let c = Contact(from: entry(aspect: nil, appData: propagationAppData(name: "Hub")))
-        XCTAssertEqual(c.badgeType, .peer)
+        XCTAssertEqual(c.badgeType, .unsupported)
         XCTAssertFalse(c.isRelay)
     }
 
-    /// An unrecognized/future aspect defaults to peer (matches Android
-    /// NodeType.fromAspect's default), never a relay.
-    func testUnknownAspectIsPeerNotRelay() {
+    /// Unknown is intentionally distinct from a proven LXMF delivery peer.
+    func testUnknownAspectIsUnsupportedNotRelay() {
         let c = Contact(from: entry(aspect: "some.future.aspect", appData: threeElementAppData()))
-        XCTAssertEqual(c.badgeType, .peer)
+        XCTAssertEqual(c.badgeType, .unsupported)
         XCTAssertFalse(c.isRelay)
     }
 
@@ -136,5 +172,25 @@ final class AnnounceClassificationTests: XCTestCase {
         let c = Contact(from: entry(aspect: "nomadnetwork.node", appData: threeElementAppData()))
         XCTAssertEqual(c.badgeType, .node)
         XCTAssertFalse(c.isRelay)
+    }
+
+    func testEmptyDisplayNameFallsBackToHashPrefix() {
+        let contact = Contact(
+            id: "unnamed-relay",
+            displayName: "   ",
+            identityHash: Data(repeating: 0xab, count: 16),
+            identityHashHex: String(repeating: "ab", count: 16),
+            badgeType: .relay,
+            hopCount: 1,
+            signalStrength: 4,
+            timestamp: Date(),
+            isOnline: true,
+            isFavorite: false,
+            isPinned: false,
+            isRelay: true,
+            aspect: "lxmf.propagation"
+        )
+
+        XCTAssertEqual(contact.resolvedDisplayName, "Peer ABABABAB")
     }
 }

--- a/Tests/RNSAPITests/AppDataParserTests.swift
+++ b/Tests/RNSAPITests/AppDataParserTests.swift
@@ -38,6 +38,17 @@ final class AppDataParserTests: XCTestCase {
         ]))
     }
 
+    // LXMF 0.4.0–0.8.0 propagation announce layout:
+    // [node_state, timebase, per_transfer_limit, wanted_inbound_peers]
+    private func legacyPropagationAppData(nodeState: Bool = true) -> Data {
+        packMsgPack(.array([
+            .bool(nodeState),
+            .uint(1_700_000_000),
+            .uint(25_000),
+            .nil,
+        ]))
+    }
+
     // MARK: - Delivery
 
     func testDeliveryName() {
@@ -93,6 +104,22 @@ final class AppDataParserTests: XCTestCase {
         XCTAssertNotNil(info)
         XCTAssertEqual(info?.enabled, false)
         XCTAssertNil(info?.displayName)
+    }
+
+    func testLegacyPropagationNodeInfoParse() {
+        let info = PropagationNodeInfo.parse(from: legacyPropagationAppData())
+        XCTAssertNotNil(info)
+        XCTAssertEqual(info?.enabled, true)
+        XCTAssertEqual(info?.perTransferLimit, 25_000)
+        XCTAssertEqual(info?.perSyncLimit, 0)
+        XCTAssertEqual(info?.stampCost, 0)
+        XCTAssertNil(info?.displayName)
+    }
+
+    func testLegacyPropagationNodeInfoStateFalse() {
+        let info = PropagationNodeInfo.parse(from: legacyPropagationAppData(nodeState: false))
+        XCTAssertNotNil(info)
+        XCTAssertEqual(info?.enabled, false)
     }
 
     func testPropagationNodeInfoRejectsGarbage() {

--- a/Tests/static/test_explicit_destination_aspects.py
+++ b/Tests/static/test_explicit_destination_aspects.py
@@ -1,0 +1,55 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class ExplicitDestinationAspectContracts(unittest.TestCase):
+    @staticmethod
+    def read(relative: str) -> str:
+        return (ROOT / relative).read_text()
+
+    def test_exact_aspect_model_and_unknown_type(self):
+        compat = self.read("Sources/RNSAPI/Compat.swift")
+        contacts = self.read("Sources/ColumbaApp/ViewModels/ContactsViewModel.swift")
+
+        for value in (
+            'case lxmfDelivery = "lxmf.delivery"',
+            'case lxmfPropagation = "lxmf.propagation"',
+            'case lxstTelephony = "lxst.telephony"',
+            'case nomadNetworkNode = "nomadnetwork.node"',
+            "case unsupported",
+        ):
+            self.assertIn(value, compat)
+        self.assertIn("switch entry.destinationAspect", contacts)
+        self.assertIn("case .unsupported:", contacts)
+        self.assertIn("self.badgeType = .unsupported", contacts)
+        self.assertIn("aspect: .some(contact.aspect)", contacts)
+
+    def test_actions_and_relay_selection_require_exact_aspect(self):
+        details = self.read("Sources/ColumbaApp/Views/Contacts/NodeDetailsView.swift")
+        contacts_view = self.read("Sources/ColumbaApp/Views/Contacts/ContactsView.swift")
+        manager = self.read("Sources/ColumbaApp/Services/PropagationNodeManager.swift")
+
+        self.assertIn("displayedContact.destinationAspect == .lxmfPropagation", details)
+        self.assertIn("c.destinationAspect == .lxmfDelivery", details)
+        self.assertIn("c.destinationAspect == .lxstTelephony", details)
+        self.assertIn("c.destinationAspect == .nomadNetworkNode", details)
+        self.assertIn("onStartChat: { contact in", contacts_view)
+        self.assertGreaterEqual(
+            manager.count("entry.destinationAspect == .lxmfPropagation"), 2
+        )
+        self.assertIn("info.enabled else", manager)
+
+    def test_saved_contact_enrichment_copies_aspect_on_startup_and_live_updates(self):
+        contacts = self.read("Sources/ColumbaApp/ViewModels/ContactsViewModel.swift")
+
+        self.assertIn("existing.aspect != contact.aspect", contacts)
+        self.assertIn("aspect: .some(contact.aspect)", contacts)
+        self.assertIn("announce.aspect != contact.aspect", contacts)
+        self.assertIn("aspect: .some(announce.aspect)", contacts)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tests/static/test_lxst_voice_call_routing.py
+++ b/Tests/static/test_lxst_voice_call_routing.py
@@ -36,7 +36,7 @@ class LXSTVoiceCallRoutingContracts(unittest.TestCase):
         self.assertIsNotNone(resolver)
         assert resolver is not None
         body = resolver.group(0)
-        self.assertIn('source.detectedAspect == "lxst.telephony"', body)
+        self.assertIn("source.destinationAspect == .lxstTelephony", body)
         self.assertIn("guard sourceHash == derivedHash", body)
         self.assertIn(
             "TelephonyCallTarget(destinationHash: sourceHash, publicKeys: source.publicKeys)",
@@ -74,16 +74,16 @@ class LXSTVoiceCallRoutingContracts(unittest.TestCase):
         details = self._read(
             "Sources/ColumbaApp/Views/Contacts/NodeDetailsView.swift"
         )
-        self.assertIn("if c.badgeType == .audio, let onStartCall", details)
+        self.assertIn("if c.destinationAspect == .lxstTelephony, let onStartCall", details)
         self.assertIn('title: "Call"', details)
         self.assertIn("onStartCall(c)", details)
         self.assertIn(
-            "c.badgeType != .node && c.badgeType != .audio, let onStartChat",
+            "c.destinationAspect == .lxmfDelivery, let onStartChat",
             details,
         )
 
         contacts = self._read("Sources/ColumbaApp/Views/Contacts/ContactsView.swift")
-        self.assertIn("onStartCall: contact.badgeType == .audio", contacts)
+        self.assertIn("onStartCall: { contact in", contacts)
         self.assertIn("CodecSelectionSheet { profile in", contacts)
         self.assertIn("destinationHash: contact.identityHash", contacts)
 


### PR DESCRIPTION
## Summary
- centralize the four supported Reticulum destination aspects in `DestinationAspect`
- classify contacts and route chat, call, site, and relay actions from the exact aspect instead of legacy booleans or payload shape
- represent unknown aspects as unsupported and require an exact enabled `lxmf.propagation` announce for relay discovery and selection

## Tests
- `python3 -B -m unittest discover -s Tests/static -p "test_*.py"` — 144 passed
- focused `AnnounceClassificationTests` — 9 passed
- shipping `Columba` native suite — 131 passed
- `Columba-ModelB` native suite — 14 passed

## Risk / rollback
The change is limited to destination classification and direct action eligibility. It adds no persistence, locking, navigation lifecycle, or relay transaction architecture. Unknown or unverified aspects fail closed as unsupported. Roll back by reverting this single commit.