### PR TITLE
fix: open backup save flow after export

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,7 +73,8 @@ jobs:
           python3 -B -m unittest \
             Tests.static.test_host_entitlements_contract \
             Tests.static.test_ci_artifact_isolation \
-            Tests.static.test_fetch_python_resilience
+            Tests.static.test_fetch_python_resilience \
+            Tests.static.test_migration_export_flow
 
       - name: Build shipping artifact (embedded Python)
         run: |

--- a/Sources/ColumbaApp/ViewModels/MigrationViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/MigrationViewModel.swift
@@ -22,7 +22,6 @@ final class MigrationViewModel {
         case idle
         case loadingPreview
         case exporting(progress: Float)
-        case exportComplete(url: URL)
         case passwordRequired(fileData: Data)
         case wrongPassword(fileData: Data)
         case importPreview(preview: MigrationPreview, fileData: Data, password: String?)
@@ -35,7 +34,6 @@ final class MigrationViewModel {
             case (.idle, .idle): return true
             case (.loadingPreview, .loadingPreview): return true
             case (.exporting(let a), .exporting(let b)): return a == b
-            case (.exportComplete(let a), .exportComplete(let b)): return a == b
             case (.passwordRequired, .passwordRequired): return true
             case (.wrongPassword, .wrongPassword): return true
             case (.importPreview, .importPreview): return true
@@ -104,15 +102,24 @@ final class MigrationViewModel {
         exportPassword.count >= 8 && exportPassword == exportPasswordConfirm
     }
 
-    /// Start the export process.
-    func startExport() async {
-        guard isExportPasswordValid, activeExportGeneration == nil else { return }
+    /// Whether a new export can begin. File-picker cancellation and failure
+    /// both leave this true once the user supplies another valid password.
+    var canStartExport: Bool {
+        isExportPasswordValid && activeExportGeneration == nil
+    }
+
+    /// Generate the encrypted backup and return its temporary URL so the view
+    /// can immediately present the system file exporter.
+    func startExport() async -> URL? {
+        guard canStartExport else { return nil }
         let generation = UUID()
         activeExportGeneration = generation
         defer {
             if activeExportGeneration == generation {
                 activeExportGeneration = nil
             }
+            exportPassword = ""
+            exportPasswordConfirm = ""
         }
         let password = exportPassword
         showExportPasswordSheet = false
@@ -125,17 +132,34 @@ final class MigrationViewModel {
                     self?.state = .exporting(progress: progress)
                 }
             }
+            // Invalidate queued progress jobs before handing the generated
+            // backup to the system save flow. Generation is not save success.
             activeExportGeneration = nil
-            state = .exportComplete(url: url)
-            logger.info("Export complete: \(url.lastPathComponent)")
+            state = .exporting(progress: 1)
+            logger.info("Export generated: \(url.lastPathComponent)")
+            return url
         } catch {
             activeExportGeneration = nil
             state = .error(message: "Export failed: \(error.localizedDescription)")
             logger.error("Export failed: \(error)")
+            return nil
         }
+    }
 
-        exportPassword = ""
-        exportPasswordConfirm = ""
+    /// Finalize the export only after the system file picker completes.
+    /// Cancellation returns to idle; write failures remain visible and retryable.
+    func handleExportSaveResult(_ result: Result<URL, Error>) {
+        switch result {
+        case .success:
+            state = .idle
+        case .failure(let error):
+            if error is CancellationError ||
+                (error as? CocoaError)?.code == CocoaError.Code.userCancelled {
+                state = .idle
+            } else {
+                state = .error(message: "Save failed: \(error.localizedDescription)")
+            }
+        }
     }
 
     // MARK: - Import

--- a/Sources/ColumbaApp/Views/Settings/MigrationScreen.swift
+++ b/Sources/ColumbaApp/Views/Settings/MigrationScreen.swift
@@ -64,9 +64,8 @@ struct MigrationScreen: View {
             contentType: columbaUTType,
             defaultFilename: exportFileName
         ) { result in
-            if case .failure(let error) = result {
-                viewModel.state = .error(message: "Save failed: \(error.localizedDescription)")
-            }
+            exportDocument = nil
+            viewModel.handleExportSaveResult(result)
         }
     }
 
@@ -115,7 +114,7 @@ struct MigrationScreen: View {
                 }
             }
 
-            // Export action / progress / result
+            // Export action / progress
             VStack(spacing: 12) {
                 switch viewModel.state {
                 case .exporting(let progress):
@@ -125,36 +124,6 @@ struct MigrationScreen: View {
                     Text("Exporting... \(Int(progress * 100))%")
                         .font(.caption)
                         .foregroundStyle(Theme.textSecondary)
-
-                case .exportComplete(let url):
-                    HStack(spacing: 8) {
-                        Image(systemName: "checkmark.circle.fill")
-                            .foregroundStyle(Theme.success)
-                        Text("Export complete!")
-                            .font(.subheadline.weight(.medium))
-                            .foregroundStyle(Theme.success)
-                    }
-
-                    Button {
-                        if let data = try? Data(contentsOf: url) {
-                            exportDocument = ColumbaBackupDocument(data: data)
-                            exportFileName = url.lastPathComponent
-                            showFileExporter = true
-                        }
-                    } label: {
-                        HStack(spacing: 8) {
-                            Image(systemName: "folder.badge.plus")
-                                .font(.system(size: 14, weight: .medium))
-                            Text("Save Backup File")
-                                .font(.system(size: 15, weight: .medium))
-                        }
-                        .foregroundStyle(.white)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 12)
-                        .background(Theme.accentColor)
-                        .clipShape(RoundedRectangle(cornerRadius: Theme.cornerRadiusMedium))
-                    }
-                    .padding(.horizontal, 16)
 
                 default:
                     Button {
@@ -474,7 +443,7 @@ struct MigrationScreen: View {
                 }
 
                 Button {
-                    Task { await viewModel.startExport() }
+                    Task { await beginExport() }
                 } label: {
                     Text("Export")
                         .font(.system(size: 16, weight: .semibold))
@@ -581,6 +550,19 @@ struct MigrationScreen: View {
     }
 
     // MARK: - File Handling
+
+    private func beginExport() async {
+        guard let url = await viewModel.startExport() else { return }
+
+        do {
+            let data = try Data(contentsOf: url)
+            exportDocument = ColumbaBackupDocument(data: data)
+            exportFileName = url.lastPathComponent
+            showFileExporter = true
+        } catch {
+            viewModel.state = .error(message: "Failed to prepare backup: \(error.localizedDescription)")
+        }
+    }
 
     private func handleFileImport(_ result: Result<[URL], Error>) {
         switch result {

--- a/Tests/ColumbaAppTests/MigrationRoundTripTests.swift
+++ b/Tests/ColumbaAppTests/MigrationRoundTripTests.swift
@@ -408,5 +408,40 @@ final class MigrationRoundTripTests: XCTestCase {
             XCTAssertTrue(error is MigrationCryptoError, "expected a MigrationCryptoError, got \(error)")
         }
     }
+
+    @MainActor
+    func testExportPickerCancellationReturnsToRetryableIdleState() {
+        let viewModel = MigrationViewModel(
+            identityManager: IdentityManager(),
+            settingsRepository: SettingsRepository()
+        )
+
+        viewModel.handleExportSaveResult(.failure(CocoaError(.userCancelled)))
+        viewModel.exportPassword = password
+        viewModel.exportPasswordConfirm = password
+
+        XCTAssertEqual(viewModel.state, .idle)
+        XCTAssertTrue(viewModel.canStartExport)
+    }
+
+    @MainActor
+    func testExportPickerFailureRemainsVisibleAndRetryable() {
+        let viewModel = MigrationViewModel(
+            identityManager: IdentityManager(),
+            settingsRepository: SettingsRepository()
+        )
+        let saveError = NSError(
+            domain: "MigrationExportFlowTests",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "write denied"]
+        )
+
+        viewModel.handleExportSaveResult(.failure(saveError))
+        viewModel.exportPassword = password
+        viewModel.exportPasswordConfirm = password
+
+        XCTAssertEqual(viewModel.state, .error(message: "Save failed: write denied"))
+        XCTAssertTrue(viewModel.canStartExport)
+    }
 }
 #endif

--- a/Tests/static/test_migration_export_flow.py
+++ b/Tests/static/test_migration_export_flow.py
@@ -1,0 +1,51 @@
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCREEN = ROOT / "Sources/ColumbaApp/Views/Settings/MigrationScreen.swift"
+VIEW_MODEL = ROOT / "Sources/ColumbaApp/ViewModels/MigrationViewModel.swift"
+
+
+def source(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+class MigrationExportFlowContractTests(unittest.TestCase):
+    def test_password_export_opens_file_exporter_without_intermediate_save_action(self) -> None:
+        screen = source(SCREEN)
+        view_model = source(VIEW_MODEL)
+
+        self.assertNotIn('Text("Save Backup File")', screen)
+        self.assertNotIn('Text("Export complete!")', screen)
+        self.assertNotIn("case .exportComplete", view_model)
+        self.assertIn("Task { await beginExport() }", screen)
+
+        begin_export = screen.split("private func beginExport() async {", 1)[1].split(
+            "private func handleFileImport", 1
+        )[0]
+        self.assertIn("guard let url = await viewModel.startExport() else { return }", begin_export)
+        self.assertIn("exportDocument = ColumbaBackupDocument(data: data)", begin_export)
+        self.assertLess(
+            begin_export.index("exportDocument = ColumbaBackupDocument(data: data)"),
+            begin_export.index("showFileExporter = true"),
+        )
+
+    def test_export_picker_completion_is_retryable_and_generation_safe(self) -> None:
+        screen = source(SCREEN)
+        view_model = source(VIEW_MODEL)
+
+        exporter_completion = screen.split(".fileExporter(", 1)[1].split("// MARK: - Export Section", 1)[0]
+        self.assertIn("viewModel.handleExportSaveResult(result)", exporter_completion)
+        self.assertIn("var canStartExport: Bool", view_model)
+        self.assertIn("guard canStartExport else { return nil }", view_model)
+        self.assertIn("CocoaError.Code.userCancelled", view_model)
+        self.assertIn("state = .idle", view_model)
+        self.assertIn('state = .error(message: "Save failed:', view_model)
+        self.assertLess(
+            view_model.index("activeExportGeneration = nil\n            state = .exporting(progress: 1)"),
+            view_model.index("return url"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tests/static/test_onboarding_interface_selection.py
+++ b/Tests/static/test_onboarding_interface_selection.py
@@ -208,9 +208,10 @@ class OnboardingInterfaceSelectionContracts(unittest.TestCase):
         self.assertIn("guard self?.activeImportGeneration == generation else { return }", migration_view_model)
         self.assertIn("activeExportGeneration = generation", migration_view_model)
         self.assertIn("guard self?.activeExportGeneration == generation else { return }", migration_view_model)
+        self.assertNotIn("case exportComplete", migration_view_model)
         self.assertLess(
-            migration_view_model.index("activeExportGeneration = nil\n            state = .exportComplete"),
-            migration_view_model.index("state = .exportComplete"),
+            migration_view_model.index("activeExportGeneration = nil\n            state = .exporting(progress: 1)"),
+            migration_view_model.index("return url"),
         )
         self.assertLess(
             migration_view_model.index("activeImportGeneration = nil\n            state = .importComplete"),


### PR DESCRIPTION
## Summary

- open the iOS file exporter immediately after encrypted backup generation
- remove the premature Export Complete state and separate Save Backup File action
- finalize export state only after the system picker succeeds, is cancelled, or fails
- preserve generation-gated progress and retryable cancellation/error behavior
- add static and XCTest regression coverage and register the static contract in CI

## Verification

- portable CI contracts: 41 passed
- onboarding contracts: 10 passed
- MigrationRoundTripTests: 18 passed, 0 failed
- Shipping Release simulator build passed
- Model B Release simulator build passed
- independent exact-head review found no blockers

## Risk and rollback

The change is isolated to migration export presentation/state handling and its tests. Revert the single commit to restore the previous two-step save flow.