### PR TITLE
fix: configure incoming LXMF message size limit

### DIFF
--- a/Columba.xcodeproj/project.pbxproj
+++ b/Columba.xcodeproj/project.pbxproj
@@ -115,6 +115,7 @@
 		0B768533EC90008D3E23C326 /* AudioManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A8D344945F752C18EF2D9E /* AudioManager.swift */; };
 		0E85864BF022C4B2A2595D0F /* ReticulumSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 15F82FBE10E56E30D4706B40 /* ReticulumSwift */; };
 		0FF6A5C5596A39C092AADA29 /* MigrationRoundTripTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 853F1E1C2B6E5305277FCB2A /* MigrationRoundTripTests.swift */; };
+		A1B2C3D4E5F60718293A4B5C /* IncomingMessageSizeLimitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3E4F5061728394A5B6C /* IncomingMessageSizeLimitTests.swift */; };
 		113FFF9C5A228CC0C294A3D9 /* SharedFrameQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = F076 /* SharedFrameQueue.swift */; };
 		11D0621686D1D65C9602C911 /* RNSAPI in Frameworks */ = {isa = PBXBuildFile; productRef = F196C8A0BA9EBC9F7F2FCF9F /* RNSAPI */; };
 		11DE32B4ABEF3646B6B42728 /* MaterialDesignIcons.swift in Sources */ = {isa = PBXBuildFile; fileRef = F036 /* MaterialDesignIcons.swift */; };
@@ -414,6 +415,7 @@
 		71922EC204982A357F814F23 /* CallControlButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CallControlButton.swift; sourceTree = "<group>"; };
 		7529BF99835005DE07E1B65F /* CodecSelectionSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CodecSelectionSheet.swift; sourceTree = "<group>"; };
 		853F1E1C2B6E5305277FCB2A /* MigrationRoundTripTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MigrationRoundTripTests.swift; sourceTree = "<group>"; };
+		B1C2D3E4F5061728394A5B6C /* IncomingMessageSizeLimitTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IncomingMessageSizeLimitTests.swift; sourceTree = "<group>"; };
 		86E428836698BA8A8973A92F /* CallManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CallManager.swift; sourceTree = "<group>"; };
 		894C730FEB9AE4CDB4B949F8 /* BackgroundDeliveryPage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BackgroundDeliveryPage.swift; sourceTree = "<group>"; };
 		8CAFC5BF3DDB882B1864F1C0 /* PythonRNSBackend.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PythonRNSBackend.swift; sourceTree = "<group>"; };
@@ -997,6 +999,7 @@
 				ACT01 /* AnnounceClassificationTests.swift */,
 				EA0AA6C472B1D4EFA2896086 /* RNodeSeamTests.swift */,
 				853F1E1C2B6E5305277FCB2A /* MigrationRoundTripTests.swift */,
+				B1C2D3E4F5061728394A5B6C /* IncomingMessageSizeLimitTests.swift */,
 				6C8CFC274AF9EF63E9A75238 /* PythonConfigWriterTests.swift */,
 				RFT001 /* RuntimeFlavorTests.swift */,
 				RMLT001 /* RuntimeActivityMonitorLeaseTests.swift */,
@@ -1660,6 +1663,7 @@
 				9566DCEF56FEFC97BAAA47BA /* MessageFormattedTimeTests.swift in Sources */,
 				ACT02 /* AnnounceClassificationTests.swift in Sources */,
 				0FF6A5C5596A39C092AADA29 /* MigrationRoundTripTests.swift in Sources */,
+				A1B2C3D4E5F60718293A4B5C /* IncomingMessageSizeLimitTests.swift in Sources */,
 				26D564FAEE8E3C750E8E2442 /* PythonConfigWriterTests.swift in Sources */,
 				RFT002 /* RuntimeFlavorTests.swift in Sources */,
 				RMLT002 /* RuntimeActivityMonitorLeaseTests.swift in Sources */,

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -1575,6 +1575,8 @@ public final class AppServices {
             return
         }
 
+        await applyIncomingMessageSizeLimitFromSettings()
+
         // Outbound LXMF now goes directly through `backend.lxmf.sendLxmfMessage`
         // (MessagingViewModel + RnsLxmf) with TYPED fields, so the old Compat
         // router sendHook — which forwarded content only and dropped every field —
@@ -2168,6 +2170,21 @@ public final class AppServices {
             }
         }
         #endif // DEBUG — test-only deep-link observers
+    }
+
+    @MainActor
+    public func applyIncomingMessageSizeLimitFromSettings() async {
+        let limitKB = await settingsRepository.getIncomingMessageSizeLimitKB()
+        guard let pythonBackend = backend as? PythonRNSBackend else {
+            DiagLog.log("[LXMF_CAP] skipping inbound cap apply: shipping Python backend unavailable")
+            return
+        }
+        do {
+            let applied = try await pythonBackend.setIncomingMessageSizeLimitKB(limitKB)
+            DiagLog.log("[LXMF_CAP] applied inbound cap=\(limitKB)KB applied=\(applied)")
+        } catch {
+            DiagLog.log("[LXMF_CAP] failed to apply inbound cap=\(limitKB)KB error=\(error.localizedDescription)")
+        }
     }
 
     /// Look up the matching Python interface for each user `InterfaceEntity`

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -472,6 +472,9 @@ public final class AppServices {
     /// Propagation node manager for relay discovery and sync.
     public private(set) var propagationManager: PropagationNodeManager?
 
+    /// Shared settings access for startup-time runtime configuration.
+    private let settingsRepository = SettingsRepository()
+
     /// Auto announce manager for periodic network announces.
     public private(set) var autoAnnounceManager: AutoAnnounceManager?
 

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -2174,6 +2174,7 @@ public final class AppServices {
 
     @MainActor
     public func applyIncomingMessageSizeLimitFromSettings() async {
+        #if COLUMBA_RUNTIME_PYTHON
         let limitKB = await settingsRepository.getIncomingMessageSizeLimitKB()
         guard let pythonBackend = backend as? PythonRNSBackend else {
             DiagLog.log("[LXMF_CAP] skipping inbound cap apply: shipping Python backend unavailable")
@@ -2185,6 +2186,7 @@ public final class AppServices {
         } catch {
             DiagLog.log("[LXMF_CAP] failed to apply inbound cap=\(limitKB)KB error=\(error.localizedDescription)")
         }
+        #endif
     }
 
     /// Look up the matching Python interface for each user `InterfaceEntity`

--- a/Sources/ColumbaApp/Services/MigrationExporter.swift
+++ b/Sources/ColumbaApp/Services/MigrationExporter.swift
@@ -194,6 +194,7 @@ actor MigrationExporter {
         let autoSelectRelay = await settingsRepository.getAutoSelectRelay()
         let periodicSync = await settingsRepository.getPeriodicSyncEnabled()
         let syncInterval = await settingsRepository.getSyncInterval()
+        let incomingLimitKB = await settingsRepository.getIncomingMessageSizeLimitKB()
 
         var prefs: [PreferenceEntry] = []
         prefs.append(.string("displayName", displayName))
@@ -202,6 +203,7 @@ actor MigrationExporter {
         prefs.append(.bool("autoSelectRelay", autoSelectRelay))
         prefs.append(.bool("periodicSyncEnabled", periodicSync))
         prefs.append(.double("syncIntervalSeconds", syncInterval))
+        prefs.append(.int("incoming_message_size_limit_kb", incomingLimitKB))
 
         // Auto-announce settings
         let autoAnnounce = UserDefaults.standard.bool(forKey: "auto_announce_enabled")

--- a/Sources/ColumbaApp/Services/MigrationImporter.swift
+++ b/Sources/ColumbaApp/Services/MigrationImporter.swift
@@ -60,11 +60,17 @@ enum MigrationInterfaceValidationError: Error, LocalizedError {
 actor MigrationImporter {
     private let identityManager: IdentityManager
     private let settingsRepository: SettingsRepository
+    private let appServices: AppServices?
     private let logger = Logger(subsystem: "network.columba.Columba", category: "MigrationImporter")
 
-    init(identityManager: IdentityManager, settingsRepository: SettingsRepository) {
+    init(
+        identityManager: IdentityManager,
+        settingsRepository: SettingsRepository,
+        appServices: AppServices? = nil
+    ) {
         self.identityManager = identityManager
         self.settingsRepository = settingsRepository
+        self.appServices = appServices
     }
 
     /// Validate every restored identity before the importer performs any durable write.
@@ -368,6 +374,7 @@ actor MigrationImporter {
         onProgress(0.8)
 
         // 4. Import settings
+        var importedIncomingMessageSizeLimit = false
         for pref in bundle.settings.preferences {
             switch pref.key {
             case "displayName":
@@ -396,6 +403,7 @@ actor MigrationImporter {
             case "incoming_message_size_limit_kb":
                 if let value = Int(pref.value) {
                     await settingsRepository.setIncomingMessageSizeLimitKB(value)
+                    importedIncomingMessageSizeLimit = true
                     settingsImported += 1
                 }
             case "auto_announce_enabled":
@@ -421,6 +429,9 @@ actor MigrationImporter {
             default:
                 break
             }
+        }
+        if importedIncomingMessageSizeLimit {
+            await appServices?.applyIncomingMessageSizeLimitFromSettings()
         }
         onProgress(1.0)
 

--- a/Sources/ColumbaApp/Services/MigrationImporter.swift
+++ b/Sources/ColumbaApp/Services/MigrationImporter.swift
@@ -393,6 +393,11 @@ actor MigrationImporter {
                     await settingsRepository.setSyncInterval(interval)
                     settingsImported += 1
                 }
+            case "incoming_message_size_limit_kb":
+                if let value = Int(pref.value) {
+                    await settingsRepository.setIncomingMessageSizeLimitKB(value)
+                    settingsImported += 1
+                }
             case "auto_announce_enabled":
                 UserDefaults.standard.set(pref.value == "true", forKey: "auto_announce_enabled")
                 settingsImported += 1

--- a/Sources/ColumbaApp/Services/SettingsRepository.swift
+++ b/Sources/ColumbaApp/Services/SettingsRepository.swift
@@ -14,6 +14,17 @@ import RNSAPI
 /// Uses App Group UserDefaults for data sharing between main app
 /// and Network Extension. Stores server configuration and identity info.
 public actor SettingsRepository {
+    public enum IncomingMessageSizeLimit {
+        public static let minimumKB = 512
+        public static let defaultKB = 1_024
+        public static let unlimitedKB = 131_072
+
+        public static func normalize(_ valueKB: Int?) -> Int {
+            guard let valueKB else { return defaultKB }
+            return min(max(valueKB, minimumKB), unlimitedKB)
+        }
+    }
+
     // MARK: - Keys
 
     private enum Keys {
@@ -29,6 +40,7 @@ public actor SettingsRepository {
         static let periodicSyncEnabled = "periodicSyncEnabled"
         static let syncIntervalSeconds = "syncIntervalSeconds"
         static let lastSyncTimestamp = "lastSyncTimestamp"
+        static let incomingMessageSizeLimitKB = "incoming_message_size_limit_kb"
         static let iconName = "profileIconName"
         static let iconFgColor = "profileIconFgColor"
         static let iconBgColor = "profileIconBgColor"
@@ -200,6 +212,41 @@ public actor SettingsRepository {
     /// Set sync interval in seconds.
     public func setSyncInterval(_ interval: TimeInterval) {
         defaults.set(interval, forKey: Keys.syncIntervalSeconds)
+    }
+
+    // MARK: - Incoming Message Size Limit
+
+    /// Get the inbound packed-message cap in KB, clamped to Android-compatible bounds.
+    public func getIncomingMessageSizeLimitKB() -> Int {
+        let raw = defaults.object(forKey: Keys.incomingMessageSizeLimitKB)
+        let stored: Int?
+        switch raw {
+        case let value as Int:
+            stored = value
+        case let value as NSNumber:
+            stored = value.intValue
+        case let value as String:
+            stored = Int(value.trimmingCharacters(in: .whitespacesAndNewlines))
+        default:
+            stored = nil
+        }
+        let normalized = IncomingMessageSizeLimit.normalize(stored)
+        if normalized != stored {
+            defaults.set(normalized, forKey: Keys.incomingMessageSizeLimitKB)
+        } else if raw == nil {
+            defaults.set(normalized, forKey: Keys.incomingMessageSizeLimitKB)
+        }
+        return normalized
+    }
+
+    /// Persist the inbound packed-message cap in KB.
+    public func setIncomingMessageSizeLimitKB(_ valueKB: Int) {
+        defaults.set(IncomingMessageSizeLimit.normalize(valueKB), forKey: Keys.incomingMessageSizeLimitKB)
+    }
+
+    /// Clear the stored cap so the default is used next read.
+    public func clearIncomingMessageSizeLimitKB() {
+        defaults.removeObject(forKey: Keys.incomingMessageSizeLimitKB)
     }
 
     /// Get last sync timestamp.

--- a/Sources/ColumbaApp/ViewModels/MigrationViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/MigrationViewModel.swift
@@ -75,14 +75,19 @@ final class MigrationViewModel {
 
     // MARK: - Init
 
-    init(identityManager: IdentityManager, settingsRepository: SettingsRepository) {
+    init(
+        identityManager: IdentityManager,
+        settingsRepository: SettingsRepository,
+        appServices: AppServices? = nil
+    ) {
         self.exporter = MigrationExporter(
             identityManager: identityManager,
             settingsRepository: settingsRepository
         )
         self.importer = MigrationImporter(
             identityManager: identityManager,
-            settingsRepository: settingsRepository
+            settingsRepository: settingsRepository,
+            appServices: appServices
         )
     }
 

--- a/Sources/ColumbaApp/ViewModels/SettingsViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/SettingsViewModel.swift
@@ -238,6 +238,8 @@ public final class SettingsViewModel {
 
     /// Default delivery method for large messages: "direct" or "propagated"
     public var defaultDeliveryMethod: String = "direct"
+    /// Incoming packed-message cap in KB.
+    public var incomingMessageSizeLimitKB: Int = SettingsRepository.IncomingMessageSizeLimit.defaultKB
 
     /// Whether to retry via relay when direct delivery fails.
     public var retryViaRelay: Bool = false
@@ -352,6 +354,7 @@ public final class SettingsViewModel {
 
         // Load delivery/retrieval settings
         defaultDeliveryMethod = await settingsRepository.getDefaultDeliveryMethod()
+        incomingMessageSizeLimitKB = await settingsRepository.getIncomingMessageSizeLimitKB()
         retryViaRelay = await settingsRepository.getRetryViaRelay()
         autoSelectRelay = await settingsRepository.getAutoSelectRelay()
         autoRetrieveEnabled = await settingsRepository.getPeriodicSyncEnabled()
@@ -661,10 +664,12 @@ public final class SettingsViewModel {
     @MainActor
     public func saveDeliverySettings() async {
         await settingsRepository.setDefaultDeliveryMethod(defaultDeliveryMethod)
+        await settingsRepository.setIncomingMessageSizeLimitKB(incomingMessageSizeLimitKB)
         await settingsRepository.setRetryViaRelay(retryViaRelay)
         await settingsRepository.setAutoSelectRelay(autoSelectRelay)
         await settingsRepository.setPeriodicSyncEnabled(autoRetrieveEnabled)
         await settingsRepository.setSyncInterval(autoRetrieveInterval)
+        await appServices.applyIncomingMessageSizeLimitFromSettings()
 
         // Update propagation manager
         if let propManager = appServices.propagationManager {

--- a/Sources/ColumbaApp/Views/Onboarding/OnboardingView.swift
+++ b/Sources/ColumbaApp/Views/Onboarding/OnboardingView.swift
@@ -96,7 +96,8 @@ struct OnboardingView: View {
                                 onRestoreFile: { data in
                                     let vm = MigrationViewModel(
                                         identityManager: identityManager,
-                                        settingsRepository: settingsRepository
+                                        settingsRepository: settingsRepository,
+                                        appServices: appServices
                                     )
                                     restoreSession = RestoreSession(viewModel: vm)
                                     Task { await vm.handleImportFile(data: data) }

--- a/Sources/ColumbaApp/Views/Settings/MigrationScreen.swift
+++ b/Sources/ColumbaApp/Views/Settings/MigrationScreen.swift
@@ -19,10 +19,15 @@ struct MigrationScreen: View {
     @State private var exportDocument: ColumbaBackupDocument?
     @State private var exportFileName = "columba_backup.columba"
 
-    init(identityManager: IdentityManager, settingsRepository: SettingsRepository) {
+    init(
+        identityManager: IdentityManager,
+        settingsRepository: SettingsRepository,
+        appServices: AppServices
+    ) {
         _viewModel = State(initialValue: MigrationViewModel(
             identityManager: identityManager,
-            settingsRepository: settingsRepository
+            settingsRepository: settingsRepository,
+            appServices: appServices
         ))
     }
 

--- a/Sources/ColumbaApp/Views/Settings/SettingsView.swift
+++ b/Sources/ColumbaApp/Views/Settings/SettingsView.swift
@@ -164,7 +164,8 @@ struct SettingsView: View {
                     #if COLUMBA_MIGRATION_ENABLED
                     MigrationScreen(
                         identityManager: identityManager,
-                        settingsRepository: settingsRepository
+                        settingsRepository: settingsRepository,
+                        appServices: appServices
                     )
                     #else
                     Text("Data migration unavailable in this build")
@@ -1253,6 +1254,12 @@ struct SettingsView: View {
                         )) {
                             ForEach(Self.incomingMessageCapPresets, id: \.kb) { preset in
                                 Text(preset.title).tag(preset.kb)
+                            }
+                            if !Self.incomingMessageCapPresets.contains(where: {
+                                $0.kb == vm.incomingMessageSizeLimitKB
+                            }) {
+                                Text("Custom (\(vm.incomingMessageSizeLimitKB) KB)")
+                                    .tag(vm.incomingMessageSizeLimitKB)
                             }
                         }
                         .pickerStyle(.menu)

--- a/Sources/ColumbaApp/Views/Settings/SettingsView.swift
+++ b/Sources/ColumbaApp/Views/Settings/SettingsView.swift
@@ -1227,6 +1227,44 @@ struct SettingsView: View {
                     .font(.caption)
                     .foregroundStyle(Theme.textSecondary)
 
+#if !COLUMBA_RUNTIME_MODEL_B
+                Divider()
+                    .padding(.vertical, 4)
+
+                Text("INCOMING MESSAGE CAP")
+                    .font(.caption2)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(Theme.textSecondary)
+
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Text("Incoming Size Limit")
+                            .font(.subheadline)
+                            .foregroundStyle(Theme.textSecondary)
+
+                        Spacer()
+
+                        Picker("", selection: Binding(
+                            get: { vm.incomingMessageSizeLimitKB },
+                            set: {
+                                vm.incomingMessageSizeLimitKB = SettingsRepository.IncomingMessageSizeLimit.normalize($0)
+                                Task { await vm.saveDeliverySettings() }
+                            }
+                        )) {
+                            ForEach(Self.incomingMessageCapPresets, id: \.kb) { preset in
+                                Text(preset.title).tag(preset.kb)
+                            }
+                        }
+                        .pickerStyle(.menu)
+                        .tint(Theme.accentColor)
+                    }
+
+                    Text("Applies to packed incoming LXMF messages on this device. Oversized direct messages are rejected; oversized propagated messages remain on the relay until the cap is raised.")
+                        .font(.caption)
+                        .foregroundStyle(Theme.textSecondary)
+                }
+#endif
+
                 // Default Delivery Method
                 HStack {
                     Text("Default Method")
@@ -1389,6 +1427,22 @@ struct SettingsView: View {
             }
         }
     }
+
+#if !COLUMBA_RUNTIME_MODEL_B
+    private struct IncomingMessageCapPreset: Identifiable {
+        let kb: Int
+        let title: String
+        var id: Int { kb }
+    }
+
+    private static let incomingMessageCapPresets: [IncomingMessageCapPreset] = [
+        .init(kb: 1_024, title: "1 MB"),
+        .init(kb: 5_120, title: "5 MB"),
+        .init(kb: 10_240, title: "10 MB"),
+        .init(kb: 25_600, title: "25 MB"),
+        .init(kb: 131_072, title: "Unlimited")
+    ]
+#endif
 
     // MARK: - Onboarding Review
 

--- a/Sources/PythonBridge/PythonBridge.swift
+++ b/Sources/PythonBridge/PythonBridge.swift
@@ -42,12 +42,14 @@ public final class PythonBridge: @unchecked Sendable {
         case notStarted
         case pythonException(String)
         case marshallingFailure(String)
+        case operationFailed(String)
 
         public var errorDescription: String? {
             switch self {
             case .notStarted: return "Python bridge not started"
             case .pythonException(let m): return "Python error: \(m)"
             case .marshallingFailure(let m): return "Marshalling: \(m)"
+            case .operationFailed(let m): return "Operation failed: \(m)"
             }
         }
     }
@@ -341,6 +343,40 @@ public final class PythonBridge: @unchecked Sendable {
                 }
                 defer { Py_DecRef(result) }
                 return pyBoolFromDict(result, key: "ok") ?? false
+            }
+        }
+    }
+
+    /// Set the router's per-transfer delivery cap in KB.
+    public func setIncomingMessageSizeLimitKB(_ limitKB: Int) async throws -> Bool {
+        let bounded = max(512, min(limitKB, 131_072))
+        return try await runOnQueue { [self] in
+            try PythonRuntime.shared.withGIL { [self] in
+                guard let module = self.module else {
+                    throw BridgeError.notStarted
+                }
+                guard let fn = PyObject_GetAttrString(module, "set_incoming_message_size_limit_kb") else {
+                    throw BridgeError.pythonException(currentPythonException())
+                }
+                defer { Py_DecRef(fn) }
+                guard let arg = PyLong_FromLongLong(Int64(bounded)) else {
+                    throw BridgeError.marshallingFailure("limitKB")
+                }
+                guard let result = PyObject_CallOneArg(fn, arg) else {
+                    Py_DecRef(arg)
+                    throw BridgeError.pythonException(currentPythonException())
+                }
+                Py_DecRef(arg)
+                defer { Py_DecRef(result) }
+                let ok = pyBoolFromDict(result, key: "ok") ?? false
+                guard ok else {
+                    let reason = pyStringFromDict(result, key: "reason") ?? "unknown"
+                    if reason == "not-started" || reason == "no-router" {
+                        throw BridgeError.notStarted
+                    }
+                    throw BridgeError.operationFailed(reason)
+                }
+                return true
             }
         }
     }

--- a/Sources/RNSBackendPy/PythonRNSBackend.swift
+++ b/Sources/RNSBackendPy/PythonRNSBackend.swift
@@ -140,6 +140,12 @@ public final class PythonRNSBackend: RnsBackend, @unchecked Sendable {
         try await bridge.setPropagationNode(destHashHex: destHashHex, stampCost: stampCost)
     }
 
+    /// Set the inbound packed-message cap in KB.
+    @discardableResult
+    public func setIncomingMessageSizeLimitKB(_ limitKB: Int) async throws -> Bool {
+        try await bridge.setIncomingMessageSizeLimitKB(limitKB)
+    }
+
     /// Block until the configured propagation-node sync completes.
     public func propagationSync(timeout: TimeInterval = 60.0) async throws -> PropagationSyncResult {
         Self.map(try await bridge.propagationSync(timeout: timeout))

--- a/Tests/ColumbaAppTests/IncomingMessageSizeLimitTests.swift
+++ b/Tests/ColumbaAppTests/IncomingMessageSizeLimitTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import ColumbaApp
+
+final class IncomingMessageSizeLimitTests: XCTestCase {
+    func testIncomingMessageSizeLimitDefaultsToAndroidCompatibleValue() async {
+        guard let defaults = UserDefaults(suiteName: appGroupIdentifier) else {
+            return XCTFail("Could not create app-group UserDefaults")
+        }
+        defaults.removeObject(forKey: "incoming_message_size_limit_kb")
+        let repo = SettingsRepository()
+        let value = await repo.getIncomingMessageSizeLimitKB()
+        XCTAssertEqual(value, SettingsRepository.IncomingMessageSizeLimit.defaultKB)
+    }
+
+    func testIncomingMessageSizeLimitPersistsAndClamps() async {
+        guard let defaults = UserDefaults(suiteName: appGroupIdentifier) else {
+            return XCTFail("Could not create app-group UserDefaults")
+        }
+        defaults.removeObject(forKey: "incoming_message_size_limit_kb")
+        let repo = SettingsRepository()
+        await repo.setIncomingMessageSizeLimitKB(25_600)
+        XCTAssertEqual(await repo.getIncomingMessageSizeLimitKB(), 25_600)
+
+        await repo.setIncomingMessageSizeLimitKB(1)
+        XCTAssertEqual(await repo.getIncomingMessageSizeLimitKB(), SettingsRepository.IncomingMessageSizeLimit.minimumKB)
+
+        await repo.setIncomingMessageSizeLimitKB(500_000)
+        XCTAssertEqual(await repo.getIncomingMessageSizeLimitKB(), SettingsRepository.IncomingMessageSizeLimit.unlimitedKB)
+    }
+
+    func testIncomingMessageSizeLimitRepairsMalformedStoredValues() async {
+        guard let defaults = UserDefaults(suiteName: appGroupIdentifier) else {
+            return XCTFail("Could not create app-group UserDefaults")
+        }
+        defer {
+            defaults.removeObject(forKey: "incoming_message_size_limit_kb")
+        }
+
+        defaults.set(-7, forKey: "incoming_message_size_limit_kb")
+        let repo = SettingsRepository()
+        XCTAssertEqual(await repo.getIncomingMessageSizeLimitKB(), SettingsRepository.IncomingMessageSizeLimit.minimumKB)
+
+        defaults.set("not-a-number", forKey: "incoming_message_size_limit_kb")
+        XCTAssertEqual(await repo.getIncomingMessageSizeLimitKB(), SettingsRepository.IncomingMessageSizeLimit.defaultKB)
+    }
+}

--- a/Tests/ColumbaAppTests/IncomingMessageSizeLimitTests.swift
+++ b/Tests/ColumbaAppTests/IncomingMessageSizeLimitTests.swift
@@ -7,6 +7,8 @@ final class IncomingMessageSizeLimitTests: XCTestCase {
             return XCTFail("Could not create app-group UserDefaults")
         }
         defaults.removeObject(forKey: "incoming_message_size_limit_kb")
+        defer { defaults.removeObject(forKey: "incoming_message_size_limit_kb") }
+
         let repo = SettingsRepository()
         let value = await repo.getIncomingMessageSizeLimitKB()
         XCTAssertEqual(value, SettingsRepository.IncomingMessageSizeLimit.defaultKB)
@@ -17,30 +19,36 @@ final class IncomingMessageSizeLimitTests: XCTestCase {
             return XCTFail("Could not create app-group UserDefaults")
         }
         defaults.removeObject(forKey: "incoming_message_size_limit_kb")
+        defer { defaults.removeObject(forKey: "incoming_message_size_limit_kb") }
+
         let repo = SettingsRepository()
         await repo.setIncomingMessageSizeLimitKB(25_600)
-        XCTAssertEqual(await repo.getIncomingMessageSizeLimitKB(), 25_600)
+        let persisted = await repo.getIncomingMessageSizeLimitKB()
+        XCTAssertEqual(persisted, 25_600)
 
         await repo.setIncomingMessageSizeLimitKB(1)
-        XCTAssertEqual(await repo.getIncomingMessageSizeLimitKB(), SettingsRepository.IncomingMessageSizeLimit.minimumKB)
+        let minimum = await repo.getIncomingMessageSizeLimitKB()
+        XCTAssertEqual(minimum, SettingsRepository.IncomingMessageSizeLimit.minimumKB)
 
         await repo.setIncomingMessageSizeLimitKB(500_000)
-        XCTAssertEqual(await repo.getIncomingMessageSizeLimitKB(), SettingsRepository.IncomingMessageSizeLimit.unlimitedKB)
+        let maximum = await repo.getIncomingMessageSizeLimitKB()
+        XCTAssertEqual(maximum, SettingsRepository.IncomingMessageSizeLimit.unlimitedKB)
     }
 
     func testIncomingMessageSizeLimitRepairsMalformedStoredValues() async {
         guard let defaults = UserDefaults(suiteName: appGroupIdentifier) else {
             return XCTFail("Could not create app-group UserDefaults")
         }
-        defer {
-            defaults.removeObject(forKey: "incoming_message_size_limit_kb")
-        }
+        defaults.removeObject(forKey: "incoming_message_size_limit_kb")
+        defer { defaults.removeObject(forKey: "incoming_message_size_limit_kb") }
 
         defaults.set(-7, forKey: "incoming_message_size_limit_kb")
         let repo = SettingsRepository()
-        XCTAssertEqual(await repo.getIncomingMessageSizeLimitKB(), SettingsRepository.IncomingMessageSizeLimit.minimumKB)
+        let minimum = await repo.getIncomingMessageSizeLimitKB()
+        XCTAssertEqual(minimum, SettingsRepository.IncomingMessageSizeLimit.minimumKB)
 
         defaults.set("not-a-number", forKey: "incoming_message_size_limit_kb")
-        XCTAssertEqual(await repo.getIncomingMessageSizeLimitKB(), SettingsRepository.IncomingMessageSizeLimit.defaultKB)
+        let repaired = await repo.getIncomingMessageSizeLimitKB()
+        XCTAssertEqual(repaired, SettingsRepository.IncomingMessageSizeLimit.defaultKB)
     }
 }

--- a/Tests/ColumbaAppTests/MigrationRoundTripTests.swift
+++ b/Tests/ColumbaAppTests/MigrationRoundTripTests.swift
@@ -306,7 +306,7 @@ final class MigrationRoundTripTests: XCTestCase {
         XCTAssertEqual(Data(base64Encoded: outgoing.content), Data("reply".utf8))
 
         // Settings preferences survive.
-        XCTAssertEqual(restored.settings.preferences.count, 4)
+        XCTAssertEqual(restored.settings.preferences.count, 5)
     }
 
     /// The real importer's decrypt+parse path (previewMigration → decryptAndParse)
@@ -330,7 +330,7 @@ final class MigrationRoundTripTests: XCTestCase {
         XCTAssertEqual(preview.conversationCount, 1)
         XCTAssertEqual(preview.messageCount, 2)
         XCTAssertEqual(preview.interfaceCount, 1)
-        XCTAssertEqual(preview.settingsCount, 4)
+        XCTAssertEqual(preview.settingsCount, 5)
     }
 
     /// The message persistence path (the fix): a restored MessageRecord must

--- a/Tests/ColumbaAppTests/MigrationRoundTripTests.swift
+++ b/Tests/ColumbaAppTests/MigrationRoundTripTests.swift
@@ -93,7 +93,8 @@ final class MigrationRoundTripTests: XCTestCase {
             .string("displayName", "Alice"),
             .bool("notifications_enabled", true),
             .int("announce_interval_hours", 6),
-            .double("syncIntervalSeconds", 43_200)
+            .double("syncIntervalSeconds", 43_200),
+            .int("incoming_message_size_limit_kb", 5_120)
         ])
 
         return MigrationBundle(

--- a/Tests/static/test_modelb_target_isolation.rb
+++ b/Tests/static/test_modelb_target_isolation.rb
@@ -109,6 +109,7 @@ SHIPPING_TEST_SOURCE_PATHS = %w[
   Tests/ColumbaAppTests/MessageFormattedTimeTests.swift
   Tests/ColumbaAppTests/AnnounceClassificationTests.swift
   Tests/ColumbaAppTests/MigrationRoundTripTests.swift
+  Tests/ColumbaAppTests/IncomingMessageSizeLimitTests.swift
   Tests/ColumbaAppTests/PythonConfigWriterTests.swift
   Tests/ColumbaAppTests/RuntimeFlavorTests.swift
 ].freeze

--- a/Tests/static/test_reported_runtime_bugs.py
+++ b/Tests/static/test_reported_runtime_bugs.py
@@ -155,6 +155,9 @@ class ReportedRuntimeBugContracts(unittest.TestCase):
         self.assertIn('incoming_message_size_limit_kb', migration_exporter)
         migration_importer = (ROOT / "Sources/ColumbaApp/Services/MigrationImporter.swift").read_text()
         self.assertIn('case "incoming_message_size_limit_kb":', migration_importer)
+        self.assertIn("importedIncomingMessageSizeLimit = true", migration_importer)
+        self.assertIn("await appServices?.applyIncomingMessageSizeLimitFromSettings()", migration_importer)
+        self.assertIn('Text("Custom (\\(vm.incomingMessageSizeLimitKB) KB)")', settings)
 
 
 if __name__ == "__main__":

--- a/Tests/static/test_reported_runtime_bugs.py
+++ b/Tests/static/test_reported_runtime_bugs.py
@@ -132,6 +132,30 @@ class ReportedRuntimeBugContracts(unittest.TestCase):
             re.DOTALL,
         ))
 
+    def test_incoming_message_size_limit_contract(self) -> None:
+        bridge = BRIDGE_PY.read_text()
+        self.assertIn("def set_incoming_message_size_limit_kb(", bridge)
+        self.assertIn("router.delivery_per_transfer_limit = bounded", bridge)
+        self.assertIn('return {"ok": True, "reason": "ok", "limit_kb": bounded}', bridge)
+
+        py_bridge = PYTHON_BRIDGE.read_text()
+        self.assertIn("public func setIncomingMessageSizeLimitKB(_ limitKB: Int) async throws -> Bool", py_bridge)
+        self.assertIn('PyObject_GetAttrString(module, "set_incoming_message_size_limit_kb")', py_bridge)
+
+        py_backend = PY_BACKEND.read_text()
+        self.assertIn("public func setIncomingMessageSizeLimitKB(_ limitKB: Int) async throws -> Bool", py_backend)
+
+        settings = SETTINGS_VIEW.read_text()
+        self.assertIn("Incoming Size Limit", settings)
+        self.assertIn('"1 MB"', settings)
+        self.assertIn('"Unlimited"', settings)
+        self.assertIn("packed incoming LXMF messages", settings)
+
+        migration_exporter = (ROOT / "Sources/ColumbaApp/Services/MigrationExporter.swift").read_text()
+        self.assertIn('incoming_message_size_limit_kb', migration_exporter)
+        migration_importer = (ROOT / "Sources/ColumbaApp/Services/MigrationImporter.swift").read_text()
+        self.assertIn('case "incoming_message_size_limit_kb":', migration_importer)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/app/rns_bridge.py
+++ b/app/rns_bridge.py
@@ -498,6 +498,27 @@ def set_propagation_node(dest_hash_hex: str, stamp_cost: int = 0) -> dict[str, A
         return {"ok": True, "reason": "ok"}
 
 
+def set_incoming_message_size_limit_kb(limit_kb: int) -> dict[str, Any]:
+    """Set LXMRouter.delivery_per_transfer_limit in KB.
+
+    This single router property drives both the delivery_resource_advertised
+    transfer limit and the propagation WANT transfer limit. It must be applied
+    on a running router; callers should treat not-started/no-router as errors.
+    """
+    with _lock:
+        if not _state["started"]:
+            return {"ok": False, "reason": "not-started"}
+        router = _state["router"]
+        if router is None:
+            return {"ok": False, "reason": "no-router"}
+        bounded = max(512, min(int(limit_kb), 131072))
+        try:
+            router.delivery_per_transfer_limit = bounded
+        except Exception as e:
+            return {"ok": False, "reason": f"set-failed: {e}"}
+        return {"ok": True, "reason": "ok", "limit_kb": bounded}
+
+
 def propagation_sync(timeout: float = 60.0) -> dict[str, Any]:
     """Block until the current LXMF propagation-node sync finishes (or
     times out). Returns `{ok, state, received_messages, reason}`.


### PR DESCRIPTION
## Summary

- add an Android-compatible incoming LXMF packed-message size setting under Message Delivery and Retrieval
- persist and restore 1 MB, 5 MB, 10 MB, 25 MB, and bounded 128 MB “Unlimited” choices
- apply the stored limit at shipping-runtime startup and immediately after settings changes
- use the same `LXMRouter.delivery_per_transfer_limit` for direct Resource admission and propagation synchronization
- preserve the preference through migration export/import
- keep Python-runtime plumbing isolated from Model B

## Root cause

Shipping iOS used LXMF's default 1,000 KB packed-Resource transfer limit. A roughly 1.5 MB generic file was rejected during direct Resource delivery, causing Android to retry through propagation. iOS then advertised the same 1,000 KB cap during propagation synchronization, so the relay omitted the oversized message. Images generally remained below the cap because Columba compresses them before packing.

The selected limit applies to the complete packed LXMF message, not only the raw attachment bytes.

## Verification

- `python3 -m unittest Tests/static/test_reported_runtime_bugs.py`
- direct Python bridge boundary probe: not-started, 512 KB, 5 MB, and 128 MB cases
- signed Mac simulator XCTests:
  - `IncomingMessageSizeLimitTests`
  - `MigrationRoundTripTests`
- signed Mac simulator build of the shipping `Columba` scheme
- signed Mac simulator build of `Columba-ModelB`
- `git diff --check`

## Scope

Model-B transfer-limit support and the separate LXMF-Swift partial propagation ACK issue are intentionally deferred.
