### PR TITLE
Harden embedded RNS and LXMF runtime lifecycle

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,7 +74,8 @@ jobs:
             Tests.static.test_host_entitlements_contract \
             Tests.static.test_ci_artifact_isolation \
             Tests.static.test_fetch_python_resilience \
-            Tests.static.test_migration_export_flow
+            Tests.static.test_migration_export_flow \
+            Tests.static.test_ios_stamp_runtime_hardening
 
       - name: Build shipping artifact (embedded Python)
         run: |

--- a/Sources/SwiftBLEBridge/StampGenerator.swift
+++ b/Sources/SwiftBLEBridge/StampGenerator.swift
@@ -47,8 +47,14 @@ enum StampGenerator {
     /// hours-to-centuries — still an indefinite GIL freeze — so 32 is the
     /// defensible ceiling; a message requesting more is undeliverable anyway.)
     static let maxCost = 32
-    static func generate(workblock: Data, cost: Int) -> Data? {
+
+    static func generate(
+        workblock: Data,
+        cost: Int,
+        isCancelled: @escaping () -> Bool = { false }
+    ) -> Data? {
         guard cost >= 0, cost <= maxCost else { return nil }
+        guard !isCancelled() else { return nil }
         if cost == 0 { return Data(repeating: 0, count: stampSize) }
 
         // Absorb the workblock once. CC_SHA256_CTX is a flat value struct with
@@ -82,7 +88,13 @@ enum StampGenerator {
                 CC_SHA256_Final(&digest, &ctx)
 
                 if leadingZeroBits(digest) >= cost {
-                    result.trySet(Data(candidate))
+                    // Cancellation wins if it raced the proof. StampResultBox
+                    // also refuses a proof after any sibling observed cancel.
+                    if isCancelled() {
+                        result.cancel()
+                    } else {
+                        result.trySet(Data(candidate))
+                    }
                     return
                 }
 
@@ -95,9 +107,12 @@ enum StampGenerator {
                 }
 
                 rounds &+= 1
-                // Cheap periodic stop-check so losing workers exit shortly after
-                // a sibling finds a stamp.
-                if rounds & 0xFFF == 0 && result.isFound() { return }
+                // Poll foreign cancellation at a bounded interval rather than
+                // crossing the Python C callback boundary for every candidate.
+                if rounds & 0xFF == 0,  // at most 256 candidates per worker
+                   result.shouldStop(isCancelled: isCancelled) {
+                    return
+                }
             }
         }
 
@@ -115,13 +130,40 @@ enum StampGenerator {
     }
 }
 
-/// Thread-safe holder for the first stamp found. All access is via the lock —
-/// no data races; `isFound()` is only polled every few thousand rounds.
+/// Thread-safe shared search state. Cancellation and proof publication are
+/// linearized by the same lock, so a proof can never overwrite observed cancel.
 private final class StampResultBox: @unchecked Sendable {
-    private let state = OSAllocatedUnfairLock<Data?>(initialState: nil)
-    func trySet(_ d: Data) { state.withLock { if $0 == nil { $0 = d } } }
-    func isFound() -> Bool { state.withLock { $0 != nil } }
-    func get() -> Data? { state.withLock { $0 } }
+    private struct SearchState {
+        var stamp: Data?
+        var cancelled = false
+    }
+
+    private let state = OSAllocatedUnfairLock<SearchState>(
+        initialState: SearchState(stamp: nil)
+    )
+
+    func trySet(_ stamp: Data) {
+        state.withLock {
+            if !$0.cancelled && $0.stamp == nil { $0.stamp = stamp }
+        }
+    }
+
+    func cancel() {
+        state.withLock { $0.cancelled = true; $0.stamp = nil }
+    }
+
+    func shouldStop(isCancelled: () -> Bool) -> Bool {
+        if state.withLock({ $0.cancelled || $0.stamp != nil }) { return true }
+        if isCancelled() {
+            cancel()
+            return true
+        }
+        return state.withLock { $0.cancelled || $0.stamp != nil }
+    }
+
+    func get() -> Data? {
+        state.withLock { $0.cancelled ? nil : $0.stamp }
+    }
 }
 
 /// C-ABI shim for Python ctypes (`rns_bridge.py` → `columba_stamp_generate`).
@@ -140,6 +182,46 @@ public func columba_stamp_generate(
     }
     guard let stamp = StampGenerator.generate(workblock: wb, cost: Int(stampCost)),
           stamp.count == StampGenerator.stampSize else {
+        return 0
+    }
+    stamp.withUnsafeBytes { raw in
+        outStamp.withMemoryRebound(to: UInt8.self, capacity: StampGenerator.stampSize) { dst in
+            _ = memcpy(dst, raw.baseAddress!, StampGenerator.stampSize)
+        }
+    }
+    return Int32(StampGenerator.stampSize)
+}
+
+/// C-compatible cooperative cancellation callback. A non-zero result requests
+/// that all native workers stop and that no stamp be returned.
+public typealias ColumbaStampCancellationCallback = @convention(c) (
+    UnsafeMutableRawPointer?
+) -> Int32
+
+/// Token-aware C ABI used by LXMF's three-argument external generator contract.
+/// The legacy `columba_stamp_generate` symbol remains available for callers
+/// that do not support cancellation.
+@_cdecl("columba_stamp_generate_cancellable")
+public func columba_stamp_generate_cancellable(
+    _ workblock: UnsafePointer<CChar>?,
+    _ workblockLen: Int32,
+    _ stampCost: Int32,
+    _ outStamp: UnsafeMutablePointer<CChar>?,
+    _ cancellationCallback: ColumbaStampCancellationCallback?,
+    _ cancellationContext: UnsafeMutableRawPointer?
+) -> Int32 {
+    guard let workblock, let outStamp, let cancellationCallback,
+          workblockLen >= 0, stampCost >= 0 else {
+        return -1
+    }
+    let wb = workblock.withMemoryRebound(to: UInt8.self, capacity: Int(workblockLen)) {
+        Data(bytes: $0, count: Int(workblockLen))
+    }
+    guard let stamp = StampGenerator.generate(
+        workblock: wb,
+        cost: Int(stampCost),
+        isCancelled: { cancellationCallback(cancellationContext) != 0 }
+    ), stamp.count == StampGenerator.stampSize else {
         return 0
     }
     stamp.withUnsafeBytes { raw in

--- a/Tests/static/test_ios_stamp_runtime_hardening.py
+++ b/Tests/static/test_ios_stamp_runtime_hardening.py
@@ -85,7 +85,12 @@ class DependencyPayloadTests(unittest.TestCase):
             "serial/__init__.py", "ble_reticulum/BLEInterface.py",
         ):
             self.assertIn(payload, self.source)
-        self.assertIn("*.dist-info/METADATA", self.source)
+        for name in ("rns", "lxmf", "pyserial", "ble-reticulum"):
+            self.assertIn(f'"{name}"', self.source)
+        self.assertIn("direct_url.json", self.source)
+        self.assertIn("vcs_info", self.source)
+        self.assertIn("commit_id", self.source)
+        self.assertIn('in {"unknown", "0.0.0"}', self.source)
 
 
 class NativeStampBridgeTests(unittest.TestCase):
@@ -176,6 +181,32 @@ class NativeStampBridgeTests(unittest.TestCase):
         self.bridge.stop()
         self.assertIsNone(self.stamper.calls[-1][0][0])
         self.assertEqual(3, len(self.stamper.calls))
+
+    def test_teardown_during_registration_clears_new_callback(self) -> None:
+        self.bridge._runtime_teardown_requested.clear()
+
+        def install_then_request_teardown():
+            self.bridge._runtime_teardown_requested.set()
+
+        with mock.patch.object(
+            self.bridge,
+            "_install_native_stamp_generator",
+            side_effect=install_then_request_teardown,
+        ) as install, mock.patch.object(
+            self.bridge, "_uninstall_native_stamp_generator"
+        ) as uninstall:
+            installed = self.bridge._install_native_stamp_generator_unless_stopping()
+
+        self.assertFalse(installed)
+        install.assert_called_once_with()
+        uninstall.assert_called_once_with()
+
+    def test_pending_teardown_prevents_registration(self) -> None:
+        self.bridge._runtime_teardown_requested.set()
+        with mock.patch.object(self.bridge, "_install_native_stamp_generator") as install:
+            installed = self.bridge._install_native_stamp_generator_unless_stopping()
+        self.assertFalse(installed)
+        install.assert_not_called()
 
 
 class NativeStampStaticABITests(unittest.TestCase):

--- a/Tests/static/test_ios_stamp_runtime_hardening.py
+++ b/Tests/static/test_ios_stamp_runtime_hardening.py
@@ -18,8 +18,8 @@ ROOT = Path(__file__).resolve().parents[2]
 FETCH = ROOT / "support" / "fetch-wheels.sh"
 BRIDGE = ROOT / "app" / "rns_bridge.py"
 STAMP = ROOT / "Sources" / "SwiftBLEBridge" / "StampGenerator.swift"
-RNS_SHA = "1c2cf73443ce73613bd67ea8412e7923d34cd7e6"
-LXMF_SHA = "fbcb8f83109b93d2491632427716c7fcd645c605"
+RNS_SHA = "7d02152122cc069b88c1a02920c71fbf96c1f8d8"
+LXMF_SHA = "8912186e48b482a76bf04e2ac4b6c8940991aecc"
 
 
 def load_bridge(lx_stamper: object):

--- a/Tests/static/test_ios_stamp_runtime_hardening.py
+++ b/Tests/static/test_ios_stamp_runtime_hardening.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Portable regressions for immutable iOS payloads and native stamp lifecycle."""
+
+from __future__ import annotations
+
+import ctypes
+import hashlib
+import importlib.util
+from pathlib import Path
+import re
+import sys
+import types
+import unittest
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[2]
+FETCH = ROOT / "support" / "fetch-wheels.sh"
+BRIDGE = ROOT / "app" / "rns_bridge.py"
+STAMP = ROOT / "Sources" / "SwiftBLEBridge" / "StampGenerator.swift"
+RNS_SHA = "1c2cf73443ce73613bd67ea8412e7923d34cd7e6"
+LXMF_SHA = "fbcb8f83109b93d2491632427716c7fcd645c605"
+
+
+def load_bridge(lx_stamper: object):
+    rns = types.ModuleType("RNS")
+    rns.LOG_DEBUG = 0
+    rns.LOG_WARNING = 1
+    rns.LOG_INFO = 2
+    rns.LOG_VERBOSE = 3
+    rns.log = mock.Mock()
+    rns.Transport = types.SimpleNamespace(
+        destinations=[], interfaces=[], path_table={}, destination_table={},
+        announce_handlers=[], identities={}, deregister_announce_handler=mock.Mock(),
+    )
+    rns.Reticulum = type("Reticulum", (), {})
+
+    lxmf = types.ModuleType("LXMF")
+    lxmf.LXStamper = lx_stamper
+
+    name = f"rns_bridge_stamp_test_{id(lx_stamper)}"
+    spec = importlib.util.spec_from_file_location(name, BRIDGE)
+    module = importlib.util.module_from_spec(spec)
+    old_stdout = sys.stdout
+    with mock.patch.dict(sys.modules, {"RNS": rns, "LXMF": lxmf}):
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+    sys.stdout = old_stdout
+    return module
+
+
+class DependencyPayloadTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.source = FETCH.read_text(encoding="utf-8")
+
+    def test_default_rns_and_lxmf_refs_are_exact_immutable_commits(self) -> None:
+        self.assertIn(f'RETICULUM_REF="${{RETICULUM_REF:-{RNS_SHA}}}"', self.source)
+        self.assertIn(f'LXMF_REF="${{LXMF_REF:-{LXMF_SHA}}}"', self.source)
+        self.assertIn("Reticulum.git@${RETICULUM_REF}", self.source)
+        self.assertIn("LXMF.git@${LXMF_REF}", self.source)
+        self.assertNotRegex(self.source, r"RETICULUM_BRANCH|LXMF_BRANCH")
+        for ref in (RNS_SHA, LXMF_SHA):
+            self.assertRegex(ref, r"^[0-9a-f]{40}$")
+
+    def test_local_dependency_overrides_remain_explicit(self) -> None:
+        self.assertIn("${RETICULUM_LOCAL:-}", self.source)
+        self.assertIn("${LXMF_LOCAL:-}", self.source)
+        self.assertNotIn("../Reticulum", self.source)
+        self.assertNotIn("../LXMF", self.source)
+
+    def test_pure_packages_are_installed_once_then_copied_to_both_platforms(self) -> None:
+        calls = re.findall(r"^\s*install_pure_python\b", self.source, re.MULTILINE)
+        # One function definition plus exactly one invocation.
+        self.assertEqual(2, len(calls))
+        self.assertIn('PURE_DIR="', self.source)
+        self.assertIn('install_pure_python "$PURE_DIR"', self.source)
+        self.assertIn('copy_pure_python "$PURE_DIR" "$SIM_DIR"', self.source)
+        self.assertIn('copy_pure_python "$PURE_DIR" "$DEV_DIR"', self.source)
+        self.assertEqual(2, len(re.findall(r"^install_binary_wheel ", self.source, re.MULTILINE)))
+
+    def test_dependency_payload_and_version_metadata_are_validated(self) -> None:
+        for payload in (
+            "RNS/__init__.py", "LXMF/__init__.py",
+            "serial/__init__.py", "ble_reticulum/BLEInterface.py",
+        ):
+            self.assertIn(payload, self.source)
+        self.assertIn("*.dist-info/METADATA", self.source)
+
+
+class NativeStampBridgeTests(unittest.TestCase):
+    def setUp(self) -> None:
+        class Stamper:
+            calls = []
+
+            @classmethod
+            def set_external_generator(cls, *args, **kwargs):
+                cls.calls.append((args, kwargs))
+
+        self.stamper = Stamper
+        self.bridge = load_bridge(Stamper)
+
+    def test_token_is_forwarded_and_cancellation_returns_no_stamp(self) -> None:
+        class Token:
+            def __init__(self):
+                self.checks = 0
+
+            def is_cancelled(self):
+                self.checks += 1
+                return True
+
+        token = Token()
+        seen = {}
+
+        def native(workblock, length, cost, output, cancellation, context):
+            seen["args"] = (bytes(workblock), length, cost, context)
+            seen["cancelled"] = cancellation(context)
+            return 0
+
+        self.bridge._stamp_generate_cancellable_fn = native
+        self.assertIsNone(self.bridge._native_stamp_pow(b"work", 9, token))
+        self.assertEqual((b"work", 4, 9, None), seen["args"])
+        self.assertEqual(1, seen["cancelled"])
+        self.assertEqual(1, token.checks)
+
+    def test_valid_nonzero_cost_native_proof_path_returns_exact_stamp(self) -> None:
+        workblock = b"payload"
+        cost = 7
+        candidate_number = 0
+        while True:
+            expected = candidate_number.to_bytes(32, "big")
+            digest = hashlib.sha256(workblock + expected).digest()
+            leading_zeros = 256 - int.from_bytes(digest, "big").bit_length()
+            if leading_zeros >= cost:
+                break
+            candidate_number += 1
+
+        def native(_workblock, _length, native_cost, output, cancellation, context):
+            self.assertEqual(cost, native_cost)
+            self.assertEqual(0, cancellation(context))
+            ctypes.memmove(output, expected, len(expected))
+            return len(expected)
+
+        self.bridge._stamp_generate_cancellable_fn = native
+        token = types.SimpleNamespace(is_cancelled=lambda: False)
+        stamp = self.bridge._native_stamp_pow(workblock, cost, token)
+        self.assertEqual(expected, stamp)
+        proof = hashlib.sha256(workblock + stamp).digest()
+        self.assertGreaterEqual(256 - int.from_bytes(proof, "big").bit_length(), cost)
+
+    def test_install_requests_three_argument_contract_and_forwards_exact_token(self) -> None:
+        token = object()
+        self.bridge._stamp_generate_cancellable_fn = object()
+        self.bridge._native_stamp_pow = mock.Mock(return_value=b"x" * 32)
+
+        self.bridge._install_native_stamp_generator()
+        args, kwargs = self.stamper.calls[-1]
+        self.assertEqual({"pass_cancellation_token": True}, kwargs)
+        self.assertEqual(1, len(args))
+        self.assertEqual((b"x" * 32, 0), args[0](b"block", 5, token))
+        self.bridge._native_stamp_pow.assert_called_once_with(b"block", 5, token)
+
+    def test_repeated_install_uninstall_does_not_retain_global_callback(self) -> None:
+        self.bridge._stamp_generate_cancellable_fn = object()
+        for _ in range(2):
+            self.bridge._install_native_stamp_generator()
+            self.bridge._uninstall_native_stamp_generator()
+        self.assertIsNone(self.stamper.calls[-1][0][0])
+        self.assertEqual(4, len(self.stamper.calls))
+
+    def test_repeated_stop_when_not_started_still_clears_global_callback(self) -> None:
+        self.bridge._stamp_generate_cancellable_fn = object()
+        self.bridge._install_native_stamp_generator()
+        self.bridge._state["started"] = False
+        self.bridge.stop()
+        self.bridge.stop()
+        self.assertIsNone(self.stamper.calls[-1][0][0])
+        self.assertEqual(3, len(self.stamper.calls))
+
+
+class NativeStampStaticABITests(unittest.TestCase):
+    def test_swift_has_cancellable_abi_and_thread_safe_periodic_polling(self) -> None:
+        source = STAMP.read_text(encoding="utf-8")
+        self.assertIn('@_cdecl("columba_stamp_generate")', source)
+        self.assertIn('@_cdecl("columba_stamp_generate_cancellable")', source)
+        self.assertIn("isCancelled:", source)
+        self.assertRegex(source, r"rounds\s*&\s*0x(?:FF|[1-9A-F][0-9A-F]+)\s*==\s*0")
+        self.assertIn("OSAllocatedUnfairLock", source)
+        self.assertNotRegex(source, r"nonatomic|UnsafeMutablePointer<Bool>")
+
+    def test_shutdown_paths_unregister_before_taking_bridge_lock(self) -> None:
+        source = BRIDGE.read_text(encoding="utf-8")
+        for function in ("stop", "reset_identity"):
+            body = source[source.index(f"def {function}("):]
+            body = body.split("\ndef ", 1)[0]
+            self.assertLess(body.index("_uninstall_native_stamp_generator()"), body.index("with _lock:"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tests/static/test_ios_stamp_runtime_hardening.py
+++ b/Tests/static/test_ios_stamp_runtime_hardening.py
@@ -208,6 +208,28 @@ class NativeStampBridgeTests(unittest.TestCase):
         self.assertFalse(installed)
         install.assert_not_called()
 
+    def test_stop_balances_teardown_publication_when_cleanup_raises(self) -> None:
+        with mock.patch.object(
+            self.bridge,
+            "_clear_transport_class_state",
+            side_effect=RuntimeError("injected stop cleanup failure"),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "injected stop cleanup failure"):
+                self.bridge.stop()
+        self.assertEqual(0, self.bridge._runtime_teardown_count)
+        self.assertFalse(self.bridge._runtime_teardown_requested.is_set())
+
+    def test_reset_balances_teardown_publication_when_cleanup_raises(self) -> None:
+        with mock.patch.object(
+            self.bridge,
+            "_clear_transport_class_state",
+            side_effect=RuntimeError("injected reset cleanup failure"),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "injected reset cleanup failure"):
+                self.bridge.reset_identity("/tmp/nonexistent-columba-test-identity")
+        self.assertEqual(0, self.bridge._runtime_teardown_count)
+        self.assertFalse(self.bridge._runtime_teardown_requested.is_set())
+
 
 class NativeStampStaticABITests(unittest.TestCase):
     def test_swift_has_cancellable_abi_and_thread_safe_periodic_polling(self) -> None:

--- a/Tests/static/test_ios_stamp_runtime_hardening.py
+++ b/Tests/static/test_ios_stamp_runtime_hardening.py
@@ -18,7 +18,7 @@ ROOT = Path(__file__).resolve().parents[2]
 FETCH = ROOT / "support" / "fetch-wheels.sh"
 BRIDGE = ROOT / "app" / "rns_bridge.py"
 STAMP = ROOT / "Sources" / "SwiftBLEBridge" / "StampGenerator.swift"
-RNS_SHA = "7d02152122cc069b88c1a02920c71fbf96c1f8d8"
+RNS_SHA = "5b3a6ee4f25e2925cf84d4a2b108e6a708fbd395"
 LXMF_SHA = "8912186e48b482a76bf04e2ac4b6c8940991aecc"
 
 

--- a/app/rns_bridge.py
+++ b/app/rns_bridge.py
@@ -198,7 +198,39 @@ def _uninstall_native_stamp_generator() -> None:
         RNS.log(f"native stamp gen: unregister failed: {e}", RNS.LOG_DEBUG)
 
 
+def _install_native_stamp_generator_unless_stopping() -> bool:
+    """Install only while this startup still owns the runtime lifecycle."""
+    if _runtime_teardown_requested.is_set():
+        return False
+    _install_native_stamp_generator()
+    # Teardown may have begun during registration while waiting for `_lock`.
+    if _runtime_teardown_requested.is_set():
+        _uninstall_native_stamp_generator()
+        return False
+    return True
+
+
 _lock = threading.Lock()
+# Teardown publishes intent without waiting for `_lock`, allowing a start that
+# already owns it to reject or undo process-global callback registration.
+_runtime_teardown_requested = threading.Event()
+_runtime_teardown_lock = threading.Lock()
+_runtime_teardown_count = 0
+
+
+def _begin_runtime_teardown() -> None:
+    global _runtime_teardown_count
+    with _runtime_teardown_lock:
+        _runtime_teardown_count += 1
+        _runtime_teardown_requested.set()
+
+
+def _end_runtime_teardown() -> None:
+    global _runtime_teardown_count
+    with _runtime_teardown_lock:
+        _runtime_teardown_count = max(0, _runtime_teardown_count - 1)
+        if _runtime_teardown_count == 0:
+            _runtime_teardown_requested.clear()
 # Bumped on every start()/stop()/reset_identity() so the post-start delayed
 # re-announce daemon thread can detect it has been superseded (by a teardown
 # or a restart) and bail before announcing a dead / previous-session
@@ -510,7 +542,7 @@ def start(
 
         # Install only after startup has fully assembled all state, so an
         # exception during partial startup cannot retain a global callback.
-        _install_native_stamp_generator()
+        _install_native_stamp_generator_unless_stopping()
         _state["started"] = True
         _put("state", value="connected")
         return _local_info()
@@ -988,6 +1020,7 @@ def _clear_transport_class_state() -> None:
 def stop() -> None:
     # LXMF owns a process-global callback and may synchronously notify/cancel
     # jobs while clearing it. Never hold the bridge lock across that operation.
+    _begin_runtime_teardown()
     _uninstall_native_stamp_generator()
     with _lock:
         try:
@@ -1059,6 +1092,7 @@ def stop() -> None:
             "telephony_destination": None,
         })
         _put("state", value="disconnected")
+        _end_runtime_teardown()
 
     # Outside the lock: tear down the snapshotted links so a synchronous
     # _on_closed (which re-acquires _lock) can't deadlock.
@@ -1522,6 +1556,7 @@ def reset_identity(identity_path: str) -> None:
     # Cancel native stamp work before acquiring the bridge lock; cancellation
     # callbacks are foreign process-global state and must not participate in
     # bridge lock ordering.
+    _begin_runtime_teardown()
     _uninstall_native_stamp_generator()
     global _telephony_destination
     with _lock:
@@ -1579,6 +1614,7 @@ def reset_identity(identity_path: str) -> None:
             "handler": None,
             "telephony_destination": None,
         })
+        _end_runtime_teardown()
     # Outside the lock: tear down the snapshotted links.
     for _link in links_to_teardown:
         try:

--- a/app/rns_bridge.py
+++ b/app/rns_bridge.py
@@ -84,30 +84,50 @@ except OSError:
     _columba_lib = None
 
 
-def _bind_stamp_fn():
+_StampCancellationCallback = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_void_p)
+
+
+def _bind_stamp_fn(symbol: str, cancellable: bool = False):
     if _columba_lib is None:
         return None
     try:
-        fn = _columba_lib.columba_stamp_generate
+        fn = getattr(_columba_lib, symbol)
     except AttributeError:
         return None
-    # (workblock, workblock_len, stamp_cost, out_stamp[32]) -> bytes_written
+    # Legacy: (workblock, workblock_len, stamp_cost, out_stamp) -> bytes_written.
+    # Cancellable: the same arguments plus (callback, opaque_context).
     fn.argtypes = [ctypes.c_char_p, ctypes.c_int32, ctypes.c_int32, ctypes.c_char_p]
+    if cancellable:
+        fn.argtypes.extend([_StampCancellationCallback, ctypes.c_void_p])
     fn.restype = ctypes.c_int32
     return fn
 
 
-_stamp_generate_fn = _bind_stamp_fn()
+_stamp_generate_fn = _bind_stamp_fn("columba_stamp_generate")
+_stamp_generate_cancellable_fn = _bind_stamp_fn(
+    "columba_stamp_generate_cancellable", cancellable=True
+)
 
 
-def _native_stamp_pow(workblock: bytes, stamp_cost: int):
-    """Run the stamp PoW natively (Swift, multi-threaded across cores). Returns
-    the 32-byte stamp, or None if the native symbol is unavailable / found
-    nothing."""
-    if _stamp_generate_fn is None:
+def _native_stamp_pow(workblock: bytes, stamp_cost: int, cancellation_token: Any):
+    """Run native multi-threaded PoW with cooperative LXMF cancellation."""
+    if _stamp_generate_cancellable_fn is None:
         return None
+
+    @_StampCancellationCallback
+    def _is_cancelled(_context):
+        try:
+            return 1 if cancellation_token.is_cancelled() else 0
+        except Exception:
+            # A broken/expired foreign token must fail closed, not leave an
+            # uncancellable native search running indefinitely.
+            return 1
+
     out = ctypes.create_string_buffer(32)
-    n = _stamp_generate_fn(bytes(workblock), len(workblock), int(stamp_cost), out)
+    n = _stamp_generate_cancellable_fn(
+        bytes(workblock), len(workblock), int(stamp_cost), out,
+        _is_cancelled, None,
+    )
     if n == 32:
         return out.raw[:32]
     return None
@@ -123,14 +143,14 @@ def _install_native_stamp_generator() -> None:
     iOS analog of Android's `event_bridge.install_external_stamp_generator`.
     No-ops (warning) if the native symbol or the fork hook is absent."""
     try:
-        from LXMF import LXStamper
+        LXStamper = LXMF.LXStamper
     except Exception as e:  # noqa: BLE001
-        RNS.log(f"native stamp gen: LXStamper import failed: {e}", RNS.LOG_DEBUG)
+        RNS.log(f"native stamp gen: LXStamper unavailable: {e}", RNS.LOG_DEBUG)
         return
-    if _stamp_generate_fn is None:
+    if _stamp_generate_cancellable_fn is None:
         RNS.log(
-            "native stamp gen: columba_stamp_generate symbol not found; stamp "
-            "generation will fail on iOS (no _multiprocessing module)",
+            "native stamp gen: columba_stamp_generate_cancellable symbol not "
+            "found; stamp generation will fail on iOS",
             RNS.LOG_WARNING,
         )
         return
@@ -142,21 +162,40 @@ def _install_native_stamp_generator() -> None:
         )
         return
 
-    def _external_generator(workblock, stamp_cost):
-        # LXStamper contract: (workblock: bytes, stamp_cost: int) -> (stamp, rounds).
-        # `rounds` is cosmetic (generate_stamp recomputes value via stamp_value);
-        # the native generator doesn't surface a round count, so report 0.
+    def _external_generator(workblock, stamp_cost, cancellation_token):
+        # LXStamper contract: (workblock, cost, token) -> (stamp, rounds).
         _t0 = time.time()
-        stamp = _native_stamp_pow(bytes(workblock), int(stamp_cost))
+        stamp = _native_stamp_pow(
+            bytes(workblock), int(stamp_cost), cancellation_token
+        )
         RNS.log(
             f"native stamp: cost={stamp_cost} in {round((time.time()-_t0)*1000)}ms"
-            + ("" if stamp is not None else " (FAILED — no stamp)"),
+            + ("" if stamp is not None else " (cancelled or no stamp)"),
             RNS.LOG_INFO,
         )
         return (stamp, 0) if stamp is not None else (None, 0)
 
-    LXStamper.set_external_generator(_external_generator)
-    RNS.log("native multi-threaded stamp generator registered via set_external_generator", RNS.LOG_INFO)
+    try:
+        LXStamper.set_external_generator(
+            _external_generator, pass_cancellation_token=True
+        )
+    except Exception as e:  # noqa: BLE001
+        RNS.log(f"native stamp gen: registration failed: {e}", RNS.LOG_WARNING)
+        return
+    RNS.log("native cancellable stamp generator registered", RNS.LOG_INFO)
+
+
+def _uninstall_native_stamp_generator() -> None:
+    """Clear LXMF's process-global callback and cooperatively cancel its jobs."""
+    try:
+        LXStamper = LXMF.LXStamper
+        setter = getattr(LXStamper, "set_external_generator", None)
+        if setter is not None:
+            setter(None)
+    except Exception as e:  # noqa: BLE001
+        # Teardown is best-effort and must never prevent the remaining bridge
+        # state from being released.
+        RNS.log(f"native stamp gen: unregister failed: {e}", RNS.LOG_DEBUG)
 
 
 _lock = threading.Lock()
@@ -347,7 +386,15 @@ def start(
       3. Neither — generate a fresh identity and persist to `identity_path` (PoC
          and CLI use; iOS production should never hit this branch since the
          Keychain entry is created on first launch by Swift)."""
+    # Registration is process-global. Clear stale callbacks/jobs outside the
+    # bridge lock so LXMF cancellation cannot deadlock against bridge teardown.
     with _lock:
+        if _state["started"]:
+            return _local_info()
+    _uninstall_native_stamp_generator()
+
+    with _lock:
+        # A concurrent start may have completed while cancellation ran.
         if _state["started"]:
             return _local_info()
 
@@ -383,10 +430,6 @@ def start(
             router = LXMF.LXMRouter(identity=identity, storagepath=storage_path)
             router.register_delivery_callback(_delivery_callback)
             _state["router"] = router
-            # Route LXMF stamp PoW to the native Swift generator (iOS has no
-            # _multiprocessing). Must be installed before the first outbound
-            # message to a stamp-requiring peer.
-            _install_native_stamp_generator()
         finally:
             _signal.signal = _orig_signal
 
@@ -465,6 +508,9 @@ def start(
 
         threading.Thread(target=_delayed_reannounce, daemon=True).start()
 
+        # Install only after startup has fully assembled all state, so an
+        # exception during partial startup cannot retain a global callback.
+        _install_native_stamp_generator()
         _state["started"] = True
         _put("state", value="connected")
         return _local_info()
@@ -940,9 +986,10 @@ def _clear_transport_class_state() -> None:
 
 
 def stop() -> None:
+    # LXMF owns a process-global callback and may synchronously notify/cancel
+    # jobs while clearing it. Never hold the bridge lock across that operation.
+    _uninstall_native_stamp_generator()
     with _lock:
-        if not _state["started"]:
-            return
         try:
             existing = _state["handler"]
             if existing is not None:
@@ -1472,6 +1519,10 @@ def fetch_nomadnet_page(
 def reset_identity(identity_path: str) -> None:
     """Delete identity bytes on disk and tear down state. Caller must call
     start() again after this. Safe to call when not started."""
+    # Cancel native stamp work before acquiring the bridge lock; cancellation
+    # callbacks are foreign process-global state and must not participate in
+    # bridge lock ordering.
+    _uninstall_native_stamp_generator()
     global _telephony_destination
     with _lock:
         # Tear down the router first (stops its LXMRouter background threads),

--- a/app/rns_bridge.py
+++ b/app/rns_bridge.py
@@ -231,6 +231,17 @@ def _end_runtime_teardown() -> None:
         _runtime_teardown_count = max(0, _runtime_teardown_count - 1)
         if _runtime_teardown_count == 0:
             _runtime_teardown_requested.clear()
+
+
+def _balanced_runtime_teardown(function):
+    """Balance teardown publication even if cleanup raises unexpectedly."""
+    def wrapped(*args, **kwargs):
+        _begin_runtime_teardown()
+        try:
+            return function(*args, **kwargs)
+        finally:
+            _end_runtime_teardown()
+    return wrapped
 # Bumped on every start()/stop()/reset_identity() so the post-start delayed
 # re-announce daemon thread can detect it has been superseded (by a teardown
 # or a restart) and bail before announcing a dead / previous-session
@@ -1017,10 +1028,10 @@ def _clear_transport_class_state() -> None:
         pass
 
 
+@_balanced_runtime_teardown
 def stop() -> None:
     # LXMF owns a process-global callback and may synchronously notify/cancel
     # jobs while clearing it. Never hold the bridge lock across that operation.
-    _begin_runtime_teardown()
     _uninstall_native_stamp_generator()
     with _lock:
         try:
@@ -1092,7 +1103,6 @@ def stop() -> None:
             "telephony_destination": None,
         })
         _put("state", value="disconnected")
-        _end_runtime_teardown()
 
     # Outside the lock: tear down the snapshotted links so a synchronous
     # _on_closed (which re-acquires _lock) can't deadlock.
@@ -1550,13 +1560,13 @@ def fetch_nomadnet_page(
     return {"ok": True, "status": "ok", "data": payload, "content_type": ""}
 
 
+@_balanced_runtime_teardown
 def reset_identity(identity_path: str) -> None:
     """Delete identity bytes on disk and tear down state. Caller must call
     start() again after this. Safe to call when not started."""
     # Cancel native stamp work before acquiring the bridge lock; cancellation
     # callbacks are foreign process-global state and must not participate in
     # bridge lock ordering.
-    _begin_runtime_teardown()
     _uninstall_native_stamp_generator()
     global _telephony_destination
     with _lock:
@@ -1614,7 +1624,6 @@ def reset_identity(identity_path: str) -> None:
             "handler": None,
             "telephony_destination": None,
         })
-        _end_runtime_teardown()
     # Outside the lock: tear down the snapshotted links.
     for _link in links_to_teardown:
         try:

--- a/support/fetch-wheels.sh
+++ b/support/fetch-wheels.sh
@@ -38,38 +38,28 @@ PIP_PYTHON="$PIP_VENV/bin/python"
 #  umsgpack in RNS.vendor.umsgpack. Installing the binary msgpack wheel from PyPI
 #  pulls a macOS-built .so that won't load on iOS.)
 #
-# RNS is sourced permanently from Torlando's fork branch (not PyPI, not a local
-# checkout) so every build — CI and local — resolves the same dependency. The
-# patches/columba-ios branch carries iOS-specific patches (e.g. the
-# AutoInterface.detach() teardown that lets Columba hot-add / hot-remove
-# interfaces on a running stack).
-#
+# RNS is sourced from an immutable Torlando fork commit (not PyPI or a moving
+# branch) so every build resolves the same reviewed dependency payload.
 # To develop the fork itself, point at a local working copy explicitly:
 #   RETICULUM_LOCAL=~/repos/Reticulum support/fetch-wheels.sh
-# Otherwise the GitHub branch is always used — the local checkout is never
-# picked up implicitly (that made builds depend on whatever branch happened to
-# be checked out on the dev's machine).
-RETICULUM_BRANCH="patches/columba-ios"
+# Otherwise the pinned GitHub commit is used — a local checkout is never picked
+# up implicitly.
+RETICULUM_REF="${RETICULUM_REF:-1c2cf73443ce73613bd67ea8412e7923d34cd7e6}"
 if [ -n "${RETICULUM_LOCAL:-}" ]; then
     echo "==> RETICULUM_LOCAL set — using local Reticulum checkout: $RETICULUM_LOCAL"
     RNS_SPEC="$RETICULUM_LOCAL"
 else
-    RNS_SPEC="git+https://github.com/torlando-tech/Reticulum.git@${RETICULUM_BRANCH}"
+    RNS_SPEC="git+https://github.com/torlando-tech/Reticulum.git@${RETICULUM_REF}"
 fi
-# LXMF: torlando-tech fork with the external stamp generator hook. iOS embedded
-# CPython has no `_multiprocessing`, so stock LXStamper's job_linux crashes and
-# no stamp is produced (messages to stamp-cost peers like Sideband never
-# deliver). The fork's `set_external_generator` lets us run the PoW in native
-# Swift (see app/rns_bridge.py + Sources/SwiftBLEBridge/StampGenerator.swift).
-# Branch is 0.9.9 + the hook (forward-port of feature/external-stamp-generator).
-# Point at a local working copy to develop the fork:
-#   LXMF_LOCAL=~/repos/LXMF support/fetch-wheels.sh   (branch feature/external-stamp-generator-0.9.9)
-LXMF_BRANCH="feature/external-stamp-generator-0.9.9"
+# LXMF is likewise pinned to the cooperative external-stamp producer commit.
+# Point at a local working copy only when explicitly developing the fork:
+#   LXMF_LOCAL=~/repos/LXMF support/fetch-wheels.sh
+LXMF_REF="${LXMF_REF:-fbcb8f83109b93d2491632427716c7fcd645c605}"
 if [ -n "${LXMF_LOCAL:-}" ]; then
     echo "==> LXMF_LOCAL set — using local LXMF checkout: $LXMF_LOCAL"
     LXMF_SPEC="$LXMF_LOCAL"
 else
-    LXMF_SPEC="git+https://github.com/torlando-tech/LXMF.git@${LXMF_BRANCH}"
+    LXMF_SPEC="git+https://github.com/torlando-tech/LXMF.git@${LXMF_REF}"
 fi
 PYSERIAL_SPEC="pyserial>=3.5"
 # ble-reticulum is not on PyPI; install from GitHub unless an explicit local
@@ -91,6 +81,8 @@ fi
 
 rm -rf "$SIM_DIR" "$DEV_DIR"
 mkdir -p "$SIM_DIR" "$DEV_DIR"
+PURE_DIR="$PIP_VENV/pure-python"
+mkdir -p "$PURE_DIR"
 
 install_binary_wheel() {
     # $1 platform tag, $2 destination dir, $3+ pkg specs
@@ -119,6 +111,46 @@ install_pure_python() {
         "$@"
 }
 
+validate_pure_python() {
+    local dst=$1 metadata_count metadata
+    for payload in \
+        RNS/__init__.py \
+        LXMF/__init__.py \
+        serial/__init__.py \
+        ble_reticulum/BLEInterface.py; do
+        [ -s "$dst/$payload" ] || {
+            echo "error: pure-Python payload missing from $dst: $payload" >&2
+            exit 1
+        }
+    done
+    # Keep the shipping BLE entry point explicit: an empty/mispackaged VCS
+    # wheel must fail before either platform payload is published.
+    [ -s "$dst/ble_reticulum/BLEInterface.py" ] || {
+        echo "error: ble-reticulum package payload missing from $dst" >&2
+        exit 1
+    }
+
+    # Require named and versioned metadata for all four packages. This catches
+    # stale host build tooling producing an empty UNKNOWN-0.0.0 distribution.
+    metadata_count=0
+    for metadata in "$dst"/*.dist-info/METADATA; do
+        [ -s "$metadata" ] || continue
+        grep -q '^Name: .\+' "$metadata" || continue
+        grep -q '^Version: .\+' "$metadata" || continue
+        metadata_count=$((metadata_count + 1))
+    done
+    [ "$metadata_count" -ge 4 ] || {
+        echo "error: expected version metadata for four pure-Python packages in $dst" >&2
+        exit 1
+    }
+}
+
+copy_pure_python() {
+    local src=$1 dst=$2
+    cp -R "$src/." "$dst/"
+    validate_pure_python "$dst"
+}
+
 # cffi is needed because cryptography $CRYPTO_VERSION still depends on cffi for
 # parts of its OpenSSL bindings. Pin cffi 2.0.0 (matching cp313 wheel
 # availability on BeeWare).
@@ -129,13 +161,10 @@ BINARY_WHEELS=(
 install_binary_wheel "$PLATFORM_SIM" "$SIM_DIR" "${BINARY_WHEELS[@]}"
 install_binary_wheel "$PLATFORM_DEV" "$DEV_DIR" "${BINARY_WHEELS[@]}"
 
-for dst in "$SIM_DIR" "$DEV_DIR"; do
-    install_pure_python "$dst" "$RNS_SPEC" "$LXMF_SPEC" "$PYSERIAL_SPEC" "$BLE_RETICULUM_SPEC"
-    [ -s "$dst/ble_reticulum/BLEInterface.py" ] || {
-        echo "error: ble-reticulum package payload missing from $dst" >&2
-        exit 1
-    }
-done
+install_pure_python "$PURE_DIR" "$RNS_SPEC" "$LXMF_SPEC" "$PYSERIAL_SPEC" "$BLE_RETICULUM_SPEC"
+validate_pure_python "$PURE_DIR"
+copy_pure_python "$PURE_DIR" "$SIM_DIR"
+copy_pure_python "$PURE_DIR" "$DEV_DIR"
 
 echo
 echo "Wheels installed:"

--- a/support/fetch-wheels.sh
+++ b/support/fetch-wheels.sh
@@ -112,7 +112,7 @@ install_pure_python() {
 }
 
 validate_pure_python() {
-    local dst=$1 metadata_count metadata
+    local dst=$1
     for payload in \
         RNS/__init__.py \
         LXMF/__init__.py \
@@ -130,19 +130,57 @@ validate_pure_python() {
         exit 1
     }
 
-    # Require named and versioned metadata for all four packages. This catches
-    # stale host build tooling producing an empty UNKNOWN-0.0.0 distribution.
-    metadata_count=0
-    for metadata in "$dst"/*.dist-info/METADATA; do
-        [ -s "$metadata" ] || continue
-        grep -q '^Name: .\+' "$metadata" || continue
-        grep -q '^Version: .\+' "$metadata" || continue
-        metadata_count=$((metadata_count + 1))
-    done
-    [ "$metadata_count" -ge 4 ] || {
-        echo "error: expected version metadata for four pure-Python packages in $dst" >&2
-        exit 1
-    }
+    # Validate the exact distributions and immutable VCS revisions, not merely
+    # the number of metadata directories produced by pip.
+    "$PIP_PYTHON" - "$dst" \
+        "${RETICULUM_LOCAL:+LOCAL}${RETICULUM_LOCAL:-$RETICULUM_REF}" \
+        "${LXMF_LOCAL:+LOCAL}${LXMF_LOCAL:-$LXMF_REF}" \
+        "${BLE_RETICULUM_LOCAL:+LOCAL}${BLE_RETICULUM_LOCAL:-$BLE_RETICULUM_REF}" <<'PY'
+import email.parser
+import json
+from pathlib import Path
+import re
+import sys
+
+root = Path(sys.argv[1])
+expected_refs = dict(zip(("rns", "lxmf", "ble-reticulum"), sys.argv[2:]))
+expected_names = {"rns", "lxmf", "pyserial", "ble-reticulum"}
+found = {}
+
+
+def normalized(value):
+    return re.sub(r"[-_.]+", "-", value.strip().lower())
+
+
+for metadata_path in root.glob("*.dist-info/METADATA"):
+    metadata = email.parser.Parser().parsestr(metadata_path.read_text(encoding="utf-8"))
+    name = normalized(metadata.get("Name", ""))
+    version = metadata.get("Version", "").strip().lower()
+    if name in expected_names:
+        if not version or version in {"unknown", "0.0.0"}:
+            raise SystemExit(f"error: invalid {name} package version: {version!r}")
+        if name in found:
+            raise SystemExit(f"error: duplicate package metadata for {name}")
+        found[name] = metadata_path.parent
+
+missing = expected_names - found.keys()
+if missing:
+    raise SystemExit(f"error: missing package metadata for: {', '.join(sorted(missing))}")
+
+for name, expected_ref in expected_refs.items():
+    if expected_ref.startswith("LOCAL"):
+        continue
+    direct_url_path = found[name] / "direct_url.json"
+    try:
+        direct_url = json.loads(direct_url_path.read_text(encoding="utf-8"))
+        commit_id = direct_url["vcs_info"]["commit_id"]
+    except (OSError, KeyError, TypeError, ValueError) as error:
+        raise SystemExit(f"error: invalid VCS metadata for {name}: {error}")
+    if commit_id != expected_ref:
+        raise SystemExit(
+            f"error: {name} VCS revision {commit_id!r} does not match {expected_ref!r}"
+        )
+PY
 }
 
 copy_pure_python() {

--- a/support/fetch-wheels.sh
+++ b/support/fetch-wheels.sh
@@ -44,7 +44,7 @@ PIP_PYTHON="$PIP_VENV/bin/python"
 #   RETICULUM_LOCAL=~/repos/Reticulum support/fetch-wheels.sh
 # Otherwise the pinned GitHub commit is used — a local checkout is never picked
 # up implicitly.
-RETICULUM_REF="${RETICULUM_REF:-7d02152122cc069b88c1a02920c71fbf96c1f8d8}"
+RETICULUM_REF="${RETICULUM_REF:-5b3a6ee4f25e2925cf84d4a2b108e6a708fbd395}"
 if [ -n "${RETICULUM_LOCAL:-}" ]; then
     echo "==> RETICULUM_LOCAL set — using local Reticulum checkout: $RETICULUM_LOCAL"
     RNS_SPEC="$RETICULUM_LOCAL"

--- a/support/fetch-wheels.sh
+++ b/support/fetch-wheels.sh
@@ -44,7 +44,7 @@ PIP_PYTHON="$PIP_VENV/bin/python"
 #   RETICULUM_LOCAL=~/repos/Reticulum support/fetch-wheels.sh
 # Otherwise the pinned GitHub commit is used — a local checkout is never picked
 # up implicitly.
-RETICULUM_REF="${RETICULUM_REF:-1c2cf73443ce73613bd67ea8412e7923d34cd7e6}"
+RETICULUM_REF="${RETICULUM_REF:-7d02152122cc069b88c1a02920c71fbf96c1f8d8}"
 if [ -n "${RETICULUM_LOCAL:-}" ]; then
     echo "==> RETICULUM_LOCAL set — using local Reticulum checkout: $RETICULUM_LOCAL"
     RNS_SPEC="$RETICULUM_LOCAL"
@@ -54,7 +54,7 @@ fi
 # LXMF is likewise pinned to the cooperative external-stamp producer commit.
 # Point at a local working copy only when explicitly developing the fork:
 #   LXMF_LOCAL=~/repos/LXMF support/fetch-wheels.sh
-LXMF_REF="${LXMF_REF:-fbcb8f83109b93d2491632427716c7fcd645c605}"
+LXMF_REF="${LXMF_REF:-8912186e48b482a76bf04e2ac4b6c8940991aecc}"
 if [ -n "${LXMF_LOCAL:-}" ]; then
     echo "==> LXMF_LOCAL set — using local LXMF checkout: $LXMF_LOCAL"
     LXMF_SPEC="$LXMF_LOCAL"


### PR DESCRIPTION
## Summary
- pin embedded RNS and LXMF payloads to immutable reviewed producer commits
- add a cancellable Swift stamp-generation ABI and token-aware Python bridge
- prevent process-global callback retention across concurrent stop/reset and startup
- validate exact package names, versions, and VCS revisions during wheel provisioning
- run the focused lifecycle/payload regression module in CI

## Verification
- focused runtime hardening: 15/15 passed
- exact CI static command: 56/56 passed on Linux and macOS
- clean remote-pin wheel fetch resolved and validated both producer SHAs
- shipping iOS simulator build succeeded
- shipping artifact-isolation verification passed
- `ColumbaAppTests`: 140/140 passed
- `SwiftBLEBridge` simulator build succeeded

## Dependency pins
- RNS: `5b3a6ee4f25e2925cf84d4a2b108e6a708fbd395`
- LXMF: `8912186e48b482a76bf04e2ac4b6c8940991aecc`

## Risk / rollback
The highest-risk area is callback lifecycle ordering during concurrent startup and teardown. Deterministic regressions cover cancellation, registration races, and exception-safe teardown accounting. Reverting this PR restores the previous embedded payload and callback behavior.