### PR TITLE
Fix composer autocorrection text reappearing after send

### DIFF
--- a/Columba.xcodeproj/project.pbxproj
+++ b/Columba.xcodeproj/project.pbxproj
@@ -334,6 +334,7 @@
 		RFT002 /* RuntimeFlavorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = RFT001 /* RuntimeFlavorTests.swift */; };
 		RMLT002 /* RuntimeActivityMonitorLeaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = RMLT001 /* RuntimeActivityMonitorLeaseTests.swift */; };
 		RMLT003 /* RuntimeActivityMonitorLeaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = RMLT001 /* RuntimeActivityMonitorLeaseTests.swift */; };
+		MCST002 /* MessageComposerTextStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = MCST001 /* MessageComposerTextStateTests.swift */; };
 		T003 /* MicronParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FT03 /* MicronParserTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -568,6 +569,7 @@
 		PXIF /* ProxyIPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyIPC.swift; sourceTree = "<group>"; };
 		RFT001 /* RuntimeFlavorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RuntimeFlavorTests.swift; sourceTree = "<group>"; };
 		RMLT001 /* RuntimeActivityMonitorLeaseTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RuntimeActivityMonitorLeaseTests.swift; sourceTree = "<group>"; };
+		MCST001 /* MessageComposerTextStateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MessageComposerTextStateTests.swift; sourceTree = "<group>"; };
 		SRB002 /* SwiftRNSBackend.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SwiftRNSBackend.swift; path = Sources/RNSBackendSwift/SwiftRNSBackend.swift; sourceTree = SOURCE_ROOT; };
 		TPROD /* ColumbaAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ColumbaAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -995,6 +997,7 @@
 				6C8CFC274AF9EF63E9A75238 /* PythonConfigWriterTests.swift */,
 				RFT001 /* RuntimeFlavorTests.swift */,
 				RMLT001 /* RuntimeActivityMonitorLeaseTests.swift */,
+				MCST001 /* MessageComposerTextStateTests.swift */,
 			);
 			path = Tests/ColumbaAppTests;
 			sourceTree = "<group>";
@@ -1655,6 +1658,7 @@
 				26D564FAEE8E3C750E8E2442 /* PythonConfigWriterTests.swift in Sources */,
 				RFT002 /* RuntimeFlavorTests.swift in Sources */,
 				RMLT002 /* RuntimeActivityMonitorLeaseTests.swift in Sources */,
+				MCST002 /* MessageComposerTextStateTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/ColumbaApp/Views/Messaging/MessageInputBar.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageInputBar.swift
@@ -24,6 +24,9 @@ struct MessageInputBar: View {
     // MARK: - Properties
 
     @Binding var text: String
+    /// Recreates the TextField after send so UIKit cannot retain the old editor
+    /// while a pending autocorrection callback is being discarded by the binding.
+    var textInputGeneration: UInt64 = 0
     @Binding var attachedImage: UIImage?
     @Binding var attachedFiles: [FileAttachment]
     var replyToMessage: Message?
@@ -123,6 +126,7 @@ struct MessageInputBar: View {
                 HStack(alignment: .bottom, spacing: 8) {
                     // Text field
                     TextField("Type a message...", text: $text, axis: .vertical)
+                        .id(textInputGeneration)
                         .font(.body)
                         .foregroundStyle(Theme.textPrimary)
                         .lineLimit(1...6)

--- a/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
@@ -22,6 +22,39 @@ import AppKit
 
 private let logger = Logger(subsystem: "network.columba.Columba", category: "MessagingView")
 
+/// Owns the editor binding generation for the message composer.
+///
+/// UIKit may deliver a final autocorrection callback after the send button has
+/// cleared a SwiftUI `TextField`. A normal `Binding<String>` accepts that stale
+/// callback and repopulates the composer with the corrected word. Bindings made
+/// before `clearAfterSend()` capture the old generation and are ignored.
+@MainActor
+@Observable
+final class MessageComposerTextState {
+    private(set) var text = ""
+    private(set) var generation: UInt64 = 0
+
+    func binding() -> Binding<String> {
+        let acceptedGeneration = generation
+        return Binding(
+            get: { [weak self] in self?.text ?? "" },
+            set: { [weak self] value in
+                self?.accept(value, from: acceptedGeneration)
+            }
+        )
+    }
+
+    func clearAfterSend() {
+        text = ""
+        generation &+= 1
+    }
+
+    private func accept(_ value: String, from bindingGeneration: UInt64) {
+        guard bindingGeneration == generation else { return }
+        text = value
+    }
+}
+
 /// Main messaging/chat screen view.
 ///
 /// Layout:
@@ -44,7 +77,7 @@ struct MessagingView: View {
     // MARK: - State
 
     @State private var viewModel: MessagingViewModel?
-    @State private var messageText = ""
+    @State private var messageComposer = MessageComposerTextState()
     @State private var showPhotoPicker = false
     @State private var showFilePicker = false
     @State private var selectedPhotoItem: PhotosPickerItem?
@@ -161,7 +194,8 @@ struct MessagingView: View {
                     // the keyboard and adjusts the scroll view's visible area to match.
                     .safeAreaInset(edge: .bottom, spacing: 0) {
                         MessageInputBar(
-                            text: $messageText,
+                            text: messageComposer.binding(),
+                            textInputGeneration: messageComposer.generation,
                             attachedImage: $attachedImage,
                             attachedFiles: $attachedFiles,
                             replyToMessage: vm.replyToMessage,
@@ -576,7 +610,7 @@ struct MessagingView: View {
     // MARK: - Actions
 
     private func sendMessage() {
-        let text = messageText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let text = messageComposer.text.trimmingCharacters(in: .whitespacesAndNewlines)
         let image = attachedImage
         let files = attachedFiles
         let replyTarget = viewModel?.replyToMessage
@@ -584,7 +618,7 @@ struct MessagingView: View {
 
         guard !text.isEmpty || image != nil || !files.isEmpty else { return }
 
-        messageText = ""
+        messageComposer.clearAfterSend()
         attachedImage = nil
         attachedFiles = []
         withAnimation(.easeInOut(duration: 0.25)) {

--- a/Tests/ColumbaAppTests/MessageComposerTextStateTests.swift
+++ b/Tests/ColumbaAppTests/MessageComposerTextStateTests.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+import XCTest
+#if COLUMBA_RUNTIME_MODEL_B
+@testable import ColumbaModelBApp
+#else
+@testable import ColumbaApp
+#endif
+
+@available(iOS 17.0, macOS 14.0, *)
+@MainActor
+final class MessageComposerTextStateTests: XCTestCase {
+    func testAutocorrectionCallbackFromPreSendEditorCannotRestoreClearedText() {
+        let composer = MessageComposerTextState()
+        let preSendEditor = composer.binding()
+
+        // The user types a word for which UIKit has a pending correction.
+        preSendEditor.wrappedValue = "teh"
+        XCTAssertEqual(composer.text, "teh")
+
+        // Sending clears the composer and replaces the editor generation.
+        composer.clearAfterSend()
+        XCTAssertEqual(composer.text, "")
+
+        // UIKit can still deliver its final corrected value through the old
+        // binding. That callback must not repopulate the sent text field.
+        preSendEditor.wrappedValue = "the"
+        XCTAssertEqual(composer.text, "")
+    }
+
+    func testCurrentEditorStillAcceptsTextAfterSendReset() {
+        let composer = MessageComposerTextState()
+        let oldEditor = composer.binding()
+        oldEditor.wrappedValue = "first"
+        composer.clearAfterSend()
+
+        let currentEditor = composer.binding()
+        currentEditor.wrappedValue = "next message"
+
+        XCTAssertEqual(composer.text, "next message")
+    }
+}


### PR DESCRIPTION
## Summary
- prevent a delayed iOS autocorrection callback from restoring composer text after send
- generation-scope the SwiftUI editor binding and recreate the TextField after each successful send
- add deterministic regression tests for stale and current editor bindings

## Reproduction on current main
1. Ensure iOS **Settings → General → Keyboard → Auto-Correction** is enabled.
2. Open any conversation and focus the message composer.
3. Type a single misspelled word that iOS wants to correct, such as `teh` when the keyboard proposes `the`.
4. Do **not** tap the proposed correction and do **not** type a trailing space; leave the correction pending.
5. Tap the send button directly.
6. Observe that the message sends, but the keyboard's delayed corrected value can repopulate the composer instead of leaving it empty.

Manually accepting the correction first, or typing a space so iOS commits it before send, avoids the bug.

## Automated verification
- `MessageComposerTextStateTests`: 2/2 passed on the iOS simulator
- complete static suite: 188/188 passed
- Model B Debug simulator build: passed

Fixes #53
