### PR TITLE
Run readiness-gated UI screenshots in pull-request CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,7 +75,9 @@ jobs:
             Tests.static.test_ci_artifact_isolation \
             Tests.static.test_fetch_python_resilience \
             Tests.static.test_migration_export_flow \
-            Tests.static.test_ios_stamp_runtime_hardening
+            Tests.static.test_ios_stamp_runtime_hardening \
+            Tests.static.test_ui_screenshotter_readiness \
+            Tests.static.test_collect_maestro_screenshots
 
       - name: Build shipping artifact (embedded Python)
         run: |
@@ -94,6 +96,79 @@ jobs:
           set -euo pipefail
           SHIPPING_APP="$PWD/DerivedData-Python/Build/Products/Debug-iphonesimulator/ColumbaApp.app"
           python3 support/verify-flavor-artifact.py shipping "$SHIPPING_APP"
+
+      # PRs exercise the same deterministic Maestro flows used by the
+      # ui-screenshotter agent. Reuse the shipping simulator artifact built
+      # above instead of paying for a second Xcode build in another job.
+      - name: Cache Maestro
+        if: github.event_name == 'pull_request'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.maestro/bin
+            ~/.maestro/lib
+          key: maestro-cli-2.8.0-macos
+
+      - name: Set up Java for Maestro
+        if: github.event_name == 'pull_request'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Install Maestro
+        if: github.event_name == 'pull_request'
+        run: |
+          set -euo pipefail
+          MAESTRO_VERSION=2.8.0
+          MAESTRO_SHA256=b3e561161904fb391875ca5834d5b22cf0b01c052dd1b408ad83e30d8f8951b3
+          if [ ! -x "$HOME/.maestro/bin/maestro" ]; then
+            archive="$RUNNER_TEMP/maestro.zip"
+            extract="$RUNNER_TEMP/maestro-extract"
+            curl --fail --location --retry 3 \
+              "https://github.com/mobile-dev-inc/Maestro/releases/download/cli-${MAESTRO_VERSION}/maestro.zip" \
+              --output "$archive"
+            echo "$MAESTRO_SHA256  $archive" | shasum -a 256 --check
+            rm -rf "$extract" "$HOME/.maestro"
+            mkdir -p "$extract" "$HOME/.maestro"
+            unzip -q "$archive" -d "$extract"
+            cp -R "$extract/maestro/." "$HOME/.maestro/"
+          fi
+          echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
+          "$HOME/.maestro/bin/maestro" --version
+
+      - name: Run screenshot flows
+        if: github.event_name == 'pull_request'
+        env:
+          MAESTRO_CLI_ANALYSIS_NOTIFICATION_DISABLED: 'true'
+        run: |
+          set -euo pipefail
+          DEVICE_ID="${{ steps.sim.outputs.device_id }}"
+          SHIPPING_APP="$PWD/DerivedData-Python/Build/Products/Debug-iphonesimulator/ColumbaApp.app"
+          xcrun simctl boot "$DEVICE_ID" 2>/dev/null || true
+          xcrun simctl bootstatus "$DEVICE_ID" -b
+          xcrun simctl install "$DEVICE_ID" "$SHIPPING_APP"
+          mkdir -p "$PWD/ui-screenshots"
+          for flow in contacts-list.yml chats-list.yml settings.yml map.yml; do
+            echo "Running flows/$flow"
+            (
+              cd "$GITHUB_WORKSPACE/ui-screenshots"
+              maestro --device "$DEVICE_ID" test "$GITHUB_WORKSPACE/flows/$flow"
+            )
+          done
+          python3 support/collect-maestro-screenshots.py \
+            --output "$PWD/ui-screenshots"
+
+      - name: Upload UI screenshots and Maestro diagnostics
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ui-screenshots
+          path: |
+            ui-screenshots/**
+            ~/.maestro/tests/**
+          if-no-files-found: warn
+          retention-days: 14
 
       # The Model B scheme explicitly builds its app and network extension.
       - name: Build Model B artifact

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,7 +102,7 @@ jobs:
       # above instead of paying for a second Xcode build in another job.
       - name: Cache Maestro
         if: github.event_name == 'pull_request'
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.maestro/bin
@@ -111,7 +111,7 @@ jobs:
 
       - name: Set up Java for Maestro
         if: github.event_name == 'pull_request'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@d7793b545071e98d581d3bf084a51c3213318a07 # v4
         with:
           distribution: temurin
           java-version: '21'
@@ -148,20 +148,25 @@ jobs:
           xcrun simctl boot "$DEVICE_ID" 2>/dev/null || true
           xcrun simctl bootstatus "$DEVICE_ID" -b
           xcrun simctl install "$DEVICE_ID" "$SHIPPING_APP"
-          mkdir -p "$PWD/ui-screenshots"
+          export PATH="$HOME/.maestro/bin:$PATH"
+          mkdir -p ui-screenshots
+          screenshot_status=0
           for flow in contacts-list.yml chats-list.yml settings.yml map.yml; do
-            echo "Running flows/$flow"
-            (
-              cd "$GITHUB_WORKSPACE/ui-screenshots"
+            if ! (
+              cd ui-screenshots
               maestro --device "$DEVICE_ID" test "$GITHUB_WORKSPACE/flows/$flow"
-            )
+            ); then
+              screenshot_status=1
+            fi
           done
           python3 support/collect-maestro-screenshots.py \
+            --allow-missing \
             --output "$PWD/ui-screenshots"
+          exit "$screenshot_status"
 
       - name: Upload UI screenshots and Maestro diagnostics
         if: always() && github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ui-screenshots
           path: |

--- a/Sources/ColumbaApp/App/ColumbaApp.swift
+++ b/Sources/ColumbaApp/App/ColumbaApp.swift
@@ -501,7 +501,17 @@ struct RootView: View {
         self._pendingDeepLink = pendingDeepLink
         // Migrate existing users so they skip onboarding
         OnboardingViewModel.migrateExistingUsers()
-        self._showOnboarding = State(initialValue: !OnboardingViewModel.hasCompletedOnboarding)
+        #if DEBUG
+        let isScreenshotterLaunch = ProcessInfo.processInfo.arguments.contains("ui-screenshotter")
+        #else
+        let isScreenshotterLaunch = false
+        #endif
+        // Maestro clears app state and Keychain before every screenshot. Its
+        // explicit DEBUG-only launch argument bypasses the interactive wizard;
+        // initializeServices() creates the disposable test identity below.
+        self._showOnboarding = State(
+            initialValue: !OnboardingViewModel.hasCompletedOnboarding && !isScreenshotterLaunch
+        )
     }
 
     // MARK: - Body
@@ -762,7 +772,18 @@ struct RootView: View {
                 active = existing
             } else {
                 #if COLUMBA_ONBOARDING_ENABLED
+                #if DEBUG
+                if ProcessInfo.processInfo.arguments.contains("ui-screenshotter") {
+                    DiagLog.log("[STARTUP] Step 2: creating disposable screenshotter identity")
+                    let created = try await identityManager.createIdentity(displayName: "ColumbaSim")
+                    let switched = try await identityManager.switchToIdentity(created.identityHash)
+                    active = switched.0
+                } else {
+                    throw AppServicesError.identityNotInitialized
+                }
+                #else
                 throw AppServicesError.identityNotInitialized
+                #endif
                 #else
                 DiagLog.log("[STARTUP] Step 2: no identity — auto-creating for smoke test")
                 let created = try await identityManager.createIdentity(displayName: "ColumbaSim")

--- a/Sources/ColumbaApp/Views/Chats/ChatsView.swift
+++ b/Sources/ColumbaApp/Views/Chats/ChatsView.swift
@@ -77,6 +77,7 @@ struct ChatsView: View {
                     ProgressView()
                 }
             }
+            .accessibilityIdentifier("screen_chats")
             .navigationTitle("Chats")
             #if os(iOS)
             .navigationBarTitleDisplayMode(.large)

--- a/Sources/ColumbaApp/Views/Contacts/ContactsView.swift
+++ b/Sources/ColumbaApp/Views/Contacts/ContactsView.swift
@@ -122,6 +122,7 @@ public struct ContactsView: View {
                     // Content
                     tabContent(vm)
                 }
+                .accessibilityIdentifier("screen_contacts")
                 .background(Theme.backgroundPrimary)
                 .navigationTitle("Contacts")
                 .navigationBarTitleDisplayMode(.inline)

--- a/Sources/ColumbaApp/Views/Map/MapLibreMapView.swift
+++ b/Sources/ColumbaApp/Views/Map/MapLibreMapView.swift
@@ -42,6 +42,11 @@ struct MapLibreMapView: UIViewRepresentable {
         let initialStyleURL = mapStyleURL(forDarkMode: isDark)
         context.coordinator.lastStyleURL = initialStyleURL
         let mapView = MLNMapView(frame: .zero, styleURL: initialStyleURL)
+        // Stable UI-automation landmark while the style and visible tiles load.
+        // The coordinator promotes this to `map_canvas_ready` only after
+        // MapLibre reports that all currently requested tiles and transitions
+        // are complete.
+        mapView.accessibilityIdentifier = "screen_map"
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         mapView.showsUserLocation = showsUserLocation
         mapView.delegate = context.coordinator
@@ -176,6 +181,18 @@ struct MapLibreMapView: UIViewRepresentable {
 
         func mapView(_ mapView: MLNMapView, regionDidChangeAnimated animated: Bool) {
             metersPerPixel = mapView.metersPerPoint(atLatitude: mapView.centerCoordinate.latitude)
+        }
+
+        func mapViewWillStartLoadingMap(_ mapView: MLNMapView) {
+            mapView.accessibilityIdentifier = "screen_map"
+        }
+
+        func mapViewDidBecomeIdle(_ mapView: MLNMapView) {
+            // MLNMapViewDelegate defines idle as no active camera transition,
+            // all currently requested tiles loaded, and all fade/transition
+            // animations completed. This is the screenshotter's real network
+            // and render readiness signal; an animation timeout is not.
+            mapView.accessibilityIdentifier = "map_canvas_ready"
         }
 
         func mapView(_ mapView: MLNMapView, didUpdate userLocation: MLNUserLocation?) {

--- a/Sources/ColumbaApp/Views/Settings/SettingsView.swift
+++ b/Sources/ColumbaApp/Views/Settings/SettingsView.swift
@@ -131,6 +131,7 @@ struct SettingsView: View {
                     .padding(.horizontal, 16)
                     .padding(.vertical, 12)
                 }
+                .accessibilityIdentifier("screen_settings")
                 .background(Theme.backgroundPrimary)
                 .navigationTitle("Settings")
                 #if os(iOS)

--- a/Tests/static/test_collect_maestro_screenshots.py
+++ b/Tests/static/test_collect_maestro_screenshots.py
@@ -1,0 +1,60 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+import os
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "support/collect-maestro-screenshots.py"
+SPEC = spec_from_file_location("collect_maestro_screenshots", SCRIPT)
+assert SPEC and SPEC.loader
+MODULE = module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class CollectMaestroScreenshotsTests(unittest.TestCase):
+    def make_png(self, path: Path, payload: bytes = b"pixels") -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(MODULE.PNG_SIGNATURE + payload)
+
+    def test_collects_latest_named_take_screenshot_outputs(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "maestro"
+            output = root / "artifact"
+
+            for index, name in enumerate(MODULE.SCREENSHOTS):
+                old = source / "old-run" / name / "takeScreenshot" / f"{name}.png"
+                new = source / "new-run" / name / "takeScreenshot" / f"{name}.png"
+                self.make_png(old, b"old")
+                self.make_png(new, b"new")
+                os.utime(old, ns=(1, 1))
+                os.utime(new, ns=(index + 2, index + 2))
+
+            MODULE.collect(source, output)
+
+            for name in MODULE.SCREENSHOTS:
+                self.assertEqual(
+                    (output / f"{name}.png").read_bytes(),
+                    MODULE.PNG_SIGNATURE + b"new",
+                )
+
+    def test_rejects_missing_or_non_png_outputs(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            with self.assertRaises(FileNotFoundError):
+                MODULE.collect(root / "missing", root / "output")
+
+            source = root / "maestro"
+            for name in MODULE.SCREENSHOTS:
+                path = source / "run" / name / "takeScreenshot" / f"{name}.png"
+                self.make_png(path)
+            bad = source / "run" / MODULE.SCREENSHOTS[0] / "takeScreenshot" / f"{MODULE.SCREENSHOTS[0]}.png"
+            bad.write_bytes(b"not a png")
+            with self.assertRaises(ValueError):
+                MODULE.collect(source, root / "bad-output")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tests/static/test_collect_maestro_screenshots.py
+++ b/Tests/static/test_collect_maestro_screenshots.py
@@ -55,6 +55,21 @@ class CollectMaestroScreenshotsTests(unittest.TestCase):
             with self.assertRaises(ValueError):
                 MODULE.collect(source, root / "bad-output")
 
+    def test_allow_missing_collects_outputs_from_later_successful_flows(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "maestro"
+            output = root / "artifact"
+            for name in MODULE.SCREENSHOTS[1:]:
+                path = source / "run" / name / "takeScreenshot" / f"{name}.png"
+                self.make_png(path, name.encode())
+
+            MODULE.collect(source, output, allow_missing=True)
+
+            self.assertFalse((output / f"{MODULE.SCREENSHOTS[0]}.png").exists())
+            for name in MODULE.SCREENSHOTS[1:]:
+                self.assertTrue((output / f"{name}.png").is_file())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Tests/static/test_ui_screenshotter_readiness.py
+++ b/Tests/static/test_ui_screenshotter_readiness.py
@@ -1,0 +1,78 @@
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class UIScreenshotterReadinessContractTests(unittest.TestCase):
+    def setUp(self):
+        self.flows = {
+            "contacts-list.yml": "screen_contacts",
+            "chats-list.yml": "screen_chats",
+            "settings.yml": "screen_settings",
+            "map.yml": "map_canvas_ready",
+        }
+
+    def test_each_flow_asserts_its_screen_landmark_before_capture(self):
+        for filename, identifier in self.flows.items():
+            with self.subTest(flow=filename):
+                flow = (ROOT / "flows" / filename).read_text()
+                assertion = f'id: "{identifier}"'
+                self.assertIn("ui-screenshotter: true", flow)
+                self.assertIn("- extendedWaitUntil:", flow)
+                self.assertIn("- assertVisible:", flow)
+                self.assertIn(assertion, flow)
+                self.assertLess(flow.index(assertion), flow.index("- takeScreenshot:"))
+
+    def test_map_waits_for_native_tile_readiness_before_asserting_and_capturing(self):
+        flow = (ROOT / "flows/map.yml").read_text()
+        wait = flow.index("- extendedWaitUntil:")
+        ready = flow.index('id: "map_canvas_ready"')
+        assertion = flow.index("- assertVisible:", ready)
+        capture = flow.index("- takeScreenshot:")
+        self.assertLess(wait, ready)
+        self.assertLess(ready, assertion)
+        self.assertLess(assertion, capture)
+
+        bridge = (ROOT / "Sources/ColumbaApp/Views/Map/MapLibreMapView.swift").read_text()
+        self.assertIn("func mapViewDidBecomeIdle(_ mapView: MLNMapView)", bridge)
+        self.assertIn('mapView.accessibilityIdentifier = "map_canvas_ready"', bridge)
+        self.assertIn('mapView.accessibilityIdentifier = "screen_map"', bridge)
+
+    def test_landmark_identifiers_exist_on_the_corresponding_screens(self):
+        expected = {
+            "Sources/ColumbaApp/Views/Chats/ChatsView.swift": "screen_chats",
+            "Sources/ColumbaApp/Views/Contacts/ContactsView.swift": "screen_contacts",
+            "Sources/ColumbaApp/Views/Settings/SettingsView.swift": "screen_settings",
+        }
+        for relative_path, identifier in expected.items():
+            with self.subTest(path=relative_path):
+                source = (ROOT / relative_path).read_text()
+                self.assertIn(f'.accessibilityIdentifier("{identifier}")', source)
+
+    def test_pull_request_ci_installs_runs_and_uploads_screenshotter_output(self):
+        workflow = (ROOT / ".github/workflows/tests.yml").read_text()
+        self.assertIn("Tests.static.test_ui_screenshotter_readiness", workflow)
+        self.assertIn("Install Maestro", workflow)
+        self.assertIn("Run screenshot flows", workflow)
+        self.assertIn("mobile-dev-inc/Maestro/releases/download/cli-", workflow)
+        self.assertIn("xcrun simctl install", workflow)
+        self.assertIn('"$GITHUB_WORKSPACE/flows/$flow"', workflow)
+        self.assertIn("support/collect-maestro-screenshots.py", workflow)
+        for filename in self.flows:
+            self.assertIn(filename, workflow)
+        self.assertIn("actions/upload-artifact@v4", workflow)
+        self.assertIn("ui-screenshots", workflow)
+        self.assertIn("github.event_name == 'pull_request'", workflow)
+        self.assertTrue((ROOT / "support/collect-maestro-screenshots.py").is_file())
+
+    def test_debug_launch_hook_bypasses_onboarding_with_a_disposable_identity(self):
+        app = (ROOT / "Sources/ColumbaApp/App/ColumbaApp.swift").read_text()
+        self.assertIn('arguments.contains("ui-screenshotter")', app)
+        self.assertIn("!isScreenshotterLaunch", app)
+        self.assertIn("creating disposable screenshotter identity", app)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tests/static/test_ui_screenshotter_readiness.py
+++ b/Tests/static/test_ui_screenshotter_readiness.py
@@ -60,9 +60,18 @@ class UIScreenshotterReadinessContractTests(unittest.TestCase):
         self.assertIn("xcrun simctl install", workflow)
         self.assertIn('"$GITHUB_WORKSPACE/flows/$flow"', workflow)
         self.assertIn("support/collect-maestro-screenshots.py", workflow)
+        self.assertIn("screenshot_status=0", workflow)
+        self.assertIn("if ! (", workflow)
+        self.assertIn("--allow-missing", workflow)
+        self.assertIn('exit "$screenshot_status"', workflow)
         for filename in self.flows:
             self.assertIn(filename, workflow)
-        self.assertIn("actions/upload-artifact@v4", workflow)
+        self.assertIn(
+            "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02",
+            workflow,
+        )
+        for action in ("actions/cache", "actions/setup-java", "actions/upload-artifact"):
+            self.assertNotIn(f"{action}@v4", workflow)
         self.assertIn("ui-screenshots", workflow)
         self.assertIn("github.event_name == 'pull_request'", workflow)
         self.assertTrue((ROOT / "support/collect-maestro-screenshots.py").is_file())

--- a/flows/README.md
+++ b/flows/README.md
@@ -11,11 +11,17 @@ reviewers can see the visual change before merging.
 
 1. New file `flows/<name>.yml`. Use existing flows as templates.
 2. Make it deterministic: `clearState: true` + `clearKeychain: true` on
-   launch, handle the onboarding skip path, no network-state assumptions.
+   launch, pass `ui-screenshotter: true` to create a disposable DEBUG identity,
+   and make no persisted network-state assumptions.
 3. End with `takeScreenshot: <name>` (the agent expects the PNG to land
    at `./<name>.png`).
 4. Don't add voice-call flows yet — they need a debug-only `lxma://debug/...`
    URL handler that doesn't exist (Stage 1 limitation).
+5. Assert a stable screen-specific accessibility identifier immediately before
+   `takeScreenshot`; optional tab taps must never silently capture another tab.
+6. For asynchronously rendered content, wait on an app/native readiness
+   identifier rather than an animation timeout. The map flow waits for
+   MapLibre's `mapViewDidBecomeIdle` signal through `map_canvas_ready`.
 
 ## Running locally
 
@@ -27,9 +33,18 @@ maestro --device <UDID> test flows/contacts-list.yml
 
 The `<UDID>` is from `xcrun simctl list devices booted`.
 
+## Pull-request CI
+
+`.github/workflows/tests.yml` installs the already-built shipping simulator app
+and runs all four flows on every pull request targeting `main`. A failed
+landmark or readiness assertion fails the required test job. Screenshots and
+Maestro diagnostics are uploaded as the `ui-screenshots` artifact even when a
+flow fails.
+
 ## Stage roadmap
 
-- **Stage 1** (now): capture + write the table to PLAN.md only.
+- **Stage 1** (now): deterministic landmark/readiness assertions, capture, and
+  write the table to PLAN.md; PR CI also archives the screenshots.
 - **Stage 2**: pixel diff column.
 - **Stage 3**: regression gating (PR fails if golden flow drifts > N%).
 - **Stage 4**: graduate to PR comments + GitHub-attachment uploads.

--- a/flows/chats-list.yml
+++ b/flows/chats-list.yml
@@ -9,26 +9,16 @@ tags:
 - launchApp:
     clearState: true
     clearKeychain: true
-- waitForAnimationToEnd:
-    timeout: 5000
-- runFlow:
-    when:
-      visible: "Skip"
-    commands:
-      - tapOn: "Skip"
-      - waitForAnimationToEnd:
-          timeout: 3000
-- runFlow:
-    when:
-      visible: "Get Started"
-    commands:
-      - tapOn: "Get Started"
-      - waitForAnimationToEnd:
-          timeout: 3000
+    arguments:
+      ui-screenshotter: true
+- extendedWaitUntil:
+    visible:
+      id: "screen_chats"
+    timeout: 30000
 # Default tab is Chats — no tap needed if onboarding lands there.
 - tapOn:
     text: "Chats"
     optional: true
-- waitForAnimationToEnd:
-    timeout: 3000
+- assertVisible:
+    id: "screen_chats"
 - takeScreenshot: "chats-list"

--- a/flows/contacts-list.yml
+++ b/flows/contacts-list.yml
@@ -13,26 +13,19 @@ tags:
 - launchApp:
     clearState: true
     clearKeychain: true
-- waitForAnimationToEnd:
-    timeout: 5000
-# Onboarding may show on a fresh install; skip if "Skip" / "Get Started" is visible.
-- runFlow:
-    when:
-      visible: "Skip"
-    commands:
-      - tapOn: "Skip"
-      - waitForAnimationToEnd:
-          timeout: 3000
-- runFlow:
-    when:
-      visible: "Get Started"
-    commands:
-      - tapOn: "Get Started"
-      - waitForAnimationToEnd:
-          timeout: 3000
+    arguments:
+      ui-screenshotter: true
+- extendedWaitUntil:
+    visible:
+      id: "screen_chats"
+    timeout: 30000
 - tapOn:
     text: "Contacts"
     optional: true
-- waitForAnimationToEnd:
-    timeout: 3000
+- extendedWaitUntil:
+    visible:
+      id: "screen_contacts"
+    timeout: 10000
+- assertVisible:
+    id: "screen_contacts"
 - takeScreenshot: "contacts-list"

--- a/flows/map.yml
+++ b/flows/map.yml
@@ -10,26 +10,21 @@ tags:
 - launchApp:
     clearState: true
     clearKeychain: true
-- waitForAnimationToEnd:
-    timeout: 5000
-- runFlow:
-    when:
-      visible: "Skip"
-    commands:
-      - tapOn: "Skip"
-      - waitForAnimationToEnd:
-          timeout: 3000
-- runFlow:
-    when:
-      visible: "Get Started"
-    commands:
-      - tapOn: "Get Started"
-      - waitForAnimationToEnd:
-          timeout: 3000
+    arguments:
+      ui-screenshotter: true
+- extendedWaitUntil:
+    visible:
+      id: "screen_chats"
+    timeout: 30000
 - tapOn:
     text: "Map"
     optional: true
-# Maps need a beat to load tile JSON + first-render
-- waitForAnimationToEnd:
-    timeout: 8000
+# Wait on MapLibre's native idle signal: no camera transition, all requested
+# tiles loaded, and all fade/transition animations complete.
+- extendedWaitUntil:
+    visible:
+      id: "map_canvas_ready"
+    timeout: 20000
+- assertVisible:
+    id: "map_canvas_ready"
 - takeScreenshot: "map"

--- a/flows/settings.yml
+++ b/flows/settings.yml
@@ -9,25 +9,19 @@ tags:
 - launchApp:
     clearState: true
     clearKeychain: true
-- waitForAnimationToEnd:
-    timeout: 5000
-- runFlow:
-    when:
-      visible: "Skip"
-    commands:
-      - tapOn: "Skip"
-      - waitForAnimationToEnd:
-          timeout: 3000
-- runFlow:
-    when:
-      visible: "Get Started"
-    commands:
-      - tapOn: "Get Started"
-      - waitForAnimationToEnd:
-          timeout: 3000
+    arguments:
+      ui-screenshotter: true
+- extendedWaitUntil:
+    visible:
+      id: "screen_chats"
+    timeout: 30000
 - tapOn:
     text: "Settings"
     optional: true
-- waitForAnimationToEnd:
-    timeout: 3000
+- extendedWaitUntil:
+    visible:
+      id: "screen_settings"
+    timeout: 10000
+- assertVisible:
+    id: "screen_settings"
 - takeScreenshot: "settings"

--- a/support/collect-maestro-screenshots.py
+++ b/support/collect-maestro-screenshots.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Collect named Maestro takeScreenshot outputs into one CI artifact directory."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import shutil
+
+
+SCREENSHOTS = ("contacts-list", "chats-list", "settings", "map")
+PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+
+
+def latest_screenshot(source: Path, name: str) -> Path:
+    candidates = [
+        path
+        for path in source.rglob(f"{name}.png")
+        if path.parent.name == "takeScreenshot"
+    ]
+    if not candidates:
+        raise FileNotFoundError(f"Maestro did not produce takeScreenshot/{name}.png under {source}")
+    return max(candidates, key=lambda path: path.stat().st_mtime_ns)
+
+
+def collect(source: Path, output: Path) -> None:
+    output.mkdir(parents=True, exist_ok=True)
+    for name in SCREENSHOTS:
+        screenshot = latest_screenshot(source, name)
+        if screenshot.read_bytes()[: len(PNG_SIGNATURE)] != PNG_SIGNATURE:
+            raise ValueError(f"Maestro output is not a PNG: {screenshot}")
+        destination = output / f"{name}.png"
+        shutil.copy2(screenshot, destination)
+        print(f"collected {name}: {destination} ({destination.stat().st_size} bytes)")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--source",
+        type=Path,
+        default=Path.home() / ".maestro" / "tests",
+        help="Maestro diagnostics root (default: ~/.maestro/tests)",
+    )
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+    collect(args.source, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/support/collect-maestro-screenshots.py
+++ b/support/collect-maestro-screenshots.py
@@ -23,10 +23,16 @@ def latest_screenshot(source: Path, name: str) -> Path:
     return max(candidates, key=lambda path: path.stat().st_mtime_ns)
 
 
-def collect(source: Path, output: Path) -> None:
+def collect(source: Path, output: Path, *, allow_missing: bool = False) -> None:
     output.mkdir(parents=True, exist_ok=True)
     for name in SCREENSHOTS:
-        screenshot = latest_screenshot(source, name)
+        try:
+            screenshot = latest_screenshot(source, name)
+        except FileNotFoundError:
+            if not allow_missing:
+                raise
+            print(f"missing {name}: Maestro did not reach takeScreenshot")
+            continue
         if screenshot.read_bytes()[: len(PNG_SIGNATURE)] != PNG_SIGNATURE:
             raise ValueError(f"Maestro output is not a PNG: {screenshot}")
         destination = output / f"{name}.png"
@@ -43,8 +49,13 @@ def main() -> None:
         help="Maestro diagnostics root (default: ~/.maestro/tests)",
     )
     parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument(
+        "--allow-missing",
+        action="store_true",
+        help="collect successful flows while the workflow reports failures separately",
+    )
     args = parser.parse_args()
-    collect(args.source, args.output)
+    collect(args.source, args.output, allow_missing=args.allow_missing)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add stable accessibility landmarks for Chats, Contacts, Settings, and Map screenshot flows
- gate Map capture on MapLibre's native idle callback instead of an animation timeout
- add a DEBUG-only deterministic screenshotter launch mode that creates a disposable identity after Maestro clears state and Keychain
- run all four Maestro flows in pull-request CI against the already-built shipping simulator app
- pin and checksum Maestro 2.8.0, cache its runtime, and upload screenshots plus diagnostics even on failure
- add static contracts and a tested screenshot artifact collector

## CI behavior
On every pull request targeting `main`, the existing macOS test job now:
1. builds and verifies the shipping app;
2. boots the selected simulator and installs that exact artifact;
3. runs `contacts-list.yml`, `chats-list.yml`, `settings.yml`, and `map.yml`;
4. fails if a screen landmark or MapLibre readiness assertion fails;
5. uploads the four PNGs and Maestro diagnostics as the `ui-screenshots` artifact.

Pushes to `main` skip the Maestro steps; PRs are the requested gating surface.

## Verification
Exact head: `56c0fa19500c5f98b760dfaad47c345c3b978622`

- complete static suite: 195/195 passed
- shipping Debug simulator build: passed
- Model B Debug simulator build: passed
- exact-head Maestro flows on iPhone 17 / iOS 26.4 simulator: 4/4 passed
- collected exact-head artifacts:
  - contacts-list.png: 141,364 bytes
  - chats-list.png: 145,665 bytes
  - settings.png: 531,503 bytes
  - map.png: 1,617,186 bytes
- map artifact visually verified to contain rendered OpenFreeMap streets/labels rather than a blank/loading surface

Fixes #71
Fixes #72
