### PR TITLE
fix(iOS): retain LXMF names on telemetry markers

### DIFF
--- a/Sources/ColumbaApp/Services/IncomingMessageHandler.swift
+++ b/Sources/ColumbaApp/Services/IncomingMessageHandler.swift
@@ -309,11 +309,23 @@ public final class IncomingMessageHandler: LXMRouterDelegate {
                 requiredOK = false
             }
 
-            // Look up sender display name from path table (announce data) and update conversation
+            // Look up the sender's LXMF display name from announce data. Keep a
+            // local copy for telemetry: FIELD_TELEMETRY does not embed the name,
+            // so passing nil here discards information we just resolved.
+            var senderDisplayName: String?
             if let pathTable = self.pathTable {
                 if let entry = await pathTable.lookup(destinationHash: sourceHash),
                    !entry.displayName.isEmpty {
+                    senderDisplayName = entry.displayName
                     try? await self.messageRepository.ensureConversation(sourceHash, displayName: entry.displayName)
+                }
+            }
+            if senderDisplayName == nil,
+               message.fields?[LXMessage.FIELD_TELEMETRY] != nil {
+                do {
+                    senderDisplayName = try await self.messageRepository.fetchConversation(sourceHash)?.displayName
+                } catch {
+                    self.logger.debug("Could not resolve persisted display name for telemetry sender \(sourceHashHex): \(error.localizedDescription)")
                 }
             }
 
@@ -364,7 +376,7 @@ public final class IncomingMessageHandler: LXMRouterDelegate {
                     self.locationSharingManager?.handleIncomingTelemetry(
                         from: message.sourceHash,
                         packet: packet,
-                        displayName: nil,
+                        displayName: senderDisplayName,
                         iconAppearance: peerIcon
                     )
                     #endif

--- a/Sources/ColumbaApp/Services/LocationSharingManager.swift
+++ b/Sources/ColumbaApp/Services/LocationSharingManager.swift
@@ -76,6 +76,14 @@ enum TelemetryDisplayNameResolver {
         }
         return nil
     }
+
+    static func diagnosticValue(_ displayName: String?) -> String {
+        guard let data = try? JSONEncoder().encode(displayName ?? ""),
+              let encoded = String(data: data, encoding: .utf8) else {
+            return "\"\""
+        }
+        return encoded
+    }
 }
 
 // MARK: - SharingDuration
@@ -336,7 +344,8 @@ public final class LocationSharingManager: NSObject {
         // MDI glyph name; fg/bg are 6-char RGB hex.
         let iconDesc = resolvedIcon.map { "\($0.iconName) fg=\($0.fgColor) bg=\($0.bgColor)" }
             ?? "- fg=- bg=-"
-        DiagLog.log("[LOC-RECV] peer=\(hex) name=\"\(resolvedDisplayName ?? "")\" lat=\(location.latitude) lon=\(location.longitude) icon=\(iconDesc)")
+        let diagnosticName = TelemetryDisplayNameResolver.diagnosticValue(resolvedDisplayName)
+        DiagLog.log("[LOC-RECV] peer=\(hex) name=\(diagnosticName) lat=\(location.latitude) lon=\(location.longitude) icon=\(iconDesc)")
     }
 
     /// Update foreground/background state to adjust send interval.

--- a/Sources/ColumbaApp/Services/LocationSharingManager.swift
+++ b/Sources/ColumbaApp/Services/LocationSharingManager.swift
@@ -66,6 +66,18 @@ public struct PeerLocation: Identifiable, Equatable {
     }
 }
 
+enum TelemetryDisplayNameResolver {
+    static func resolve(incoming: String?, existing: String?) -> String? {
+        for candidate in [incoming, existing] {
+            if let candidate,
+               !candidate.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                return candidate
+            }
+        }
+        return nil
+    }
+}
+
 // MARK: - SharingDuration
 
 /// Duration options for location sharing (matches Android Columba SharingDuration).
@@ -286,12 +298,21 @@ public final class LocationSharingManager: NSObject {
         // Sideband-compatible Telemeter codec to get the structured location.
         guard let location = LXMFSwift.TelemetryPacket.decode(from: packet.payload)?.location else { return }
 
+        // A telemetry frame does not carry the sender's LXMF announce name.
+        // Prefer the name resolved by IncomingMessageHandler, but do not let a
+        // later frame with no currently cached announce erase a name already
+        // attached to this peer's map marker.
+        let resolvedDisplayName = TelemetryDisplayNameResolver.resolve(
+            incoming: displayName,
+            existing: peerLocations[peerHash]?.displayName
+        )
+
         // Preserve existing icon if new message doesn't include one
         let resolvedIcon = iconAppearance ?? peerLocations[peerHash]?.iconAppearance
 
         let peerLoc = PeerLocation(
             id: peerHash,
-            displayName: displayName,
+            displayName: resolvedDisplayName,
             latitude: location.latitude,
             longitude: location.longitude,
             altitude: location.altitude,
@@ -315,7 +336,7 @@ public final class LocationSharingManager: NSObject {
         // MDI glyph name; fg/bg are 6-char RGB hex.
         let iconDesc = resolvedIcon.map { "\($0.iconName) fg=\($0.fgColor) bg=\($0.bgColor)" }
             ?? "- fg=- bg=-"
-        DiagLog.log("[LOC-RECV] peer=\(hex) lat=\(location.latitude) lon=\(location.longitude) icon=\(iconDesc)")
+        DiagLog.log("[LOC-RECV] peer=\(hex) name=\"\(resolvedDisplayName ?? "")\" lat=\(location.latitude) lon=\(location.longitude) icon=\(iconDesc)")
     }
 
     /// Update foreground/background state to adjust send interval.

--- a/Tests/ColumbaAppTests/MicronParserTests.swift
+++ b/Tests/ColumbaAppTests/MicronParserTests.swift
@@ -1229,6 +1229,16 @@ final class MessageRepositoryAdapterTests: XCTestCase {
         XCTAssertNil(TelemetryDisplayNameResolver.resolve(incoming: nil, existing: nil))
     }
 
+    func testTelemetryDiagnosticNameIsSingleLineJSON() throws {
+        let encoded = TelemetryDisplayNameResolver.diagnosticValue("Peer \"North\"\nInjected")
+        XCTAssertEqual(encoded, "\"Peer \\\"North\\\"\\nInjected\"")
+        XCTAssertFalse(encoded.contains("\n"))
+        XCTAssertEqual(
+            try JSONDecoder().decode(String.self, from: Data(encoded.utf8)),
+            "Peer \"North\"\nInjected"
+        )
+    }
+
     // Note: the empty/field-map/wire discriminator is covered through the public
     // adapters by testFieldMapRowRecoversAttachments + testWireRowRecoversAttachments
     // (which call mapRecord/mapToLXMessage -> the internal recoverFields/normalizedFieldMap).

--- a/Tests/ColumbaAppTests/MicronParserTests.swift
+++ b/Tests/ColumbaAppTests/MicronParserTests.swift
@@ -1207,6 +1207,28 @@ final class MessageRepositoryAdapterTests: XCTestCase {
         XCTAssertEqual(maximumActive, 1)
     }
 
+    func testTelemetryDisplayNamePrefersCurrentLXMFAnnounceName() {
+        XCTAssertEqual(
+            TelemetryDisplayNameResolver.resolve(incoming: "Current Name", existing: "Older Name"),
+            "Current Name"
+        )
+    }
+
+    func testTelemetryDisplayNameRetainsExistingNameWhenFrameHasNoName() {
+        XCTAssertEqual(
+            TelemetryDisplayNameResolver.resolve(incoming: nil, existing: "Known Peer"),
+            "Known Peer"
+        )
+        XCTAssertEqual(
+            TelemetryDisplayNameResolver.resolve(incoming: "   ", existing: "Known Peer"),
+            "Known Peer"
+        )
+    }
+
+    func testTelemetryDisplayNameRemainsNilWhenNoNameHasBeenResolved() {
+        XCTAssertNil(TelemetryDisplayNameResolver.resolve(incoming: nil, existing: nil))
+    }
+
     // Note: the empty/field-map/wire discriminator is covered through the public
     // adapters by testFieldMapRowRecoversAttachments + testWireRowRecoversAttachments
     // (which call mapRecord/mapToLXMessage -> the internal recoverFields/normalizedFieldMap).

--- a/Tests/interop/test_telemetry.py
+++ b/Tests/interop/test_telemetry.py
@@ -27,6 +27,7 @@ compile gate this used to be blocked on was removed on 2026-05-28.)
 """
 
 from __future__ import annotations
+import json
 import re
 import time
 from pathlib import Path
@@ -323,12 +324,14 @@ def test_location_sideband_to_ios(sim, sideband):
     line = _wait_for_loc_recv(sim)
     expected_name = _wait_for_peer_display_name(sim, sideband)
     m = re.search(
-        r'\[LOC-RECV\] peer=(\w+) name="([^"]*)" lat=(-?[\d.]+) lon=(-?[\d.]+) '
+        r'\[LOC-RECV\] peer=(\w+) name=("(?:\\.|[^"\\])*") '
+        r'lat=(-?[\d.]+) lon=(-?[\d.]+) '
         r"icon=(\S+) fg=(\S+) bg=(\S+)",
         line,
     )
     assert m, f"[LOC-RECV] line didn't parse: {line!r}"
-    peer, display_name, lat, lon, icon, fg, bg = m.groups()
+    peer, encoded_name, lat, lon, icon, fg, bg = m.groups()
+    display_name = json.loads(encoded_name)
     assert peer == sideband.identity_hex[:len(peer)], \
         f"telemetry attributed to {peer}, expected {sideband.identity_hex[:len(peer)]}"
     assert display_name == expected_name, \

--- a/Tests/interop/test_telemetry.py
+++ b/Tests/interop/test_telemetry.py
@@ -277,6 +277,21 @@ def _wait_for_loc_recv(sim, *, timeout: float = 30.0) -> str:
     pytest.fail(f"iOS never logged [LOC-RECV] for inbound telemetry within {timeout}s")
 
 
+def _wait_for_peer_display_name(sim, sideband, *, timeout: float = 20.0) -> str:
+    """Return the non-empty lxmf.delivery name iOS learned for Sideband."""
+    pat = re.compile(
+        rf'announce dest={sideband.identity_hex}\s+aspect=lxmf\.delivery\s+name="([^"]+)"'
+    )
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        for line in reversed(sim._tail_diag(800)):
+            match = pat.search(line)
+            if match:
+                return match.group(1)
+        time.sleep(0.4)
+    pytest.fail("iOS did not observe a named Sideband lxmf.delivery announce")
+
+
 def test_location_sideband_to_ios(sim, sideband):
     """Sideband → iOS location telemetry with an icon appearance.
 
@@ -306,15 +321,18 @@ def test_location_sideband_to_ios(sim, sideband):
     # expose). Capture first — it's logged on receipt regardless of UI
     # state, so it's independent of the map-navigation step below.
     line = _wait_for_loc_recv(sim)
+    expected_name = _wait_for_peer_display_name(sim, sideband)
     m = re.search(
-        r"\[LOC-RECV\] peer=(\w+) lat=(-?[\d.]+) lon=(-?[\d.]+) "
+        r'\[LOC-RECV\] peer=(\w+) name="([^"]*)" lat=(-?[\d.]+) lon=(-?[\d.]+) '
         r"icon=(\S+) fg=(\S+) bg=(\S+)",
         line,
     )
     assert m, f"[LOC-RECV] line didn't parse: {line!r}"
-    peer, lat, lon, icon, fg, bg = m.groups()
+    peer, display_name, lat, lon, icon, fg, bg = m.groups()
     assert peer == sideband.identity_hex[:len(peer)], \
         f"telemetry attributed to {peer}, expected {sideband.identity_hex[:len(peer)]}"
+    assert display_name == expected_name, \
+        f"telemetry marker lost LXMF display name: got {display_name!r}, expected {expected_name!r}"
     assert abs(float(lat) - expect_lat) < 1e-4, f"lat drift: {lat}"
     assert abs(float(lon) - expect_lon) < 1e-4, f"lon drift: {lon}"
     assert icon == icon_name, f"icon name didn't round-trip: {icon!r}"

--- a/Tests/static/test_reported_runtime_bugs.py
+++ b/Tests/static/test_reported_runtime_bugs.py
@@ -18,9 +18,24 @@ SETTINGS_VIEW = ROOT / "Sources/ColumbaApp/Views/Settings/SettingsView.swift"
 MAIN_TAB_VIEW = ROOT / "Sources/ColumbaApp/Views/MainTabView.swift"
 MESSAGE_BUBBLE = ROOT / "Sources/ColumbaApp/Views/Messaging/MessageBubble.swift"
 MESSAGING_VIEW = ROOT / "Sources/ColumbaApp/Views/Messaging/MessagingView.swift"
+INCOMING_MESSAGE_HANDLER = ROOT / "Sources/ColumbaApp/Services/IncomingMessageHandler.swift"
+LOCATION_SHARING_MANAGER = ROOT / "Sources/ColumbaApp/Services/LocationSharingManager.swift"
 
 
 class ReportedRuntimeBugContracts(unittest.TestCase):
+    def test_inbound_telemetry_retains_lxmf_display_name(self) -> None:
+        handler = INCOMING_MESSAGE_HANDLER.read_text()
+        telemetry_dispatch = re.search(
+            r"handleIncomingTelemetry\(.*?\n\s*\)", handler, re.DOTALL
+        )
+        self.assertIsNotNone(telemetry_dispatch)
+        assert telemetry_dispatch is not None
+        self.assertIn("displayName: senderDisplayName", telemetry_dispatch.group(0))
+        self.assertNotIn("displayName: nil", telemetry_dispatch.group(0))
+
+        manager = LOCATION_SHARING_MANAGER.read_text()
+        self.assertIn("TelemetryDisplayNameResolver.resolve(", manager)
+
     def test_inbound_event_preserves_canonical_lxmf_hash_end_to_end(self) -> None:
         bridge = BRIDGE_PY.read_text()
         callback = re.search(


### PR DESCRIPTION
## Summary
- propagate the sender's LXMF announce display name into inbound location telemetry
- fall back to the persisted conversation name when announce data is unavailable
- preserve a map marker's existing name across later nameless telemetry frames
- extend native, static, and Sideband interoperability coverage for display-name retention

## Verification
- `python3 -B -m unittest discover -s Tests/static -p 'test_*.py'` — 197 passed
- shipping `ColumbaAppTests` — 147 passed
- Model B Debug simulator build — passed
- Sideband → iOS location telemetry — passed with `name="Anonymous Peer"` retained on the decoded marker
- iOS → Sideband location telemetry — passed with a valid signature and `FIELD_TELEMETRY`

## Protocol note
LXMF telemetry does not embed a display name in `FIELD_TELEMETRY`; recipients resolve the name from `lxmf.delivery` announce data. This change prevents iOS from discarding that resolved identity metadata.

## Risk / rollback
The change is limited to inbound telemetry marker metadata and retains the existing hash fallback when no name is known. Roll back this commit to restore the previous behavior.