### PR TITLE
fix(ios): retain native ABI in TestFlight archives

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,8 +72,26 @@ jobs:
             Tests.static.test_ui_screenshotter_readiness \
             Tests.static.test_collect_maestro_screenshots
 
-      # xcodebuild test builds the Debug host. Reuse that product for artifact
-      # isolation checks instead of paying for a separate shipping build first.
+      # Verify a standalone production-layout app before xcodebuild test embeds
+      # ColumbaAppTests.xctest under PlugIns in its hosted test copy.
+      - name: Build shipping artifact (embedded Python)
+        run: |
+          set -euo pipefail
+          xcodebuild build \
+            -project Columba.xcodeproj \
+            -scheme Columba \
+            -configuration Debug \
+            -sdk iphonesimulator \
+            -destination "id=${{ steps.sim.outputs.device_id }}" \
+            -derivedDataPath "$PWD/DerivedData-Python" \
+            CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=YES DEVELOPMENT_TEAM="" PROVISIONING_PROFILE_SPECIFIER=""
+
+      - name: Verify shipping artifact isolation
+        run: |
+          set -euo pipefail
+          SHIPPING_APP="$PWD/DerivedData-Python/Build/Products/Debug-iphonesimulator/ColumbaApp.app"
+          python3 support/verify-flavor-artifact.py shipping "$SHIPPING_APP"
+
       - name: Build and run shipping tests
         run: |
           set -euo pipefail
@@ -89,12 +107,6 @@ jobs:
             -resultBundlePath TestResults.xcresult \
             -enableCodeCoverage YES \
             CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=YES DEVELOPMENT_TEAM="" PROVISIONING_PROFILE_SPECIFIER=""
-
-      - name: Verify shipping artifact isolation
-        run: |
-          set -euo pipefail
-          SHIPPING_APP="$PWD/DerivedData-Python/Build/Products/Debug-iphonesimulator/ColumbaApp.app"
-          python3 support/verify-flavor-artifact.py shipping "$SHIPPING_APP"
 
       # A normal Release build still contains symbols that Xcode removes during
       # archive post-processing. Force that stripping stage and inspect the
@@ -200,8 +212,27 @@ jobs:
           echo "device_id=$DEVICE_ID" >> "$GITHUB_OUTPUT"
           echo "Using simulator: $DEVICE_ID"
 
-      # xcodebuild test builds the app and extension. Verify those exact products
-      # instead of performing a redundant Model B build first.
+      # Verify a standalone production-layout app before xcodebuild test adds
+      # ColumbaModelBAppTests.xctest beside the network extension in PlugIns.
+      - name: Build Model B artifact
+        run: |
+          set -euo pipefail
+          xcodebuild build \
+            -project Columba.xcodeproj \
+            -scheme Columba-ModelB \
+            -configuration Debug \
+            -sdk iphonesimulator \
+            -destination "id=${{ steps.sim.outputs.device_id }}" \
+            -derivedDataPath "$PWD/DerivedData-ModelB" \
+            CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=YES DEVELOPMENT_TEAM="" PROVISIONING_PROFILE_SPECIFIER=""
+
+      - name: Verify Model B artifact isolation
+        run: |
+          set -euo pipefail
+          MODELB_APP="$PWD/DerivedData-ModelB/Build/Products/Debug-iphonesimulator/ColumbaModelBApp.app"
+          python3 support/verify-flavor-artifact.py \
+            modelb "$MODELB_APP" --allow-empty-simulator-entitlements
+
       - name: Build and run Model B tests
         run: |
           set -euo pipefail
@@ -216,13 +247,6 @@ jobs:
             -only-testing:ColumbaModelBAppTests \
             -resultBundlePath ModelBTestResults.xcresult \
             CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=YES DEVELOPMENT_TEAM="" PROVISIONING_PROFILE_SPECIFIER=""
-
-      - name: Verify Model B artifact isolation
-        run: |
-          set -euo pipefail
-          MODELB_APP="$PWD/DerivedData-ModelB/Build/Products/Debug-iphonesimulator/ColumbaModelBApp.app"
-          python3 support/verify-flavor-artifact.py \
-            modelb "$MODELB_APP" --allow-empty-simulator-entitlements
 
   ui:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,6 +73,7 @@ jobs:
           python3 -B -m unittest \
             Tests.static.test_host_entitlements_contract \
             Tests.static.test_ci_artifact_isolation \
+            Tests.static.test_ios_ble_bridge_contract \
             Tests.static.test_fetch_python_resilience \
             Tests.static.test_migration_export_flow \
             Tests.static.test_ios_stamp_runtime_hardening \
@@ -96,6 +97,28 @@ jobs:
           set -euo pipefail
           SHIPPING_APP="$PWD/DerivedData-Python/Build/Products/Debug-iphonesimulator/ColumbaApp.app"
           python3 support/verify-flavor-artifact.py shipping "$SHIPPING_APP"
+
+      # A normal Release build still contains symbols that Xcode removes during
+      # archive post-processing. Force that same stripping stage in CI, then
+      # validate every embedded-Python C ABI export against the final Mach-O.
+      - name: Build post-processed Release artifact
+        run: |
+          set -euo pipefail
+          xcodebuild build \
+            -project Columba.xcodeproj \
+            -scheme Columba \
+            -configuration Release \
+            -sdk iphonesimulator \
+            -destination "id=${{ steps.sim.outputs.device_id }}" \
+            -derivedDataPath "$PWD/DerivedData-Python" \
+            DEPLOYMENT_POSTPROCESSING=YES STRIP_INSTALLED_PRODUCT=YES \
+            CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=YES DEVELOPMENT_TEAM="" PROVISIONING_PROFILE_SPECIFIER=""
+
+      - name: Verify post-processed Release native ABI
+        run: |
+          set -euo pipefail
+          RELEASE_APP="$PWD/DerivedData-Python/Build/Products/Release-iphonesimulator/ColumbaApp.app"
+          python3 support/verify-flavor-artifact.py shipping "$RELEASE_APP"
 
       # PRs exercise the same deterministic Maestro flows used by the
       # ui-screenshotter agent. Reuse the shipping simulator artifact built

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,11 +10,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Keep the shipping, Model B, and UI lanes independent. They intentionally use
+# separate runners and DerivedData so a slow UI flow or one flavor cannot block
+# feedback from the other validation lanes.
 jobs:
-  test:
+  python:
     # macos-26 carries Xcode 26.x, which the embedded-Python shipping scheme
-    # needs — the Python.framework clang module map fails to resolve under
-    # Xcode 16.x ("module 'Python' … not defined in any loaded module map").
+    # needs. The Python.framework module map does not resolve under Xcode 16.x.
     runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
@@ -26,8 +28,6 @@ jobs:
           git clone https://github.com/torlando-tech/LXMF-swift.git ../LXMF-swift
           git clone https://github.com/torlando-tech/LXST-swift.git ../LXST-swift
 
-      # The shipping (`Columba`) scheme links Python.xcframework and bundles
-      # wheels. Fetch both before resolving or building either flavor.
       - name: Fetch Python framework + wheels
         run: |
           set -euo pipefail
@@ -43,17 +43,12 @@ jobs:
           sudo xcode-select -s "$XCODE"
           xcodebuild -version
 
-      # Resolve both explicit flavor schemes up front so all later actions
-      # reuse the same local Swift package resolution.
-      - name: Resolve Swift packages
+      - name: Resolve shipping Swift packages
         run: |
           set -euo pipefail
           xcodebuild -resolvePackageDependencies \
             -project Columba.xcodeproj \
             -scheme Columba
-          xcodebuild -resolvePackageDependencies \
-            -project Columba.xcodeproj \
-            -scheme Columba-ModelB
 
       - name: Find simulator
         id: sim
@@ -64,9 +59,6 @@ jobs:
           echo "device_id=$DEVICE_ID" >> "$GITHUB_OUTPUT"
           echo "Using simulator: $DEVICE_ID"
 
-      # Simulator ad-hoc signing leaves effective entitlements empty. Exercise
-      # source entitlement contracts in CI; signed archives/device products are
-      # still checked strictly by the artifact checker.
       - name: Run static flavor and entitlement contracts
         run: |
           set -euo pipefail
@@ -80,16 +72,22 @@ jobs:
             Tests.static.test_ui_screenshotter_readiness \
             Tests.static.test_collect_maestro_screenshots
 
-      - name: Build shipping artifact (embedded Python)
+      # xcodebuild test builds the Debug host. Reuse that product for artifact
+      # isolation checks instead of paying for a separate shipping build first.
+      - name: Build and run shipping tests
         run: |
           set -euo pipefail
-          xcodebuild build \
+          rm -rf TestResults.xcresult
+          xcodebuild test \
             -project Columba.xcodeproj \
             -scheme Columba \
             -configuration Debug \
             -sdk iphonesimulator \
             -destination "id=${{ steps.sim.outputs.device_id }}" \
             -derivedDataPath "$PWD/DerivedData-Python" \
+            -only-testing:ColumbaAppTests \
+            -resultBundlePath TestResults.xcresult \
+            -enableCodeCoverage YES \
             CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=YES DEVELOPMENT_TEAM="" PROVISIONING_PROFILE_SPECIFIER=""
 
       - name: Verify shipping artifact isolation
@@ -99,8 +97,8 @@ jobs:
           python3 support/verify-flavor-artifact.py shipping "$SHIPPING_APP"
 
       # A normal Release build still contains symbols that Xcode removes during
-      # archive post-processing. Force that same stripping stage in CI, then
-      # validate every embedded-Python C ABI export against the final Mach-O.
+      # archive post-processing. Force that stripping stage and inspect the
+      # final Mach-O against every embedded-Python C ABI export.
       - name: Build post-processed Release artifact
         run: |
           set -euo pipefail
@@ -120,11 +118,169 @@ jobs:
           RELEASE_APP="$PWD/DerivedData-Python/Build/Products/Release-iphonesimulator/ColumbaApp.app"
           python3 support/verify-flavor-artifact.py shipping "$RELEASE_APP"
 
-      # PRs exercise the same deterministic Maestro flows used by the
-      # ui-screenshotter agent. Reuse the shipping simulator artifact built
-      # above instead of paying for a second Xcode build in another job.
+      - name: Export coverage report (function-level lcov)
+        run: |
+          set -euo pipefail
+          XCRESULT=TestResults.xcresult
+          if [ ! -d "$XCRESULT" ]; then
+            echo "$XCRESULT does not exist" >&2
+            exit 1
+          fi
+          mkdir -p coverage
+          xcrun xccov view --report --json "$XCRESULT" > coverage/coverage.json
+
+          python3 <<'PY'
+          import json, sys
+          data = json.load(open('coverage/coverage.json'))
+          out = []
+          file_count = 0
+          for target in data.get('targets', []):
+              for f in target.get('files', []):
+                  path = f['path']
+                  if 'Tests' in path or 'SourcePackages' in path or 'DerivedData' in path:
+                      continue
+                  out.append(f"SF:{path}")
+                  for fn in f.get('functions', []):
+                      ln = fn.get('lineNumber', 0)
+                      hits = fn.get('executionCount', 0)
+                      name = fn.get('name', '?')
+                      out.append(f"FN:{ln},{name}")
+                      out.append(f"FNDA:{hits},{name}")
+                  out.append("end_of_record")
+                  file_count += 1
+          with open('coverage/coverage.lcov', 'w') as fh:
+              fh.write("\n".join(out) + "\n")
+          print(f"Wrote {file_count} files, {len(out)} total lcov lines")
+          if file_count == 0:
+              print("ERROR: zero files; coverage extraction is broken", file=sys.stderr)
+              sys.exit(1)
+          PY
+          head -5 coverage/coverage.lcov
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: coverage/coverage.lcov
+          fail_ci_if_error: false
+
+  modelb:
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Clone sibling packages
+        run: |
+          set -euo pipefail
+          git clone https://github.com/torlando-tech/reticulum-swift.git ../reticulum-swift
+          git clone https://github.com/torlando-tech/LXMF-swift.git ../LXMF-swift
+          git clone https://github.com/torlando-tech/LXST-swift.git ../LXST-swift
+
+      - name: Select Xcode
+        run: |
+          set -euo pipefail
+          echo "Available Xcodes:"; ls -d /Applications/Xcode_*.app 2>/dev/null || true
+          XCODE=$(ls -d /Applications/Xcode_*.app 2>/dev/null | sort -V | tail -1)
+          echo "Using $XCODE"
+          sudo xcode-select -s "$XCODE"
+          xcodebuild -version
+
+      - name: Resolve Model B Swift packages
+        run: |
+          set -euo pipefail
+          xcodebuild -resolvePackageDependencies \
+            -project Columba.xcodeproj \
+            -scheme Columba-ModelB
+
+      - name: Find simulator
+        id: sim
+        run: |
+          set -euo pipefail
+          DEVICE_ID=$(xcrun simctl list devices available -j \
+            | python3 -c "import sys,json; devs=json.load(sys.stdin)['devices']; print(next(d['udid'] for rt in devs for d in devs[rt] if 'iPhone' in d['name']))")
+          echo "device_id=$DEVICE_ID" >> "$GITHUB_OUTPUT"
+          echo "Using simulator: $DEVICE_ID"
+
+      # xcodebuild test builds the app and extension. Verify those exact products
+      # instead of performing a redundant Model B build first.
+      - name: Build and run Model B tests
+        run: |
+          set -euo pipefail
+          rm -rf ModelBTestResults.xcresult
+          xcodebuild test \
+            -project Columba.xcodeproj \
+            -scheme Columba-ModelB \
+            -configuration Debug \
+            -sdk iphonesimulator \
+            -destination "id=${{ steps.sim.outputs.device_id }}" \
+            -derivedDataPath "$PWD/DerivedData-ModelB" \
+            -only-testing:ColumbaModelBAppTests \
+            -resultBundlePath ModelBTestResults.xcresult \
+            CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=YES DEVELOPMENT_TEAM="" PROVISIONING_PROFILE_SPECIFIER=""
+
+      - name: Verify Model B artifact isolation
+        run: |
+          set -euo pipefail
+          MODELB_APP="$PWD/DerivedData-ModelB/Build/Products/Debug-iphonesimulator/ColumbaModelBApp.app"
+          python3 support/verify-flavor-artifact.py \
+            modelb "$MODELB_APP" --allow-empty-simulator-entitlements
+
+  ui:
+    if: github.event_name == 'pull_request'
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Clone sibling packages
+        run: |
+          set -euo pipefail
+          git clone https://github.com/torlando-tech/reticulum-swift.git ../reticulum-swift
+          git clone https://github.com/torlando-tech/LXMF-swift.git ../LXMF-swift
+          git clone https://github.com/torlando-tech/LXST-swift.git ../LXST-swift
+
+      - name: Fetch Python framework + wheels
+        run: |
+          set -euo pipefail
+          support/fetch-python.sh
+          support/fetch-wheels.sh
+
+      - name: Select Xcode
+        run: |
+          set -euo pipefail
+          echo "Available Xcodes:"; ls -d /Applications/Xcode_*.app 2>/dev/null || true
+          XCODE=$(ls -d /Applications/Xcode_*.app 2>/dev/null | sort -V | tail -1)
+          echo "Using $XCODE"
+          sudo xcode-select -s "$XCODE"
+          xcodebuild -version
+
+      - name: Resolve shipping Swift packages
+        run: |
+          set -euo pipefail
+          xcodebuild -resolvePackageDependencies \
+            -project Columba.xcodeproj \
+            -scheme Columba
+
+      - name: Find simulator
+        id: sim
+        run: |
+          set -euo pipefail
+          DEVICE_ID=$(xcrun simctl list devices available -j \
+            | python3 -c "import sys,json; devs=json.load(sys.stdin)['devices']; print(next(d['udid'] for rt in devs for d in devs[rt] if 'iPhone' in d['name']))")
+          echo "device_id=$DEVICE_ID" >> "$GITHUB_OUTPUT"
+          echo "Using simulator: $DEVICE_ID"
+
+      - name: Build shipping artifact for UI flows
+        run: |
+          set -euo pipefail
+          xcodebuild build \
+            -project Columba.xcodeproj \
+            -scheme Columba \
+            -configuration Debug \
+            -sdk iphonesimulator \
+            -destination "id=${{ steps.sim.outputs.device_id }}" \
+            -derivedDataPath "$PWD/DerivedData-Python" \
+            CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=YES DEVELOPMENT_TEAM="" PROVISIONING_PROFILE_SPECIFIER=""
+
       - name: Cache Maestro
-        if: github.event_name == 'pull_request'
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
@@ -133,14 +289,12 @@ jobs:
           key: maestro-cli-2.8.0-macos
 
       - name: Set up Java for Maestro
-        if: github.event_name == 'pull_request'
         uses: actions/setup-java@d7793b545071e98d581d3bf084a51c3213318a07 # v4
         with:
           distribution: temurin
           java-version: '21'
 
       - name: Install Maestro
-        if: github.event_name == 'pull_request'
         run: |
           set -euo pipefail
           MAESTRO_VERSION=2.8.0
@@ -161,7 +315,6 @@ jobs:
           "$HOME/.maestro/bin/maestro" --version
 
       - name: Run screenshot flows
-        if: github.event_name == 'pull_request'
         env:
           MAESTRO_CLI_ANALYSIS_NOTIFICATION_DISABLED: 'true'
         run: |
@@ -188,7 +341,7 @@ jobs:
           exit "$screenshot_status"
 
       - name: Upload UI screenshots and Maestro diagnostics
-        if: always() && github.event_name == 'pull_request'
+        if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ui-screenshots
@@ -197,113 +350,3 @@ jobs:
             ~/.maestro/tests/**
           if-no-files-found: warn
           retention-days: 14
-
-      # The Model B scheme explicitly builds its app and network extension.
-      - name: Build Model B artifact
-        run: |
-          set -euo pipefail
-          xcodebuild build \
-            -project Columba.xcodeproj \
-            -scheme Columba-ModelB \
-            -configuration Debug \
-            -sdk iphonesimulator \
-            -destination "id=${{ steps.sim.outputs.device_id }}" \
-            -derivedDataPath "$PWD/DerivedData-ModelB" \
-            CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=YES DEVELOPMENT_TEAM="" PROVISIONING_PROFILE_SPECIFIER=""
-
-      - name: Verify Model B artifact isolation
-        run: |
-          set -euo pipefail
-          MODELB_APP="$PWD/DerivedData-ModelB/Build/Products/Debug-iphonesimulator/ColumbaModelBApp.app"
-          python3 support/verify-flavor-artifact.py \
-            modelb "$MODELB_APP" --allow-empty-simulator-entitlements
-
-      - name: Build and run Model B tests
-        run: |
-          set -euo pipefail
-          rm -rf ModelBTestResults.xcresult
-          xcodebuild test \
-            -project Columba.xcodeproj \
-            -scheme Columba-ModelB \
-            -configuration Debug \
-            -sdk iphonesimulator \
-            -destination "id=${{ steps.sim.outputs.device_id }}" \
-            -derivedDataPath "$PWD/DerivedData-ModelB" \
-            -only-testing:ColumbaModelBAppTests \
-            -resultBundlePath ModelBTestResults.xcresult \
-            CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=YES DEVELOPMENT_TEAM="" PROVISIONING_PROFILE_SPECIFIER=""
-
-      - name: Build and run shipping tests
-        run: |
-          set -euo pipefail
-          rm -rf TestResults.xcresult
-          xcodebuild test \
-            -project Columba.xcodeproj \
-            -scheme Columba \
-            -configuration Debug \
-            -sdk iphonesimulator \
-            -destination "id=${{ steps.sim.outputs.device_id }}" \
-            -derivedDataPath "$PWD/DerivedData-Python" \
-            -only-testing:ColumbaAppTests \
-            -resultBundlePath TestResults.xcresult \
-            -enableCodeCoverage YES \
-            CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=YES DEVELOPMENT_TEAM="" PROVISIONING_PROFILE_SPECIFIER=""
-
-      - name: Export coverage report (function-level lcov)
-        run: |
-          set -euo pipefail
-          # Coverage on iOS app projects with -resultBundlePath lives
-          # inside the .xcresult bundle. The only toolchain path that
-          # reads it cleanly under Xcode 16 is
-          # `xccov view --report --json`, which exposes function-level
-          # granularity (no per-line `DA:` records). Per-line data
-          # would require either a working `xccov view --file` (broken
-          # against both the bare .xcresult and `xcresulttool export
-          # coverage`'s output: "Error: unrecognized file format") or
-          # a raw .profdata (Xcode embeds it inside the xcresult, not
-          # in DerivedData). codecov's `patch` check is configured
-          # `informational: true` so the absence of line records is
-          # advisory rather than blocking.
-          XCRESULT=TestResults.xcresult
-          if [ ! -d "$XCRESULT" ]; then
-            echo "$XCRESULT does not exist" >&2
-            exit 1
-          fi
-          mkdir -p coverage
-          xcrun xccov view --report --json "$XCRESULT" > coverage/coverage.json
-
-          python3 <<'PY'
-          import json, sys
-          data = json.load(open('coverage/coverage.json'))
-          out = []
-          file_count = 0
-          for target in data.get('targets', []):
-              for f in target.get('files', []):
-                  path = f['path']
-                  # Filter out tests + third-party packages so the
-                  # report shows first-party app code only.
-                  if 'Tests' in path or 'SourcePackages' in path or 'DerivedData' in path:
-                      continue
-                  out.append(f"SF:{path}")
-                  for fn in f.get('functions', []):
-                      ln = fn.get('lineNumber', 0)
-                      hits = fn.get('executionCount', 0)
-                      name = fn.get('name', '?')
-                      out.append(f"FN:{ln},{name}")
-                      out.append(f"FNDA:{hits},{name}")
-                  out.append("end_of_record")
-                  file_count += 1
-          with open('coverage/coverage.lcov', 'w') as fh:
-              fh.write("\n".join(out) + "\n")
-          print(f"Wrote {file_count} files, {len(out)} total lcov lines")
-          if file_count == 0:
-              print("ERROR: zero files — coverage extraction is broken", file=sys.stderr)
-              sys.exit(1)
-          PY
-          head -5 coverage/coverage.lcov
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          files: coverage/coverage.lcov
-          fail_ci_if_error: false

--- a/Columba.xcodeproj/project.pbxproj
+++ b/Columba.xcodeproj/project.pbxproj
@@ -2005,6 +2005,7 @@
 				ENABLE_DEBUG_DYLIB = NO;
 				ENABLE_PREVIEWS = YES;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
+				EXPORTED_SYMBOLS_FILE = Sources/ColumbaApp/Resources/ColumbaApp.exports;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Sources/ColumbaApp/Resources/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Columba;
@@ -2051,6 +2052,7 @@
 				DEVELOPMENT_TEAM = M2977H5PM5;
 				ENABLE_PREVIEWS = YES;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
+				EXPORTED_SYMBOLS_FILE = Sources/ColumbaApp/Resources/ColumbaApp.exports;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Sources/ColumbaApp/Resources/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Columba;
@@ -2072,6 +2074,7 @@
 				MARKETING_VERSION = 0.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = network.columba.Columba;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRIP_STYLE = non-global;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) COLUMBA_RUNTIME_PYTHON COLUMBA_ONBOARDING_ENABLED COLUMBA_MIGRATION_ENABLED COLUMBA_RNODE_ENABLED";

--- a/Columba.xcodeproj/project.pbxproj
+++ b/Columba.xcodeproj/project.pbxproj
@@ -2005,7 +2005,6 @@
 				ENABLE_DEBUG_DYLIB = NO;
 				ENABLE_PREVIEWS = YES;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
-				EXPORTED_SYMBOLS_FILE = Sources/ColumbaApp/Resources/ColumbaApp.exports;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Sources/ColumbaApp/Resources/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Columba;

--- a/Sources/ColumbaApp/Resources/ColumbaApp.exports
+++ b/Sources/ColumbaApp/Resources/ColumbaApp.exports
@@ -1,0 +1,31 @@
+# C ABI entry points resolved at runtime by embedded Python through ctypes.CDLL(None).
+# Keep this list synchronized with every @_cdecl declaration in Sources.
+_columba_ble_configure_power
+_columba_ble_connect
+_columba_ble_disconnect
+_columba_ble_get_peer_mtu
+_columba_ble_get_peer_role
+_columba_ble_request_identity_resync
+_columba_ble_send
+_columba_ble_set_identity
+_columba_ble_start
+_columba_ble_start_advertising
+_columba_ble_start_scanning
+_columba_ble_stop
+_columba_ble_stop_advertising
+_columba_ble_stop_scanning
+_columba_ble_sync_existing_connections
+_columba_rnode_connect
+_columba_rnode_disconnect
+_columba_rnode_read
+_columba_rnode_session_close
+_columba_rnode_session_open
+_columba_rnode_session_read
+_columba_rnode_session_set_online
+_columba_rnode_session_state
+_columba_rnode_session_write
+_columba_rnode_set_online
+_columba_rnode_state
+_columba_rnode_write
+_columba_stamp_generate
+_columba_stamp_generate_cancellable

--- a/Sources/ColumbaApp/Views/MainTabView.swift
+++ b/Sources/ColumbaApp/Views/MainTabView.swift
@@ -60,6 +60,7 @@ struct MainTabView: View {
             )
             .tabItem {
                 Label(Tab.chats.title, systemImage: Tab.chats.icon)
+                    .accessibilityIdentifier("tab_chats")
             }
             .tag(Tab.chats)
 
@@ -71,6 +72,7 @@ struct MainTabView: View {
             )
             .tabItem {
                 Label(Tab.contacts.title, systemImage: Tab.contacts.icon)
+                    .accessibilityIdentifier("tab_contacts")
             }
             .tag(Tab.contacts)
 
@@ -82,6 +84,7 @@ struct MainTabView: View {
             )
                 .tabItem {
                     Label(Tab.map.title, systemImage: Tab.map.icon)
+                        .accessibilityIdentifier("tab_map")
                 }
                 .tag(Tab.map)
             #endif
@@ -96,6 +99,7 @@ struct MainTabView: View {
             )
             .tabItem {
                 Label(Tab.settings.title, systemImage: Tab.settings.icon)
+                    .accessibilityIdentifier("tab_settings")
             }
             .tag(Tab.settings)
         }

--- a/Tests/static/test_ci_artifact_isolation.py
+++ b/Tests/static/test_ci_artifact_isolation.py
@@ -13,6 +13,7 @@ import unittest
 ROOT = Path(__file__).resolve().parents[2]
 CHECKER = ROOT / "support/verify-flavor-artifact.py"
 WORKFLOW = ROOT / ".github/workflows/tests.yml"
+EXPORTS = ROOT / "Sources/ColumbaApp/Resources/ColumbaApp.exports"
 
 
 def load_checker():
@@ -55,19 +56,13 @@ class ArtifactFixture:
             ("nm", str(self.app / executable)): b"_$s7Columba13ShippingGraphV\n",
         }
         if flavor == "shipping":
-            self.outputs[("nm", str(self.app / executable))] += (
-                b"_columba_rnode_session_open\n"
-                b"_columba_rnode_session_close\n"
-                b"_columba_rnode_session_state\n"
-                b"_columba_rnode_session_read\n"
-                b"_columba_rnode_session_write\n"
-                b"_columba_rnode_session_set_online\n"
-                b"_columba_rnode_connect\n"
-                b"_columba_rnode_disconnect\n"
-                b"_columba_rnode_state\n"
-                b"_columba_rnode_read\n"
-                b"_columba_rnode_write\n"
-                b"_columba_rnode_set_online\n"
+            native_exports = (
+                line.encode("ascii")
+                for line in EXPORTS.read_text().splitlines()
+                if line and not line.startswith("#")
+            )
+            self.outputs[("nm", str(self.app / executable))] += b"".join(
+                symbol + b"\n" for symbol in native_exports
             )
             framework = self.app / "Frameworks/Python.framework"
             framework.mkdir(parents=True)
@@ -171,14 +166,19 @@ class ArtifactCheckerTests(unittest.TestCase):
             shutil.rmtree(fixture.app / "app_packages/ble_reticulum")
             self.assert_rejected(fixture, "shipping", "ble_reticulum")
 
-    def test_shipping_rejects_missing_python_rnode_bridge_symbol_or_payload(self):
-        with tempfile.TemporaryDirectory() as directory:
-            fixture = ArtifactFixture(Path(directory), "shipping")
-            key = ("nm", str(fixture.app / fixture.executable))
-            fixture.outputs[key] = fixture.outputs[key].replace(
-                b"_columba_rnode_write\n", b""
-            )
-            self.assert_rejected(fixture, "shipping", "missing Python RNode C ABI symbol")
+    def test_shipping_rejects_any_missing_python_native_symbol_or_rnode_payload(self):
+        for symbol in (
+            b"_columba_ble_send",
+            b"_columba_rnode_write",
+            b"_columba_stamp_generate",
+        ):
+            with self.subTest(symbol=symbol), tempfile.TemporaryDirectory() as directory:
+                fixture = ArtifactFixture(Path(directory), "shipping")
+                key = ("nm", str(fixture.app / fixture.executable))
+                fixture.outputs[key] = fixture.outputs[key].replace(symbol + b"\n", b"")
+                self.assert_rejected(
+                    fixture, "shipping", "missing embedded-Python C ABI symbol"
+                )
 
         for name in ("IOSRNodeInterface.py", "IOSRNodeDriver.py"):
             with self.subTest(name=name), tempfile.TemporaryDirectory() as directory:
@@ -685,10 +685,16 @@ class WorkflowContractTests(unittest.TestCase):
             workflow,
         )
         self.assertIn(
+            'RELEASE_APP="$PWD/DerivedData-Python/Build/Products/Release-iphonesimulator/ColumbaApp.app"',
+            workflow,
+        )
+        self.assertIn(
             'MODELB_APP="$PWD/DerivedData-ModelB/Build/Products/Debug-iphonesimulator/ColumbaModelBApp.app"',
             workflow,
         )
         self.assertIn('verify-flavor-artifact.py shipping "$SHIPPING_APP"', workflow)
+        self.assertIn('verify-flavor-artifact.py shipping "$RELEASE_APP"', workflow)
+        self.assertIn("DEPLOYMENT_POSTPROCESSING=YES STRIP_INSTALLED_PRODUCT=YES", workflow)
         self.assertIn('modelb "$MODELB_APP" --allow-empty-simulator-entitlements', workflow)
 
     def test_workflow_runs_both_dedicated_test_targets_and_keeps_shipping_coverage(self):
@@ -712,9 +718,10 @@ class WorkflowContractTests(unittest.TestCase):
             'CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=YES DEVELOPMENT_TEAM="" '
             'PROVISIONING_PROFILE_SPECIFIER=""'
         )
-        self.assertEqual(workflow.count(signing), 4)
+        self.assertEqual(workflow.count(signing), 5)
         self.assertIn("test_host_entitlements_contract", workflow)
         self.assertIn("test_ci_artifact_isolation", workflow)
+        self.assertIn("test_ios_ble_bridge_contract", workflow)
         self.assertIn("--allow-empty-simulator-entitlements", workflow)
         self.assertNotIn("CODE_SIGNING_ALLOWED=NO", workflow)
 

--- a/Tests/static/test_ci_artifact_isolation.py
+++ b/Tests/static/test_ci_artifact_isolation.py
@@ -677,7 +677,7 @@ class WorkflowContractTests(unittest.TestCase):
         workflow = WORKFLOW.read_text(encoding="utf-8")
         self.assertNotIn("Columba-Swift", workflow)
         self.assertGreaterEqual(workflow.count("-scheme Columba"), 3)
-        self.assertGreaterEqual(workflow.count("-scheme Columba-ModelB"), 2)
+        self.assertGreaterEqual(workflow.count("-scheme Columba-ModelB"), 1)
         self.assertIn('-derivedDataPath "$PWD/DerivedData-Python"', workflow)
         self.assertIn('-derivedDataPath "$PWD/DerivedData-ModelB"', workflow)
         self.assertIn(
@@ -707,6 +707,28 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertIn("-resultBundlePath ModelBTestResults.xcresult", workflow)
         self.assertIn("rm -rf ModelBTestResults.xcresult", workflow)
 
+    def test_workflow_runs_python_modelb_and_ui_as_independent_lanes(self):
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("\n  python:\n", workflow)
+        self.assertIn("\n  modelb:\n", workflow)
+        self.assertIn("\n  ui:\n", workflow)
+        self.assertNotIn("\n    needs:", workflow)
+
+        modelb = workflow.split("\n  modelb:\n", 1)[1].split("\n  ui:\n", 1)[0]
+        self.assertNotIn("Fetch Python framework + wheels", modelb)
+        self.assertNotIn("support/fetch-python.sh", modelb)
+        self.assertIn("Build and run Model B tests", modelb)
+        self.assertNotIn("Build Model B artifact", modelb)
+
+        python_lane = workflow.split("\n  python:\n", 1)[1].split("\n  modelb:\n", 1)[0]
+        self.assertIn("Build and run shipping tests", python_lane)
+        self.assertNotIn("Build shipping artifact (embedded Python)", python_lane)
+        self.assertIn("Build post-processed Release artifact", python_lane)
+
+        ui = workflow.split("\n  ui:\n", 1)[1]
+        self.assertIn("if: github.event_name == 'pull_request'", ui)
+        self.assertIn("Run screenshot flows", ui)
+
     def test_every_shell_block_is_fail_fast_and_builds_use_adhoc_signing(self):
         lines = WORKFLOW.read_text(encoding="utf-8").splitlines()
         for index, line in enumerate(lines):
@@ -718,7 +740,7 @@ class WorkflowContractTests(unittest.TestCase):
             'CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=YES DEVELOPMENT_TEAM="" '
             'PROVISIONING_PROFILE_SPECIFIER=""'
         )
-        self.assertEqual(workflow.count(signing), 5)
+        self.assertEqual(workflow.count(signing), 4)
         self.assertIn("test_host_entitlements_contract", workflow)
         self.assertIn("test_ci_artifact_isolation", workflow)
         self.assertIn("test_ios_ble_bridge_contract", workflow)

--- a/Tests/static/test_ci_artifact_isolation.py
+++ b/Tests/static/test_ci_artifact_isolation.py
@@ -718,11 +718,19 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertNotIn("Fetch Python framework + wheels", modelb)
         self.assertNotIn("support/fetch-python.sh", modelb)
         self.assertIn("Build and run Model B tests", modelb)
-        self.assertNotIn("Build Model B artifact", modelb)
+        self.assertIn("Build Model B artifact", modelb)
+        self.assertLess(
+            modelb.index("Verify Model B artifact isolation"),
+            modelb.index("Build and run Model B tests"),
+        )
 
         python_lane = workflow.split("\n  python:\n", 1)[1].split("\n  modelb:\n", 1)[0]
         self.assertIn("Build and run shipping tests", python_lane)
-        self.assertNotIn("Build shipping artifact (embedded Python)", python_lane)
+        self.assertIn("Build shipping artifact (embedded Python)", python_lane)
+        self.assertLess(
+            python_lane.index("Verify shipping artifact isolation"),
+            python_lane.index("Build and run shipping tests"),
+        )
         self.assertIn("Build post-processed Release artifact", python_lane)
 
         ui = workflow.split("\n  ui:\n", 1)[1]
@@ -740,7 +748,7 @@ class WorkflowContractTests(unittest.TestCase):
             'CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=YES DEVELOPMENT_TEAM="" '
             'PROVISIONING_PROFILE_SPECIFIER=""'
         )
-        self.assertEqual(workflow.count(signing), 4)
+        self.assertEqual(workflow.count(signing), 6)
         self.assertIn("test_host_entitlements_contract", workflow)
         self.assertIn("test_ci_artifact_isolation", workflow)
         self.assertIn("test_ios_ble_bridge_contract", workflow)

--- a/Tests/static/test_ios_ble_bridge_contract.py
+++ b/Tests/static/test_ios_ble_bridge_contract.py
@@ -17,6 +17,7 @@ INTERFACE = ROOT / "app/ble/IOSBLEInterface.py"
 FETCH_WHEELS = ROOT / "support/fetch-wheels.sh"
 PROJECT = ROOT / "Columba.xcodeproj/project.pbxproj"
 EXPORTS = ROOT / "Sources/ColumbaApp/Resources/ColumbaApp.exports"
+RECONCILER = ROOT / "support/isolate-modelb-targets.rb"
 
 
 class IOSBLEBridgeContracts(unittest.TestCase):
@@ -252,6 +253,26 @@ class IOSBLEBridgeContracts(unittest.TestCase):
             if line and not line.startswith("#")
         }
         self.assertEqual(declared, exported)
+
+    def test_reconciler_keeps_native_exports_shipping_only(self) -> None:
+        source = RECONCILER.read_text()
+        self.assertIn(
+            "PYTHON_NATIVE_EXPORTS_FILE = "
+            "'Sources/ColumbaApp/Resources/ColumbaApp.exports'",
+            source,
+        )
+        self.assertIn(
+            "PYTHON_NATIVE_BUILD_SETTINGS.each { |setting| "
+            "configuration.build_settings.delete(setting) }",
+            source,
+        )
+        self.assertIn(
+            "configuration.build_settings['EXPORTED_SYMBOLS_FILE'] = "
+            "PYTHON_NATIVE_EXPORTS_FILE",
+            source,
+        )
+        self.assertIn("if configuration.name == 'Release'", source)
+        self.assertIn("configuration.build_settings['STRIP_STYLE'] = 'non-global'", source)
 
     def test_central_payload_capacity_refreshes_after_handshake(self) -> None:
         source = BRIDGE.read_text()

--- a/Tests/static/test_ios_ble_bridge_contract.py
+++ b/Tests/static/test_ios_ble_bridge_contract.py
@@ -2,6 +2,7 @@
 """Contracts for shipping iOS↔Android BLEInterface lifecycle and framing."""
 
 from pathlib import Path
+import re
 import unittest
 
 
@@ -15,6 +16,7 @@ DRIVER = ROOT / "app/ble/IOSBLEDriver.py"
 INTERFACE = ROOT / "app/ble/IOSBLEInterface.py"
 FETCH_WHEELS = ROOT / "support/fetch-wheels.sh"
 PROJECT = ROOT / "Columba.xcodeproj/project.pbxproj"
+EXPORTS = ROOT / "Sources/ColumbaApp/Resources/ColumbaApp.exports"
 
 
 class IOSBLEBridgeContracts(unittest.TestCase):
@@ -226,6 +228,30 @@ class IOSBLEBridgeContracts(unittest.TestCase):
         shipping_debug = project.split("TDBG /* Debug */ = {", 1)[1]
         shipping_debug = shipping_debug.split("name = Debug;", 1)[0]
         self.assertIn("ENABLE_DEBUG_DYLIB = NO;", shipping_debug)
+
+    def test_archive_exports_every_python_native_binding(self) -> None:
+        project = PROJECT.read_text()
+        shipping_debug = project.split("TDBG /* Debug */ = {", 1)[1]
+        shipping_debug = shipping_debug.split("name = Debug;", 1)[0]
+        shipping_release = project.split("TREL /* Release */ = {", 1)[1]
+        shipping_release = shipping_release.split("name = Release;", 1)[0]
+        setting = (
+            "EXPORTED_SYMBOLS_FILE = "
+            "Sources/ColumbaApp/Resources/ColumbaApp.exports;"
+        )
+        self.assertIn(setting, shipping_debug)
+        self.assertIn(setting, shipping_release)
+        self.assertIn("STRIP_STYLE = non-global;", shipping_release)
+
+        declared = set()
+        for source in (ROOT / "Sources").rglob("*.swift"):
+            declared.update(re.findall(r'@_cdecl\("([^\"]+)"\)', source.read_text()))
+        exported = {
+            line.removeprefix("_")
+            for line in EXPORTS.read_text().splitlines()
+            if line and not line.startswith("#")
+        }
+        self.assertEqual(declared, exported)
 
     def test_central_payload_capacity_refreshes_after_handshake(self) -> None:
         source = BRIDGE.read_text()

--- a/Tests/static/test_ios_ble_bridge_contract.py
+++ b/Tests/static/test_ios_ble_bridge_contract.py
@@ -240,7 +240,7 @@ class IOSBLEBridgeContracts(unittest.TestCase):
             "EXPORTED_SYMBOLS_FILE = "
             "Sources/ColumbaApp/Resources/ColumbaApp.exports;"
         )
-        self.assertIn(setting, shipping_debug)
+        self.assertNotIn(setting, shipping_debug)
         self.assertIn(setting, shipping_release)
         self.assertIn("STRIP_STYLE = non-global;", shipping_release)
 

--- a/Tests/static/test_modelb_target_isolation.rb
+++ b/Tests/static/test_modelb_target_isolation.rb
@@ -72,6 +72,7 @@ PYTHON_ONLY_SOURCE_PATHS = %w[
 PYTHON_FRAMEWORK_PATH = 'Frameworks/Python.xcframework'
 PYTHON_RESOURCE_PATH = 'app'
 PYTHON_BRIDGING_HEADER = 'Sources/PythonBridge/ColumbaPython-Bridging-Header.h'
+PYTHON_NATIVE_EXPORTS_FILE = 'Sources/ColumbaApp/Resources/ColumbaApp.exports'
 PYTHON_EMBED_PHASE_NAME = 'Embed Frameworks'
 PYTHON_SHELL_PHASE_NAME = 'Install Python stdlib & process dylibs'
 PYTHON_INSTALL_SCRIPT = <<~'SH'.freeze
@@ -441,9 +442,18 @@ class ModelBTargetIsolationTests < Minitest::Test
     @shipping.build_configurations.each do |configuration|
       assert_equal PYTHON_BRIDGING_HEADER,
                    configuration.build_settings['SWIFT_OBJC_BRIDGING_HEADER']
+      assert_equal PYTHON_NATIVE_EXPORTS_FILE,
+                   configuration.build_settings['EXPORTED_SYMBOLS_FILE']
+      if configuration.name == 'Release'
+        assert_equal 'non-global', configuration.build_settings['STRIP_STYLE']
+      else
+        refute configuration.build_settings.key?('STRIP_STYLE')
+      end
     end
     @model_b.build_configurations.each do |configuration|
       refute configuration.build_settings.key?('SWIFT_OBJC_BRIDGING_HEADER')
+      refute configuration.build_settings.key?('EXPORTED_SYMBOLS_FILE')
+      refute configuration.build_settings.key?('STRIP_STYLE')
     end
 
     shipping_products = @shipping.package_product_dependencies.map(&:product_name)
@@ -751,6 +761,46 @@ class ModelBTargetIsolationTests < Minitest::Test
       assert phase_owners.values.all?(&:one?), 'repair retained a multi-owner build phase'
       assert all_build_files.all? { |build_file| build_file_owners[build_file.uuid].one? },
              'repair retained an orphan or multi-owner PBXBuildFile'
+      assert_second_run_byte_idempotent(temporary_project)
+    end
+  end
+
+  def test_reconciler_scopes_python_native_archive_settings_to_shipping
+    Dir.mktmpdir('columba-python-native-settings') do |directory|
+      temporary_project = File.join(directory, 'Columba.xcodeproj')
+      FileUtils.cp_r(PROJECT_PATH, temporary_project)
+      fixture = Xcodeproj::Project.open(temporary_project)
+      shipping = fixture.targets.find { |target| target.name == 'ColumbaApp' }
+      model_b = fixture.targets.find { |target| target.name == 'ColumbaModelBApp' }
+
+      shipping.build_configurations.each do |configuration|
+        configuration.build_settings.delete('EXPORTED_SYMBOLS_FILE')
+        configuration.build_settings['STRIP_STYLE'] = 'all'
+      end
+      model_b.build_configurations.each do |configuration|
+        configuration.build_settings['EXPORTED_SYMBOLS_FILE'] = 'Stale/Exports.list'
+        configuration.build_settings['STRIP_STYLE'] = 'non-global'
+      end
+      fixture.save
+
+      run_reconciler(temporary_project, 'python-native-settings')
+      reconciled = Xcodeproj::Project.open(temporary_project)
+      reconciled_shipping = reconciled.targets.find { |target| target.name == 'ColumbaApp' }
+      reconciled_model_b = reconciled.targets.find { |target| target.name == 'ColumbaModelBApp' }
+
+      reconciled_shipping.build_configurations.each do |configuration|
+        assert_equal PYTHON_NATIVE_EXPORTS_FILE,
+                     configuration.build_settings['EXPORTED_SYMBOLS_FILE']
+        if configuration.name == 'Release'
+          assert_equal 'non-global', configuration.build_settings['STRIP_STYLE']
+        else
+          refute configuration.build_settings.key?('STRIP_STYLE')
+        end
+      end
+      reconciled_model_b.build_configurations.each do |configuration|
+        refute configuration.build_settings.key?('EXPORTED_SYMBOLS_FILE')
+        refute configuration.build_settings.key?('STRIP_STYLE')
+      end
       assert_second_run_byte_idempotent(temporary_project)
     end
   end

--- a/Tests/static/test_modelb_target_isolation.rb
+++ b/Tests/static/test_modelb_target_isolation.rb
@@ -442,11 +442,12 @@ class ModelBTargetIsolationTests < Minitest::Test
     @shipping.build_configurations.each do |configuration|
       assert_equal PYTHON_BRIDGING_HEADER,
                    configuration.build_settings['SWIFT_OBJC_BRIDGING_HEADER']
-      assert_equal PYTHON_NATIVE_EXPORTS_FILE,
-                   configuration.build_settings['EXPORTED_SYMBOLS_FILE']
       if configuration.name == 'Release'
+        assert_equal PYTHON_NATIVE_EXPORTS_FILE,
+                     configuration.build_settings['EXPORTED_SYMBOLS_FILE']
         assert_equal 'non-global', configuration.build_settings['STRIP_STYLE']
       else
+        refute configuration.build_settings.key?('EXPORTED_SYMBOLS_FILE')
         refute configuration.build_settings.key?('STRIP_STYLE')
       end
     end
@@ -789,11 +790,12 @@ class ModelBTargetIsolationTests < Minitest::Test
       reconciled_model_b = reconciled.targets.find { |target| target.name == 'ColumbaModelBApp' }
 
       reconciled_shipping.build_configurations.each do |configuration|
-        assert_equal PYTHON_NATIVE_EXPORTS_FILE,
-                     configuration.build_settings['EXPORTED_SYMBOLS_FILE']
         if configuration.name == 'Release'
+          assert_equal PYTHON_NATIVE_EXPORTS_FILE,
+                       configuration.build_settings['EXPORTED_SYMBOLS_FILE']
           assert_equal 'non-global', configuration.build_settings['STRIP_STYLE']
         else
+          refute configuration.build_settings.key?('EXPORTED_SYMBOLS_FILE')
           refute configuration.build_settings.key?('STRIP_STYLE')
         end
       end

--- a/Tests/static/test_ui_screenshotter_readiness.py
+++ b/Tests/static/test_ui_screenshotter_readiness.py
@@ -51,6 +51,20 @@ class UIScreenshotterReadinessContractTests(unittest.TestCase):
                 source = (ROOT / relative_path).read_text()
                 self.assertIn(f'.accessibilityIdentifier("{identifier}")', source)
 
+    def test_flows_use_stable_tab_identifiers_instead_of_visible_text(self):
+        tabs = {
+            "contacts-list.yml": "tab_contacts",
+            "settings.yml": "tab_settings",
+            "map.yml": "tab_map",
+        }
+        main_tabs = (ROOT / "Sources/ColumbaApp/Views/MainTabView.swift").read_text()
+        for filename, identifier in tabs.items():
+            with self.subTest(flow=filename):
+                flow = (ROOT / "flows" / filename).read_text()
+                self.assertIn(f'id: "{identifier}"', flow)
+                self.assertNotIn("optional: true", flow)
+                self.assertIn(f'.accessibilityIdentifier("{identifier}")', main_tabs)
+
     def test_pull_request_ci_installs_runs_and_uploads_screenshotter_output(self):
         workflow = (ROOT / ".github/workflows/tests.yml").read_text()
         self.assertIn("Tests.static.test_ui_screenshotter_readiness", workflow)

--- a/Tests/static/test_ui_screenshotter_readiness.py
+++ b/Tests/static/test_ui_screenshotter_readiness.py
@@ -53,15 +53,15 @@ class UIScreenshotterReadinessContractTests(unittest.TestCase):
 
     def test_flows_use_stable_tab_identifiers_instead_of_visible_text(self):
         tabs = {
-            "contacts-list.yml": "tab_contacts",
-            "settings.yml": "tab_settings",
-            "map.yml": "tab_map",
+            "contacts-list.yml": ("tab_contacts", "person.2.fill"),
+            "settings.yml": ("tab_settings", "gearshape.fill"),
+            "map.yml": ("tab_map", "map.fill"),
         }
         main_tabs = (ROOT / "Sources/ColumbaApp/Views/MainTabView.swift").read_text()
-        for filename, identifier in tabs.items():
+        for filename, (identifier, native_fallback) in tabs.items():
             with self.subTest(flow=filename):
                 flow = (ROOT / "flows" / filename).read_text()
-                self.assertIn(f'id: "{identifier}"', flow)
+                self.assertIn(f'id: "{identifier}|{native_fallback}"', flow)
                 self.assertNotIn("optional: true", flow)
                 self.assertIn(f'.accessibilityIdentifier("{identifier}")', main_tabs)
 

--- a/flows/chats-list.yml
+++ b/flows/chats-list.yml
@@ -15,10 +15,7 @@ tags:
     visible:
       id: "screen_chats"
     timeout: 30000
-# Default tab is Chats — no tap needed if onboarding lands there.
-- tapOn:
-    text: "Chats"
-    optional: true
+# Default tab is Chats, so no navigation tap is required.
 - assertVisible:
     id: "screen_chats"
 - takeScreenshot: "chats-list"

--- a/flows/contacts-list.yml
+++ b/flows/contacts-list.yml
@@ -20,8 +20,7 @@ tags:
       id: "screen_chats"
     timeout: 30000
 - tapOn:
-    text: "Contacts"
-    optional: true
+    id: "tab_contacts"
 - extendedWaitUntil:
     visible:
       id: "screen_contacts"

--- a/flows/contacts-list.yml
+++ b/flows/contacts-list.yml
@@ -20,7 +20,7 @@ tags:
       id: "screen_chats"
     timeout: 30000
 - tapOn:
-    id: "tab_contacts"
+    id: "tab_contacts|person.2.fill"
 - extendedWaitUntil:
     visible:
       id: "screen_contacts"

--- a/flows/map.yml
+++ b/flows/map.yml
@@ -17,7 +17,7 @@ tags:
       id: "screen_chats"
     timeout: 30000
 - tapOn:
-    id: "tab_map"
+    id: "tab_map|map.fill"
 # Wait on MapLibre's native idle signal: no camera transition, all requested
 # tiles loaded, and all fade/transition animations complete.
 - extendedWaitUntil:

--- a/flows/map.yml
+++ b/flows/map.yml
@@ -17,8 +17,7 @@ tags:
       id: "screen_chats"
     timeout: 30000
 - tapOn:
-    text: "Map"
-    optional: true
+    id: "tab_map"
 # Wait on MapLibre's native idle signal: no camera transition, all requested
 # tiles loaded, and all fade/transition animations complete.
 - extendedWaitUntil:

--- a/flows/settings.yml
+++ b/flows/settings.yml
@@ -16,7 +16,7 @@ tags:
       id: "screen_chats"
     timeout: 30000
 - tapOn:
-    id: "tab_settings"
+    id: "tab_settings|gearshape.fill"
 - extendedWaitUntil:
     visible:
       id: "screen_settings"

--- a/flows/settings.yml
+++ b/flows/settings.yml
@@ -16,8 +16,7 @@ tags:
       id: "screen_chats"
     timeout: 30000
 - tapOn:
-    text: "Settings"
-    optional: true
+    id: "tab_settings"
 - extendedWaitUntil:
     visible:
       id: "screen_settings"

--- a/support/isolate-modelb-targets.rb
+++ b/support/isolate-modelb-targets.rb
@@ -41,6 +41,8 @@ EXTENSION_TARGET_NAME = 'ColumbaNetworkExtension'
 LEGACY_SWIFT_CONFIGURATION_NAMES = %w[Debug-Swift Release-Swift].freeze
 SHIPPING_ENTITLEMENTS = 'Sources/ColumbaApp/Resources/ColumbaApp.entitlements'
 MODEL_B_ENTITLEMENTS = 'Sources/ColumbaApp/Resources/ColumbaModelBApp.entitlements'
+PYTHON_NATIVE_EXPORTS_FILE = 'Sources/ColumbaApp/Resources/ColumbaApp.exports'
+PYTHON_NATIVE_BUILD_SETTINGS = %w[EXPORTED_SYMBOLS_FILE STRIP_STYLE].freeze
 CANONICAL_FLAGS = %w[
   COLUMBA_RUNTIME_PYTHON
   COLUMBA_RUNTIME_MODEL_B
@@ -1133,6 +1135,7 @@ module ModelBTargetIsolation
       configuration.build_settings = duplicate_value(source.build_settings)
       configuration.build_settings['CODE_SIGN_ENTITLEMENTS'] = MODEL_B_ENTITLEMENTS
       configuration.build_settings.delete('SWIFT_OBJC_BRIDGING_HEADER')
+      PYTHON_NATIVE_BUILD_SETTINGS.each { |setting| configuration.build_settings.delete(setting) }
       required = destination_tokens
       required.concat(SHARED_APP_FLAGS)
       required.concat(MODEL_B_FLAGS)
@@ -1155,6 +1158,12 @@ module ModelBTargetIsolation
     shipping.build_configurations.each do |configuration|
       configuration.build_settings['CODE_SIGN_ENTITLEMENTS'] = SHIPPING_ENTITLEMENTS
       configuration.build_settings['SWIFT_OBJC_BRIDGING_HEADER'] = PYTHON_BRIDGING_HEADER
+      configuration.build_settings['EXPORTED_SYMBOLS_FILE'] = PYTHON_NATIVE_EXPORTS_FILE
+      if configuration.name == 'Release'
+        configuration.build_settings['STRIP_STYLE'] = 'non-global'
+      else
+        configuration.build_settings.delete('STRIP_STYLE')
+      end
       set_compilation_tokens(
         configuration,
         ['COLUMBA_RUNTIME_PYTHON'] + SHARED_APP_FLAGS + SHIPPING_APP_FLAGS,

--- a/support/isolate-modelb-targets.rb
+++ b/support/isolate-modelb-targets.rb
@@ -1158,10 +1158,11 @@ module ModelBTargetIsolation
     shipping.build_configurations.each do |configuration|
       configuration.build_settings['CODE_SIGN_ENTITLEMENTS'] = SHIPPING_ENTITLEMENTS
       configuration.build_settings['SWIFT_OBJC_BRIDGING_HEADER'] = PYTHON_BRIDGING_HEADER
-      configuration.build_settings['EXPORTED_SYMBOLS_FILE'] = PYTHON_NATIVE_EXPORTS_FILE
       if configuration.name == 'Release'
+        configuration.build_settings['EXPORTED_SYMBOLS_FILE'] = PYTHON_NATIVE_EXPORTS_FILE
         configuration.build_settings['STRIP_STYLE'] = 'non-global'
       else
+        configuration.build_settings.delete('EXPORTED_SYMBOLS_FILE')
         configuration.build_settings.delete('STRIP_STYLE')
       end
       set_compilation_tokens(

--- a/support/verify-flavor-artifact.py
+++ b/support/verify-flavor-artifact.py
@@ -31,20 +31,28 @@ MODEL_B_SYMBOLS = (
     b"NEReticulumNode",
     b"TunnelManager",
 )
-SHIPPING_RNODE_C_ABI_SYMBOLS = (
-    b"_columba_rnode_session_open",
-    b"_columba_rnode_session_close",
-    b"_columba_rnode_session_state",
-    b"_columba_rnode_session_read",
-    b"_columba_rnode_session_write",
-    b"_columba_rnode_session_set_online",
-    b"_columba_rnode_connect",
-    b"_columba_rnode_disconnect",
-    b"_columba_rnode_state",
-    b"_columba_rnode_read",
-    b"_columba_rnode_write",
-    b"_columba_rnode_set_online",
+NATIVE_EXPORTS_FILE = (
+    Path(__file__).resolve().parents[1]
+    / "Sources/ColumbaApp/Resources/ColumbaApp.exports"
 )
+
+
+def _load_native_exports() -> Tuple[bytes, ...]:
+    try:
+        lines = NATIVE_EXPORTS_FILE.read_text(encoding="utf-8").splitlines()
+    except OSError as error:
+        raise RuntimeError("cannot read native ABI export manifest: {}".format(error))
+    exports = tuple(
+        line.strip().encode("ascii")
+        for line in lines
+        if line.strip() and not line.lstrip().startswith("#")
+    )
+    if not exports or len(exports) != len(set(exports)):
+        raise RuntimeError("native ABI export manifest is empty or contains duplicates")
+    return exports
+
+
+SHIPPING_NATIVE_C_ABI_SYMBOLS = _load_native_exports()
 SHIPPING_RNODE_PYTHON_PAYLOADS = (
     "app/rnode/IOSRNodeInterface.py",
     "app/rnode/IOSRNodeDriver.py",
@@ -382,14 +390,15 @@ def _verify_shipping(
                 marker.decode("ascii")
             )
         )
-    missing_rnode_symbol = next(
-        (name for name in SHIPPING_RNODE_C_ABI_SYMBOLS if name not in symbols),
+    defined_symbols = set(symbols.splitlines())
+    missing_native_symbol = next(
+        (name for name in SHIPPING_NATIVE_C_ABI_SYMBOLS if name not in defined_symbols),
         None,
     )
-    if missing_rnode_symbol is not None:
+    if missing_native_symbol is not None:
         raise VerificationError(
-            "shipping executable is missing Python RNode C ABI symbol {}".format(
-                missing_rnode_symbol.decode("ascii")
+            "shipping executable is missing embedded-Python C ABI symbol {}".format(
+                missing_native_symbol.decode("ascii")
             )
         )
     if PYTHON_LOAD not in libraries:


### PR DESCRIPTION
## Summary

- preserve every embedded-Python `@_cdecl` entry point in archived Release executables
- make the export manifest cover BLE, RNode, and stamp-generation bridges rather than one subsystem
- build a post-processed Release artifact in CI and verify the final Mach-O contains every declared export
- add source/configuration contracts and mutation coverage so future bridge additions or stripping regressions fail closed

## Root cause

A normal Release build retained the native C ABI, but Xcode's Archive post-processing stripped it. Native CoreBluetooth therefore continued to populate the BLE UI while embedded Python could not resolve `columba_ble_start`, `columba_ble_connect`, or `columba_ble_send` through `ctypes.CDLL(None)`. The Reticulum interface stayed offline and could not exchange announces.

## Verification

- reproduced the archived baseline with `0/14` BLE ABI symbols
- corrected signed Release archive contains `29/29` Python-facing native ABI symbols
- codesign verification passed
- CI-equivalent post-processed Release simulator artifact passed the shipping artifact checker with `29/29` exports
- focused CI and bridge contracts: `54/54`
- complete static suite: `201/201`
- physical Release install preserved app data
- Android received 20 complete packets with zero observed send failures
- physical BLE/announce behavior confirmed restored

## Risk and rollback

The Release executable keeps only the explicitly listed global entry points through archive stripping. The static contract requires the export manifest to exactly match every Swift `@_cdecl`, and the artifact checker validates exact defined symbols after post-processing. Rollback is the two commits in this PR, but that would restore the TestFlight failure.
