### PR TITLE
Fix iOS QR contact send path resolution

### DIFF
--- a/Columba.xcodeproj/project.pbxproj
+++ b/Columba.xcodeproj/project.pbxproj
@@ -142,6 +142,7 @@
 		2F8EC8232FC732AF00235991 /* LXMFSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 2F8EC8222FC732AF00235991 /* LXMFSwift */; };
 		D4E5F60718293A4B5C6D7E8B /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = D4E5F60718293A4B5C6D7E8A /* GRDB */; };
 		D4E5F60718293A4B5C6D7E8D /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = D4E5F60718293A4B5C6D7E8C /* GRDB */; };
+		E5F60718293A4B5C6D7E8F91 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = E5F60718293A4B5C6D7E8F90 /* GRDB */; };
 		31F207DBD45E2CA682A3F830 /* MyIdentityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F017 /* MyIdentityView.swift */; };
 		33CCBDB91636352EFC4A7790 /* BLEConnectionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F071 /* BLEConnectionsView.swift */; };
 		33E0E91CAEFB07F13C04637D /* SwiftRNSBackend.swift in Sources */ = {isa = PBXBuildFile; fileRef = SRB002 /* SwiftRNSBackend.swift */; };
@@ -632,6 +633,7 @@
 				9D9069A3F6302111A4727454 /* SwiftBLEBridge in Frameworks */,
 				35DF1F7406C71743BBE8C39B /* ReticulumSwift in Frameworks */,
 				98547ADE9B17DD692240E7F7 /* LXMFSwift in Frameworks */,
+				E5F60718293A4B5C6D7E8F91 /* GRDB in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1213,6 +1215,7 @@
 				E049A7D4D6D58690C0B674CE /* RNSAPI */,
 				DD88CFE74E7E22427BC4D163 /* SwiftBLEBridge */,
 				DA31FE974552414C399D4949 /* ReticulumSwift */,
+				E5F60718293A4B5C6D7E8F90 /* GRDB */,
 				85B9530D8CAE0E16D5371319 /* LXMFSwift */,
 			);
 			productName = ColumbaAppTests;
@@ -2332,6 +2335,10 @@
 		F196C8A0BA9EBC9F7F2FCF9F /* RNSAPI */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = RNSAPI;
+		};
+		E5F60718293A4B5C6D7E8F90 /* GRDB */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = GRDB;
 		};
 		FE4D25F362FFD8A793C143FC /* LXSTSwift */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Columba.xcodeproj/project.pbxproj
+++ b/Columba.xcodeproj/project.pbxproj
@@ -140,6 +140,8 @@
 		2DAA350A34E3332DEC1545B0 /* PeerChildInterfaceRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8A2F8952F6F036C94824552 /* PeerChildInterfaceRegistry.swift */; };
 		2DEF38CCE53F632284B5A50D /* MonospaceLineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F084 /* MonospaceLineView.swift */; };
 		2F8EC8232FC732AF00235991 /* LXMFSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 2F8EC8222FC732AF00235991 /* LXMFSwift */; };
+		D4E5F60718293A4B5C6D7E8B /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = D4E5F60718293A4B5C6D7E8A /* GRDB */; };
+		D4E5F60718293A4B5C6D7E8D /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = D4E5F60718293A4B5C6D7E8C /* GRDB */; };
 		31F207DBD45E2CA682A3F830 /* MyIdentityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F017 /* MyIdentityView.swift */; };
 		33CCBDB91636352EFC4A7790 /* BLEConnectionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F071 /* BLEConnectionsView.swift */; };
 		33E0E91CAEFB07F13C04637D /* SwiftRNSBackend.swift in Sources */ = {isa = PBXBuildFile; fileRef = SRB002 /* SwiftRNSBackend.swift */; };
@@ -582,6 +584,7 @@
 				11D0621686D1D65C9602C911 /* RNSAPI in Frameworks */,
 				876F4CCF3FA441B67D08BBEC /* SwiftBLEBridge in Frameworks */,
 				E34B504A6DCC8F5E7F44E491 /* LXMFSwift in Frameworks */,
+				D4E5F60718293A4B5C6D7E8D /* GRDB in Frameworks */,
 				73B2FC9ECC25BA7B4AFF3D96 /* ReticulumSwift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -614,6 +617,7 @@
 				F4CA7E2F745F05E21D45E11A /* RNSAPI in Frameworks */,
 				13F299C3C99F5D86B797FA11 /* SwiftBLEBridge in Frameworks */,
 				2F8EC8232FC732AF00235991 /* LXMFSwift in Frameworks */,
+				D4E5F60718293A4B5C6D7E8B /* GRDB in Frameworks */,
 				83F513B2A83B444F977E44D9 /* ReticulumSwift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1114,6 +1118,7 @@
 				F196C8A0BA9EBC9F7F2FCF9F /* RNSAPI */,
 				5D099DB326374C07812E3FBD /* SwiftBLEBridge */,
 				E0DE32143A4DF2A0284C1911 /* LXMFSwift */,
+				D4E5F60718293A4B5C6D7E8C /* GRDB */,
 				030380C51B178354F4D4E88F /* ReticulumSwift */,
 			);
 			productName = ColumbaModelBApp;
@@ -1182,6 +1187,7 @@
 				0FD6A68A52A54D21FDB70324 /* RNSAPI */,
 				5BE4B79EB452909EE61ACE6C /* SwiftBLEBridge */,
 				2F8EC8222FC732AF00235991 /* LXMFSwift */,
+				D4E5F60718293A4B5C6D7E8A /* GRDB */,
 				A1380C075A9F67E1B173EA94 /* ReticulumSwift */,
 			);
 			productName = ColumbaApp;
@@ -2286,6 +2292,14 @@
 			isa = XCSwiftPackageProductDependency;
 			package = PKGREF3 /* XCRemoteSwiftPackageReference "LXST-swift" */;
 			productName = LXSTSwift;
+		};
+		D4E5F60718293A4B5C6D7E8A /* GRDB */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = GRDB;
+		};
+		D4E5F60718293A4B5C6D7E8C /* GRDB */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = GRDB;
 		};
 		B528C71CCBFAB3CB30E0BFB2 /* LXMFSwift */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -1188,7 +1188,12 @@ public final class AppServices {
         Self.migrateLXMFDatabaseToAppGroupIfNeeded(identityHashHex: newIdentity.hexHash)
         let grdbPath = Self.grdbDatabaseFilePath(for: newIdentity.hexHash)
         self.grdbDatabasePath = grdbPath
-        self.messageRepository = try MessageRepository(grdbPath: grdbPath)
+        let messageRepository = try MessageRepository(grdbPath: grdbPath)
+        self.messageRepository = messageRepository
+        let recoveredRetryCount = try await messageRepository.recoverInterruptedRetries()
+        if recoveredRetryCount > 0 {
+            logger.warning("Recovered \(recoveredRetryCount, privacy: .public) interrupted message retries")
+        }
 
         // 5. Create LXMRouter with identity and database path
         let newRouter = try await LXMRouter(identity: newIdentity, databasePath: dbPath)
@@ -3020,7 +3025,12 @@ public final class AppServices {
         Self.migrateLXMFDatabaseToAppGroupIfNeeded(identityHashHex: identityHash)
         let grdbPath = Self.grdbDatabaseFilePath(for: identityHash)
         self.grdbDatabasePath = grdbPath
-        self.messageRepository = try MessageRepository(grdbPath: grdbPath)
+        let messageRepository = try MessageRepository(grdbPath: grdbPath)
+        self.messageRepository = messageRepository
+        let recoveredRetryCount = try await messageRepository.recoverInterruptedRetries()
+        if recoveredRetryCount > 0 {
+            logger.warning("Recovered \(recoveredRetryCount, privacy: .public) interrupted message retries")
+        }
 
         // 5. Create LXMRouter with identity and database path
         let newRouter = try await LXMRouter(identity: identity, databasePath: dbPath)

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -3905,7 +3905,12 @@ public final class AppServices {
             Self.migrateLXMFDatabaseToAppGroupIfNeeded(identityHashHex: existingIdentity.hexHash)
             let grdbPath = Self.grdbDatabaseFilePath(for: existingIdentity.hexHash)
             self.grdbDatabasePath = grdbPath
-            self.messageRepository = try MessageRepository(grdbPath: grdbPath)
+            let messageRepository = try MessageRepository(grdbPath: grdbPath)
+            self.messageRepository = messageRepository
+            let recoveredRetryCount = try await messageRepository.recoverInterruptedRetries()
+            if recoveredRetryCount > 0 {
+                logger.warning("Recovered \(recoveredRetryCount, privacy: .public) interrupted message retries")
+            }
         }
 
         // 5. Router

--- a/Sources/ColumbaApp/Services/MessageRepository.swift
+++ b/Sources/ColumbaApp/Services/MessageRepository.swift
@@ -233,12 +233,50 @@ public actor MessageRepository {
     }
 
     /// Stage one failed retry as app-owned `.sending` before network submission.
-    /// The durable marker lets startup recovery distinguish it from NE work.
+    /// The compare-and-set prevents concurrent taps from owning the same row.
     public func stageRetry(_ message: RNSAPI.LXMessage, replacing oldId: Data) async throws {
-        try await replaceMessageRecord(
-            message,
-            replacing: oldId,
-            retryMarker: Self.stagedRetryMarker
+        try await replacementPool.write { db in
+            try db.execute(
+                sql: """
+                    UPDATE messages
+                    SET message_id = ?, state = ?, method = ?, timestamp = ?,
+                        receiving_interface = ?, updated_at = ?
+                    WHERE message_id = ? AND incoming = 0 AND state = ?
+                      AND (receiving_interface IS NULL OR receiving_interface = ?)
+                    """,
+                arguments: [
+                    message.hash,
+                    Self.mapStateToGRDB(message.state).rawValue,
+                    Self.mapMethodToGRDB(message.method).rawValue,
+                    message.timestamp,
+                    Self.stagedRetryMarker,
+                    Date().timeIntervalSince1970,
+                    oldId,
+                    LXMFSwift.LXMessageState.failed.rawValue,
+                    Self.uncertainRetryMarker,
+                ]
+            )
+            guard db.changesCount == 1 else {
+                throw MessageRepositoryError.replacementSourceMissing
+            }
+            try db.execute(
+                sql: """
+                    UPDATE conversations
+                    SET last_message_timestamp = ?, updated_at = ?
+                    WHERE destination_hash = ? AND last_message_timestamp <= ?
+                    """,
+                arguments: [
+                    message.timestamp,
+                    Date().timeIntervalSince1970,
+                    message.destinationHash,
+                    message.timestamp,
+                ]
+            )
+        }
+        NotificationCenter.default.post(
+            name: Self.conversationActivityNotification,
+            object: nil,
+            userInfo: [Self.conversationHashUserInfoKey: message.destinationHash]
         )
     }
 
@@ -310,6 +348,27 @@ public actor MessageRepository {
                 ]
             )
             return db.changesCount
+        }
+    }
+
+    /// Check the entire conversation, independently of message pagination, for
+    /// a recovered retry whose delivery outcome remains unknown.
+    public func hasUncertainRetry(for destinationHash: Data) async throws -> Bool {
+        try await replacementPool.read { db in
+            let count = try Int.fetchOne(
+                db,
+                sql: """
+                    SELECT COUNT(*) FROM messages
+                    WHERE destination_hash = ? AND incoming = 0 AND state = ?
+                      AND receiving_interface = ?
+                    """,
+                arguments: [
+                    destinationHash,
+                    LXMFSwift.LXMessageState.failed.rawValue,
+                    Self.uncertainRetryMarker,
+                ]
+            ) ?? 0
+            return count > 0
         }
     }
 

--- a/Sources/ColumbaApp/Services/MessageRepository.swift
+++ b/Sources/ColumbaApp/Services/MessageRepository.swift
@@ -51,6 +51,8 @@ public actor MessageRepository {
         Notification.Name("network.columba.conversationActivity")
 
     public static let conversationHashUserInfoKey = "conversationHash"
+    public static let stagedRetryMarker = "columba-app-retry-staged-v1"
+    public static let uncertainRetryMarker = "columba-app-retry-uncertain-v1"
 
     // MARK: - Properties
 
@@ -58,9 +60,7 @@ public actor MessageRepository {
     private let database: LXMFSwift.LXMFDatabase
     /// Suspension-aware pool used only for atomic app-owned retry replacement.
     private let replacementPool: DatabasePool
-    /// Retry hashes actively owned by this process. Recovery ignores these so
-    /// reopening a conversation cannot race a send still awaiting its outcome.
-    private var activeRetryHashes: Set<Data> = []
+
 
     // MARK: - Initialization
 
@@ -229,21 +229,41 @@ public actor MessageRepository {
     /// hash accepted by the network backend. Payload columns stay on the same
     /// row, so a crash cannot expose both a stale retry and a sent duplicate.
     public func replaceMessage(_ message: RNSAPI.LXMessage, replacing oldId: Data) async throws {
+        try await replaceMessageRecord(message, replacing: oldId, retryMarker: nil)
+    }
+
+    /// Stage one failed retry as app-owned `.sending` before network submission.
+    /// The durable marker lets startup recovery distinguish it from NE work.
+    public func stageRetry(_ message: RNSAPI.LXMessage, replacing oldId: Data) async throws {
+        try await replaceMessageRecord(
+            message,
+            replacing: oldId,
+            retryMarker: Self.stagedRetryMarker
+        )
+    }
+
+    private func replaceMessageRecord(
+        _ message: RNSAPI.LXMessage,
+        replacing oldId: Data,
+        retryMarker: String?
+    ) async throws {
         try await replacementPool.write { db in
             try db.execute(
                 sql: """
                     UPDATE messages
-                    SET message_id = ?, state = ?, method = ?, timestamp = ?, updated_at = ?
+                    SET message_id = ?, state = ?, method = ?, timestamp = ?,
+                        receiving_interface = ?, updated_at = ?
                     WHERE message_id = ?
                     """,
-                arguments: [
+                arguments: StatementArguments([
                     message.hash,
                     Self.mapStateToGRDB(message.state).rawValue,
                     Self.mapMethodToGRDB(message.method).rawValue,
                     message.timestamp,
+                    retryMarker,
                     Date().timeIntervalSince1970,
                     oldId,
-                ]
+                ] as [DatabaseValueConvertible?])
             )
             guard db.changesCount == 1 else {
                 throw MessageRepositoryError.replacementSourceMissing
@@ -270,70 +290,26 @@ public actor MessageRepository {
         )
     }
 
-    /// Stage one failed retry as `.sending` before network submission and mark
-    /// it as actively owned by this process.
-    public func stageRetry(_ message: RNSAPI.LXMessage, replacing oldId: Data) async throws {
-        activeRetryHashes.insert(message.hash)
-        do {
-            try await replaceMessage(message, replacing: oldId)
-        } catch {
-            activeRetryHashes.remove(message.hash)
-            throw error
-        }
-    }
-
-    /// Release process ownership. If no definitive result replaced the staged
-    /// row, expose it as failed instead of leaving it indefinitely pending.
-    public func finishRetry(_ messageId: Data) async {
-        activeRetryHashes.remove(messageId)
-        try? await replacementPool.write { db in
+    /// Recover only app-owned retries left staged by a prior process. The
+    /// uncertainty marker remains durable until a later retry or deletion, so
+    /// a transient UI-load failure cannot erase the warning.
+    public func recoverInterruptedRetries() async throws -> Int {
+        try await replacementPool.write { db in
             try db.execute(
                 sql: """
-                    UPDATE messages SET state = ?, updated_at = ?
-                    WHERE message_id = ? AND state = ?
+                    UPDATE messages
+                    SET state = ?, receiving_interface = ?, updated_at = ?
+                    WHERE incoming = 0 AND state = ? AND receiving_interface = ?
                     """,
                 arguments: [
                     LXMFSwift.LXMessageState.failed.rawValue,
+                    Self.uncertainRetryMarker,
                     Date().timeIntervalSince1970,
-                    messageId,
                     LXMFSwift.LXMessageState.sending.rawValue,
+                    Self.stagedRetryMarker,
                 ]
             )
-        }
-    }
-
-    /// Recover retry rows left in `.sending` by termination before the backend
-    /// returned a definitive result. They become user-visible failures rather
-    /// than remaining indefinitely pending or being resent automatically.
-    public func recoverInterruptedRetries(for destinationHash: Data) async throws -> Int {
-        let active = activeRetryHashes
-        return try await replacementPool.write { db in
-            let rows = try Row.fetchAll(
-                db,
-                sql: """
-                    SELECT message_id FROM messages
-                    WHERE destination_hash = ? AND incoming = 0 AND state = ?
-                    """,
-                arguments: [
-                    destinationHash,
-                    LXMFSwift.LXMessageState.sending.rawValue,
-                ]
-            )
-            let interrupted = rows.compactMap { row -> Data? in
-                let messageId: Data = row["message_id"]
-                return active.contains(messageId) ? nil : messageId
-            }
-            for messageId in interrupted {
-                try db.execute(
-                    sql: "UPDATE messages SET state = ?, updated_at = ? WHERE message_id = ?",
-                    arguments: [
-                        LXMFSwift.LXMessageState.failed.rawValue,
-                        Date().timeIntervalSince1970,
-                        messageId,
-                    ]
-                )
-            }
-            return interrupted.count
+            return db.changesCount
         }
     }
 

--- a/Sources/ColumbaApp/Services/MessageRepository.swift
+++ b/Sources/ColumbaApp/Services/MessageRepository.swift
@@ -58,6 +58,9 @@ public actor MessageRepository {
     private let database: LXMFSwift.LXMFDatabase
     /// Suspension-aware pool used only for atomic app-owned retry replacement.
     private let replacementPool: DatabasePool
+    /// Retry hashes actively owned by this process. Recovery ignores these so
+    /// reopening a conversation cannot race a send still awaiting its outcome.
+    private var activeRetryHashes: Set<Data> = []
 
     // MARK: - Initialization
 
@@ -265,6 +268,73 @@ public actor MessageRepository {
             object: nil,
             userInfo: [Self.conversationHashUserInfoKey: message.destinationHash]
         )
+    }
+
+    /// Stage one failed retry as `.sending` before network submission and mark
+    /// it as actively owned by this process.
+    public func stageRetry(_ message: RNSAPI.LXMessage, replacing oldId: Data) async throws {
+        activeRetryHashes.insert(message.hash)
+        do {
+            try await replaceMessage(message, replacing: oldId)
+        } catch {
+            activeRetryHashes.remove(message.hash)
+            throw error
+        }
+    }
+
+    /// Release process ownership. If no definitive result replaced the staged
+    /// row, expose it as failed instead of leaving it indefinitely pending.
+    public func finishRetry(_ messageId: Data) async {
+        activeRetryHashes.remove(messageId)
+        try? await replacementPool.write { db in
+            try db.execute(
+                sql: """
+                    UPDATE messages SET state = ?, updated_at = ?
+                    WHERE message_id = ? AND state = ?
+                    """,
+                arguments: [
+                    LXMFSwift.LXMessageState.failed.rawValue,
+                    Date().timeIntervalSince1970,
+                    messageId,
+                    LXMFSwift.LXMessageState.sending.rawValue,
+                ]
+            )
+        }
+    }
+
+    /// Recover retry rows left in `.sending` by termination before the backend
+    /// returned a definitive result. They become user-visible failures rather
+    /// than remaining indefinitely pending or being resent automatically.
+    public func recoverInterruptedRetries(for destinationHash: Data) async throws -> Int {
+        let active = activeRetryHashes
+        return try await replacementPool.write { db in
+            let rows = try Row.fetchAll(
+                db,
+                sql: """
+                    SELECT message_id FROM messages
+                    WHERE destination_hash = ? AND incoming = 0 AND state = ?
+                    """,
+                arguments: [
+                    destinationHash,
+                    LXMFSwift.LXMessageState.sending.rawValue,
+                ]
+            )
+            let interrupted = rows.compactMap { row -> Data? in
+                let messageId: Data = row["message_id"]
+                return active.contains(messageId) ? nil : messageId
+            }
+            for messageId in interrupted {
+                try db.execute(
+                    sql: "UPDATE messages SET state = ?, updated_at = ? WHERE message_id = ?",
+                    arguments: [
+                        LXMFSwift.LXMessageState.failed.rawValue,
+                        Date().timeIntervalSince1970,
+                        messageId,
+                    ]
+                )
+            }
+            return interrupted.count
+        }
     }
 
     /// Get message by ID (LXMessage form), rebuilt from the GRDB record.

--- a/Sources/ColumbaApp/Services/MessageRepository.swift
+++ b/Sources/ColumbaApp/Services/MessageRepository.swift
@@ -31,6 +31,7 @@
 import Foundation
 import RNSAPI
 import LXMFSwift
+import SQLite3
 
 /// Actor for thread-safe message database operations.
 ///
@@ -55,6 +56,10 @@ public actor MessageRepository {
 
     /// The GRDB-backed canonical store written by the Swift / NE backend.
     private let database: LXMFSwift.LXMFDatabase
+    /// Path used for the app-owned atomic retry rekey. LXMFDatabase exposes
+    /// save and delete as separate transactions, so retries use one SQLite
+    /// transaction against the same WAL database instead.
+    private let replacementPath: String
 
     // MARK: - Initialization
 
@@ -69,6 +74,7 @@ public actor MessageRepository {
     /// - Throws: rethrows `LXMFSwift.LXMFDatabase` initialization errors.
     public init(grdbPath: String) throws {
         self.database = try LXMFSwift.LXMFDatabase(path: grdbPath, readonly: false)
+        self.replacementPath = grdbPath
     }
 
     // MARK: - Conversation Operations
@@ -212,6 +218,99 @@ public actor MessageRepository {
         }
     }
 
+    /// Atomically rekey an app-owned optimistic or failed row to the canonical
+    /// hash accepted by the network backend. Payload columns stay on the same
+    /// row, so a crash cannot expose both a stale retry and a sent duplicate.
+    public func replaceMessage(_ message: RNSAPI.LXMessage, replacing oldId: Data) async throws {
+        var connection: OpaquePointer?
+        guard sqlite3_open_v2(
+            replacementPath,
+            &connection,
+            SQLITE_OPEN_READWRITE | SQLITE_OPEN_FULLMUTEX,
+            nil
+        ) == SQLITE_OK, let connection else {
+            throw MessageRepositoryError.sqlite("open failed")
+        }
+        defer { sqlite3_close(connection) }
+        sqlite3_busy_timeout(connection, 5_000)
+
+        func execute(_ sql: String) throws {
+            guard sqlite3_exec(connection, sql, nil, nil, nil) == SQLITE_OK else {
+                throw MessageRepositoryError.sqlite(String(cString: sqlite3_errmsg(connection)))
+            }
+        }
+
+        let transient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+        func bind(_ data: Data, to statement: OpaquePointer?, at index: Int32) throws {
+            let result = data.withUnsafeBytes { bytes in
+                sqlite3_bind_blob(statement, index, bytes.baseAddress, Int32(data.count), transient)
+            }
+            guard result == SQLITE_OK else {
+                throw MessageRepositoryError.sqlite(String(cString: sqlite3_errmsg(connection)))
+            }
+        }
+
+        try execute("BEGIN IMMEDIATE")
+        do {
+            var statement: OpaquePointer?
+            defer { sqlite3_finalize(statement) }
+            let sql = """
+                UPDATE messages
+                SET message_id = ?, state = ?, method = ?, timestamp = ?, updated_at = ?
+                WHERE message_id = ?
+                """
+            guard sqlite3_prepare_v2(connection, sql, -1, &statement, nil) == SQLITE_OK else {
+                throw MessageRepositoryError.sqlite(String(cString: sqlite3_errmsg(connection)))
+            }
+            try bind(message.hash, to: statement, at: 1)
+            sqlite3_bind_int(statement, 2, Int32(Self.mapStateToGRDB(message.state).rawValue))
+            sqlite3_bind_int(statement, 3, Int32(Self.mapMethodToGRDB(message.method).rawValue))
+            sqlite3_bind_double(statement, 4, message.timestamp)
+            sqlite3_bind_double(statement, 5, Date().timeIntervalSince1970)
+            try bind(oldId, to: statement, at: 6)
+            guard sqlite3_step(statement) == SQLITE_DONE else {
+                throw MessageRepositoryError.sqlite(String(cString: sqlite3_errmsg(connection)))
+            }
+            guard sqlite3_changes(connection) == 1 else {
+                throw MessageRepositoryError.replacementSourceMissing
+            }
+
+            var conversationStatement: OpaquePointer?
+            defer { sqlite3_finalize(conversationStatement) }
+            let conversationSQL = """
+                UPDATE conversations
+                SET last_message_timestamp = ?, updated_at = ?
+                WHERE destination_hash = ? AND last_message_timestamp <= ?
+                """
+            guard sqlite3_prepare_v2(
+                connection,
+                conversationSQL,
+                -1,
+                &conversationStatement,
+                nil
+            ) == SQLITE_OK else {
+                throw MessageRepositoryError.sqlite(String(cString: sqlite3_errmsg(connection)))
+            }
+            sqlite3_bind_double(conversationStatement, 1, message.timestamp)
+            sqlite3_bind_double(conversationStatement, 2, Date().timeIntervalSince1970)
+            try bind(message.destinationHash, to: conversationStatement, at: 3)
+            sqlite3_bind_double(conversationStatement, 4, message.timestamp)
+            guard sqlite3_step(conversationStatement) == SQLITE_DONE else {
+                throw MessageRepositoryError.sqlite(String(cString: sqlite3_errmsg(connection)))
+            }
+            try execute("COMMIT")
+        } catch {
+            try? execute("ROLLBACK")
+            throw error
+        }
+
+        NotificationCenter.default.post(
+            name: Self.conversationActivityNotification,
+            object: nil,
+            userInfo: [Self.conversationHashUserInfoKey: message.destinationHash]
+        )
+    }
+
     /// Get message by ID (LXMessage form), rebuilt from the GRDB record.
     public func getMessage(id: Data) async throws -> RNSAPI.LXMessage? {
         try await database.getMessageRecord(id: id).map(Self.mapToLXMessage)
@@ -262,6 +361,11 @@ public actor MessageRepository {
         }
         return out
     }
+}
+
+enum MessageRepositoryError: Error {
+    case replacementSourceMissing
+    case sqlite(String)
 }
 
 // MARK: - Adapters (LXMFSwift <- -> RNSAPI)

--- a/Sources/ColumbaApp/Services/MessageRepository.swift
+++ b/Sources/ColumbaApp/Services/MessageRepository.swift
@@ -31,7 +31,7 @@
 import Foundation
 import RNSAPI
 import LXMFSwift
-import SQLite3
+import GRDB
 
 /// Actor for thread-safe message database operations.
 ///
@@ -56,10 +56,8 @@ public actor MessageRepository {
 
     /// The GRDB-backed canonical store written by the Swift / NE backend.
     private let database: LXMFSwift.LXMFDatabase
-    /// Path used for the app-owned atomic retry rekey. LXMFDatabase exposes
-    /// save and delete as separate transactions, so retries use one SQLite
-    /// transaction against the same WAL database instead.
-    private let replacementPath: String
+    /// Suspension-aware pool used only for atomic app-owned retry replacement.
+    private let replacementPool: DatabasePool
 
     // MARK: - Initialization
 
@@ -74,7 +72,13 @@ public actor MessageRepository {
     /// - Throws: rethrows `LXMFSwift.LXMFDatabase` initialization errors.
     public init(grdbPath: String) throws {
         self.database = try LXMFSwift.LXMFDatabase(path: grdbPath, readonly: false)
-        self.replacementPath = grdbPath
+        var config = Configuration()
+        config.defaultTransactionKind = .immediate
+        config.observesSuspensionNotifications = true
+        config.prepareDatabase { db in
+            try db.execute(sql: "PRAGMA busy_timeout=5000")
+        }
+        self.replacementPool = try DatabasePool(path: grdbPath, configuration: config)
     }
 
     // MARK: - Conversation Operations
@@ -222,86 +226,38 @@ public actor MessageRepository {
     /// hash accepted by the network backend. Payload columns stay on the same
     /// row, so a crash cannot expose both a stale retry and a sent duplicate.
     public func replaceMessage(_ message: RNSAPI.LXMessage, replacing oldId: Data) async throws {
-        var connection: OpaquePointer?
-        guard sqlite3_open_v2(
-            replacementPath,
-            &connection,
-            SQLITE_OPEN_READWRITE | SQLITE_OPEN_FULLMUTEX,
-            nil
-        ) == SQLITE_OK, let connection else {
-            throw MessageRepositoryError.sqlite("open failed")
-        }
-        defer { sqlite3_close(connection) }
-        sqlite3_busy_timeout(connection, 5_000)
-
-        func execute(_ sql: String) throws {
-            guard sqlite3_exec(connection, sql, nil, nil, nil) == SQLITE_OK else {
-                throw MessageRepositoryError.sqlite(String(cString: sqlite3_errmsg(connection)))
-            }
-        }
-
-        let transient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
-        func bind(_ data: Data, to statement: OpaquePointer?, at index: Int32) throws {
-            let result = data.withUnsafeBytes { bytes in
-                sqlite3_bind_blob(statement, index, bytes.baseAddress, Int32(data.count), transient)
-            }
-            guard result == SQLITE_OK else {
-                throw MessageRepositoryError.sqlite(String(cString: sqlite3_errmsg(connection)))
-            }
-        }
-
-        try execute("BEGIN IMMEDIATE")
-        do {
-            var statement: OpaquePointer?
-            defer { sqlite3_finalize(statement) }
-            let sql = """
-                UPDATE messages
-                SET message_id = ?, state = ?, method = ?, timestamp = ?, updated_at = ?
-                WHERE message_id = ?
-                """
-            guard sqlite3_prepare_v2(connection, sql, -1, &statement, nil) == SQLITE_OK else {
-                throw MessageRepositoryError.sqlite(String(cString: sqlite3_errmsg(connection)))
-            }
-            try bind(message.hash, to: statement, at: 1)
-            sqlite3_bind_int(statement, 2, Int32(Self.mapStateToGRDB(message.state).rawValue))
-            sqlite3_bind_int(statement, 3, Int32(Self.mapMethodToGRDB(message.method).rawValue))
-            sqlite3_bind_double(statement, 4, message.timestamp)
-            sqlite3_bind_double(statement, 5, Date().timeIntervalSince1970)
-            try bind(oldId, to: statement, at: 6)
-            guard sqlite3_step(statement) == SQLITE_DONE else {
-                throw MessageRepositoryError.sqlite(String(cString: sqlite3_errmsg(connection)))
-            }
-            guard sqlite3_changes(connection) == 1 else {
+        try await replacementPool.write { db in
+            try db.execute(
+                sql: """
+                    UPDATE messages
+                    SET message_id = ?, state = ?, method = ?, timestamp = ?, updated_at = ?
+                    WHERE message_id = ?
+                    """,
+                arguments: [
+                    message.hash,
+                    Self.mapStateToGRDB(message.state).rawValue,
+                    Self.mapMethodToGRDB(message.method).rawValue,
+                    message.timestamp,
+                    Date().timeIntervalSince1970,
+                    oldId,
+                ]
+            )
+            guard db.changesCount == 1 else {
                 throw MessageRepositoryError.replacementSourceMissing
             }
-
-            var conversationStatement: OpaquePointer?
-            defer { sqlite3_finalize(conversationStatement) }
-            let conversationSQL = """
-                UPDATE conversations
-                SET last_message_timestamp = ?, updated_at = ?
-                WHERE destination_hash = ? AND last_message_timestamp <= ?
-                """
-            guard sqlite3_prepare_v2(
-                connection,
-                conversationSQL,
-                -1,
-                &conversationStatement,
-                nil
-            ) == SQLITE_OK else {
-                throw MessageRepositoryError.sqlite(String(cString: sqlite3_errmsg(connection)))
-            }
-            sqlite3_bind_double(conversationStatement, 1, message.timestamp)
-            sqlite3_bind_double(conversationStatement, 2, Date().timeIntervalSince1970)
-            try bind(message.destinationHash, to: conversationStatement, at: 3)
-            sqlite3_bind_double(conversationStatement, 4, message.timestamp)
-            guard sqlite3_step(conversationStatement) == SQLITE_DONE else {
-                throw MessageRepositoryError.sqlite(String(cString: sqlite3_errmsg(connection)))
-            }
-            try execute("COMMIT")
-        } catch {
-            try? execute("ROLLBACK")
-            throw error
+            try db.execute(
+                sql: """
+                    UPDATE conversations
+                    SET last_message_timestamp = ?, updated_at = ?
+                    WHERE destination_hash = ? AND last_message_timestamp <= ?
+                    """,
+                arguments: [
+                    message.timestamp,
+                    Date().timeIntervalSince1970,
+                    message.destinationHash,
+                    message.timestamp,
+                ]
+            )
         }
 
         NotificationCenter.default.post(
@@ -365,7 +321,6 @@ public actor MessageRepository {
 
 enum MessageRepositoryError: Error {
     case replacementSourceMissing
-    case sqlite(String)
 }
 
 // MARK: - Adapters (LXMFSwift <- -> RNSAPI)

--- a/Sources/ColumbaApp/Services/SettingsRepository.swift
+++ b/Sources/ColumbaApp/Services/SettingsRepository.swift
@@ -115,7 +115,10 @@ public actor SettingsRepository {
 
     /// Get whether to retry failed direct sends via relay.
     public func getRetryViaRelay() -> Bool {
-        defaults.bool(forKey: Keys.retryViaRelay)
+        guard defaults.object(forKey: Keys.retryViaRelay) != nil else {
+            return true
+        }
+        return defaults.bool(forKey: Keys.retryViaRelay)
     }
 
     /// Set whether to retry via relay on direct failure.

--- a/Sources/ColumbaApp/ViewModels/ContactsViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/ContactsViewModel.swift
@@ -215,7 +215,10 @@ public struct Contact: Identifiable, Sendable, Hashable {
         self.iconFgColor = record.iconFgColor
         self.iconBgColor = record.iconBgColor
         self.interfaceId = nil
-        self.aspect = nil
+        // Conversation records are keyed by LXMF delivery destinations. This is
+        // explicit provenance, not payload-shape inference, so saved/QR contacts
+        // remain chat-capable even when no announce is currently cached.
+        self.aspect = "lxmf.delivery"
     }
 
     public init(
@@ -963,6 +966,17 @@ public final class ContactsViewModel {
             return nil
         }
 
+        // Bind the claimed delivery hash to the supplied public identity. A QR
+        // code is explicit LXMF-delivery provenance only when these agree.
+        guard let identity = try? Identity(publicKeyBytes: pubkeyData),
+              Destination.hash(
+                identity: identity,
+                appName: "lxmf",
+                aspects: ["delivery"]
+              ) == hashData else {
+            return nil
+        }
+
         return (destinationHash: hashData, publicKey: pubkeyData)
     }
 
@@ -975,11 +989,21 @@ public final class ContactsViewModel {
 
     /// Add a contact from a QR code scan or deep link.
     @MainActor
-    public func addContactFromQR(destinationHash: Data, publicKey: Data, nickname: String?) async {
+    public func addContactFromQR(destinationHash: Data, publicKey: Data, nickname: String?) async -> Bool {
         let hex = destinationHash.map { String(format: "%02x", $0) }.joined()
-        guard !myContacts.contains(where: { $0.id == hex }) else { return }
 
         do {
+            // Retain the already-validated public identity locally. This is a
+            // cache write only: path discovery remains strictly send-triggered.
+            let remembered = await appServices.backend?.core.rememberPeerIdentity(
+                destHashHex: hex,
+                publicKey: publicKey
+            ) ?? false
+            guard remembered else {
+                errorMessage = "The contact identity could not be saved. Please try again."
+                return false
+            }
+            guard !myContacts.contains(where: { $0.id == hex }) else { return true }
             try await messageRepository.ensureConversation(
                 destinationHash,
                 displayName: nickname
@@ -997,15 +1021,18 @@ public final class ContactsViewModel {
                 timestamp: Date(),
                 isOnline: false,
                 isFavorite: true,
-                isRelay: false
+                isRelay: false,
+                aspect: "lxmf.delivery"
             )
             if let existingIndex = myContacts.firstIndex(where: { $0.id == hex }) {
                 myContacts[existingIndex] = contact
             } else {
                 myContacts.append(contact)
             }
+            return true
         } catch {
             errorMessage = "Failed to add contact: \(error.localizedDescription)"
+            return false
         }
     }
 

--- a/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
@@ -478,6 +478,7 @@ public final class MessagingViewModel {
                     let retryHash = try Self.queuedHash(from: retryOutcome)
                     retryMessage.hash = retryHash
                     retryMessage.state = .sent
+                    retryMessage.method = .propagated
                     let realId = retryMessage.hash.map { String(format: "%02x", $0) }.joined()
                     if let index = messages.firstIndex(where: { $0.id == optimisticId }) {
                         withAnimation(.easeInOut(duration: 0.2)) {

--- a/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
@@ -50,6 +50,7 @@ public final class MessagingViewModel {
     private let settingsRepository = SettingsRepository()
     private let displayName: String?
     private let logger = Logger(subsystem: "network.columba.Columba", category: "MessagingViewModel")
+    private var didRecoverInterruptedRetries = false
 
     /// Observation token for incoming message notifications.
     private var notificationTask: Any?
@@ -128,6 +129,14 @@ public final class MessagingViewModel {
         defer { isLoading = false }
 
         do {
+            var recoveredInterruptedRetries = 0
+            if !didRecoverInterruptedRetries {
+                recoveredInterruptedRetries = try await repository.recoverInterruptedRetries(
+                    for: conversationHash
+                )
+                didRecoverInterruptedRetries = true
+            }
+
             // Ensure conversation exists, then clear unread state as soon as the
             // user opens it. Message decoding or reply-preview failures must not
             // leave a stale badge behind after the conversation was viewed.
@@ -162,7 +171,9 @@ public final class MessagingViewModel {
             // were included in the page we just displayed.
             try await repository.markConversationRead(conversationHash)
 
-            errorMessage = nil
+            errorMessage = recoveredInterruptedRetries > 0
+                ? "A message retry was interrupted before delivery confirmation. Verify whether it arrived before retrying."
+                : nil
         } catch {
             errorMessage = error.localizedDescription
         }
@@ -295,6 +306,17 @@ public final class MessagingViewModel {
             return false
         }
 
+        // Process ownership prevents another view from recovering a retry that
+        // is still active. On every return, any row still marked `.sending` is
+        // released as an unknown-delivery failure.
+        defer {
+            if let retryHash = localRetryHash {
+                Task { [repository] in
+                    await repository.finishRetry(retryHash)
+                }
+            }
+        }
+
         // Always start with opportunistic (single encrypted packet, no link needed).
         // For large messages that exceed single-packet size, handleOutbound() will
         // auto-fallback using the fallbackMethod (direct or propagated per settings).
@@ -347,12 +369,12 @@ public final class MessagingViewModel {
         lxMessage.hash = optimisticHash
 
         // A retry must stop being durably retryable before the wire send starts.
-        // If canonical replacement later fails, this outbound row remains the
-        // single durable owner and cannot be sent again as a failed message.
+        // A new conversation view recovers an interrupted `.sending` row as a
+        // visible failure with an unknown-delivery warning.
         if let storedHash = replacedStorageHash ?? localRetryHash {
-            lxMessage.state = .outbound
+            lxMessage.state = .sending
             do {
-                try await repository.replaceMessage(lxMessage, replacing: storedHash)
+                try await repository.stageRetry(lxMessage, replacing: storedHash)
             } catch {
                 errorMessage = "The failed message could not be prepared for retry. Please try again."
                 return false
@@ -436,9 +458,9 @@ public final class MessagingViewModel {
             } catch {
                 logger.error("[MSG_VM] saveMessage(outbound) failed: \(error.localizedDescription)")
                 if let index = messages.firstIndex(where: { $0.id == realId }) {
-                    messages[index].deliveryStatus = .sending
+                    messages[index].deliveryStatus = .failed
                 }
-                errorMessage = "Message was sent, but local confirmation could not be saved. It will remain pending and will not be retried automatically."
+                errorMessage = "Message was sent, but local confirmation could not be saved. Verify whether it arrived before retrying."
             }
 
             return true
@@ -501,9 +523,9 @@ public final class MessagingViewModel {
                     } catch {
                         logger.error("[MSG_VM] saveMessage(retry-relay) failed: \(error.localizedDescription)")
                         if let index = messages.firstIndex(where: { $0.id == realId }) {
-                            messages[index].deliveryStatus = .sending
+                            messages[index].deliveryStatus = .failed
                         }
-                        errorMessage = "Message was relayed, but local confirmation could not be saved. It will remain pending and will not be retried automatically."
+                        errorMessage = "Message was relayed, but local confirmation could not be saved. Verify whether it arrived before retrying."
                     }
                     return true
                 } catch {

--- a/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
@@ -50,7 +50,6 @@ public final class MessagingViewModel {
     private let settingsRepository = SettingsRepository()
     private let displayName: String?
     private let logger = Logger(subsystem: "network.columba.Columba", category: "MessagingViewModel")
-    private var didRecoverInterruptedRetries = false
 
     /// Observation token for incoming message notifications.
     private var notificationTask: Any?
@@ -129,14 +128,6 @@ public final class MessagingViewModel {
         defer { isLoading = false }
 
         do {
-            var recoveredInterruptedRetries = 0
-            if !didRecoverInterruptedRetries {
-                recoveredInterruptedRetries = try await repository.recoverInterruptedRetries(
-                    for: conversationHash
-                )
-                didRecoverInterruptedRetries = true
-            }
-
             // Ensure conversation exists, then clear unread state as soon as the
             // user opens it. Message decoding or reply-preview failures must not
             // leave a stale badge behind after the conversation was viewed.
@@ -146,6 +137,9 @@ public final class MessagingViewModel {
             // Fetch most recent page
             let records = try await repository.fetchMessageRecords(
                 for: conversationHash, limit: Self.pageSize, offset: 0)
+            let hasInterruptedRetry = records.contains {
+                $0.receivingInterface == MessageRepository.uncertainRetryMarker
+            }
             let loaded = records.reversed()
                 .map { Message(from: $0, localHash: appServices.localIdentityHash) }
                 .filter { !$0.isEmpty }  // Hide telemetry-only messages (e.g. location sharing)
@@ -171,7 +165,7 @@ public final class MessagingViewModel {
             // were included in the page we just displayed.
             try await repository.markConversationRead(conversationHash)
 
-            errorMessage = recoveredInterruptedRetries > 0
+            errorMessage = hasInterruptedRetry
                 ? "A message retry was interrupted before delivery confirmation. Verify whether it arrived before retrying."
                 : nil
         } catch {
@@ -306,16 +300,6 @@ public final class MessagingViewModel {
             return false
         }
 
-        // Process ownership prevents another view from recovering a retry that
-        // is still active. On every return, any row still marked `.sending` is
-        // released as an unknown-delivery failure.
-        defer {
-            if let retryHash = localRetryHash {
-                Task { [repository] in
-                    await repository.finishRetry(retryHash)
-                }
-            }
-        }
 
         // Always start with opportunistic (single encrypted packet, no link needed).
         // For large messages that exceed single-packet size, handleOutbound() will

--- a/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
@@ -196,9 +196,56 @@ public final class MessagingViewModel {
         }
     }
 
-    /// Thrown when the backend rejects a send pre-flight (bad hash / not started)
-    /// so the existing catch path (retry-via-relay, then failed status) runs.
-    private enum SendError: Error { case notQueued }
+    /// Actionable failure returned when a backend does not accept a send.
+    private struct SendFailure: LocalizedError {
+        let category: String
+        let errorDescription: String?
+    }
+
+    static func failureDescription(for outcome: SendOutcome) -> String? {
+        switch outcome {
+        case .queued:
+            return nil
+        case .requestingPath:
+            return "No active path to this contact was found after waiting 10 seconds."
+        case .badHash:
+            return "The contact has an invalid LXMF destination."
+        case .notStarted:
+            return "The messaging network is not ready."
+        case .other(let reason):
+            return reason.isEmpty ? "The messaging backend rejected the message." : reason
+        }
+    }
+
+    private static func failureCategory(for outcome: SendOutcome) -> String {
+        switch outcome {
+        case .queued: return "invalid-message-hash"
+        case .requestingPath: return "path-unavailable"
+        case .badHash: return "invalid-destination"
+        case .notStarted: return "backend-not-started"
+        case .other: return "backend-rejected"
+        }
+    }
+
+    private static func queuedHash(from outcome: SendOutcome) throws -> Data {
+        if case .queued(let hashHex) = outcome {
+            guard let hash = Data(hexString: hashHex), hash.count == 32 else {
+                throw SendFailure(
+                    category: "invalid-message-hash",
+                    errorDescription: "The network backend accepted the message but returned an invalid message identifier."
+                )
+            }
+            return hash
+        }
+        throw SendFailure(
+            category: failureCategory(for: outcome),
+            errorDescription: failureDescription(for: outcome)
+        )
+    }
+
+    private static func failureCategory(_ error: Error) -> String {
+        (error as? SendFailure)?.category ?? "backend-error"
+    }
 
     /// Send a text-only message (convenience wrapper).
     @MainActor
@@ -221,7 +268,9 @@ public final class MessagingViewModel {
         imageData: Data?,
         imageFormat: String?,
         attachments: [(name: String, data: Data)]?,
-        replyToId: String? = nil
+        replyToId: String? = nil,
+        localRetryHash: Data? = nil,
+        replacedStorageHash: Data? = nil
     ) async -> Bool {
         let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedText.isEmpty || imageData != nil || (attachments != nil && !attachments!.isEmpty) else {
@@ -282,9 +331,12 @@ public final class MessagingViewModel {
         )
         lxMessage.fallbackMethod = fallbackForLargeMessages
 
-        // Generate temporary hash for optimistic UI
-        let optimisticId = UUID().uuidString
-        lxMessage.hash = optimisticId.data(using: .utf8)!
+        // Use a canonical-width local ID so failed rows remain retryable after
+        // reload. A retry reuses its existing ID and atomically replaces that
+        // row instead of accumulating stale failed copies.
+        let optimisticHash = localRetryHash ?? Data((0..<32).map { _ in UInt8.random(in: 0...255) })
+        let optimisticId = optimisticHash.map { String(format: "%02x", $0) }.joined()
+        lxMessage.hash = optimisticHash
 
         // Build reply preview for optimistic display
         let replyPreview: String? = {
@@ -309,9 +361,15 @@ public final class MessagingViewModel {
             replyToPreview: replyPreview
         )
 
-        // Add to UI immediately
+        // Add to UI immediately, or replace the existing failed row in place.
         withAnimation(.easeOut(duration: 0.25)) {
-            messages.append(optimisticMessage)
+            if let index = messages.firstIndex(where: { $0.id == optimisticId }) {
+                messages[index] = optimisticMessage
+                messages[index].messageHash = optimisticHash
+            } else {
+                messages.append(optimisticMessage)
+                messages[messages.count - 1].messageHash = optimisticHash
+            }
         }
 
         do {
@@ -328,10 +386,9 @@ public final class MessagingViewModel {
                 fileAttachments: attachments?.map { RnsFileAttachment(name: $0.name, data: $0.data) },
                 iconAppearance: icon,
                 replyToMessageHashHex: replyToId, replyQuotedContent: replyPreview, extraFields: nil)
-            guard case .queued(let sentHashHex) = outcome, let sentHash = Data(hexString: sentHashHex) else {
-                throw SendError.notQueued
-            }
+            let sentHash = try Self.queuedHash(from: outcome)
             lxMessage.hash = sentHash
+            lxMessage.state = .sent
 
             // Replace optimistic message with real one (using actual hash from pack)
             let realId = lxMessage.hash.map { String(format: "%02x", $0) }.joined()
@@ -355,12 +412,17 @@ public final class MessagingViewModel {
             // Persist so a subsequent loadMessages() doesn't wipe it.
             do {
                 try await repository.saveMessage(lxMessage)
+                if let oldHash = replacedStorageHash ?? localRetryHash,
+                   oldHash != lxMessage.hash {
+                    try await repository.deleteMessage(oldHash)
+                }
             } catch {
                 logger.error("[MSG_VM] saveMessage(outbound) failed: \(error.localizedDescription)")
             }
 
             return true
         } catch {
+            var failure: Error = error
             // Retry via relay if enabled
             let retryViaRelay = await settingsRepository.getRetryViaRelay()
             if retryViaRelay {
@@ -392,10 +454,9 @@ public final class MessagingViewModel {
                         fileAttachments: attachments?.map { RnsFileAttachment(name: $0.name, data: $0.data) },
                         iconAppearance: icon,
                         replyToMessageHashHex: replyToId, replyQuotedContent: replyPreview, extraFields: nil)
-                    guard case .queued(let retryHashHex) = retryOutcome, let retryHash = Data(hexString: retryHashHex) else {
-                        throw SendError.notQueued
-                    }
+                    let retryHash = try Self.queuedHash(from: retryOutcome)
                     retryMessage.hash = retryHash
+                    retryMessage.state = .sent
                     let realId = retryMessage.hash.map { String(format: "%02x", $0) }.joined()
                     if let index = messages.firstIndex(where: { $0.id == optimisticId }) {
                         withAnimation(.easeInOut(duration: 0.2)) {
@@ -415,13 +476,33 @@ public final class MessagingViewModel {
                     }
                     do {
                         try await repository.saveMessage(retryMessage)
+                        if let oldHash = replacedStorageHash ?? localRetryHash,
+                           oldHash != retryMessage.hash {
+                            try await repository.deleteMessage(oldHash)
+                        }
                     } catch {
                         logger.error("[MSG_VM] saveMessage(retry-relay) failed: \(error.localizedDescription)")
                     }
                     return true
                 } catch {
+                    failure = error
                     logger.error("[MSG_VM] Relay retry also failed: \(error.localizedDescription)")
                 }
+            }
+
+            // Failed outbound attempts are still conversation activity. Persist
+            // the failed row so it remains visible on Chats and can be retried.
+            lxMessage.state = .failed
+            var persisted = false
+            do {
+                try await repository.saveMessage(lxMessage)
+                if let oldHash = replacedStorageHash ?? localRetryHash,
+                   oldHash != lxMessage.hash {
+                    try await repository.deleteMessage(oldHash)
+                }
+                persisted = true
+            } catch {
+                logger.error("[MSG_VM] saveMessage(failed) failed: \(error.localizedDescription)")
             }
 
             // Update to failed status with real hash so retry can delete from DB
@@ -438,6 +519,9 @@ public final class MessagingViewModel {
                             timestamp: messages[index].timestamp,
                             isFromMe: true,
                             deliveryStatus: .failed,
+                            imageData: imageData,
+                            imageFormat: imageFormat,
+                            attachments: attachments?.map { FileAttachment(name: $0.name, data: $0.data) },
                             replyToId: replyToId,
                             replyToPreview: replyPreview
                         )
@@ -445,7 +529,13 @@ public final class MessagingViewModel {
                     }
                 }
             }
-            errorMessage = "Failed to send: \(error.localizedDescription)"
+            let category = Self.failureCategory(failure)
+            DiagLog.log("[MSG_SEND] failed category=\(category) persisted=\(persisted)")
+            if persisted {
+                errorMessage = "Message failed: \(failure.localizedDescription) It was saved for retry."
+            } else {
+                errorMessage = "Message failed: \(failure.localizedDescription) It could not be saved locally."
+            }
             return false
         }
     }
@@ -459,19 +549,30 @@ public final class MessagingViewModel {
         }
 
         let failedMessage = messages[index]
-
-        // Delete from database if we have the hash
-        if let hash = failedMessage.messageHash {
-            try? await repository.deleteMessage(hash)
+        let storedHash = failedMessage.messageHash ?? Self.hexToData(failedMessage.id)
+        let retryHash: Data
+        if let storedHash, storedHash.count == 32 {
+            retryHash = storedHash
+        } else {
+            retryHash = Data((0..<32).map { _ in UInt8.random(in: 0...255) })
         }
 
-        // Remove from UI
-        _ = withAnimation {
-            messages.remove(at: index)
+        // Reuse a canonical local ID and the complete payload. The send path
+        // replaces the failed row only after the replacement is safely saved,
+        // including migration of legacy non-32-byte temporary IDs.
+        _ = await sendMessage(
+            text: failedMessage.content,
+            imageData: failedMessage.imageData,
+            imageFormat: failedMessage.imageFormat,
+            attachments: failedMessage.attachments?.map { (name: $0.name, data: $0.data) },
+            replyToId: failedMessage.replyToId,
+            localRetryHash: retryHash,
+            replacedStorageHash: storedHash
+        )
+        let retryId = retryHash.map { String(format: "%02x", $0) }.joined()
+        if retryId != messageId, messages.contains(where: { $0.id == retryId }) {
+            messages.removeAll { $0.id == messageId }
         }
-
-        // Resend
-        _ = await sendMessage(text: failedMessage.content)
     }
 
     /// Delete a message from the conversation.

--- a/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
@@ -41,6 +41,8 @@ public final class MessagingViewModel {
 
     /// Page size for message fetching.
     private static let pageSize = 50
+    private static let interruptedRetryWarning =
+        "A message retry was interrupted before delivery confirmation. Verify whether it arrived before retrying."
 
     // MARK: - Dependencies
 
@@ -135,11 +137,9 @@ public final class MessagingViewModel {
             try await repository.markConversationRead(conversationHash)
 
             // Fetch most recent page
+            let hasInterruptedRetry = try await repository.hasUncertainRetry(for: conversationHash)
             let records = try await repository.fetchMessageRecords(
                 for: conversationHash, limit: Self.pageSize, offset: 0)
-            let hasInterruptedRetry = records.contains {
-                $0.receivingInterface == MessageRepository.uncertainRetryMarker
-            }
             let loaded = records.reversed()
                 .map { Message(from: $0, localHash: appServices.localIdentityHash) }
                 .filter { !$0.isEmpty }  // Hide telemetry-only messages (e.g. location sharing)
@@ -166,7 +166,7 @@ public final class MessagingViewModel {
             try await repository.markConversationRead(conversationHash)
 
             errorMessage = hasInterruptedRetry
-                ? "A message retry was interrupted before delivery confirmation. Verify whether it arrived before retrying."
+                ? Self.interruptedRetryWarning
                 : nil
         } catch {
             errorMessage = error.localizedDescription
@@ -182,8 +182,14 @@ public final class MessagingViewModel {
 
         do {
             let offset = messages.count
+            let hasInterruptedRetry = try await repository.hasUncertainRetry(for: conversationHash)
             let records = try await repository.fetchMessageRecords(
                 for: conversationHash, limit: Self.pageSize, offset: offset)
+            if hasInterruptedRetry {
+                errorMessage = Self.interruptedRetryWarning
+            } else if errorMessage == Self.interruptedRetryWarning {
+                errorMessage = nil
+            }
             if records.isEmpty {
                 allMessagesLoaded = true
                 return

--- a/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
@@ -247,6 +247,14 @@ public final class MessagingViewModel {
         (error as? SendFailure)?.category ?? "backend-error"
     }
 
+    private func persistMessage(_ message: LXMessage, replacing oldHash: Data?) async throws {
+        if let oldHash {
+            try await repository.replaceMessage(message, replacing: oldHash)
+        } else {
+            try await repository.saveMessage(message)
+        }
+    }
+
     /// Send a text-only message (convenience wrapper).
     @MainActor
     public func sendMessage(text: String) async -> Bool {
@@ -338,6 +346,19 @@ public final class MessagingViewModel {
         let optimisticId = optimisticHash.map { String(format: "%02x", $0) }.joined()
         lxMessage.hash = optimisticHash
 
+        // A retry must stop being durably retryable before the wire send starts.
+        // If canonical replacement later fails, this outbound row remains the
+        // single durable owner and cannot be sent again as a failed message.
+        if let storedHash = replacedStorageHash ?? localRetryHash {
+            lxMessage.state = .outbound
+            do {
+                try await repository.replaceMessage(lxMessage, replacing: storedHash)
+            } catch {
+                errorMessage = "The failed message could not be prepared for retry. Please try again."
+                return false
+            }
+        }
+
         // Build reply preview for optimistic display
         let replyPreview: String? = {
             guard let replyToId else { return nil }
@@ -411,13 +432,13 @@ public final class MessagingViewModel {
 
             // Persist so a subsequent loadMessages() doesn't wipe it.
             do {
-                try await repository.saveMessage(lxMessage)
-                if let oldHash = replacedStorageHash ?? localRetryHash,
-                   oldHash != lxMessage.hash {
-                    try await repository.deleteMessage(oldHash)
-                }
+                try await persistMessage(lxMessage, replacing: localRetryHash)
             } catch {
                 logger.error("[MSG_VM] saveMessage(outbound) failed: \(error.localizedDescription)")
+                if let index = messages.firstIndex(where: { $0.id == realId }) {
+                    messages[index].deliveryStatus = .sending
+                }
+                errorMessage = "Message was sent, but local confirmation could not be saved. It will remain pending and will not be retried automatically."
             }
 
             return true
@@ -475,13 +496,13 @@ public final class MessagingViewModel {
                         }
                     }
                     do {
-                        try await repository.saveMessage(retryMessage)
-                        if let oldHash = replacedStorageHash ?? localRetryHash,
-                           oldHash != retryMessage.hash {
-                            try await repository.deleteMessage(oldHash)
-                        }
+                        try await persistMessage(retryMessage, replacing: localRetryHash)
                     } catch {
                         logger.error("[MSG_VM] saveMessage(retry-relay) failed: \(error.localizedDescription)")
+                        if let index = messages.firstIndex(where: { $0.id == realId }) {
+                            messages[index].deliveryStatus = .sending
+                        }
+                        errorMessage = "Message was relayed, but local confirmation could not be saved. It will remain pending and will not be retried automatically."
                     }
                     return true
                 } catch {
@@ -495,11 +516,7 @@ public final class MessagingViewModel {
             lxMessage.state = .failed
             var persisted = false
             do {
-                try await repository.saveMessage(lxMessage)
-                if let oldHash = replacedStorageHash ?? localRetryHash,
-                   oldHash != lxMessage.hash {
-                    try await repository.deleteMessage(oldHash)
-                }
+                try await persistMessage(lxMessage, replacing: localRetryHash)
                 persisted = true
             } catch {
                 logger.error("[MSG_VM] saveMessage(failed) failed: \(error.localizedDescription)")

--- a/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
@@ -349,6 +349,7 @@ public final class MessagingViewModel {
             fields: fields.isEmpty ? nil : fields,
             desiredMethod: .opportunistic
         )
+        lxMessage.method = .opportunistic
         lxMessage.fallbackMethod = fallbackForLargeMessages
 
         // Use a canonical-width local ID so failed rows remain retryable after

--- a/Sources/ColumbaApp/ViewModels/SettingsViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/SettingsViewModel.swift
@@ -44,10 +44,10 @@ public struct IdentityInfo: Equatable {
     /// QR code string in Android Columba-compatible format.
     /// Format: `lxma://<destination_hash_hex>:<public_key_hex>`
     public var qrCodeString: String {
-        guard !identityHash.isEmpty, !publicKeyHex.isEmpty else {
-            return identityHash
+        guard !destinationHash.isEmpty, !publicKeyHex.isEmpty else {
+            return destinationHash
         }
-        return "lxma://\(identityHash):\(publicKeyHex)"
+        return "lxma://\(destinationHash):\(publicKeyHex)"
     }
 
     public init(

--- a/Sources/ColumbaApp/Views/Contacts/AddContactSheet.swift
+++ b/Sources/ColumbaApp/Views/Contacts/AddContactSheet.swift
@@ -71,6 +71,13 @@ struct AddContactSheet: View {
                 }
                 .padding(.horizontal, 24)
 
+                if let errorMessage = viewModel.errorMessage {
+                    Text(errorMessage)
+                        .font(.caption)
+                        .foregroundStyle(Theme.error)
+                        .padding(.horizontal, 24)
+                }
+
                 Spacer()
 
                 // Buttons
@@ -109,30 +116,31 @@ struct AddContactSheet: View {
             #if os(iOS)
             .navigationBarTitleDisplayMode(.inline)
             #endif
-            .alert("Contact Already Added", isPresented: $alreadyExists) {
+            .alert("Contact Updated", isPresented: $alreadyExists) {
                 Button("OK") { onDismiss() }
             } message: {
-                Text("This contact is already in your contacts list.")
+                Text("The QR identity was refreshed for this existing contact.")
             }
         }
     }
 
     private func addContact() {
-        if viewModel.contactExists(scannedContact.destinationHash) {
-            alreadyExists = true
-            return
-        }
-
+        let existed = viewModel.contactExists(scannedContact.destinationHash)
         isAdding = true
         Task {
             let name = nickname.trimmingCharacters(in: .whitespacesAndNewlines)
-            await viewModel.addContactFromQR(
+            let succeeded = await viewModel.addContactFromQR(
                 destinationHash: scannedContact.destinationHash,
                 publicKey: scannedContact.publicKey,
                 nickname: name.isEmpty ? nil : name
             )
             isAdding = false
-            onDismiss()
+            guard succeeded else { return }
+            if existed {
+                alreadyExists = true
+            } else {
+                onDismiss()
+            }
         }
     }
 }

--- a/Sources/ColumbaApp/Views/Contacts/NodeDetailsView.swift
+++ b/Sources/ColumbaApp/Views/Contacts/NodeDetailsView.swift
@@ -56,7 +56,7 @@ struct NodeDetailsView: View {
     /// Live snapshot seeded from the parent-supplied `contact` and refreshed
     /// whenever the path table reports a newer entry for this destination.
     /// All bindings in the view read from this so the badge transitions from
-    /// "Expired" to "Online" the moment an announce arrives.
+    /// "No Active Path" to "Online" the moment an announce arrives.
     @State private var liveContact: Contact?
     /// Source of truth for the toolbar star, kept separate from `liveContact`
     /// because `mergedContact`/`applyOfflineState` always re-derive
@@ -135,9 +135,6 @@ struct NodeDetailsView: View {
                 }
             }
         }
-        .refreshable {
-            await refreshFromNetwork()
-        }
         .task(id: contact.id) {
             // Seed the live snapshot from the parent-supplied contact so the
             // first render uses whatever the parent already knew, then keep
@@ -195,7 +192,7 @@ struct NodeDetailsView: View {
                 .fill(isOnline ? Theme.success : Theme.error)
                 .frame(width: 8, height: 8)
 
-            Text(isOnline ? "Online" : "Expired")
+            Text(isOnline ? "Online" : "No Active Path")
                 .font(.subheadline)
                 .fontWeight(.medium)
                 .foregroundStyle(isOnline ? Theme.success : Theme.error)
@@ -208,12 +205,10 @@ struct NodeDetailsView: View {
         }
     }
 
-    // MARK: - Expired Hint
+    // MARK: - Missing Path Hint
 
-    /// Help text shown when a contact's path entry has expired (no recent
-    /// announce on the network). Most common right after scanning a QR — the
-    /// destination hash is known but the network hasn't yet relayed an
-    /// announce we can use to route to them.
+    /// Help text shown when no current path is cached. Browsing remains passive;
+    /// the messaging backend requests and awaits a path only when Send is used.
     private var expiredHint: some View {
         HStack(alignment: .top, spacing: 12) {
             Image(systemName: "info.circle.fill")
@@ -221,12 +216,12 @@ struct NodeDetailsView: View {
                 .foregroundStyle(Theme.accentColor)
 
             VStack(alignment: .leading, spacing: 4) {
-                Text("Path needs refresh")
+                Text("No active path")
                     .font(.subheadline)
                     .fontWeight(.semibold)
                     .foregroundStyle(Theme.textPrimary)
 
-                Text("We haven't routed to this contact recently. Tap an action to issue a path request — any node on the network with a recent announce will respond.")
+                Text("Columba will request a path automatically when you send a message.")
                     .font(.caption)
                     .foregroundStyle(Theme.textSecondary)
                     .fixedSize(horizontal: false, vertical: true)
@@ -644,17 +639,4 @@ struct NodeDetailsView: View {
         }
     }
 
-    /// Pull-to-refresh handler. Re-resolves path data and, if the transport
-    /// supports it, sends an active path request to probe for the contact.
-    private func refreshFromNetwork() async {
-        // Trigger an active probe so the network has a chance to surface a
-        // fresh announce before we re-read the table. This is best-effort —
-        // if no node responds, we just re-display whatever the cache holds.
-        if let transport = appServices.transport {
-            await transport.requestPath(for: contact.identityHash)
-        }
-        // Give the path request a brief window to land before reloading.
-        try? await Task.sleep(for: .milliseconds(500))
-        await loadPathDetails()
-    }
 }

--- a/Sources/PythonBridge/PythonBridge.swift
+++ b/Sources/PythonBridge/PythonBridge.swift
@@ -95,6 +95,13 @@ public final class PythonBridge: @unchecked Sendable {
     /// access regardless of thread — the same pattern the BLE callback path
     /// already relies on.
     private let blockingQueue = DispatchQueue(label: "network.columba.python.blocking", qos: .userInitiated)
+    /// Dedicated path resolver queue so unrelated blocking bridge work cannot
+    /// delay the start of a send's bounded path wait.
+    private let pathResolutionQueue = DispatchQueue(
+        label: "network.columba.python.path-resolution",
+        qos: .userInitiated,
+        attributes: .concurrent
+    )
     private var module: UnsafeMutablePointer<PyObject>?
 
     public init() {}
@@ -447,6 +454,60 @@ public final class PythonBridge: @unchecked Sendable {
                     throw BridgeError.pythonException(currentPythonException())
                 }
                 Py_DecRef(arg)
+                defer { Py_DecRef(result) }
+                return pyBoolFromDict(result, key: "ok") ?? false
+            }
+        }
+    }
+
+    /// Retain a verified QR peer identity in Python's known-destination cache.
+    /// This performs no path request.
+    public func rememberPeerIdentity(destHashHex: String, publicKey: Data) async throws -> Bool {
+        try await runOnQueue { [self] in
+            try PythonRuntime.shared.withGIL { [self] in
+                guard let module = self.module else { return false }
+                guard let fn = PyObject_GetAttrString(module, "remember_peer_identity") else {
+                    throw BridgeError.pythonException(currentPythonException())
+                }
+                defer { Py_DecRef(fn) }
+                guard let args = PyTuple_New(2) else { throw BridgeError.marshallingFailure("PyTuple_New") }
+                defer { Py_DecRef(args) }
+                guard let dest = PyUnicode_FromString(destHashHex),
+                      let key = PyUnicode_FromString(publicKey.toHex()) else {
+                    throw BridgeError.marshallingFailure("PyUnicode_FromString")
+                }
+                PyTuple_SetItem(args, 0, dest)
+                PyTuple_SetItem(args, 1, key)
+                guard let result = PyObject_CallObject(fn, args) else {
+                    throw BridgeError.pythonException(currentPythonException())
+                }
+                defer { Py_DecRef(result) }
+                return pyBoolFromDict(result, key: "ok") ?? false
+            }
+        }
+    }
+
+    /// Resolve a recipient path at send time. Python issues at most one active
+    /// request and waits until both the route and recalled identity are usable.
+    public func resolvePath(destHashHex: String, timeout: TimeInterval = 10.0) async throws -> Bool {
+        try await runOnQueue(on: pathResolutionQueue) { [self] in
+            try PythonRuntime.shared.withGIL { [self] in
+                guard let module = self.module else { return false }
+                guard let fn = PyObject_GetAttrString(module, "resolve_path") else {
+                    throw BridgeError.pythonException(currentPythonException())
+                }
+                defer { Py_DecRef(fn) }
+                guard let args = PyTuple_New(2) else { throw BridgeError.marshallingFailure("PyTuple_New") }
+                defer { Py_DecRef(args) }
+                guard let dest = PyUnicode_FromString(destHashHex),
+                      let seconds = PyFloat_FromDouble(max(0, timeout)) else {
+                    throw BridgeError.marshallingFailure("path arguments")
+                }
+                PyTuple_SetItem(args, 0, dest)
+                PyTuple_SetItem(args, 1, seconds)
+                guard let result = PyObject_CallObject(fn, args) else {
+                    throw BridgeError.pythonException(currentPythonException())
+                }
                 defer { Py_DecRef(result) }
                 return pyBoolFromDict(result, key: "ok") ?? false
             }

--- a/Sources/RNSAPI/Protocols/RnsBackend.swift
+++ b/Sources/RNSAPI/Protocols/RnsBackend.swift
@@ -234,6 +234,12 @@ public protocol RnsCore: AnyObject, Sendable {
     func statusSnapshot() async -> StatusSnapshot?
     @discardableResult func persist() async -> Bool
 
+    /// Retain a verified peer public identity without requesting a network path.
+    /// QR imports use this so a later propagated send can encrypt for an offline
+    /// peer. Backends that do not own an identity cache may return false.
+    @discardableResult
+    func rememberPeerIdentity(destHashHex: String, publicKey: Data) async -> Bool
+
     /// Lowercase-hex destination hashes this node has actually registered
     /// (its `lxmf.delivery` destination, plus `lxst.telephony` where the backend
     /// surfaces it). Backend-neutral so the Network Extension's sniff-only
@@ -252,6 +258,9 @@ public extension RnsCore {
     /// Default: no native BLE interface ⇒ no peers. Keeps the non-Model-B backends
     /// (Swift / Python) conforming without each needing a stub.
     func bleConnections() async -> [BLEConnectionInfo] { [] }
+
+    @discardableResult
+    func rememberPeerIdentity(destHashHex: String, publicKey: Data) async -> Bool { false }
 }
 
 /// RNS.Link operations backing LXST voice (the Swift state machine drives these;

--- a/Sources/RNSBackendPy/PythonRNSBackend.swift
+++ b/Sources/RNSBackendPy/PythonRNSBackend.swift
@@ -84,6 +84,14 @@ public final class PythonRNSBackend: RnsBackend, @unchecked Sendable {
     }
 
     @discardableResult
+    public func rememberPeerIdentity(destHashHex: String, publicKey: Data) async -> Bool {
+        (try? await bridge.rememberPeerIdentity(
+            destHashHex: destHashHex,
+            publicKey: publicKey
+        )) ?? false
+    }
+
+    @discardableResult
     public func sendLxmfMessage(
         destHashHex: String,
         content: String,
@@ -96,6 +104,14 @@ public final class PythonRNSBackend: RnsBackend, @unchecked Sendable {
         replyQuotedContent: String?,
         extraFields: [UInt8: Data]?
     ) async throws -> SendOutcome {
+        // Browse/add/open remain passive. Only an actual non-propagated send
+        // actively resolves the recipient path, with one request and a bounded
+        // wait in Python. Propagated sends need the retained identity but do not
+        // require the recipient to be online.
+        if method != .propagated,
+           try await bridge.resolvePath(destHashHex: destHashHex, timeout: 10.0) == false {
+            return .requestingPath
+        }
         // Build the canonical LXMF field map (shared builder → identical to the
         // Swift backend) and forward it MessagePack-packed (hex) to Python, which
         // unpacks it onto the outbound LXMF message.
@@ -125,6 +141,9 @@ public final class PythonRNSBackend: RnsBackend, @unchecked Sendable {
     @discardableResult
     public func sendReaction(destHashHex: String, targetMessageHashHex: String, emoji: String) async throws -> SendOutcome {
         guard let targetHash = try? targetMessageHashHex.hexToData() else { return .badHash }
+        if try await bridge.resolvePath(destHashHex: destHashHex, timeout: 10.0) == false {
+            return .requestingPath
+        }
         // Canonical FIELD_REACTION (0x40) on an empty-content message.
         let reaction: [UInt8: Any] = [
             LxmfFields.REACTION_TO: targetHash,

--- a/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
+++ b/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
@@ -369,6 +369,14 @@ final class MessageRepositoryAtomicReplacementTests: XCTestCase {
 
         retry.state = .sending
         try await repository.stageRetry(retry, replacing: retryHash)
+        do {
+            try await repository.stageRetry(retry, replacing: retryHash)
+            XCTFail("Expected a second retry owner to lose the compare-and-set")
+        } catch {
+            // Expected: the first stage changed the durable source state.
+        }
+        let uncertainBeforeRecovery = try await repository.hasUncertainRetry(for: destination)
+        XCTAssertFalse(uncertainBeforeRecovery)
         let recoveredCount = try await repository.recoverInterruptedRetries()
         XCTAssertEqual(recoveredCount, 1)
 
@@ -376,6 +384,8 @@ final class MessageRepositoryAtomicReplacementTests: XCTestCase {
         let recovered = try XCTUnwrap(storedRecovered)
         XCTAssertEqual(recovered.state, LXMessageState.failed.rawValue)
         XCTAssertEqual(recovered.receivingInterface, MessageRepository.uncertainRetryMarker)
+        let uncertainAfterRecovery = try await repository.hasUncertainRetry(for: destination)
+        XCTAssertTrue(uncertainAfterRecovery)
         let secondRecoveryCount = try await repository.recoverInterruptedRetries()
         XCTAssertEqual(secondRecoveryCount, 0)
     }
@@ -399,6 +409,8 @@ final class MessageRepositoryAtomicReplacementTests: XCTestCase {
         try await repository.replaceMessage(retry, replacing: retryHash)
         let recoveredCount = try await repository.recoverInterruptedRetries()
         XCTAssertEqual(recoveredCount, 0)
+        let hasUncertainRetry = try await repository.hasUncertainRetry(for: destination)
+        XCTAssertFalse(hasUncertainRetry)
 
         let stored = try await repository.getMessageRecord(id: retryHash)
         let untouched = try XCTUnwrap(stored)

--- a/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
+++ b/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
@@ -138,6 +138,60 @@ final class AnnounceClassificationTests: XCTestCase {
         XCTAssertEqual(enriched.badgeType, .audio)
     }
 
+    func testSavedConversationIsExplicitlyTypedAsLXMFDelivery() {
+        let saved = Contact(from: ConversationRecord(
+            hash: Data(repeating: 0x42, count: 16),
+            displayName: "Saved peer",
+            isFavorite: 1
+        ))
+
+        XCTAssertEqual(saved.destinationAspect, .lxmfDelivery)
+        XCTAssertEqual(saved.badgeType, .peer)
+    }
+
+    func testValidLXMAContactBindsDestinationHashToPublicIdentity() throws {
+        let identity = Identity()
+        let destinationHash = Destination.hash(
+            identity: identity,
+            appName: "lxmf",
+            aspects: ["delivery"]
+        )
+        let destinationHex = destinationHash.map { String(format: "%02x", $0) }.joined()
+        let publicKeyHex = identity.publicKeys.map { String(format: "%02x", $0) }.joined()
+        let uri = "lxma://\(destinationHex):\(publicKeyHex)"
+
+        let parsed = ContactsViewModel.parseLXMA(uri)
+
+        XCTAssertEqual(parsed?.destinationHash, destinationHash)
+        XCTAssertEqual(parsed?.publicKey, identity.publicKeys)
+    }
+
+    func testLXMAContactRejectsPublicIdentityThatDoesNotOwnDestination() throws {
+        let destinationIdentity = Identity()
+        let differentIdentity = Identity()
+        let destinationHash = Destination.hash(
+            identity: destinationIdentity,
+            appName: "lxmf",
+            aspects: ["delivery"]
+        )
+        let destinationHex = destinationHash.map { String(format: "%02x", $0) }.joined()
+        let publicKeyHex = differentIdentity.publicKeys.map { String(format: "%02x", $0) }.joined()
+        let uri = "lxma://\(destinationHex):\(publicKeyHex)"
+
+        XCTAssertNil(ContactsViewModel.parseLXMA(uri))
+    }
+
+    func testSharedQRCodeUsesLXMFDeliveryDestinationNotIdentityHash() {
+        let info = IdentityInfo(
+            identityHash: String(repeating: "11", count: 16),
+            publicKeyHex: String(repeating: "22", count: 64),
+            destinationHash: String(repeating: "33", count: 16)
+        )
+
+        XCTAssertTrue(info.qrCodeString.hasPrefix("lxma://\(String(repeating: "33", count: 16))"))
+        XCTAssertFalse(info.qrCodeString.contains(String(repeating: "11", count: 16)))
+    }
+
     /// Aspect is the sole relay signal: an UNTAGGED announce (no aspect) whose
     /// app_data happens to be propagation-shaped is NOT promoted to a relay.
     /// (Both backends guarantee a genuine propagation node arrives tagged
@@ -192,5 +246,34 @@ final class AnnounceClassificationTests: XCTestCase {
         )
 
         XCTAssertEqual(contact.resolvedDisplayName, "Peer ABABABAB")
+    }
+
+    func testSendPathTimeoutExplainsWhatFailed() {
+        XCTAssertEqual(
+            MessagingViewModel.failureDescription(for: .requestingPath),
+            "No active path to this contact was found after waiting 10 seconds."
+        )
+    }
+
+    func testSendReadinessAndDestinationFailuresAreActionable() {
+        XCTAssertEqual(
+            MessagingViewModel.failureDescription(for: .notStarted),
+            "The messaging network is not ready."
+        )
+        XCTAssertEqual(
+            MessagingViewModel.failureDescription(for: .badHash),
+            "The contact has an invalid LXMF destination."
+        )
+    }
+
+    func testSendBackendReasonIsPreserved() {
+        XCTAssertEqual(
+            MessagingViewModel.failureDescription(for: .other("No propagation node is configured.")),
+            "No propagation node is configured."
+        )
+    }
+
+    func testQueuedSendHasNoFailureDescription() {
+        XCTAssertNil(MessagingViewModel.failureDescription(for: .queued(messageHash: "00")))
     }
 }

--- a/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
+++ b/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
@@ -368,18 +368,19 @@ final class MessageRepositoryAtomicReplacementTests: XCTestCase {
         try await repository.saveMessage(retry)
 
         retry.state = .sending
-        try await repository.replaceMessage(retry, replacing: retryHash)
-        let recoveredCount = try await repository.recoverInterruptedRetries(for: destination)
+        try await repository.stageRetry(retry, replacing: retryHash)
+        let recoveredCount = try await repository.recoverInterruptedRetries()
         XCTAssertEqual(recoveredCount, 1)
 
         let storedRecovered = try await repository.getMessageRecord(id: retryHash)
         let recovered = try XCTUnwrap(storedRecovered)
         XCTAssertEqual(recovered.state, LXMessageState.failed.rawValue)
-        let secondRecoveryCount = try await repository.recoverInterruptedRetries(for: destination)
+        XCTAssertEqual(recovered.receivingInterface, MessageRepository.uncertainRetryMarker)
+        let secondRecoveryCount = try await repository.recoverInterruptedRetries()
         XCTAssertEqual(secondRecoveryCount, 0)
     }
 
-    func testActiveRetryIsNotRecoveredUntilItsOwnerFinishes() async throws {
+    func testNonAppSendingRowIsNotRecovered() async throws {
         let databaseURL = temporaryDatabaseURL()
         defer { removeDatabase(at: databaseURL) }
         let repository = try MessageRepository(grdbPath: databaseURL.path)
@@ -395,13 +396,13 @@ final class MessageRepositoryAtomicReplacementTests: XCTestCase {
         try await repository.saveMessage(retry)
 
         retry.state = .sending
-        try await repository.stageRetry(retry, replacing: retryHash)
-        let whileActive = try await repository.recoverInterruptedRetries(for: destination)
-        XCTAssertEqual(whileActive, 0)
+        try await repository.replaceMessage(retry, replacing: retryHash)
+        let recoveredCount = try await repository.recoverInterruptedRetries()
+        XCTAssertEqual(recoveredCount, 0)
 
-        await repository.finishRetry(retryHash)
         let stored = try await repository.getMessageRecord(id: retryHash)
-        let finished = try XCTUnwrap(stored)
-        XCTAssertEqual(finished.state, LXMessageState.failed.rawValue)
+        let untouched = try XCTUnwrap(stored)
+        XCTAssertEqual(untouched.state, LXMessageState.sending.rawValue)
+        XCTAssertNil(untouched.receivingInterface)
     }
 }

--- a/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
+++ b/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import ColumbaApp
 import RNSAPI
+import GRDB
 
 /// Tests for `Contact.init(from: PathEntry)` announce classification — the
 /// single backend-independent point where every networkAnnounces entry gets
@@ -290,10 +291,23 @@ final class MessageRepositoryAtomicReplacementTests: XCTestCase {
         try? FileManager.default.removeItem(atPath: url.path + "-wal")
     }
 
+    private func rawMessageSnapshot(_ queue: DatabaseQueue, id: Data) throws -> [String: String] {
+        try queue.read { db in
+            let row = try XCTUnwrap(
+                Row.fetchOne(db, sql: "SELECT * FROM messages WHERE message_id = ?", arguments: [id])
+            )
+            return Dictionary(uniqueKeysWithValues: row.columnNames.map { name in
+                let value: DatabaseValue = row[name]
+                return (name, String(reflecting: value))
+            })
+        }
+    }
+
     func testRetryReplacementRekeysExactlyOneDurableRow() async throws {
         let databaseURL = temporaryDatabaseURL()
         defer { removeDatabase(at: databaseURL) }
         let repository = try MessageRepository(grdbPath: databaseURL.path)
+        let queue = try DatabaseQueue(path: databaseURL.path)
         let destination = Data(repeating: 0x11, count: 16)
         let oldHash = Data(repeating: 0x22, count: 32)
         let canonicalHash = Data(repeating: 0x33, count: 32)
@@ -301,12 +315,27 @@ final class MessageRepositoryAtomicReplacementTests: XCTestCase {
         let failed = RNSAPI.LXMessage(
             destinationHash: destination,
             sourceIdentity: nil,
-            content: Data("payload".utf8)
+            content: Data("payload".utf8),
+            title: Data("title".utf8),
+            fields: [
+                RNSAPI.LXMessage.FIELD_IMAGE: ["png", Data([0x01, 0x02])] as [Any],
+                RNSAPI.LXMessage.FIELD_FILE_ATTACHMENTS: [
+                    ["notes.txt", Data("attachment".utf8)] as [Any]
+                ] as [Any],
+                RNSAPI.LXMessage.FIELD_APP_DATA: ["reply_to": "parent-hash"],
+            ]
         )
         failed.hash = oldHash
         failed.state = .failed
         failed.method = .opportunistic
         try await repository.saveMessage(failed)
+        try await repository.updateReplyToId(oldHash, replyToId: "parent-hash")
+        let originalStored = try await repository.getMessageRecord(id: oldHash)
+        let original = try XCTUnwrap(originalStored)
+        let originalRaw = try rawMessageSnapshot(queue, id: oldHash)
+
+        failed.state = .sending
+        try await repository.stageRetry(failed, replacing: oldHash)
 
         let sent = RNSAPI.LXMessage(
             destinationHash: destination,
@@ -321,10 +350,16 @@ final class MessageRepositoryAtomicReplacementTests: XCTestCase {
         let oldRecord = try await repository.getMessageRecord(id: oldHash)
         let storedCanonical = try await repository.getMessageRecord(id: canonicalHash)
         let canonicalRecord = try XCTUnwrap(storedCanonical)
+        let canonicalRaw = try rawMessageSnapshot(queue, id: canonicalHash)
         XCTAssertNil(oldRecord)
         XCTAssertEqual(canonicalRecord.content, Data("payload".utf8))
+        XCTAssertEqual(canonicalRaw["title"], originalRaw["title"])
+        XCTAssertEqual(canonicalRecord.packedLxmf, original.packedLxmf)
+        XCTAssertEqual(canonicalRecord.replyToId, "parent-hash")
         XCTAssertEqual(canonicalRecord.state, LXMessageState.sent.rawValue)
         XCTAssertEqual(canonicalRecord.method, LXDeliveryMethod.propagated.rawValue)
+        XCTAssertEqual(canonicalRecord.timestamp, sent.timestamp)
+        XCTAssertNil(canonicalRecord.receivingInterface)
     }
 
     func testMissingRetrySourceDoesNotCreateCanonicalRow() async throws {
@@ -349,6 +384,61 @@ final class MessageRepositoryAtomicReplacementTests: XCTestCase {
         } catch {
             let canonicalRecord = try await repository.getMessageRecord(id: canonicalHash)
             XCTAssertNil(canonicalRecord)
+        }
+    }
+
+    func testReplacementRollsBackAfterPostUpdateFailure() async throws {
+        let databaseURL = temporaryDatabaseURL()
+        defer { removeDatabase(at: databaseURL) }
+        let repository = try MessageRepository(grdbPath: databaseURL.path)
+        let queue = try DatabaseQueue(path: databaseURL.path)
+        let destination = Data(repeating: 0x81, count: 16)
+        let oldHash = Data(repeating: 0x82, count: 32)
+        let canonicalHash = Data(repeating: 0x83, count: 32)
+        let failed = RNSAPI.LXMessage(
+            destinationHash: destination,
+            sourceIdentity: nil,
+            content: Data("rollback-payload".utf8),
+            title: Data("rollback-title".utf8),
+            fields: [
+                RNSAPI.LXMessage.FIELD_FILE_ATTACHMENTS: [
+                    ["rollback.bin", Data([0xaa, 0xbb, 0xcc])] as [Any]
+                ] as [Any]
+            ]
+        )
+        failed.hash = oldHash
+        failed.state = .failed
+        failed.method = .opportunistic
+        try await repository.saveMessage(failed)
+        try await repository.updateReplyToId(oldHash, replyToId: "rollback-parent")
+        let before = try rawMessageSnapshot(queue, id: oldHash)
+
+        try await queue.write { db in
+            try db.execute(sql: """
+                CREATE TRIGGER force_conversation_update_failure
+                BEFORE UPDATE ON conversations
+                BEGIN
+                    SELECT RAISE(ABORT, 'forced post-message-update failure');
+                END
+                """)
+        }
+
+        let sent = RNSAPI.LXMessage(
+            destinationHash: destination,
+            sourceIdentity: nil,
+            content: Data("ignored-new-content".utf8)
+        )
+        sent.hash = canonicalHash
+        sent.state = .sent
+        sent.method = .propagated
+        do {
+            try await repository.replaceMessage(sent, replacing: oldHash)
+            XCTFail("Expected the conversation trigger to abort replacement")
+        } catch {
+            let after = try rawMessageSnapshot(queue, id: oldHash)
+            XCTAssertEqual(after, before)
+            let canonical = try await repository.getMessageRecord(id: canonicalHash)
+            XCTAssertNil(canonical)
         }
     }
 

--- a/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
+++ b/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
@@ -324,6 +324,7 @@ final class MessageRepositoryAtomicReplacementTests: XCTestCase {
         XCTAssertNil(oldRecord)
         XCTAssertEqual(canonicalRecord.content, Data("payload".utf8))
         XCTAssertEqual(canonicalRecord.state, LXMessageState.sent.rawValue)
+        XCTAssertEqual(canonicalRecord.method, LXDeliveryMethod.propagated.rawValue)
     }
 
     func testMissingRetrySourceDoesNotCreateCanonicalRow() async throws {

--- a/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
+++ b/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
@@ -351,4 +351,57 @@ final class MessageRepositoryAtomicReplacementTests: XCTestCase {
             XCTAssertNil(canonicalRecord)
         }
     }
+
+    func testInterruptedRetryIsRecoveredAsUserVisibleFailure() async throws {
+        let databaseURL = temporaryDatabaseURL()
+        defer { removeDatabase(at: databaseURL) }
+        let repository = try MessageRepository(grdbPath: databaseURL.path)
+        let destination = Data(repeating: 0x61, count: 16)
+        let retryHash = Data(repeating: 0x62, count: 32)
+        let retry = RNSAPI.LXMessage(
+            destinationHash: destination,
+            sourceIdentity: nil,
+            content: Data("retry".utf8)
+        )
+        retry.hash = retryHash
+        retry.state = .failed
+        try await repository.saveMessage(retry)
+
+        retry.state = .sending
+        try await repository.replaceMessage(retry, replacing: retryHash)
+        let recoveredCount = try await repository.recoverInterruptedRetries(for: destination)
+        XCTAssertEqual(recoveredCount, 1)
+
+        let storedRecovered = try await repository.getMessageRecord(id: retryHash)
+        let recovered = try XCTUnwrap(storedRecovered)
+        XCTAssertEqual(recovered.state, LXMessageState.failed.rawValue)
+        let secondRecoveryCount = try await repository.recoverInterruptedRetries(for: destination)
+        XCTAssertEqual(secondRecoveryCount, 0)
+    }
+
+    func testActiveRetryIsNotRecoveredUntilItsOwnerFinishes() async throws {
+        let databaseURL = temporaryDatabaseURL()
+        defer { removeDatabase(at: databaseURL) }
+        let repository = try MessageRepository(grdbPath: databaseURL.path)
+        let destination = Data(repeating: 0x71, count: 16)
+        let retryHash = Data(repeating: 0x72, count: 32)
+        let retry = RNSAPI.LXMessage(
+            destinationHash: destination,
+            sourceIdentity: nil,
+            content: Data("active".utf8)
+        )
+        retry.hash = retryHash
+        retry.state = .failed
+        try await repository.saveMessage(retry)
+
+        retry.state = .sending
+        try await repository.stageRetry(retry, replacing: retryHash)
+        let whileActive = try await repository.recoverInterruptedRetries(for: destination)
+        XCTAssertEqual(whileActive, 0)
+
+        await repository.finishRetry(retryHash)
+        let stored = try await repository.getMessageRecord(id: retryHash)
+        let finished = try XCTUnwrap(stored)
+        XCTAssertEqual(finished.state, LXMessageState.failed.rawValue)
+    }
 }

--- a/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
+++ b/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
@@ -277,3 +277,77 @@ final class AnnounceClassificationTests: XCTestCase {
         XCTAssertNil(MessagingViewModel.failureDescription(for: .queued(messageHash: "00")))
     }
 }
+
+final class MessageRepositoryAtomicReplacementTests: XCTestCase {
+    private func temporaryDatabaseURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("columba-atomic-retry-\(UUID().uuidString).sqlite")
+    }
+
+    private func removeDatabase(at url: URL) {
+        try? FileManager.default.removeItem(at: url)
+        try? FileManager.default.removeItem(atPath: url.path + "-shm")
+        try? FileManager.default.removeItem(atPath: url.path + "-wal")
+    }
+
+    func testRetryReplacementRekeysExactlyOneDurableRow() async throws {
+        let databaseURL = temporaryDatabaseURL()
+        defer { removeDatabase(at: databaseURL) }
+        let repository = try MessageRepository(grdbPath: databaseURL.path)
+        let destination = Data(repeating: 0x11, count: 16)
+        let oldHash = Data(repeating: 0x22, count: 32)
+        let canonicalHash = Data(repeating: 0x33, count: 32)
+
+        let failed = RNSAPI.LXMessage(
+            destinationHash: destination,
+            sourceIdentity: nil,
+            content: Data("payload".utf8)
+        )
+        failed.hash = oldHash
+        failed.state = .failed
+        failed.method = .opportunistic
+        try await repository.saveMessage(failed)
+
+        let sent = RNSAPI.LXMessage(
+            destinationHash: destination,
+            sourceIdentity: nil,
+            content: Data("payload".utf8)
+        )
+        sent.hash = canonicalHash
+        sent.state = .sent
+        sent.method = .propagated
+        try await repository.replaceMessage(sent, replacing: oldHash)
+
+        let oldRecord = try await repository.getMessageRecord(id: oldHash)
+        let storedCanonical = try await repository.getMessageRecord(id: canonicalHash)
+        let canonicalRecord = try XCTUnwrap(storedCanonical)
+        XCTAssertNil(oldRecord)
+        XCTAssertEqual(canonicalRecord.content, Data("payload".utf8))
+        XCTAssertEqual(canonicalRecord.state, LXMessageState.sent.rawValue)
+    }
+
+    func testMissingRetrySourceDoesNotCreateCanonicalRow() async throws {
+        let databaseURL = temporaryDatabaseURL()
+        defer { removeDatabase(at: databaseURL) }
+        let repository = try MessageRepository(grdbPath: databaseURL.path)
+        let canonicalHash = Data(repeating: 0x44, count: 32)
+        let message = RNSAPI.LXMessage(
+            destinationHash: Data(repeating: 0x55, count: 16),
+            sourceIdentity: nil,
+            content: Data("payload".utf8)
+        )
+        message.hash = canonicalHash
+        message.state = .sent
+
+        do {
+            try await repository.replaceMessage(
+                message,
+                replacing: Data(repeating: 0x66, count: 32)
+            )
+            XCTFail("Expected replacement of a missing source row to fail")
+        } catch {
+            let canonicalRecord = try await repository.getMessageRecord(id: canonicalHash)
+            XCTAssertNil(canonicalRecord)
+        }
+    }
+}

--- a/Tests/static/test_qr_contact_send_path_contract.py
+++ b/Tests/static/test_qr_contact_send_path_contract.py
@@ -158,7 +158,7 @@ class QRContactSendPathContractTests(unittest.TestCase):
         view_model = self._read("Sources/ColumbaApp/ViewModels/MessagingViewModel.swift")
         repository = self._read("Sources/ColumbaApp/Services/MessageRepository.swift")
         app_services = self._read("Sources/ColumbaApp/Services/AppServices.swift")
-        self.assertIn("messageRepository.recoverInterruptedRetries()", app_services)
+        self.assertGreaterEqual(app_services.count("messageRepository.recoverInterruptedRetries()"), 3)
         self.assertIn("Verify whether it arrived before retrying", view_model)
         self.assertIn("repository.hasUncertainRetry(for: conversationHash)", view_model)
         self.assertIn("public func recoverInterruptedRetries", repository)

--- a/Tests/static/test_qr_contact_send_path_contract.py
+++ b/Tests/static/test_qr_contact_send_path_contract.py
@@ -148,8 +148,9 @@ class QRContactSendPathContractTests(unittest.TestCase):
         wire_send = send.index("backend.lxmf.sendLxmfMessage")
         self.assertLess(stage, wire_send)
         self.assertIn("repository.replaceMessage(lxMessage, replacing: storedHash)", send)
-        self.assertIn('execute("BEGIN IMMEDIATE")', repository)
-        self.assertIn('execute("COMMIT")', repository)
+        self.assertIn("config.observesSuspensionNotifications = true", repository)
+        self.assertIn("try await replacementPool.write", repository)
+        self.assertIn("retryMessage.method = .propagated", send)
         self.assertIn("replacementSourceMissing", repository)
         self.assertNotIn("repository.deleteMessage(oldHash)", send)
 

--- a/Tests/static/test_qr_contact_send_path_contract.py
+++ b/Tests/static/test_qr_contact_send_path_contract.py
@@ -148,7 +148,6 @@ class QRContactSendPathContractTests(unittest.TestCase):
         wire_send = send.index("backend.lxmf.sendLxmfMessage")
         self.assertLess(stage, wire_send)
         self.assertIn("repository.stageRetry(lxMessage, replacing: storedHash)", send)
-        self.assertIn("repository.finishRetry(retryHash)", send)
         self.assertIn("config.observesSuspensionNotifications = true", repository)
         self.assertIn("try await replacementPool.write", repository)
         self.assertIn("retryMessage.method = .propagated", send)
@@ -158,13 +157,15 @@ class QRContactSendPathContractTests(unittest.TestCase):
     def test_interrupted_retry_is_recovered_once_as_failed(self) -> None:
         view_model = self._read("Sources/ColumbaApp/ViewModels/MessagingViewModel.swift")
         repository = self._read("Sources/ColumbaApp/Services/MessageRepository.swift")
-        self.assertIn("private var didRecoverInterruptedRetries = false", view_model)
-        self.assertIn("repository.recoverInterruptedRetries", view_model)
-        self.assertIn("didRecoverInterruptedRetries = true", view_model)
+        app_services = self._read("Sources/ColumbaApp/Services/AppServices.swift")
+        self.assertIn("messageRepository.recoverInterruptedRetries()", app_services)
         self.assertIn("Verify whether it arrived before retrying", view_model)
+        self.assertIn("MessageRepository.uncertainRetryMarker", view_model)
         self.assertIn("public func recoverInterruptedRetries", repository)
         self.assertIn("LXMFSwift.LXMessageState.sending.rawValue", repository)
-        self.assertIn("incoming = 0 AND state = ?", repository)
+        self.assertIn("receiving_interface = ?", repository)
+        self.assertIn("Self.stagedRetryMarker", repository)
+        self.assertIn("Self.uncertainRetryMarker", repository)
 
     def test_existing_qr_contact_can_refresh_peer_identity(self) -> None:
         add_sheet = self._read("Sources/ColumbaApp/Views/Contacts/AddContactSheet.swift")

--- a/Tests/static/test_qr_contact_send_path_contract.py
+++ b/Tests/static/test_qr_contact_send_path_contract.py
@@ -150,6 +150,7 @@ class QRContactSendPathContractTests(unittest.TestCase):
         self.assertIn("repository.stageRetry(lxMessage, replacing: storedHash)", send)
         self.assertIn("config.observesSuspensionNotifications = true", repository)
         self.assertIn("try await replacementPool.write", repository)
+        self.assertIn("lxMessage.method = .opportunistic", send)
         self.assertIn("retryMessage.method = .propagated", send)
         self.assertIn("replacementSourceMissing", repository)
         self.assertNotIn("repository.deleteMessage(oldHash)", send)

--- a/Tests/static/test_qr_contact_send_path_contract.py
+++ b/Tests/static/test_qr_contact_send_path_contract.py
@@ -144,15 +144,27 @@ class QRContactSendPathContractTests(unittest.TestCase):
             "    /// Retry sending a failed message.",
         )
         repository = self._read("Sources/ColumbaApp/Services/MessageRepository.swift")
-        stage = send.index("lxMessage.state = .outbound")
+        stage = send.index("lxMessage.state = .sending")
         wire_send = send.index("backend.lxmf.sendLxmfMessage")
         self.assertLess(stage, wire_send)
-        self.assertIn("repository.replaceMessage(lxMessage, replacing: storedHash)", send)
+        self.assertIn("repository.stageRetry(lxMessage, replacing: storedHash)", send)
+        self.assertIn("repository.finishRetry(retryHash)", send)
         self.assertIn("config.observesSuspensionNotifications = true", repository)
         self.assertIn("try await replacementPool.write", repository)
         self.assertIn("retryMessage.method = .propagated", send)
         self.assertIn("replacementSourceMissing", repository)
         self.assertNotIn("repository.deleteMessage(oldHash)", send)
+
+    def test_interrupted_retry_is_recovered_once_as_failed(self) -> None:
+        view_model = self._read("Sources/ColumbaApp/ViewModels/MessagingViewModel.swift")
+        repository = self._read("Sources/ColumbaApp/Services/MessageRepository.swift")
+        self.assertIn("private var didRecoverInterruptedRetries = false", view_model)
+        self.assertIn("repository.recoverInterruptedRetries", view_model)
+        self.assertIn("didRecoverInterruptedRetries = true", view_model)
+        self.assertIn("Verify whether it arrived before retrying", view_model)
+        self.assertIn("public func recoverInterruptedRetries", repository)
+        self.assertIn("LXMFSwift.LXMessageState.sending.rawValue", repository)
+        self.assertIn("incoming = 0 AND state = ?", repository)
 
     def test_existing_qr_contact_can_refresh_peer_identity(self) -> None:
         add_sheet = self._read("Sources/ColumbaApp/Views/Contacts/AddContactSheet.swift")

--- a/Tests/static/test_qr_contact_send_path_contract.py
+++ b/Tests/static/test_qr_contact_send_path_contract.py
@@ -119,7 +119,7 @@ class QRContactSendPathContractTests(unittest.TestCase):
         start = body.index("        } catch {\n            var failure")
         final_failure = body[start:]
         self.assertIn("lxMessage.state = .failed", final_failure)
-        self.assertIn("repository.saveMessage(lxMessage)", final_failure)
+        self.assertIn("persistMessage(lxMessage, replacing: localRetryHash)", final_failure)
         self.assertIn("failure.localizedDescription", final_failure)
         self.assertIn("DiagLog.log", final_failure)
         self.assertNotIn('errorMessage = "Failed to send: \\(error.localizedDescription)"', final_failure)
@@ -136,6 +136,22 @@ class QRContactSendPathContractTests(unittest.TestCase):
         self.assertIn("imageData: failedMessage.imageData", retry)
         self.assertIn("attachments: failedMessage.attachments", retry)
         self.assertNotIn("repository.deleteMessage", retry)
+
+    def test_retry_replacement_is_staged_and_atomic(self) -> None:
+        send = self._swift_function(
+            "Sources/ColumbaApp/ViewModels/MessagingViewModel.swift",
+            "    public func sendMessage(\n",
+            "    /// Retry sending a failed message.",
+        )
+        repository = self._read("Sources/ColumbaApp/Services/MessageRepository.swift")
+        stage = send.index("lxMessage.state = .outbound")
+        wire_send = send.index("backend.lxmf.sendLxmfMessage")
+        self.assertLess(stage, wire_send)
+        self.assertIn("repository.replaceMessage(lxMessage, replacing: storedHash)", send)
+        self.assertIn('execute("BEGIN IMMEDIATE")', repository)
+        self.assertIn('execute("COMMIT")', repository)
+        self.assertIn("replacementSourceMissing", repository)
+        self.assertNotIn("repository.deleteMessage(oldHash)", send)
 
     def test_existing_qr_contact_can_refresh_peer_identity(self) -> None:
         add_sheet = self._read("Sources/ColumbaApp/Views/Contacts/AddContactSheet.swift")

--- a/Tests/static/test_qr_contact_send_path_contract.py
+++ b/Tests/static/test_qr_contact_send_path_contract.py
@@ -160,12 +160,15 @@ class QRContactSendPathContractTests(unittest.TestCase):
         app_services = self._read("Sources/ColumbaApp/Services/AppServices.swift")
         self.assertIn("messageRepository.recoverInterruptedRetries()", app_services)
         self.assertIn("Verify whether it arrived before retrying", view_model)
-        self.assertIn("MessageRepository.uncertainRetryMarker", view_model)
+        self.assertIn("repository.hasUncertainRetry(for: conversationHash)", view_model)
         self.assertIn("public func recoverInterruptedRetries", repository)
         self.assertIn("LXMFSwift.LXMessageState.sending.rawValue", repository)
         self.assertIn("receiving_interface = ?", repository)
         self.assertIn("Self.stagedRetryMarker", repository)
         self.assertIn("Self.uncertainRetryMarker", repository)
+        self.assertIn("message_id = ? AND incoming = 0 AND state = ?", repository)
+        self.assertIn("receiving_interface IS NULL OR receiving_interface = ?", repository)
+        self.assertIn("public func hasUncertainRetry", repository)
 
     def test_existing_qr_contact_can_refresh_peer_identity(self) -> None:
         add_sheet = self._read("Sources/ColumbaApp/Views/Contacts/AddContactSheet.swift")

--- a/Tests/static/test_qr_contact_send_path_contract.py
+++ b/Tests/static/test_qr_contact_send_path_contract.py
@@ -1,0 +1,262 @@
+import ast
+import pathlib
+import re
+import threading
+import unittest
+from unittest import mock
+from typing import Any
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class QRContactSendPathContractTests(unittest.TestCase):
+    def _read(self, relative: str) -> str:
+        return (ROOT / relative).read_text(encoding="utf-8")
+
+    def _swift_function(self, relative: str, signature: str, next_marker: str) -> str:
+        source = self._read(relative)
+        start = source.index(signature)
+        end = source.index(next_marker, start)
+        return source[start:end]
+
+    def _load_resolve_path(self, *, resolves_after_sleep: bool):
+        source = self._read("app/rns_bridge.py")
+        tree = ast.parse(source)
+        function = next(
+            node for node in tree.body
+            if isinstance(node, ast.FunctionDef) and node.name == "resolve_path"
+        )
+
+        class FakeTransport:
+            requests = 0
+            path_known = False
+
+            @classmethod
+            def has_path(cls, _destination: bytes) -> bool:
+                return cls.path_known
+
+            @classmethod
+            def request_path(cls, _destination: bytes) -> None:
+                cls.requests += 1
+
+        class FakeIdentity:
+            @staticmethod
+            def recall(_destination: bytes):
+                return object() if FakeTransport.path_known else None
+
+        class FakeRNS:
+            Transport = FakeTransport
+            Identity = FakeIdentity
+
+        class FakeTime:
+            now = 0.0
+
+            @classmethod
+            def monotonic(cls) -> float:
+                return cls.now
+
+            @classmethod
+            def sleep(cls, interval: float) -> None:
+                cls.now += interval
+                if resolves_after_sleep:
+                    FakeTransport.path_known = True
+
+        namespace = {
+            "Any": Any,
+            "RNS": FakeRNS,
+            "time": FakeTime,
+            "_lock": threading.Lock(),
+            "_state": {"started": True},
+        }
+        exec(compile(ast.Module(body=[function], type_ignores=[]), "rns_bridge.py", "exec"), namespace)
+        return namespace["resolve_path"], FakeTransport
+
+    def test_contact_add_and_details_do_not_request_paths(self) -> None:
+        contacts = self._swift_function(
+            "Sources/ColumbaApp/ViewModels/ContactsViewModel.swift",
+            "public func addContactFromQR(",
+            "/// Convert a hex string to Data",
+        )
+        details = self._read("Sources/ColumbaApp/Views/Contacts/NodeDetailsView.swift")
+
+        self.assertNotIn("requestPath", contacts)
+        self.assertNotIn("requestPath", details)
+        self.assertNotIn("Tap an action to issue a path request", details)
+
+    def test_shipping_send_resolves_path_before_bridge_send(self) -> None:
+        backend = self._swift_function(
+            "Sources/RNSBackendPy/PythonRNSBackend.swift",
+            "public func sendLxmfMessage(",
+            "public func sendReaction(",
+        )
+        resolve = backend.index("bridge.resolvePath")
+        send = backend.index("bridge.sendOpportunistic")
+        self.assertLess(resolve, send)
+
+    def test_shipping_path_wait_uses_dedicated_bridge_queue(self) -> None:
+        body = self._swift_function(
+            "Sources/PythonBridge/PythonBridge.swift",
+            "    public func resolvePath(",
+            "    /// Send an LXMF message via the Python bridge.",
+        )
+        self.assertIn("runOnQueue(on: pathResolutionQueue)", body)
+
+    def test_shipping_reaction_resolves_path_before_send(self) -> None:
+        body = self._swift_function(
+            "Sources/RNSBackendPy/PythonRNSBackend.swift",
+            "    public func sendReaction(",
+            "    /// Set / clear the outbound LXMF propagation node.",
+        )
+        self.assertLess(body.index("bridge.resolvePath"), body.index("bridge.sendOpportunistic"))
+
+    def test_failed_send_is_persisted_with_actionable_reason(self) -> None:
+        body = self._swift_function(
+            "Sources/ColumbaApp/ViewModels/MessagingViewModel.swift",
+            "    public func sendMessage(\n        text: String,",
+            "    /// Retry sending a failed message.",
+        )
+        start = body.index("        } catch {\n            var failure")
+        final_failure = body[start:]
+        self.assertIn("lxMessage.state = .failed", final_failure)
+        self.assertIn("repository.saveMessage(lxMessage)", final_failure)
+        self.assertIn("failure.localizedDescription", final_failure)
+        self.assertIn("DiagLog.log", final_failure)
+        self.assertNotIn('errorMessage = "Failed to send: \\(error.localizedDescription)"', final_failure)
+
+    def test_failed_send_retry_preserves_identity_and_payload(self) -> None:
+        source = self._read("Sources/ColumbaApp/ViewModels/MessagingViewModel.swift")
+        self.assertIn("Data((0..<32).map", source)
+        self.assertIn("localRetryHash", source)
+        retry = self._swift_function(
+            "Sources/ColumbaApp/ViewModels/MessagingViewModel.swift",
+            "    public func retryMessage(",
+            "    /// Delete a message from the conversation.",
+        )
+        self.assertIn("imageData: failedMessage.imageData", retry)
+        self.assertIn("attachments: failedMessage.attachments", retry)
+        self.assertNotIn("repository.deleteMessage", retry)
+
+    def test_existing_qr_contact_can_refresh_peer_identity(self) -> None:
+        add_sheet = self._read("Sources/ColumbaApp/Views/Contacts/AddContactSheet.swift")
+        contacts = self._swift_function(
+            "Sources/ColumbaApp/ViewModels/ContactsViewModel.swift",
+            "public func addContactFromQR(",
+            "/// Convert a hex string to Data",
+        )
+        self.assertNotIn("alreadyExists = true\n            return", add_sheet)
+        self.assertIn("guard remembered else", contacts)
+        self.assertLess(contacts.index("guard remembered else"), contacts.index("guard !myContacts.contains"))
+
+    def test_relay_fallback_defaults_on_when_unset(self) -> None:
+        settings = self._swift_function(
+            "Sources/ColumbaApp/Services/SettingsRepository.swift",
+            "    public func getRetryViaRelay()",
+            "    /// Set whether to retry via relay on direct failure.",
+        )
+        self.assertIn("object(forKey:", settings)
+        self.assertIn("return true", settings)
+
+    def test_python_path_resolver_requests_once_and_is_bounded(self) -> None:
+        bridge = self._read("app/rns_bridge.py")
+        match = re.search(r"def resolve_path\(.*?\n(?=\ndef )", bridge, re.DOTALL)
+        self.assertIsNotNone(match)
+        assert match is not None
+        body = match.group(0)
+        self.assertIn("RNS.Transport.has_path", body)
+        self.assertEqual(body.count("RNS.Transport.request_path"), 1)
+        self.assertIn("time.monotonic()", body)
+        self.assertIn("timeout_seconds", body)
+
+    def test_python_path_resolver_is_passive_for_known_path(self) -> None:
+        resolve_path, transport = self._load_resolve_path(resolves_after_sleep=False)
+        transport.path_known = True
+
+        result = resolve_path("00" * 16, 1.0)
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(0, transport.requests)
+
+    def test_python_path_resolver_requests_once_then_observes_resolution(self) -> None:
+        resolve_path, transport = self._load_resolve_path(resolves_after_sleep=True)
+
+        result = resolve_path("00" * 16, 1.0)
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(1, transport.requests)
+
+    def test_python_path_resolver_times_out_after_one_request(self) -> None:
+        resolve_path, transport = self._load_resolve_path(resolves_after_sleep=False)
+
+        result = resolve_path("00" * 16, 0.2)
+
+        self.assertEqual({"ok": False, "reason": "timeout"}, result)
+        self.assertEqual(1, transport.requests)
+
+    def test_python_remembered_identity_is_bound_to_delivery_destination(self) -> None:
+        try:
+            import RNS
+            import app.rns_bridge as bridge
+        except ImportError as exc:
+            self.skipTest(f"embedded RNS runtime unavailable: {exc}")
+
+        identity = RNS.Identity()
+        destination = RNS.Destination(
+            identity,
+            RNS.Destination.OUT,
+            RNS.Destination.SINGLE,
+            "lxmf",
+            "delivery",
+        )
+        destination_hash = bytes(getattr(destination, "hash"))
+        public_key = identity.get_public_key()
+        self.assertIsNotNone(public_key)
+        assert public_key is not None
+        original_started = bridge._state["started"]
+        bridge._state["started"] = True
+        try:
+            with mock.patch.object(RNS.Identity, "remember") as remember, \
+                 mock.patch.object(RNS.Identity, "persist_data") as persist:
+                persist.return_value = False
+                persistence_failure = bridge.remember_peer_identity(
+                    destination_hash.hex(),
+                    public_key.hex(),
+                )
+                self.assertFalse(persistence_failure["ok"])
+                self.assertEqual("persist-failed", persistence_failure["reason"])
+
+                remember.reset_mock()
+                persist.reset_mock()
+                persist.return_value = None
+                result = bridge.remember_peer_identity(
+                    destination_hash.hex(),
+                    public_key.hex(),
+                )
+                self.assertTrue(result["ok"])
+                remember.assert_called_once()
+                persist.assert_called_once()
+
+                mismatch = bridge.remember_peer_identity(
+                    (b"\x00" * 16).hex(),
+                    public_key.hex(),
+                )
+                self.assertEqual("identity-mismatch", mismatch["reason"])
+                self.assertEqual(1, remember.call_count)
+        finally:
+            bridge._state["started"] = original_started
+
+    def test_qr_sheet_stays_open_when_identity_persistence_fails(self) -> None:
+        contacts = self._swift_function(
+            "Sources/ColumbaApp/ViewModels/ContactsViewModel.swift",
+            "public func addContactFromQR(",
+            "/// Convert a hex string to Data",
+        )
+        sheet = self._read("Sources/ColumbaApp/Views/Contacts/AddContactSheet.swift")
+        self.assertIn("async -> Bool", contacts)
+        self.assertIn("let succeeded = await viewModel.addContactFromQR", sheet)
+        self.assertIn("guard succeeded else", sheet)
+        self.assertIn("viewModel.errorMessage", sheet)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/app/rns_bridge.py
+++ b/app/rns_bridge.py
@@ -1367,6 +1367,69 @@ def persist() -> dict[str, Any]:
         return {"ok": True, "reason": "persisted"}
 
 
+def remember_peer_identity(dest_hash_hex: str, public_key_hex: str) -> dict[str, Any]:
+    """Retain a QR-provided LXMF delivery identity without requesting a path."""
+    with _lock:
+        if not _state["started"]:
+            return {"ok": False, "reason": "not-started"}
+    try:
+        dest_hash = bytes.fromhex(dest_hash_hex)
+        public_key = bytes.fromhex(public_key_hex)
+    except ValueError:
+        return {"ok": False, "reason": "bad-identity"}
+    if len(dest_hash) != 16 or len(public_key) != 64:
+        return {"ok": False, "reason": "bad-identity"}
+    try:
+        candidate = RNS.Identity(create_keys=False)
+        candidate.load_public_key(public_key)
+        candidate_dest = RNS.Destination(
+            candidate, RNS.Destination.OUT, RNS.Destination.SINGLE,
+            "lxmf", "delivery",
+        )
+        if candidate_dest.hash != dest_hash:
+            return {"ok": False, "reason": "identity-mismatch"}
+        RNS.Identity.remember(None, dest_hash, public_key, None)
+        persistence_result = RNS.Identity.persist_data()
+        # Current RNS returns None on success. An explicit False from this
+        # boundary means the identity was not durably retained.
+        if persistence_result is False:
+            return {"ok": False, "reason": "persist-failed"}
+        return {"ok": True, "reason": "remembered"}
+    except Exception as e:
+        return {"ok": False, "reason": f"remember-failed: {e}"}
+
+
+def resolve_path(dest_hash_hex: str, timeout_seconds: float = 10.0) -> dict[str, Any]:
+    """Request a missing path once and wait boundedly for route + identity."""
+    with _lock:
+        if not _state["started"]:
+            return {"ok": False, "reason": "not-started"}
+    try:
+        dest_hash = bytes.fromhex(dest_hash_hex)
+    except ValueError:
+        return {"ok": False, "reason": "bad-hash"}
+
+    def resolved() -> bool:
+        try:
+            return bool(RNS.Transport.has_path(dest_hash)) and RNS.Identity.recall(dest_hash) is not None
+        except Exception:
+            return False
+
+    if resolved():
+        return {"ok": True, "reason": "known"}
+    try:
+        RNS.Transport.request_path(dest_hash)
+    except Exception as e:
+        return {"ok": False, "reason": f"request-failed: {e}"}
+
+    deadline = time.monotonic() + max(0.0, float(timeout_seconds))
+    while time.monotonic() < deadline:
+        if resolved():
+            return {"ok": True, "reason": "resolved"}
+        time.sleep(0.1)
+    return {"ok": False, "reason": "timeout"}
+
+
 def send_opportunistic(dest_hash_hex: str, content: str, fields_hex: str = "",
                        method: str = "opportunistic") -> dict[str, Any]:
     """Send an LXMF message. Returns a dict with 'ok' (bool) and 'reason'


### PR DESCRIPTION
## Summary

- generate `lxma://` QR codes from the LXMF delivery destination instead of the identity hash
- validate that an imported public key cryptographically owns the claimed `lxmf.delivery` destination
- retain verified peer identities in the shipping Python runtime without requesting a path while browsing or importing contacts
- request and boundedly await missing paths only when sending messages or reactions, using a dedicated bridge executor
- persist actionable failed-send state and retry the complete message payload without deleting the only durable row first

## Scope

This change targets the shipping embedded-Python RNS/LXMF runtime only. It does not change Model B, the Network Extension, Proxy IPC, App Group outbox behavior, or LXMF-swift dependencies.

## Verification

- `python3 -m unittest Tests.static.test_qr_contact_send_path_contract -v` - 14 passed
- `python3 -m unittest discover -s Tests/static -p 'test_*.py'` - 221 passed, 1 skipped
- `python3 -m py_compile app/rns_bridge.py` - passed
- shipping `xcodebuild test` on iPhone 17 simulator - 156 passed
- `git diff --check origin/main...HEAD` - passed

The automated tests cover QR destination binding, Python identity retention, bounded one-request path resolution, passive contact behavior, actionable send failures, and payload-preserving retry. Real camera focus, metadata recognition, vibration, scanner dismissal, and Add Contact presentation still require physical-device verification.
