### PR TITLE
fix: preserve sent message text below reply preview

### DIFF
--- a/Columba.xcodeproj/project.pbxproj
+++ b/Columba.xcodeproj/project.pbxproj
@@ -229,6 +229,7 @@
 		922658C82CEEA53695143F9B /* MapLibre in Frameworks */ = {isa = PBXBuildFile; productRef = DBD8F3A253D413F087742BC0 /* MapLibre */; };
 		92DDF4AE0AB493CC2AA0BA20 /* LXSTSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 6000D5CED2C3C89F74999BC1 /* LXSTSwift */; };
 		9566DCEF56FEFC97BAAA47BA /* MessageFormattedTimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC4EF2D71A3D88C71D5BEDAD /* MessageFormattedTimeTests.swift */; };
+		A1B2C3D4E5F60718293A4B5E /* MessageBubbleLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718293A4B5D /* MessageBubbleLayoutTests.swift */; };
 		9673457897893BF9DE512A0F /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F006 /* SettingsViewModel.swift */; };
 		973B4BBFD50C0935D1525F8E /* NomadNetBrowserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F081 /* NomadNetBrowserView.swift */; };
 		97FCC1B1FF91DD6EF2706B04 /* LoRaPresets.swift in Sources */ = {isa = PBXBuildFile; fileRef = F045 /* LoRaPresets.swift */; };
@@ -433,6 +434,7 @@
 		B1AB71D8977FE792BA9B176D /* JetBrainsMono-Bold.ttf */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; path = "JetBrainsMono-Bold.ttf"; sourceTree = "<group>"; };
 		B68384C48BFF8F5294340EDB /* PttButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PttButton.swift; sourceTree = "<group>"; };
 		BC4EF2D71A3D88C71D5BEDAD /* MessageFormattedTimeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MessageFormattedTimeTests.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F60718293A4B5D /* MessageBubbleLayoutTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MessageBubbleLayoutTests.swift; sourceTree = "<group>"; };
 		BF48C97880B30682DC35613C /* CeaseTelemetry.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CeaseTelemetry.swift; sourceTree = "<group>"; };
 		BGTF /* BackgroundTransportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundTransportView.swift; sourceTree = "<group>"; };
 		BKF002 /* BackendFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendFactory.swift; sourceTree = "<group>"; };
@@ -994,6 +996,7 @@
 				6FE282FA3937E59BC026E072 /* AudioManagerConfigChangeTests.swift */,
 				30A79B9ECDB4166F8A36A670 /* CallManagerCallKitTests.swift */,
 				BC4EF2D71A3D88C71D5BEDAD /* MessageFormattedTimeTests.swift */,
+				A1B2C3D4E5F60718293A4B5D /* MessageBubbleLayoutTests.swift */,
 				ACT01 /* AnnounceClassificationTests.swift */,
 				EA0AA6C472B1D4EFA2896086 /* RNodeSeamTests.swift */,
 				853F1E1C2B6E5305277FCB2A /* MigrationRoundTripTests.swift */,
@@ -1658,6 +1661,7 @@
 				A0C0D9AE12F728A484F0F108 /* AudioManagerConfigChangeTests.swift in Sources */,
 				E49B977D311DA1C9ACE14CAB /* CallManagerCallKitTests.swift in Sources */,
 				9566DCEF56FEFC97BAAA47BA /* MessageFormattedTimeTests.swift in Sources */,
+				A1B2C3D4E5F60718293A4B5E /* MessageBubbleLayoutTests.swift in Sources */,
 				ACT02 /* AnnounceClassificationTests.swift in Sources */,
 				0FF6A5C5596A39C092AADA29 /* MigrationRoundTripTests.swift in Sources */,
 				A1B2C3D4E5F60718293A4B5C /* IncomingMessageSizeLimitTests.swift in Sources */,

--- a/Sources/ColumbaApp/Views/Messaging/MessageBubble.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageBubble.swift
@@ -54,17 +54,19 @@ struct MessageBubble: View {
                                 onTapReplyPreview?(replyId)
                             }
                         } label: {
-                            HStack(spacing: 6) {
-                                Rectangle()
-                                    .fill(Theme.accentColor)
-                                    .frame(width: 2)
-                                Text(replyPreview)
-                                    .font(.caption)
-                                    .foregroundStyle(message.isFromMe ? .white.opacity(0.7) : .secondary)
-                                    .lineLimit(2)
-                                    .multilineTextAlignment(.leading)
-                            }
-                            .padding(.vertical, 4)
+                            Text(replyPreview)
+                                .font(.caption)
+                                .foregroundStyle(message.isFromMe ? .white.opacity(0.7) : .secondary)
+                                .lineLimit(2)
+                                .multilineTextAlignment(.leading)
+                                .fixedSize(horizontal: false, vertical: true)
+                                .padding(.leading, 8)
+                                .overlay(alignment: .leading) {
+                                    Rectangle()
+                                        .fill(Theme.accentColor)
+                                        .frame(width: 2)
+                                }
+                                .padding(.vertical, 4)
                         }
                         .buttonStyle(.plain)
                     }
@@ -90,6 +92,7 @@ struct MessageBubble: View {
                         Text(message.content)
                             .font(.body)
                             .foregroundStyle(message.isFromMe ? .white : Theme.textPrimary)
+                            .fixedSize(horizontal: false, vertical: true)
                             // The text is already findable via Maestro's
                             // `text:` matcher; the identifier just lets the
                             // harness disambiguate the bubble's text from

--- a/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
+++ b/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
@@ -23,11 +23,24 @@ final class MessageBubbleLayoutTests: XCTestCase {
         let fitted = host.sizeThatFits(
             in: CGSize(width: 390, height: 1_000)
         )
+        let bodyOnlyMessage = Message(
+            content: message.content,
+            timestamp: message.timestamp,
+            isFromMe: message.isFromMe,
+            deliveryStatus: message.deliveryStatus
+        )
+        let bodyOnlyHost = UIHostingController(
+            rootView: MessageBubble(message: bodyOnlyMessage)
+                .frame(width: 390)
+        )
+        let bodyOnlyFitted = bodyOnlyHost.sizeThatFits(
+            in: CGSize(width: 390, height: 1_000)
+        )
 
         XCTAssertGreaterThan(
             fitted.height,
-            150,
-            "The reply preview and wrapped body must both contribute to bubble height"
+            bodyOnlyFitted.height + 25,
+            "The reply bubble must retain the full body height plus visible reply context"
         )
         XCTAssertLessThan(
             fitted.height,

--- a/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
+++ b/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+import UIKit
+import XCTest
+@testable import ColumbaApp
+
+final class MessageBubbleLayoutTests: XCTestCase {
+
+    @MainActor
+    func testReplyBubbleUsesContentHeightAndPreservesLongMessageBody() {
+        let message = Message(
+            content: "Test response: this sentence is intentionally long enough to wrap across several lines. The complete sent message must remain visible below its reply preview without truncation.",
+            timestamp: Date(),
+            isFromMe: true,
+            deliveryStatus: .delivered,
+            replyToId: "reply-target",
+            replyToPreview: "That narrows it down to the iOS rendering path for received responses, not outbound transport."
+        )
+        let host = UIHostingController(
+            rootView: MessageBubble(message: message)
+                .frame(width: 390)
+        )
+
+        let fitted = host.sizeThatFits(
+            in: CGSize(width: 390, height: 1_000)
+        )
+
+        XCTAssertGreaterThan(
+            fitted.height,
+            150,
+            "The reply preview and wrapped body must both contribute to bubble height"
+        )
+        XCTAssertLessThan(
+            fitted.height,
+            400,
+            "The reply indicator must not greedily expand to the parent's proposed height"
+        )
+    }
+}

--- a/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
+++ b/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
@@ -6,7 +6,7 @@ import XCTest
 final class MessageBubbleLayoutTests: XCTestCase {
 
     @MainActor
-    func testReplyBubbleUsesContentHeightAndPreservesLongMessageBody() {
+    func testReplyBubbleUsesContentHeightAndPreservesLongMessageBody() throws {
         let message = Message(
             content: "Test response: this sentence is intentionally long enough to wrap across several lines. The complete sent message must remain visible below its reply preview without truncation.",
             timestamp: Date(),
@@ -34,5 +34,18 @@ final class MessageBubbleLayoutTests: XCTestCase {
             400,
             "The reply indicator must not greedily expand to the parent's proposed height"
         )
+
+        let renderer = ImageRenderer(
+            content: MessageBubble(message: message)
+                .frame(width: 390)
+                .padding()
+                .background(Color.black)
+        )
+        renderer.scale = 3
+        let image = try XCTUnwrap(renderer.uiImage)
+        let screenshot = XCTAttachment(image: image)
+        screenshot.name = "reply-bubble-long-message"
+        screenshot.lifetime = .keepAlways
+        add(screenshot)
     }
 }


### PR DESCRIPTION
## Summary
- prevent the reply-preview accent bar from expanding to the parent height
- preserve the full wrapped message body while retaining the two-line reply preview
- add a native SwiftUI geometry regression and retained visual artifact

## Verification
- regression before fix: 1 test executed, 1 failed with a 1000-point fitted height
- focused regression after fix: 1 test executed, 1 passed
- full shipping `ColumbaAppTests`: 162 tests passed
- simulator-rendered bubble visually verified with complete body text and correctly sized accent bar
- two independent exact-head reviews approved commit `013dce0e1bbac86f8ffd9277e13a699029081bea`

## Risk and rollback
- low-risk localized SwiftUI layout change
- rollback by reverting the three commits in this PR