### PR TITLE
fix: stabilize the iOS conversation timeline

### DIFF
--- a/Columba.xcodeproj/project.pbxproj
+++ b/Columba.xcodeproj/project.pbxproj
@@ -1370,11 +1370,8 @@
 				140E03C294121F7FA2D478A9 /* ContactCard.swift in Sources */,
 				C6816EEC9864A2903840C8AC /* NetworkAnnouncesTab.swift in Sources */,
 				BED8754AAD30B1CB58755EF8 /* MessagingView.swift in Sources */,
-<<<<<<< HEAD
 				TSP003 /* TextSizePickerSheet.swift in Sources */,
-=======
 				A41F10000000000000000002 /* MessageTimelineView.swift in Sources */,
->>>>>>> b7867d04 (fix: use collection view for message timeline)
 				C204F5778ABB560C1FD4DC60 /* MessageBubble.swift in Sources */,
 				D93546FFCB0106CF3F68B2C5 /* MessageDetailView.swift in Sources */,
 				D709D8EDF36F85DEB5AABEC4 /* MessageInputBar.swift in Sources */,
@@ -1553,11 +1550,8 @@
 				011 /* ContactCard.swift in Sources */,
 				012 /* NetworkAnnouncesTab.swift in Sources */,
 				013 /* MessagingView.swift in Sources */,
-<<<<<<< HEAD
 				TSP002 /* TextSizePickerSheet.swift in Sources */,
-=======
 				A41F10000000000000000001 /* MessageTimelineView.swift in Sources */,
->>>>>>> b7867d04 (fix: use collection view for message timeline)
 				014 /* MessageBubble.swift in Sources */,
 				073 /* MessageDetailView.swift in Sources */,
 				015 /* MessageInputBar.swift in Sources */,

--- a/Columba.xcodeproj/project.pbxproj
+++ b/Columba.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		012 /* NetworkAnnouncesTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = F012 /* NetworkAnnouncesTab.swift */; };
 		013 /* MessagingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F013 /* MessagingView.swift */; };
 		TSP002 /* TextSizePickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = TSP001 /* TextSizePickerSheet.swift */; };
+		A41F10000000000000000001 /* MessageTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A41F10000000000000000003 /* MessageTimelineView.swift */; };
 		014 /* MessageBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = F014 /* MessageBubble.swift */; };
 		015 /* MessageInputBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = F015 /* MessageInputBar.swift */; };
 		016 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F016 /* SettingsView.swift */; };
@@ -267,6 +268,7 @@
 		BE3C19C7804FA366826A5A7A /* OfflineMapsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F063 /* OfflineMapsScreen.swift */; platformFilter = ios; };
 		BED8754AAD30B1CB58755EF8 /* MessagingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F013 /* MessagingView.swift */; };
 		TSP003 /* TextSizePickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = TSP001 /* TextSizePickerSheet.swift */; };
+		A41F10000000000000000002 /* MessageTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A41F10000000000000000003 /* MessageTimelineView.swift */; };
 		BKF001 /* BackendFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = BKF002 /* BackendFactory.swift */; };
 		C0904C776958B1A10E0A8128 /* WelcomePage.swift in Sources */ = {isa = PBXBuildFile; fileRef = F04D /* WelcomePage.swift */; };
 		C126E88E13D9DB7CCE7AD8A0 /* MicronDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = F07D /* MicronDocument.swift */; };
@@ -467,6 +469,7 @@
 		F012 /* NetworkAnnouncesTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkAnnouncesTab.swift; sourceTree = "<group>"; };
 		F013 /* MessagingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagingView.swift; sourceTree = "<group>"; };
 		TSP001 /* TextSizePickerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextSizePickerSheet.swift; sourceTree = "<group>"; };
+		A41F10000000000000000003 /* MessageTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageTimelineView.swift; sourceTree = "<group>"; };
 		F014 /* MessageBubble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBubble.swift; sourceTree = "<group>"; };
 		F015 /* MessageInputBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageInputBar.swift; sourceTree = "<group>"; };
 		F016 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
@@ -842,6 +845,7 @@
 			children = (
 				F013 /* MessagingView.swift */,
 				TSP001 /* TextSizePickerSheet.swift */,
+				A41F10000000000000000003 /* MessageTimelineView.swift */,
 				F014 /* MessageBubble.swift */,
 				F015 /* MessageInputBar.swift */,
 				F073 /* MessageDetailView.swift */,
@@ -1366,7 +1370,11 @@
 				140E03C294121F7FA2D478A9 /* ContactCard.swift in Sources */,
 				C6816EEC9864A2903840C8AC /* NetworkAnnouncesTab.swift in Sources */,
 				BED8754AAD30B1CB58755EF8 /* MessagingView.swift in Sources */,
+<<<<<<< HEAD
 				TSP003 /* TextSizePickerSheet.swift in Sources */,
+=======
+				A41F10000000000000000002 /* MessageTimelineView.swift in Sources */,
+>>>>>>> b7867d04 (fix: use collection view for message timeline)
 				C204F5778ABB560C1FD4DC60 /* MessageBubble.swift in Sources */,
 				D93546FFCB0106CF3F68B2C5 /* MessageDetailView.swift in Sources */,
 				D709D8EDF36F85DEB5AABEC4 /* MessageInputBar.swift in Sources */,
@@ -1545,7 +1553,11 @@
 				011 /* ContactCard.swift in Sources */,
 				012 /* NetworkAnnouncesTab.swift in Sources */,
 				013 /* MessagingView.swift in Sources */,
+<<<<<<< HEAD
 				TSP002 /* TextSizePickerSheet.swift in Sources */,
+=======
+				A41F10000000000000000001 /* MessageTimelineView.swift in Sources */,
+>>>>>>> b7867d04 (fix: use collection view for message timeline)
 				014 /* MessageBubble.swift in Sources */,
 				073 /* MessageDetailView.swift in Sources */,
 				015 /* MessageInputBar.swift in Sources */,

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -2897,8 +2897,12 @@ public final class AppServices {
             // Update the GRDB canonical store (where outbound messages are
             // persisted and the UI reads from), via the shared repository's
             // RNSAPI-typed method — not the Compat `database`.
+            var proofPersisted = false
             if let repo = self.messageRepository {
-                try? await repo.applyDeliveryProof(canonicalHash: hashData, state: newState)
+                proofPersisted = (try? await repo.applyDeliveryProof(
+                    canonicalHash: hashData,
+                    state: newState
+                )) ?? false
             }
             // Notify the open chat so it can flip the bubble's indicator
             // (double-check for delivered / failed) without a full reload.
@@ -2908,6 +2912,7 @@ public final class AppServices {
                 userInfo: [
                     "messageHash": hashData,
                     "state": state,
+                    "persisted": proofPersisted,
                 ]
             )
         case .linkState(let linkId, let state, let reason, let inbound, _):

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -2898,7 +2898,7 @@ public final class AppServices {
             // persisted and the UI reads from), via the shared repository's
             // RNSAPI-typed method — not the Compat `database`.
             if let repo = self.messageRepository {
-                try? await repo.updateMessageState(id: hashData, state: newState)
+                try? await repo.applyDeliveryProof(canonicalHash: hashData, state: newState)
             }
             // Notify the open chat so it can flip the bubble's indicator
             // (double-check for delivered / failed) without a full reload.

--- a/Sources/ColumbaApp/Services/MessageRepository.swift
+++ b/Sources/ColumbaApp/Services/MessageRepository.swift
@@ -57,6 +57,31 @@ public actor MessageRepository {
     public static let stagedRetryMarker = "columba-app-retry-staged-v1"
     public static let uncertainRetryMarker = "columba-app-retry-uncertain-v1"
 
+    public static func uncertainRetryMarker(canonicalHash: Data?) -> String {
+        guard let canonicalHash else { return uncertainRetryMarker }
+        return uncertainRetryMarker + ":" + canonicalHash.map { String(format: "%02x", $0) }.joined()
+    }
+
+    public static func isUncertainRetryMarker(_ marker: String?) -> Bool {
+        marker?.hasPrefix(uncertainRetryMarker) == true
+    }
+
+    public static func canonicalHashFromUncertainRetryMarker(_ marker: String?) -> Data? {
+        guard let marker,
+              marker.hasPrefix(uncertainRetryMarker + ":") else { return nil }
+        let hex = String(marker.dropFirst(uncertainRetryMarker.count + 1))
+        guard hex.count == 64 else { return nil }
+        var data = Data()
+        var index = hex.startIndex
+        while index < hex.endIndex {
+            let end = hex.index(index, offsetBy: 2)
+            guard let byte = UInt8(hex[index..<end], radix: 16) else { return nil }
+            data.append(byte)
+            index = end
+        }
+        return data
+    }
+
     // MARK: - Properties
 
     /// The GRDB-backed canonical store written by the Swift / NE backend.
@@ -289,7 +314,7 @@ public actor MessageRepository {
                     SET message_id = ?, state = ?, method = ?, timestamp = ?,
                         receiving_interface = ?, updated_at = ?
                     WHERE message_id = ? AND incoming = 0 AND state = ?
-                      AND (receiving_interface IS NULL OR receiving_interface = ?)
+                      AND (receiving_interface IS NULL OR receiving_interface LIKE ?)
                     """,
                 arguments: [
                     message.hash,
@@ -300,7 +325,7 @@ public actor MessageRepository {
                     Date().timeIntervalSince1970,
                     oldId,
                     LXMFSwift.LXMessageState.failed.rawValue,
-                    Self.uncertainRetryMarker,
+                    Self.uncertainRetryMarker + "%",
                 ]
             )
             guard db.changesCount == 1 else {
@@ -329,7 +354,7 @@ public actor MessageRepository {
 
     /// Return an interrupted staged retry to a durable, explicitly uncertain
     /// failed state without deleting its only database row.
-    public func recoverStagedRetry(_ messageId: Data) async throws {
+    public func recoverStagedRetry(_ messageId: Data, canonicalHash: Data? = nil) async throws {
         try await replacementPool.write { db in
             try db.execute(
                 sql: """
@@ -340,7 +365,7 @@ public actor MessageRepository {
                     """,
                 arguments: [
                     LXMFSwift.LXMessageState.failed.rawValue,
-                    Self.uncertainRetryMarker,
+                    Self.uncertainRetryMarker(canonicalHash: canonicalHash),
                     Date().timeIntervalSince1970,
                     messageId,
                     Self.stagedRetryMarker,

--- a/Sources/ColumbaApp/Services/MessageRepository.swift
+++ b/Sources/ColumbaApp/Services/MessageRepository.swift
@@ -302,7 +302,10 @@ public actor MessageRepository {
     /// hash accepted by the network backend. Payload columns stay on the same
     /// row, so a crash cannot expose both a stale retry and a sent duplicate.
     public func replaceMessage(_ message: RNSAPI.LXMessage, replacing oldId: Data) async throws {
-        try await replaceMessageRecord(message, replacing: oldId, retryMarker: nil)
+        let marker = message.receivingInterface == Self.optimisticOutboundMarker
+            ? Self.optimisticOutboundMarker
+            : nil
+        try await replaceMessageRecord(message, replacing: oldId, retryMarker: marker)
     }
 
     /// Stage one failed retry as app-owned `.sending` before network submission.
@@ -506,7 +509,20 @@ public actor MessageRepository {
                     """,
                 arguments: [mappedState, now, canonicalHash]
             )
-            if db.changesCount == 1 { return true }
+            if db.changesCount == 1 {
+                try db.execute(
+                    sql: """
+                        DELETE FROM messages
+                        WHERE message_id != ? AND incoming = 0
+                          AND receiving_interface = ?
+                        """,
+                    arguments: [
+                        canonicalHash,
+                        Self.uncertainRetryMarker(canonicalHash: canonicalHash),
+                    ]
+                )
+                return true
+            }
 
             try db.execute(
                 sql: """

--- a/Sources/ColumbaApp/Services/MessageRepository.swift
+++ b/Sources/ColumbaApp/Services/MessageRepository.swift
@@ -56,6 +56,7 @@ public actor MessageRepository {
     public static let conversationHashUserInfoKey = "conversationHash"
     public static let stagedRetryMarker = "columba-app-retry-staged-v1"
     public static let uncertainRetryMarker = "columba-app-retry-uncertain-v1"
+    public static let optimisticOutboundMarker = "columba-app-outbound-optimistic-v1"
 
     public static func uncertainRetryMarker(canonicalHash: Data?) -> String {
         guard let canonicalHash else { return uncertainRetryMarker }
@@ -314,7 +315,8 @@ public actor MessageRepository {
                     SET message_id = ?, state = ?, method = ?, timestamp = ?,
                         receiving_interface = ?, updated_at = ?
                     WHERE message_id = ? AND incoming = 0 AND state = ?
-                      AND (receiving_interface IS NULL OR receiving_interface LIKE ?)
+                      AND (receiving_interface IS NULL OR receiving_interface LIKE ?
+                           OR receiving_interface = ?)
                     """,
                 arguments: [
                     message.hash,
@@ -326,6 +328,7 @@ public actor MessageRepository {
                     oldId,
                     LXMFSwift.LXMessageState.failed.rawValue,
                     Self.uncertainRetryMarker + "%",
+                    Self.optimisticOutboundMarker,
                 ]
             )
             guard db.changesCount == 1 else {
@@ -457,12 +460,12 @@ public actor MessageRepository {
                 sql: """
                     SELECT COUNT(*) FROM messages
                     WHERE destination_hash = ? AND incoming = 0 AND state = ?
-                      AND receiving_interface = ?
+                      AND receiving_interface LIKE ?
                     """,
                 arguments: [
                     destinationHash,
                     LXMFSwift.LXMessageState.failed.rawValue,
-                    Self.uncertainRetryMarker,
+                    Self.uncertainRetryMarker + "%",
                 ]
             ) ?? 0
             return count > 0
@@ -482,6 +485,45 @@ public actor MessageRepository {
     /// Update message delivery state.
     public func updateMessageState(id: Data, state: RNSAPI.LXMessageState) async throws {
         try await database.updateMessageState(id: id, state: Self.mapStateToGRDB(state))
+    }
+
+    /// Persist an authoritative backend delivery proof. If canonical message
+    /// persistence previously failed during a retry, atomically resolve the
+    /// durable storage-key row through its canonical uncertainty marker and
+    /// rekey it to the wire hash. This path works without an open chat view.
+    @discardableResult
+    public func applyDeliveryProof(
+        canonicalHash: Data,
+        state: RNSAPI.LXMessageState
+    ) async throws -> Bool {
+        try await replacementPool.write { db in
+            let mappedState = Self.mapStateToGRDB(state).rawValue
+            let now = Date().timeIntervalSince1970
+            try db.execute(
+                sql: """
+                    UPDATE messages SET state = ?, updated_at = ?
+                    WHERE message_id = ?
+                    """,
+                arguments: [mappedState, now, canonicalHash]
+            )
+            if db.changesCount == 1 { return true }
+
+            try db.execute(
+                sql: """
+                    UPDATE messages
+                    SET message_id = ?, state = ?, receiving_interface = NULL,
+                        updated_at = ?
+                    WHERE incoming = 0 AND receiving_interface = ?
+                    """,
+                arguments: [
+                    canonicalHash,
+                    mappedState,
+                    now,
+                    Self.uncertainRetryMarker(canonicalHash: canonicalHash),
+                ]
+            )
+            return db.changesCount == 1
+        }
     }
 
     /// Load pending outbound messages (state == .outbound).

--- a/Sources/ColumbaApp/Services/MessageRepository.swift
+++ b/Sources/ColumbaApp/Services/MessageRepository.swift
@@ -327,6 +327,31 @@ public actor MessageRepository {
         )
     }
 
+    /// Return an interrupted staged retry to a durable, explicitly uncertain
+    /// failed state without deleting its only database row.
+    public func recoverStagedRetry(_ messageId: Data) async throws {
+        try await replacementPool.write { db in
+            try db.execute(
+                sql: """
+                    UPDATE messages
+                    SET state = ?, receiving_interface = ?, updated_at = ?
+                    WHERE message_id = ? AND incoming = 0
+                      AND receiving_interface = ?
+                    """,
+                arguments: [
+                    LXMFSwift.LXMessageState.failed.rawValue,
+                    Self.uncertainRetryMarker,
+                    Date().timeIntervalSince1970,
+                    messageId,
+                    Self.stagedRetryMarker,
+                ]
+            )
+            guard db.changesCount == 1 else {
+                throw MessageRepositoryError.replacementSourceMissing
+            }
+        }
+    }
+
     private func replaceMessageRecord(
         _ message: RNSAPI.LXMessage,
         replacing oldId: Data,

--- a/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
@@ -64,7 +64,6 @@ public final class MessagingViewModel {
     private var stagedRetryRecoveryHashes: [String: Data] = [:]
     private var pendingOutboundAliases: [String: String] = [:]
     private var pendingDeliveryProofs: [String: LXMessageState] = [:]
-    private var unsafeTargetMessageIDs: Set<String> = []
 
     // MARK: - Initialization
 
@@ -209,10 +208,20 @@ public final class MessagingViewModel {
                         resolvedMessages[i].replyToPreview = await resolveReplyPreview(replyId)
                     }
                 }
-                if let proof = pendingDeliveryProofs[resolvedMessages[i].id] {
+                if !resolvedMessages[i].isTargetSafe,
+                   let canonicalHash = resolvedMessages[i].messageHash,
+                   canonicalHash != resolvedMessages[i].storageHash {
+                    pendingOutboundAliases[Self.hexString(canonicalHash)] = resolvedMessages[i].id
+                }
+                if let proof = Self.pendingProof(
+                    forVisibleID: resolvedMessages[i].id,
+                    aliases: pendingOutboundAliases,
+                    proofs: pendingDeliveryProofs
+                ) {
                     resolvedMessages[i].deliveryStatus = (proof == .delivered) ? .delivered : .failed
                 }
             }
+            await reconcileAliasedDeliveryProofs(in: resolvedMessages)
 
             guard loadGeneration == paginationGeneration else {
                 pendingRefresh = true
@@ -315,10 +324,13 @@ public final class MessagingViewModel {
     }
 
     @MainActor
-    private func recoverStagedRetryAfterPersistenceFailure(_ hash: Data?) async -> Bool {
+    private func recoverStagedRetryAfterPersistenceFailure(
+        _ hash: Data?,
+        canonicalHash: Data?
+    ) async -> Bool {
         guard let hash else { return true }
         do {
-            try await repository.recoverStagedRetry(hash)
+            try await repository.recoverStagedRetry(hash, canonicalHash: canonicalHash)
             await invalidatePaginationAndRefresh()
             return true
         } catch {
@@ -357,6 +369,23 @@ public final class MessagingViewModel {
     }
 
     @MainActor
+    private func reconcileAliasedDeliveryProofs(in loaded: [Message]) async {
+        for message in loaded where !message.isTargetSafe {
+            guard let canonicalHash = message.messageHash,
+                  let storageHash = message.storageHash,
+                  let proof = pendingDeliveryProofs[Self.hexString(canonicalHash)] else { continue }
+            do {
+                try await repository.updateMessageState(id: storageHash, state: proof)
+                if pendingDeliveryProofs[Self.hexString(canonicalHash)] == proof {
+                    pendingDeliveryProofs.removeValue(forKey: Self.hexString(canonicalHash))
+                }
+            } catch {
+                logger.error("[MSG_VM] aliased delivery proof reconciliation failed: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    @MainActor
     private func pendingDeliveryProof(for hash: Data) -> LXMessageState? {
         let hashHex = Self.hexString(hash)
         return pendingDeliveryProofs[hashHex]
@@ -382,6 +411,20 @@ public final class MessagingViewModel {
         aliases: [String: String]
     ) -> String {
         aliases[realID] ?? realID
+    }
+
+    static func pendingProof(
+        forVisibleID visibleID: String,
+        aliases: [String: String],
+        proofs: [String: LXMessageState]
+    ) -> LXMessageState? {
+        if let direct = proofs[visibleID] { return direct }
+        guard let canonicalID = aliases.first(where: {
+            $0.value == visibleID && proofs[$0.key] != nil
+        })?.key else {
+            return nil
+        }
+        return proofs[canonicalID]
     }
 
     static func mergingPendingOutbound(
@@ -592,7 +635,9 @@ public final class MessagingViewModel {
             imageFormat: imageFormat,
             attachments: attachments?.map { FileAttachment(name: $0.name, data: $0.data) },
             replyToId: replyToId,
-            replyToPreview: replyPreview
+            replyToPreview: replyPreview,
+            storageHash: localRetryHash,
+            isTargetSafe: false
         )
 
         // Add to UI immediately, or replace the existing failed row in place.
@@ -633,12 +678,13 @@ public final class MessagingViewModel {
                 unpersistedOutboundIDs.remove(optimisticId)
                 unsavedFailedOutboundIDs.remove(optimisticId)
                 stagedRetryRecoveryHashes.removeValue(forKey: optimisticId)
-                unsafeTargetMessageIDs.remove(optimisticId)
                 await invalidatePaginationAndRefresh()
             } catch {
                 let proof = pendingDeliveryProof(for: sentHash)
-                unsafeTargetMessageIDs.insert(optimisticId)
-                let recovered = await recoverStagedRetryAfterPersistenceFailure(localRetryHash)
+                let recovered = await recoverStagedRetryAfterPersistenceFailure(
+                    localRetryHash,
+                    canonicalHash: sentHash
+                )
                 if localRetryHash != nil && recovered {
                     unpersistedOutboundIDs.remove(optimisticId)
                     unsavedFailedOutboundIDs.remove(optimisticId)
@@ -701,12 +747,13 @@ public final class MessagingViewModel {
                         unpersistedOutboundIDs.remove(optimisticId)
                         unsavedFailedOutboundIDs.remove(optimisticId)
                         stagedRetryRecoveryHashes.removeValue(forKey: optimisticId)
-                        unsafeTargetMessageIDs.remove(optimisticId)
                         await invalidatePaginationAndRefresh()
                     } catch {
                         let proof = pendingDeliveryProof(for: retryHash)
-                        unsafeTargetMessageIDs.insert(optimisticId)
-                        let recovered = await recoverStagedRetryAfterPersistenceFailure(localRetryHash)
+                        let recovered = await recoverStagedRetryAfterPersistenceFailure(
+                            localRetryHash,
+                            canonicalHash: retryHash
+                        )
                         if localRetryHash != nil && recovered {
                             unpersistedOutboundIDs.remove(optimisticId)
                             unsavedFailedOutboundIDs.remove(optimisticId)
@@ -740,11 +787,12 @@ public final class MessagingViewModel {
                 unpersistedOutboundIDs.remove(optimisticId)
                 unsavedFailedOutboundIDs.remove(optimisticId)
                 stagedRetryRecoveryHashes.removeValue(forKey: optimisticId)
-                unsafeTargetMessageIDs.remove(optimisticId)
                 await invalidatePaginationAndRefresh()
             } catch {
-                unsafeTargetMessageIDs.insert(optimisticId)
-                let recovered = await recoverStagedRetryAfterPersistenceFailure(localRetryHash)
+                let recovered = await recoverStagedRetryAfterPersistenceFailure(
+                    localRetryHash,
+                    canonicalHash: nil
+                )
                 persisted = localRetryHash != nil && recovered
                 if localRetryHash != nil && recovered {
                     unpersistedOutboundIDs.remove(optimisticId)
@@ -805,7 +853,10 @@ public final class MessagingViewModel {
         if unsavedFailedOutboundIDs.contains(messageId),
            let stagedHash = stagedRetryRecoveryHashes[messageId] {
             do {
-                try await repository.recoverStagedRetry(stagedHash)
+                try await repository.recoverStagedRetry(
+                    stagedHash,
+                    canonicalHash: failedMessage.messageHash
+                )
                 stagedRetryRecoveryHashes.removeValue(forKey: messageId)
                 unsavedFailedOutboundIDs.remove(messageId)
                 unpersistedOutboundIDs.remove(messageId)
@@ -816,7 +867,6 @@ public final class MessagingViewModel {
             }
         } else if unsavedFailedOutboundIDs.contains(messageId) {
             clearPendingAliases(for: messageId)
-            unsafeTargetMessageIDs.remove(messageId)
             unsavedFailedOutboundIDs.remove(messageId)
             unpersistedOutboundIDs.remove(messageId)
             messages.removeAll { $0.id == messageId }
@@ -830,7 +880,9 @@ public final class MessagingViewModel {
             return
         }
 
-        let storedHash = failedMessage.messageHash ?? Self.hexToData(failedMessage.id)
+        let storedHash = failedMessage.storageHash
+            ?? failedMessage.messageHash
+            ?? Self.hexToData(failedMessage.id)
         let retryHash: Data
         if let storedHash, storedHash.count == 32 {
             retryHash = storedHash
@@ -842,7 +894,6 @@ public final class MessagingViewModel {
         // replaces the failed row only after the replacement is safely saved,
         // including migration of legacy non-32-byte temporary IDs.
         clearPendingAliases(for: messageId)
-        unsafeTargetMessageIDs.remove(messageId)
         _ = await sendMessage(
             text: failedMessage.content,
             imageData: failedMessage.imageData,
@@ -867,8 +918,9 @@ public final class MessagingViewModel {
     }
 
     public func canTargetMessage(messageId: String) -> Bool {
-        !unpersistedOutboundIDs.contains(messageId)
-            && !unsafeTargetMessageIDs.contains(messageId)
+        guard !unpersistedOutboundIDs.contains(messageId),
+              let message = messages.first(where: { $0.id == messageId }) else { return false }
+        return message.isTargetSafe
     }
 
     static func canDeleteMessage(
@@ -882,11 +934,16 @@ public final class MessagingViewModel {
     @MainActor
     public func deleteMessage(messageId: String, messageHash: Data?) async {
         guard canDeleteMessage(messageId: messageId) else { return }
+        let visibleMessage = messages.first(where: { $0.id == messageId })
+        let durableHash = visibleMessage?.storageHash ?? messageHash
 
         var wasUnsavedFailure = unsavedFailedOutboundIDs.contains(messageId)
         if wasUnsavedFailure, let stagedHash = stagedRetryRecoveryHashes[messageId] {
             do {
-                try await repository.recoverStagedRetry(stagedHash)
+                try await repository.recoverStagedRetry(
+                    stagedHash,
+                    canonicalHash: visibleMessage?.messageHash
+                )
                 wasUnsavedFailure = false
             } catch {
                 errorMessage = "The staged retry could not be recovered for deletion. Please try again."
@@ -898,7 +955,6 @@ public final class MessagingViewModel {
         unpersistedOutboundIDs.remove(messageId)
         stagedRetryRecoveryHashes.removeValue(forKey: messageId)
         clearPendingAliases(for: messageId)
-        unsafeTargetMessageIDs.remove(messageId)
 
         // Remove from UI immediately
         withAnimation {
@@ -910,8 +966,8 @@ public final class MessagingViewModel {
             return
         }
 
-        // Delete from database if we have the hash
-        if let hash = messageHash {
+        // Delete from database if we have the durable storage key.
+        if let hash = durableHash {
             do {
                 try await repository.deleteMessage(hash)
                 await invalidatePaginationAndRefresh()
@@ -931,7 +987,11 @@ public final class MessagingViewModel {
     /// Send an emoji reaction to a message (toggle: adds if not present, removes if present).
     @MainActor
     public func sendReaction(targetMessageId: String, targetMessageHash: Data?, emoji: String) async {
-        guard let hash = targetMessageHash else { return }
+        guard let target = messages.first(where: { $0.id == targetMessageId }),
+              target.isTargetSafe,
+              let canonicalHash = target.messageHash,
+              canonicalHash == targetMessageHash else { return }
+        let storageHash = target.storageHash ?? canonicalHash
         guard let backend = appServices.backend else { return }
 
         let localHashHex = appServices.localIdentityHash.map { String(format: "%02x", $0) }.joined()
@@ -943,7 +1003,7 @@ public final class MessagingViewModel {
         do {
             committedReactions = try await ReactionMutationGate.shared.withLock {
                 var reactionsDict: [String: [String]] = [:]
-                if let json = try await repository.getReactionsJson(hash),
+                if let json = try await repository.getReactionsJson(storageHash),
                    let data = json.data(using: .utf8),
                    let dict = try? JSONSerialization.jsonObject(with: data) as? [String: [String]] {
                     reactionsDict = dict
@@ -963,7 +1023,7 @@ public final class MessagingViewModel {
 
                 let jsonData = try JSONSerialization.data(withJSONObject: reactionsDict)
                 let jsonStr = String(decoding: jsonData, as: UTF8.self)
-                try await repository.updateReactions(hash, reactionsJson: jsonStr)
+                try await repository.updateReactions(storageHash, reactionsJson: jsonStr)
                 return reactionsDict
             }
         } catch {
@@ -991,7 +1051,7 @@ public final class MessagingViewModel {
         do {
             try await backend.lxmf.sendReaction(
                 destHashHex: conversationHash.map { String(format: "%02x", $0) }.joined(),
-                targetMessageHashHex: targetMessageId,
+                targetMessageHashHex: Self.hexString(canonicalHash),
                 emoji: emoji)
         } catch {
             logger.error("Failed to send reaction: \(error.localizedDescription)")

--- a/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
@@ -427,6 +427,16 @@ public final class MessagingViewModel {
         return proofs[canonicalID]
     }
 
+    static func retryableRefreshedMessage(
+        messageId: String,
+        stagedHash: Data,
+        messages: [Message]
+    ) -> Message? {
+        messages.first(where: {
+            $0.id == messageId || $0.storageHash == stagedHash
+        }).flatMap { $0.deliveryStatus == .failed ? $0 : nil }
+    }
+
     static func mergingPendingOutbound(
         loaded: [Message],
         current: [Message],
@@ -780,6 +790,10 @@ public final class MessagingViewModel {
             // Failed outbound attempts are still conversation activity. Persist
             // the failed row so it remains visible on Chats and can be retried.
             lxMessage.state = .failed
+            // This hash was generated locally and was never accepted by a
+            // backend. Persist that provenance explicitly: 32-byte width alone
+            // must not make a reloaded row safe for replies or reactions.
+            lxMessage.receivingInterface = MessageRepository.optimisticOutboundMarker
             var persisted = false
             do {
                 try await persistMessage(lxMessage, replacing: localRetryHash)
@@ -849,7 +863,7 @@ public final class MessagingViewModel {
             return
         }
 
-        let failedMessage = messages[index]
+        var failedMessage = messages[index]
         if unsavedFailedOutboundIDs.contains(messageId),
            let stagedHash = stagedRetryRecoveryHashes[messageId] {
             do {
@@ -861,6 +875,14 @@ public final class MessagingViewModel {
                 unsavedFailedOutboundIDs.remove(messageId)
                 unpersistedOutboundIDs.remove(messageId)
                 await invalidatePaginationAndRefresh()
+                guard let refreshed = Self.retryableRefreshedMessage(
+                    messageId: messageId,
+                    stagedHash: stagedHash,
+                    messages: messages
+                ) else {
+                    return
+                }
+                failedMessage = refreshed
             } catch {
                 errorMessage = "The staged retry could not be recovered. Please try again."
                 return

--- a/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
@@ -57,6 +57,7 @@ public final class MessagingViewModel {
     /// Observation token for incoming message notifications.
     private var notificationTask: Any?
     private var deliveryTask: Any?
+    private var pendingRefresh = false
 
     // MARK: - Initialization
 
@@ -127,8 +128,11 @@ public final class MessagingViewModel {
     /// Load the most recent page of messages for this conversation.
     @MainActor
     public func loadMessages() async {
+        guard !isLoading, !isLoadingMore else {
+            pendingRefresh = true
+            return
+        }
         isLoading = true
-        defer { isLoading = false }
 
         do {
             // Ensure conversation exists, then clear unread state as soon as the
@@ -181,14 +185,16 @@ public final class MessagingViewModel {
         } catch {
             errorMessage = error.localizedDescription
         }
+
+        isLoading = false
+        await runPendingRefreshIfNeeded()
     }
 
     /// Load older messages when scrolling up.
     @MainActor
     public func loadMoreMessages() async {
-        guard !isLoadingMore, !allMessagesLoaded else { return }
+        guard !isLoading, !isLoadingMore, !allMessagesLoaded else { return }
         isLoadingMore = true
-        defer { isLoadingMore = false }
 
         do {
             // Database pages can contain telemetry-only records that do not
@@ -206,20 +212,32 @@ public final class MessagingViewModel {
             }
             if records.isEmpty {
                 allMessagesLoaded = true
-                return
-            }
-            pageCursor.recordFetchedPage(recordCount: records.count)
-            let older = records.reversed()
-                .map { Message(from: $0, localHash: appServices.localIdentityHash) }
-                .filter { !$0.isEmpty }  // Hide telemetry-only messages
+            } else {
+                pageCursor.recordFetchedPage(recordCount: records.count)
+                let older = records.reversed()
+                    .map { Message(from: $0, localHash: appServices.localIdentityHash) }
+                    .filter { !$0.isEmpty }  // Hide telemetry-only messages
+                var knownIDs = Set(messages.map(\.id))
+                let uniqueOlder = older.filter { knownIDs.insert($0.id).inserted }
 
-            messages.insert(contentsOf: older, at: 0)
-            if records.count < Self.pageSize {
-                allMessagesLoaded = true
+                messages.insert(contentsOf: uniqueOlder, at: 0)
+                if records.count < Self.pageSize {
+                    allMessagesLoaded = true
+                }
             }
         } catch {
             logger.error("Failed to load more messages: \(error.localizedDescription)")
         }
+
+        isLoadingMore = false
+        await runPendingRefreshIfNeeded()
+    }
+
+    @MainActor
+    private func runPendingRefreshIfNeeded() async {
+        guard pendingRefresh, !isLoading, !isLoadingMore else { return }
+        pendingRefresh = false
+        await loadMessages()
     }
 
     /// Actionable failure returned when a backend does not accept a send.
@@ -461,6 +479,9 @@ public final class MessagingViewModel {
             // Persist so a subsequent loadMessages() doesn't wipe it.
             do {
                 try await persistMessage(lxMessage, replacing: localRetryHash)
+                if localRetryHash == nil {
+                    pageCursor.recordInsertedAtNewest()
+                }
             } catch {
                 logger.error("[MSG_VM] saveMessage(outbound) failed: \(error.localizedDescription)")
                 if let index = messages.firstIndex(where: { $0.id == realId }) {
@@ -526,6 +547,9 @@ public final class MessagingViewModel {
                     }
                     do {
                         try await persistMessage(retryMessage, replacing: localRetryHash)
+                        if localRetryHash == nil {
+                            pageCursor.recordInsertedAtNewest()
+                        }
                     } catch {
                         logger.error("[MSG_VM] saveMessage(retry-relay) failed: \(error.localizedDescription)")
                         if let index = messages.firstIndex(where: { $0.id == realId }) {

--- a/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
@@ -60,6 +60,7 @@ public final class MessagingViewModel {
     private var pendingRefresh = false
     private var paginationGeneration: UInt64 = 0
     private var unpersistedOutboundIDs: Set<String> = []
+    private var unsavedFailedOutboundIDs: Set<String> = []
 
     // MARK: - Initialization
 
@@ -152,7 +153,7 @@ public final class MessagingViewModel {
             let priorOldestID = messages.first {
                 !unpersistedOutboundIDs.contains($0.id)
             }?.id
-            var fetchLimit = max(Self.pageSize, retainedRecordCount + 1)
+            var fetchLimit = max(Self.pageSize, retainedRecordCount)
 
             let hasInterruptedRetry = try await repository.hasUncertainRetry(for: conversationHash)
             var records = try await repository.fetchMessageRecords(
@@ -172,6 +173,13 @@ public final class MessagingViewModel {
                     for: conversationHash, limit: fetchLimit, offset: 0
                 )
             }
+            let reachedDatabaseEnd = records.count < fetchLimit
+            let retainedCount = MessageRefreshWindowPolicy.retainedPrefixCount(
+                recordIDs: records.map(Self.recordID),
+                priorOldestID: priorOldestID
+            )
+            let trimmedToPriorWindow = retainedCount < records.count
+            records = Array(records.prefix(retainedCount))
             let loaded = records.reversed()
                 .map { Message(from: $0, localHash: appServices.localIdentityHash) }
                 .filter { !$0.isEmpty }  // Hide telemetry-only messages (e.g. location sharing)
@@ -203,7 +211,7 @@ public final class MessagingViewModel {
                 pendingIDs: unpersistedOutboundIDs
             )
             pageCursor.reset(recordCount: records.count)
-            allMessagesLoaded = records.count < fetchLimit
+            allMessagesLoaded = reachedDatabaseEnd && !trimmedToPriorWindow
 
             // Reconcile messages that arrived after the initial read reset but
             // were included in the page we just displayed.
@@ -290,16 +298,26 @@ public final class MessagingViewModel {
         await runPendingRefreshIfNeeded()
     }
 
+    @MainActor
+    private func removeStagedRetryAfterPersistenceFailure(_ hash: Data?) async {
+        guard let hash else { return }
+        do {
+            try await repository.deleteMessage(hash)
+            await invalidatePaginationAndRefresh()
+        } catch {
+            logger.error("[MSG_VM] failed to remove staged retry: \(error.localizedDescription)")
+        }
+    }
+
     static func mergingPendingOutbound(
         loaded: [Message],
         current: [Message],
         pendingIDs: Set<String>
     ) -> [Message] {
-        let loadedIDs = Set(loaded.map(\.id))
-        let pending = current.filter {
-            pendingIDs.contains($0.id) && !loadedIDs.contains($0.id)
-        }
-        return (loaded + pending)
+        let pending = current.filter { pendingIDs.contains($0.id) }
+        let pendingMessageIDs = Set(pending.map(\.id))
+        let durable = loaded.filter { !pendingMessageIDs.contains($0.id) }
+        return (durable + pending)
             .enumerated()
             .sorted { lhs, rhs in
                 if lhs.element.timestamp == rhs.element.timestamp {
@@ -512,9 +530,7 @@ public final class MessagingViewModel {
                 messages[messages.count - 1].messageHash = optimisticHash
             }
         }
-        if localRetryHash == nil {
-            unpersistedOutboundIDs.insert(optimisticId)
-        }
+        unpersistedOutboundIDs.insert(optimisticId)
 
         do {
             // Send through the neutral LXMF facet with TYPED fields (image /
@@ -534,40 +550,17 @@ public final class MessagingViewModel {
             lxMessage.hash = sentHash
             lxMessage.state = .sent
 
-            // Replace optimistic message with real one (using actual hash from pack)
-            let realId = lxMessage.hash.map { String(format: "%02x", $0) }.joined()
-            if let index = messages.firstIndex(where: { $0.id == optimisticId }) {
-                withAnimation(.easeInOut(duration: 0.2)) {
-                    messages[index] = Message(
-                        id: realId,
-                        content: trimmedText,
-                        timestamp: Date(timeIntervalSince1970: lxMessage.timestamp),
-                        isFromMe: true,
-                        deliveryStatus: .sent,
-                        imageData: imageData,
-                        imageFormat: imageFormat,
-                        attachments: attachments?.map { FileAttachment(name: $0.name, data: $0.data) },
-                        replyToId: replyToId,
-                        replyToPreview: replyPreview
-                    )
-                }
-            }
-            if localRetryHash == nil {
-                unpersistedOutboundIDs.remove(optimisticId)
-                unpersistedOutboundIDs.insert(realId)
-            }
-
             // Persist so a subsequent loadMessages() doesn't wipe it.
             do {
                 try await persistMessage(lxMessage, replacing: localRetryHash)
-                if localRetryHash == nil {
-                    unpersistedOutboundIDs.remove(realId)
-                    await invalidatePaginationAndRefresh()
-                }
+                unpersistedOutboundIDs.remove(optimisticId)
+                unsavedFailedOutboundIDs.remove(optimisticId)
+                await invalidatePaginationAndRefresh()
             } catch {
-                unpersistedOutboundIDs.remove(realId)
+                unsavedFailedOutboundIDs.insert(optimisticId)
+                await removeStagedRetryAfterPersistenceFailure(localRetryHash)
                 logger.error("[MSG_VM] saveMessage(outbound) failed: \(error.localizedDescription)")
-                if let index = messages.firstIndex(where: { $0.id == realId }) {
+                if let index = messages.firstIndex(where: { $0.id == optimisticId }) {
                     messages[index].deliveryStatus = .failed
                 }
                 errorMessage = "Message was sent, but local confirmation could not be saved. Verify whether it arrived before retrying."
@@ -611,37 +604,16 @@ public final class MessagingViewModel {
                     retryMessage.hash = retryHash
                     retryMessage.state = .sent
                     retryMessage.method = .propagated
-                    let realId = retryMessage.hash.map { String(format: "%02x", $0) }.joined()
-                    if let index = messages.firstIndex(where: { $0.id == optimisticId }) {
-                        withAnimation(.easeInOut(duration: 0.2)) {
-                            messages[index] = Message(
-                                id: realId,
-                                content: trimmedText,
-                                timestamp: Date(timeIntervalSince1970: retryMessage.timestamp),
-                                isFromMe: true,
-                                deliveryStatus: .sent,
-                                imageData: imageData,
-                                imageFormat: imageFormat,
-                                attachments: attachments?.map { FileAttachment(name: $0.name, data: $0.data) },
-                                replyToId: replyToId,
-                                replyToPreview: replyPreview
-                            )
-                        }
-                    }
-                    if localRetryHash == nil {
-                        unpersistedOutboundIDs.remove(optimisticId)
-                        unpersistedOutboundIDs.insert(realId)
-                    }
                     do {
                         try await persistMessage(retryMessage, replacing: localRetryHash)
-                        if localRetryHash == nil {
-                            unpersistedOutboundIDs.remove(realId)
-                            await invalidatePaginationAndRefresh()
-                        }
+                        unpersistedOutboundIDs.remove(optimisticId)
+                        unsavedFailedOutboundIDs.remove(optimisticId)
+                        await invalidatePaginationAndRefresh()
                     } catch {
-                        unpersistedOutboundIDs.remove(realId)
+                        unsavedFailedOutboundIDs.insert(optimisticId)
+                        await removeStagedRetryAfterPersistenceFailure(localRetryHash)
                         logger.error("[MSG_VM] saveMessage(retry-relay) failed: \(error.localizedDescription)")
-                        if let index = messages.firstIndex(where: { $0.id == realId }) {
+                        if let index = messages.firstIndex(where: { $0.id == optimisticId }) {
                             messages[index].deliveryStatus = .failed
                         }
                         errorMessage = "Message was relayed, but local confirmation could not be saved. Verify whether it arrived before retrying."
@@ -660,12 +632,12 @@ public final class MessagingViewModel {
             do {
                 try await persistMessage(lxMessage, replacing: localRetryHash)
                 persisted = true
-                if localRetryHash == nil {
-                    unpersistedOutboundIDs.remove(optimisticId)
-                    await invalidatePaginationAndRefresh()
-                }
-            } catch {
                 unpersistedOutboundIDs.remove(optimisticId)
+                unsavedFailedOutboundIDs.remove(optimisticId)
+                await invalidatePaginationAndRefresh()
+            } catch {
+                unsavedFailedOutboundIDs.insert(optimisticId)
+                await removeStagedRetryAfterPersistenceFailure(localRetryHash)
                 logger.error("[MSG_VM] saveMessage(failed) failed: \(error.localizedDescription)")
             }
 
@@ -713,6 +685,19 @@ public final class MessagingViewModel {
         }
 
         let failedMessage = messages[index]
+        if unsavedFailedOutboundIDs.remove(messageId) != nil {
+            unpersistedOutboundIDs.remove(messageId)
+            messages.removeAll { $0.id == messageId }
+            _ = await sendMessage(
+                text: failedMessage.content,
+                imageData: failedMessage.imageData,
+                imageFormat: failedMessage.imageFormat,
+                attachments: failedMessage.attachments?.map { (name: $0.name, data: $0.data) },
+                replyToId: failedMessage.replyToId
+            )
+            return
+        }
+
         let storedHash = failedMessage.messageHash ?? Self.hexToData(failedMessage.id)
         let retryHash: Data
         if let storedHash, storedHash.count == 32 {
@@ -739,13 +724,35 @@ public final class MessagingViewModel {
         }
     }
 
+    /// Whether a message has reached durable storage and can be deleted safely.
+    public func canDeleteMessage(messageId: String) -> Bool {
+        Self.canDeleteMessage(
+            isUnpersisted: unpersistedOutboundIDs.contains(messageId),
+            isUnsavedFailure: unsavedFailedOutboundIDs.contains(messageId)
+        )
+    }
+
+    static func canDeleteMessage(
+        isUnpersisted: Bool,
+        isUnsavedFailure: Bool
+    ) -> Bool {
+        !isUnpersisted || isUnsavedFailure
+    }
+
     /// Delete a message from the conversation.
     @MainActor
     public func deleteMessage(messageId: String, messageHash: Data?) async {
+        guard canDeleteMessage(messageId: messageId) else { return }
+
+        let wasUnsavedFailure = unsavedFailedOutboundIDs.remove(messageId) != nil
+        unpersistedOutboundIDs.remove(messageId)
+
         // Remove from UI immediately
         withAnimation {
             messages.removeAll { $0.id == messageId }
         }
+
+        guard !wasUnsavedFailure else { return }
 
         // Delete from database if we have the hash
         if let hash = messageHash {

--- a/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
@@ -144,18 +144,34 @@ public final class MessagingViewModel {
             try await repository.ensureConversation(conversationHash, displayName: displayName)
             try await repository.markConversationRead(conversationHash)
 
-            // Preserve the current history depth when a repository notification
-            // refreshes the newest records. One record of slack retains the
-            // previous oldest row when the refresh includes a newly arrived
-            // message.
+            // Preserve the current history depth when repository notifications
+            // refresh the newest records. If a burst arrived, expand the fetch
+            // until it still contains the prior oldest persisted row; a fixed
+            // one-record allowance can evict the visible anchor.
             let retainedRecordCount = pageCursor.nextOffset
-            let refreshSlack = retainedRecordCount > 0 && !messages.isEmpty ? 1 : 0
-            let fetchLimit = max(Self.pageSize, retainedRecordCount + refreshSlack)
+            let priorOldestID = messages.first {
+                !unpersistedOutboundIDs.contains($0.id)
+            }?.id
+            var fetchLimit = max(Self.pageSize, retainedRecordCount + 1)
 
-            // Fetch the newest retained history window.
             let hasInterruptedRetry = try await repository.hasUncertainRetry(for: conversationHash)
-            let records = try await repository.fetchMessageRecords(
+            var records = try await repository.fetchMessageRecords(
                 for: conversationHash, limit: fetchLimit, offset: 0)
+            while loadGeneration == paginationGeneration,
+                  let priorOldestID,
+                  let expandedLimit = MessageRefreshWindowPolicy.expandedLimit(
+                    currentLimit: fetchLimit,
+                    fetchedCount: records.count,
+                    containsPriorOldest: records.contains {
+                        Self.recordID($0) == priorOldestID
+                    },
+                    pageSize: Self.pageSize
+                  ) {
+                fetchLimit = expandedLimit
+                records = try await repository.fetchMessageRecords(
+                    for: conversationHash, limit: fetchLimit, offset: 0
+                )
+            }
             let loaded = records.reversed()
                 .map { Message(from: $0, localHash: appServices.localIdentityHash) }
                 .filter { !$0.isEmpty }  // Hide telemetry-only messages (e.g. location sharing)
@@ -268,7 +284,7 @@ public final class MessagingViewModel {
     }
 
     @MainActor
-    private func recordNewestPersistence() async {
+    private func invalidatePaginationAndRefresh() async {
         paginationGeneration &+= 1
         pendingRefresh = true
         await runPendingRefreshIfNeeded()
@@ -283,7 +299,19 @@ public final class MessagingViewModel {
         let pending = current.filter {
             pendingIDs.contains($0.id) && !loadedIDs.contains($0.id)
         }
-        return loaded + pending
+        return (loaded + pending)
+            .enumerated()
+            .sorted { lhs, rhs in
+                if lhs.element.timestamp == rhs.element.timestamp {
+                    return lhs.offset < rhs.offset
+                }
+                return lhs.element.timestamp < rhs.element.timestamp
+            }
+            .map(\.element)
+    }
+
+    private static func recordID(_ record: MessageRecord) -> String {
+        record.messageId.map { String(format: "%02x", $0) }.joined()
     }
 
     /// Actionable failure returned when a backend does not accept a send.
@@ -534,7 +562,7 @@ public final class MessagingViewModel {
                 try await persistMessage(lxMessage, replacing: localRetryHash)
                 if localRetryHash == nil {
                     unpersistedOutboundIDs.remove(realId)
-                    await recordNewestPersistence()
+                    await invalidatePaginationAndRefresh()
                 }
             } catch {
                 unpersistedOutboundIDs.remove(realId)
@@ -608,7 +636,7 @@ public final class MessagingViewModel {
                         try await persistMessage(retryMessage, replacing: localRetryHash)
                         if localRetryHash == nil {
                             unpersistedOutboundIDs.remove(realId)
-                            await recordNewestPersistence()
+                            await invalidatePaginationAndRefresh()
                         }
                     } catch {
                         unpersistedOutboundIDs.remove(realId)
@@ -634,7 +662,7 @@ public final class MessagingViewModel {
                 persisted = true
                 if localRetryHash == nil {
                     unpersistedOutboundIDs.remove(optimisticId)
-                    await recordNewestPersistence()
+                    await invalidatePaginationAndRefresh()
                 }
             } catch {
                 unpersistedOutboundIDs.remove(optimisticId)
@@ -723,6 +751,7 @@ public final class MessagingViewModel {
         if let hash = messageHash {
             do {
                 try await repository.deleteMessage(hash)
+                await invalidatePaginationAndRefresh()
             } catch {
                 logger.error("Failed to delete message: \(error.localizedDescription)")
             }

--- a/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
@@ -61,9 +61,10 @@ public final class MessagingViewModel {
     private var paginationGeneration: UInt64 = 0
     private var unpersistedOutboundIDs: Set<String> = []
     private var unsavedFailedOutboundIDs: Set<String> = []
-    private var stagedRetryCleanupHashes: [String: Data] = [:]
+    private var stagedRetryRecoveryHashes: [String: Data] = [:]
     private var pendingOutboundAliases: [String: String] = [:]
     private var pendingDeliveryProofs: [String: LXMessageState] = [:]
+    private var unsafeTargetMessageIDs: Set<String> = []
 
     // MARK: - Initialization
 
@@ -155,6 +156,7 @@ public final class MessagingViewModel {
             // leave a stale badge behind after the conversation was viewed.
             try await repository.ensureConversation(conversationHash, displayName: displayName)
             try await repository.markConversationRead(conversationHash)
+            await retryPendingDeliveryProofs()
 
             // Preserve the current history depth when repository notifications
             // refresh the newest records. If a burst arrived, expand the fetch
@@ -206,6 +208,9 @@ public final class MessagingViewModel {
                         // DB fallback for messages not in current page
                         resolvedMessages[i].replyToPreview = await resolveReplyPreview(replyId)
                     }
+                }
+                if let proof = pendingDeliveryProofs[resolvedMessages[i].id] {
+                    resolvedMessages[i].deliveryStatus = (proof == .delivered) ? .delivered : .failed
                 }
             }
 
@@ -310,14 +315,14 @@ public final class MessagingViewModel {
     }
 
     @MainActor
-    private func removeStagedRetryAfterPersistenceFailure(_ hash: Data?) async -> Bool {
+    private func recoverStagedRetryAfterPersistenceFailure(_ hash: Data?) async -> Bool {
         guard let hash else { return true }
         do {
-            try await repository.deleteMessage(hash)
+            try await repository.recoverStagedRetry(hash)
             await invalidatePaginationAndRefresh()
             return true
         } catch {
-            logger.error("[MSG_VM] failed to remove staged retry: \(error.localizedDescription)")
+            logger.error("[MSG_VM] failed to recover staged retry: \(error.localizedDescription)")
             return false
         }
     }
@@ -326,19 +331,46 @@ public final class MessagingViewModel {
     private func reconcilePendingDeliveryProof(for hash: Data) async {
         let hashHex = Self.hexString(hash)
         pendingOutboundAliases.removeValue(forKey: hashHex)
-        guard let proof = pendingDeliveryProofs.removeValue(forKey: hashHex) else { return }
+        guard let proof = pendingDeliveryProofs[hashHex] else { return }
         do {
             try await repository.updateMessageState(id: hash, state: proof)
+            pendingDeliveryProofs.removeValue(forKey: hashHex)
         } catch {
             logger.error("[MSG_VM] failed to persist delivery proof: \(error.localizedDescription)")
         }
     }
 
     @MainActor
-    private func takePendingDeliveryProof(for hash: Data) -> LXMessageState? {
+    private func retryPendingDeliveryProofs() async {
+        for (hashHex, proof) in Array(pendingDeliveryProofs) {
+            guard pendingOutboundAliases[hashHex] == nil,
+                  let hash = Self.hexToData(hashHex) else { continue }
+            do {
+                try await repository.updateMessageState(id: hash, state: proof)
+                if pendingDeliveryProofs[hashHex] == proof {
+                    pendingDeliveryProofs.removeValue(forKey: hashHex)
+                }
+            } catch {
+                logger.error("[MSG_VM] delivery proof retry failed: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    @MainActor
+    private func pendingDeliveryProof(for hash: Data) -> LXMessageState? {
         let hashHex = Self.hexString(hash)
-        pendingOutboundAliases.removeValue(forKey: hashHex)
-        return pendingDeliveryProofs.removeValue(forKey: hashHex)
+        return pendingDeliveryProofs[hashHex]
+    }
+
+    @MainActor
+    private func clearPendingAliases(for visibleID: String) {
+        let hashes = pendingOutboundAliases.compactMap { key, value in
+            value == visibleID ? key : nil
+        }
+        for hash in hashes {
+            pendingOutboundAliases.removeValue(forKey: hash)
+            pendingDeliveryProofs.removeValue(forKey: hash)
+        }
     }
 
     private static func hexString(_ data: Data) -> String {
@@ -567,10 +599,10 @@ public final class MessagingViewModel {
         withAnimation(.easeOut(duration: 0.25)) {
             if let index = messages.firstIndex(where: { $0.id == optimisticId }) {
                 messages[index] = optimisticMessage
-                messages[index].messageHash = optimisticHash
+                messages[index].messageHash = nil
             } else {
                 messages.append(optimisticMessage)
-                messages[messages.count - 1].messageHash = optimisticHash
+                messages[messages.count - 1].messageHash = nil
             }
         }
         unpersistedOutboundIDs.insert(optimisticId)
@@ -600,17 +632,25 @@ public final class MessagingViewModel {
                 await reconcilePendingDeliveryProof(for: sentHash)
                 unpersistedOutboundIDs.remove(optimisticId)
                 unsavedFailedOutboundIDs.remove(optimisticId)
-                stagedRetryCleanupHashes.removeValue(forKey: optimisticId)
+                stagedRetryRecoveryHashes.removeValue(forKey: optimisticId)
+                unsafeTargetMessageIDs.remove(optimisticId)
                 await invalidatePaginationAndRefresh()
             } catch {
-                unsavedFailedOutboundIDs.insert(optimisticId)
-                let proof = takePendingDeliveryProof(for: sentHash)
-                let cleaned = await removeStagedRetryAfterPersistenceFailure(localRetryHash)
-                if !cleaned, let localRetryHash {
-                    stagedRetryCleanupHashes[optimisticId] = localRetryHash
+                let proof = pendingDeliveryProof(for: sentHash)
+                unsafeTargetMessageIDs.insert(optimisticId)
+                let recovered = await recoverStagedRetryAfterPersistenceFailure(localRetryHash)
+                if localRetryHash != nil && recovered {
+                    unpersistedOutboundIDs.remove(optimisticId)
+                    unsavedFailedOutboundIDs.remove(optimisticId)
+                } else {
+                    unsavedFailedOutboundIDs.insert(optimisticId)
+                    if let localRetryHash {
+                        stagedRetryRecoveryHashes[optimisticId] = localRetryHash
+                    }
                 }
                 logger.error("[MSG_VM] saveMessage(outbound) failed: \(error.localizedDescription)")
                 if let index = messages.firstIndex(where: { $0.id == optimisticId }) {
+                    messages[index].messageHash = sentHash
                     messages[index].deliveryStatus = (proof == .delivered) ? .delivered : .failed
                 }
                 errorMessage = "Message was sent, but local confirmation could not be saved. Verify whether it arrived before retrying."
@@ -660,17 +700,25 @@ public final class MessagingViewModel {
                         await reconcilePendingDeliveryProof(for: retryHash)
                         unpersistedOutboundIDs.remove(optimisticId)
                         unsavedFailedOutboundIDs.remove(optimisticId)
-                        stagedRetryCleanupHashes.removeValue(forKey: optimisticId)
+                        stagedRetryRecoveryHashes.removeValue(forKey: optimisticId)
+                        unsafeTargetMessageIDs.remove(optimisticId)
                         await invalidatePaginationAndRefresh()
                     } catch {
-                        unsavedFailedOutboundIDs.insert(optimisticId)
-                        let proof = takePendingDeliveryProof(for: retryHash)
-                        let cleaned = await removeStagedRetryAfterPersistenceFailure(localRetryHash)
-                        if !cleaned, let localRetryHash {
-                            stagedRetryCleanupHashes[optimisticId] = localRetryHash
+                        let proof = pendingDeliveryProof(for: retryHash)
+                        unsafeTargetMessageIDs.insert(optimisticId)
+                        let recovered = await recoverStagedRetryAfterPersistenceFailure(localRetryHash)
+                        if localRetryHash != nil && recovered {
+                            unpersistedOutboundIDs.remove(optimisticId)
+                            unsavedFailedOutboundIDs.remove(optimisticId)
+                        } else {
+                            unsavedFailedOutboundIDs.insert(optimisticId)
+                            if let localRetryHash {
+                                stagedRetryRecoveryHashes[optimisticId] = localRetryHash
+                            }
                         }
                         logger.error("[MSG_VM] saveMessage(retry-relay) failed: \(error.localizedDescription)")
                         if let index = messages.firstIndex(where: { $0.id == optimisticId }) {
+                            messages[index].messageHash = retryHash
                             messages[index].deliveryStatus = (proof == .delivered) ? .delivered : .failed
                         }
                         errorMessage = "Message was relayed, but local confirmation could not be saved. Verify whether it arrived before retrying."
@@ -691,13 +739,21 @@ public final class MessagingViewModel {
                 persisted = true
                 unpersistedOutboundIDs.remove(optimisticId)
                 unsavedFailedOutboundIDs.remove(optimisticId)
-                stagedRetryCleanupHashes.removeValue(forKey: optimisticId)
+                stagedRetryRecoveryHashes.removeValue(forKey: optimisticId)
+                unsafeTargetMessageIDs.remove(optimisticId)
                 await invalidatePaginationAndRefresh()
             } catch {
-                unsavedFailedOutboundIDs.insert(optimisticId)
-                let cleaned = await removeStagedRetryAfterPersistenceFailure(localRetryHash)
-                if !cleaned, let localRetryHash {
-                    stagedRetryCleanupHashes[optimisticId] = localRetryHash
+                unsafeTargetMessageIDs.insert(optimisticId)
+                let recovered = await recoverStagedRetryAfterPersistenceFailure(localRetryHash)
+                persisted = localRetryHash != nil && recovered
+                if localRetryHash != nil && recovered {
+                    unpersistedOutboundIDs.remove(optimisticId)
+                    unsavedFailedOutboundIDs.remove(optimisticId)
+                } else {
+                    unsavedFailedOutboundIDs.insert(optimisticId)
+                    if let localRetryHash {
+                        stagedRetryRecoveryHashes[optimisticId] = localRetryHash
+                    }
                 }
                 logger.error("[MSG_VM] saveMessage(failed) failed: \(error.localizedDescription)")
             }
@@ -746,17 +802,21 @@ public final class MessagingViewModel {
         }
 
         let failedMessage = messages[index]
-        if unsavedFailedOutboundIDs.contains(messageId) {
-            if let stagedHash = stagedRetryCleanupHashes[messageId] {
-                do {
-                    try await repository.deleteMessage(stagedHash)
-                    stagedRetryCleanupHashes.removeValue(forKey: messageId)
-                    await invalidatePaginationAndRefresh()
-                } catch {
-                    errorMessage = "The staged retry could not be cleaned up. Please try again."
-                    return
-                }
+        if unsavedFailedOutboundIDs.contains(messageId),
+           let stagedHash = stagedRetryRecoveryHashes[messageId] {
+            do {
+                try await repository.recoverStagedRetry(stagedHash)
+                stagedRetryRecoveryHashes.removeValue(forKey: messageId)
+                unsavedFailedOutboundIDs.remove(messageId)
+                unpersistedOutboundIDs.remove(messageId)
+                await invalidatePaginationAndRefresh()
+            } catch {
+                errorMessage = "The staged retry could not be recovered. Please try again."
+                return
             }
+        } else if unsavedFailedOutboundIDs.contains(messageId) {
+            clearPendingAliases(for: messageId)
+            unsafeTargetMessageIDs.remove(messageId)
             unsavedFailedOutboundIDs.remove(messageId)
             unpersistedOutboundIDs.remove(messageId)
             messages.removeAll { $0.id == messageId }
@@ -781,6 +841,8 @@ public final class MessagingViewModel {
         // Reuse a canonical local ID and the complete payload. The send path
         // replaces the failed row only after the replacement is safely saved,
         // including migration of legacy non-32-byte temporary IDs.
+        clearPendingAliases(for: messageId)
+        unsafeTargetMessageIDs.remove(messageId)
         _ = await sendMessage(
             text: failedMessage.content,
             imageData: failedMessage.imageData,
@@ -804,6 +866,11 @@ public final class MessagingViewModel {
         )
     }
 
+    public func canTargetMessage(messageId: String) -> Bool {
+        !unpersistedOutboundIDs.contains(messageId)
+            && !unsafeTargetMessageIDs.contains(messageId)
+    }
+
     static func canDeleteMessage(
         isUnpersisted: Bool,
         isUnsavedFailure: Bool
@@ -816,19 +883,22 @@ public final class MessagingViewModel {
     public func deleteMessage(messageId: String, messageHash: Data?) async {
         guard canDeleteMessage(messageId: messageId) else { return }
 
-        let wasUnsavedFailure = unsavedFailedOutboundIDs.contains(messageId)
-        if wasUnsavedFailure, let stagedHash = stagedRetryCleanupHashes[messageId] {
+        var wasUnsavedFailure = unsavedFailedOutboundIDs.contains(messageId)
+        if wasUnsavedFailure, let stagedHash = stagedRetryRecoveryHashes[messageId] {
             do {
-                try await repository.deleteMessage(stagedHash)
+                try await repository.recoverStagedRetry(stagedHash)
+                wasUnsavedFailure = false
             } catch {
-                errorMessage = "The staged retry could not be deleted. Please try again."
+                errorMessage = "The staged retry could not be recovered for deletion. Please try again."
                 return
             }
         }
 
         unsavedFailedOutboundIDs.remove(messageId)
         unpersistedOutboundIDs.remove(messageId)
-        stagedRetryCleanupHashes.removeValue(forKey: messageId)
+        stagedRetryRecoveryHashes.removeValue(forKey: messageId)
+        clearPendingAliases(for: messageId)
+        unsafeTargetMessageIDs.remove(messageId)
 
         // Remove from UI immediately
         withAnimation {

--- a/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
@@ -58,6 +58,7 @@ public final class MessagingViewModel {
     private var notificationTask: Any?
     private var deliveryTask: Any?
     private var pendingRefresh = false
+    private var paginationGeneration: UInt64 = 0
 
     // MARK: - Initialization
 
@@ -133,6 +134,7 @@ public final class MessagingViewModel {
             return
         }
         isLoading = true
+        let loadGeneration = paginationGeneration
 
         do {
             // Ensure conversation exists, then clear unread state as soon as the
@@ -171,6 +173,13 @@ public final class MessagingViewModel {
                 }
             }
 
+            guard loadGeneration == paginationGeneration else {
+                pendingRefresh = true
+                isLoading = false
+                await runPendingRefreshIfNeeded()
+                return
+            }
+
             messages = resolvedMessages
             pageCursor.reset(recordCount: records.count)
             allMessagesLoaded = records.count < fetchLimit
@@ -192,9 +201,12 @@ public final class MessagingViewModel {
 
     /// Load older messages when scrolling up.
     @MainActor
-    public func loadMoreMessages() async {
-        guard !isLoading, !isLoadingMore, !allMessagesLoaded else { return }
+    @discardableResult
+    public func loadMoreMessages() async -> Bool {
+        guard !isLoading, !isLoadingMore, !allMessagesLoaded else { return false }
         isLoadingMore = true
+        let loadGeneration = paginationGeneration
+        var consumedPage = false
 
         do {
             // Database pages can contain telemetry-only records that do not
@@ -205,24 +217,33 @@ public final class MessagingViewModel {
             let hasInterruptedRetry = try await repository.hasUncertainRetry(for: conversationHash)
             let records = try await repository.fetchMessageRecords(
                 for: conversationHash, limit: Self.pageSize, offset: offset)
-            if hasInterruptedRetry {
-                errorMessage = Self.interruptedRetryWarning
-            } else if errorMessage == Self.interruptedRetryWarning {
-                errorMessage = nil
-            }
-            if records.isEmpty {
-                allMessagesLoaded = true
-            } else {
-                pageCursor.recordFetchedPage(recordCount: records.count)
-                let older = records.reversed()
-                    .map { Message(from: $0, localHash: appServices.localIdentityHash) }
-                    .filter { !$0.isEmpty }  // Hide telemetry-only messages
-                var knownIDs = Set(messages.map(\.id))
-                let uniqueOlder = older.filter { knownIDs.insert($0.id).inserted }
 
-                messages.insert(contentsOf: uniqueOlder, at: 0)
-                if records.count < Self.pageSize {
+            if loadGeneration != paginationGeneration {
+                // A new record was persisted at the head while this offset page
+                // was in flight. Discard the stale page and rebuild from offset
+                // zero so an overlap cannot advance the cursor past a record.
+                pendingRefresh = true
+            } else {
+                consumedPage = true
+                if hasInterruptedRetry {
+                    errorMessage = Self.interruptedRetryWarning
+                } else if errorMessage == Self.interruptedRetryWarning {
+                    errorMessage = nil
+                }
+                if records.isEmpty {
                     allMessagesLoaded = true
+                } else {
+                    pageCursor.recordFetchedPage(recordCount: records.count)
+                    let older = records.reversed()
+                        .map { Message(from: $0, localHash: appServices.localIdentityHash) }
+                        .filter { !$0.isEmpty }  // Hide telemetry-only messages
+                    var knownIDs = Set(messages.map(\.id))
+                    let uniqueOlder = older.filter { knownIDs.insert($0.id).inserted }
+
+                    messages.insert(contentsOf: uniqueOlder, at: 0)
+                    if records.count < Self.pageSize {
+                        allMessagesLoaded = true
+                    }
                 }
             }
         } catch {
@@ -231,6 +252,7 @@ public final class MessagingViewModel {
 
         isLoadingMore = false
         await runPendingRefreshIfNeeded()
+        return consumedPage
     }
 
     @MainActor
@@ -238,6 +260,16 @@ public final class MessagingViewModel {
         guard pendingRefresh, !isLoading, !isLoadingMore else { return }
         pendingRefresh = false
         await loadMessages()
+    }
+
+    @MainActor
+    private func recordNewestPersistence() {
+        paginationGeneration &+= 1
+        if isLoading || isLoadingMore {
+            pendingRefresh = true
+        } else {
+            pageCursor.recordInsertedAtNewest()
+        }
     }
 
     /// Actionable failure returned when a backend does not accept a send.
@@ -480,7 +512,7 @@ public final class MessagingViewModel {
             do {
                 try await persistMessage(lxMessage, replacing: localRetryHash)
                 if localRetryHash == nil {
-                    pageCursor.recordInsertedAtNewest()
+                    recordNewestPersistence()
                 }
             } catch {
                 logger.error("[MSG_VM] saveMessage(outbound) failed: \(error.localizedDescription)")
@@ -548,7 +580,7 @@ public final class MessagingViewModel {
                     do {
                         try await persistMessage(retryMessage, replacing: localRetryHash)
                         if localRetryHash == nil {
-                            pageCursor.recordInsertedAtNewest()
+                            recordNewestPersistence()
                         }
                     } catch {
                         logger.error("[MSG_VM] saveMessage(retry-relay) failed: \(error.localizedDescription)")

--- a/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
@@ -263,13 +263,10 @@ public final class MessagingViewModel {
     }
 
     @MainActor
-    private func recordNewestPersistence() {
+    private func recordNewestPersistence() async {
         paginationGeneration &+= 1
-        if isLoading || isLoadingMore {
-            pendingRefresh = true
-        } else {
-            pageCursor.recordInsertedAtNewest()
-        }
+        pendingRefresh = true
+        await runPendingRefreshIfNeeded()
     }
 
     /// Actionable failure returned when a backend does not accept a send.
@@ -512,7 +509,7 @@ public final class MessagingViewModel {
             do {
                 try await persistMessage(lxMessage, replacing: localRetryHash)
                 if localRetryHash == nil {
-                    recordNewestPersistence()
+                    await recordNewestPersistence()
                 }
             } catch {
                 logger.error("[MSG_VM] saveMessage(outbound) failed: \(error.localizedDescription)")
@@ -580,7 +577,7 @@ public final class MessagingViewModel {
                     do {
                         try await persistMessage(retryMessage, replacing: localRetryHash)
                         if localRetryHash == nil {
-                            recordNewestPersistence()
+                            await recordNewestPersistence()
                         }
                     } catch {
                         logger.error("[MSG_VM] saveMessage(retry-relay) failed: \(error.localizedDescription)")
@@ -603,6 +600,9 @@ public final class MessagingViewModel {
             do {
                 try await persistMessage(lxMessage, replacing: localRetryHash)
                 persisted = true
+                if localRetryHash == nil {
+                    await recordNewestPersistence()
+                }
             } catch {
                 logger.error("[MSG_VM] saveMessage(failed) failed: \(error.localizedDescription)")
             }

--- a/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
@@ -59,6 +59,7 @@ public final class MessagingViewModel {
     private var deliveryTask: Any?
     private var pendingRefresh = false
     private var paginationGeneration: UInt64 = 0
+    private var unpersistedOutboundIDs: Set<String> = []
 
     // MARK: - Initialization
 
@@ -180,7 +181,11 @@ public final class MessagingViewModel {
                 return
             }
 
-            messages = resolvedMessages
+            messages = Self.mergingPendingOutbound(
+                loaded: resolvedMessages,
+                current: messages,
+                pendingIDs: unpersistedOutboundIDs
+            )
             pageCursor.reset(recordCount: records.count)
             allMessagesLoaded = records.count < fetchLimit
 
@@ -267,6 +272,18 @@ public final class MessagingViewModel {
         paginationGeneration &+= 1
         pendingRefresh = true
         await runPendingRefreshIfNeeded()
+    }
+
+    static func mergingPendingOutbound(
+        loaded: [Message],
+        current: [Message],
+        pendingIDs: Set<String>
+    ) -> [Message] {
+        let loadedIDs = Set(loaded.map(\.id))
+        let pending = current.filter {
+            pendingIDs.contains($0.id) && !loadedIDs.contains($0.id)
+        }
+        return loaded + pending
     }
 
     /// Actionable failure returned when a backend does not accept a send.
@@ -467,6 +484,9 @@ public final class MessagingViewModel {
                 messages[messages.count - 1].messageHash = optimisticHash
             }
         }
+        if localRetryHash == nil {
+            unpersistedOutboundIDs.insert(optimisticId)
+        }
 
         do {
             // Send through the neutral LXMF facet with TYPED fields (image /
@@ -504,14 +524,20 @@ public final class MessagingViewModel {
                     )
                 }
             }
+            if localRetryHash == nil {
+                unpersistedOutboundIDs.remove(optimisticId)
+                unpersistedOutboundIDs.insert(realId)
+            }
 
             // Persist so a subsequent loadMessages() doesn't wipe it.
             do {
                 try await persistMessage(lxMessage, replacing: localRetryHash)
                 if localRetryHash == nil {
+                    unpersistedOutboundIDs.remove(realId)
                     await recordNewestPersistence()
                 }
             } catch {
+                unpersistedOutboundIDs.remove(realId)
                 logger.error("[MSG_VM] saveMessage(outbound) failed: \(error.localizedDescription)")
                 if let index = messages.firstIndex(where: { $0.id == realId }) {
                     messages[index].deliveryStatus = .failed
@@ -574,12 +600,18 @@ public final class MessagingViewModel {
                             )
                         }
                     }
+                    if localRetryHash == nil {
+                        unpersistedOutboundIDs.remove(optimisticId)
+                        unpersistedOutboundIDs.insert(realId)
+                    }
                     do {
                         try await persistMessage(retryMessage, replacing: localRetryHash)
                         if localRetryHash == nil {
+                            unpersistedOutboundIDs.remove(realId)
                             await recordNewestPersistence()
                         }
                     } catch {
+                        unpersistedOutboundIDs.remove(realId)
                         logger.error("[MSG_VM] saveMessage(retry-relay) failed: \(error.localizedDescription)")
                         if let index = messages.firstIndex(where: { $0.id == realId }) {
                             messages[index].deliveryStatus = .failed
@@ -601,9 +633,11 @@ public final class MessagingViewModel {
                 try await persistMessage(lxMessage, replacing: localRetryHash)
                 persisted = true
                 if localRetryHash == nil {
+                    unpersistedOutboundIDs.remove(optimisticId)
                     await recordNewestPersistence()
                 }
             } catch {
+                unpersistedOutboundIDs.remove(optimisticId)
                 logger.error("[MSG_VM] saveMessage(failed) failed: \(error.localizedDescription)")
             }
 

--- a/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
@@ -112,18 +112,31 @@ public final class MessagingViewModel {
             guard let self,
                   let hashData = notification.userInfo?["messageHash"] as? Data,
                   let state = notification.userInfo?["state"] as? String else { return }
+            let proofPersisted = notification.userInfo?["persisted"] as? Bool ?? false
             let hashHex = hashData.map { String(format: "%02x", $0) }.joined()
             Task { @MainActor in
                 let proofState: LXMessageState = (state == "delivered") ? .delivered : .failed
+                let wasAliased = self.pendingOutboundAliases[hashHex] != nil
                 let visibleID = Self.visibleMessageID(
                     for: hashHex,
                     aliases: self.pendingOutboundAliases
                 )
-                if self.pendingOutboundAliases[hashHex] != nil {
+                if wasAliased && !proofPersisted {
                     self.pendingDeliveryProofs[hashHex] = proofState
                 }
                 guard let index = self.messages.firstIndex(where: { $0.id == visibleID }) else { return }
-                self.messages[index].deliveryStatus = (proofState == .delivered) ? .delivered : .failed
+                if wasAliased && proofPersisted {
+                    self.messages[index] = Self.canonicalizedMessage(
+                        self.messages[index],
+                        canonicalHash: hashData,
+                        proofState: proofState
+                    )
+                    self.pendingOutboundAliases.removeValue(forKey: hashHex)
+                    self.pendingDeliveryProofs.removeValue(forKey: hashHex)
+                    await self.invalidatePaginationAndRefresh()
+                } else {
+                    self.messages[index].deliveryStatus = (proofState == .delivered) ? .delivered : .failed
+                }
             }
         }
     }
@@ -427,14 +440,32 @@ public final class MessagingViewModel {
         return proofs[canonicalID]
     }
 
-    static func retryableRefreshedMessage(
-        messageId: String,
-        stagedHash: Data,
-        messages: [Message]
-    ) -> Message? {
-        messages.first(where: {
-            $0.id == messageId || $0.storageHash == stagedHash
-        }).flatMap { $0.deliveryStatus == .failed ? $0 : nil }
+    static func canonicalizedMessage(
+        _ message: Message,
+        canonicalHash: Data,
+        proofState: LXMessageState
+    ) -> Message {
+        var canonical = Message(
+            id: hexString(canonicalHash),
+            content: message.content,
+            timestamp: message.timestamp,
+            isFromMe: message.isFromMe,
+            deliveryStatus: proofState == .delivered ? .delivered : .failed,
+            imageData: message.imageData,
+            imageFormat: message.imageFormat,
+            attachments: message.attachments,
+            replyToId: message.replyToId,
+            replyToPreview: message.replyToPreview,
+            reactions: message.reactions,
+            storageHash: canonicalHash,
+            isTargetSafe: true
+        )
+        canonical.messageHash = canonicalHash
+        canonical.deliveryMethod = message.deliveryMethod
+        canonical.rssi = message.rssi
+        canonical.snr = message.snr
+        canonical.receivedInterface = nil
+        return canonical
     }
 
     static func mergingPendingOutbound(
@@ -874,15 +905,20 @@ public final class MessagingViewModel {
                 stagedRetryRecoveryHashes.removeValue(forKey: messageId)
                 unsavedFailedOutboundIDs.remove(messageId)
                 unpersistedOutboundIDs.remove(messageId)
-                await invalidatePaginationAndRefresh()
-                guard let refreshed = Self.retryableRefreshedMessage(
-                    messageId: messageId,
-                    stagedHash: stagedHash,
-                    messages: messages
-                ) else {
+                let storedRecovered = try await repository.getMessageRecord(id: stagedHash)
+                guard let recoveredRecord = storedRecovered,
+                      recoveredRecord.state == LXMessageState.failed.rawValue,
+                      MessageRepository.isUncertainRetryMarker(
+                        recoveredRecord.receivingInterface
+                      ) else {
+                    await invalidatePaginationAndRefresh()
                     return
                 }
-                failedMessage = refreshed
+                failedMessage = Message(
+                    from: recoveredRecord,
+                    localHash: appServices.localIdentityHash
+                )
+                await invalidatePaginationAndRefresh()
             } catch {
                 errorMessage = "The staged retry could not be recovered. Please try again."
                 return

--- a/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
@@ -41,6 +41,7 @@ public final class MessagingViewModel {
 
     /// Page size for message fetching.
     private static let pageSize = 50
+    private var pageCursor = MessagePageCursor()
     private static let interruptedRetryWarning =
         "A message retry was interrupted before delivery confirmation. Verify whether it arrived before retrying."
 
@@ -136,10 +137,18 @@ public final class MessagingViewModel {
             try await repository.ensureConversation(conversationHash, displayName: displayName)
             try await repository.markConversationRead(conversationHash)
 
-            // Fetch most recent page
+            // Preserve the current history depth when a repository notification
+            // refreshes the newest records. One record of slack retains the
+            // previous oldest row when the refresh includes a newly arrived
+            // message.
+            let retainedRecordCount = pageCursor.nextOffset
+            let refreshSlack = retainedRecordCount > 0 && !messages.isEmpty ? 1 : 0
+            let fetchLimit = max(Self.pageSize, retainedRecordCount + refreshSlack)
+
+            // Fetch the newest retained history window.
             let hasInterruptedRetry = try await repository.hasUncertainRetry(for: conversationHash)
             let records = try await repository.fetchMessageRecords(
-                for: conversationHash, limit: Self.pageSize, offset: 0)
+                for: conversationHash, limit: fetchLimit, offset: 0)
             let loaded = records.reversed()
                 .map { Message(from: $0, localHash: appServices.localIdentityHash) }
                 .filter { !$0.isEmpty }  // Hide telemetry-only messages (e.g. location sharing)
@@ -159,7 +168,8 @@ public final class MessagingViewModel {
             }
 
             messages = resolvedMessages
-            allMessagesLoaded = records.count < Self.pageSize
+            pageCursor.reset(recordCount: records.count)
+            allMessagesLoaded = records.count < fetchLimit
 
             // Reconcile messages that arrived after the initial read reset but
             // were included in the page we just displayed.
@@ -181,7 +191,11 @@ public final class MessagingViewModel {
         defer { isLoadingMore = false }
 
         do {
-            let offset = messages.count
+            // Database pages can contain telemetry-only records that do not
+            // become visible bubbles. Offset by fetched records rather than
+            // `messages.count` so those hidden records cannot cause overlapping
+            // pages and duplicate IDs.
+            let offset = pageCursor.nextOffset
             let hasInterruptedRetry = try await repository.hasUncertainRetry(for: conversationHash)
             let records = try await repository.fetchMessageRecords(
                 for: conversationHash, limit: Self.pageSize, offset: offset)
@@ -194,6 +208,7 @@ public final class MessagingViewModel {
                 allMessagesLoaded = true
                 return
             }
+            pageCursor.recordFetchedPage(recordCount: records.count)
             let older = records.reversed()
                 .map { Message(from: $0, localHash: appServices.localIdentityHash) }
                 .filter { !$0.isEmpty }  // Hide telemetry-only messages

--- a/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
@@ -61,6 +61,9 @@ public final class MessagingViewModel {
     private var paginationGeneration: UInt64 = 0
     private var unpersistedOutboundIDs: Set<String> = []
     private var unsavedFailedOutboundIDs: Set<String> = []
+    private var stagedRetryCleanupHashes: [String: Data] = [:]
+    private var pendingOutboundAliases: [String: String] = [:]
+    private var pendingDeliveryProofs: [String: LXMessageState] = [:]
 
     // MARK: - Initialization
 
@@ -111,8 +114,16 @@ public final class MessagingViewModel {
                   let state = notification.userInfo?["state"] as? String else { return }
             let hashHex = hashData.map { String(format: "%02x", $0) }.joined()
             Task { @MainActor in
-                guard let index = self.messages.firstIndex(where: { $0.id == hashHex }) else { return }
-                self.messages[index].deliveryStatus = (state == "delivered") ? .delivered : .failed
+                let proofState: LXMessageState = (state == "delivered") ? .delivered : .failed
+                let visibleID = Self.visibleMessageID(
+                    for: hashHex,
+                    aliases: self.pendingOutboundAliases
+                )
+                if self.pendingOutboundAliases[hashHex] != nil {
+                    self.pendingDeliveryProofs[hashHex] = proofState
+                }
+                guard let index = self.messages.firstIndex(where: { $0.id == visibleID }) else { return }
+                self.messages[index].deliveryStatus = (proofState == .delivered) ? .delivered : .failed
             }
         }
     }
@@ -299,14 +310,46 @@ public final class MessagingViewModel {
     }
 
     @MainActor
-    private func removeStagedRetryAfterPersistenceFailure(_ hash: Data?) async {
-        guard let hash else { return }
+    private func removeStagedRetryAfterPersistenceFailure(_ hash: Data?) async -> Bool {
+        guard let hash else { return true }
         do {
             try await repository.deleteMessage(hash)
             await invalidatePaginationAndRefresh()
+            return true
         } catch {
             logger.error("[MSG_VM] failed to remove staged retry: \(error.localizedDescription)")
+            return false
         }
+    }
+
+    @MainActor
+    private func reconcilePendingDeliveryProof(for hash: Data) async {
+        let hashHex = Self.hexString(hash)
+        pendingOutboundAliases.removeValue(forKey: hashHex)
+        guard let proof = pendingDeliveryProofs.removeValue(forKey: hashHex) else { return }
+        do {
+            try await repository.updateMessageState(id: hash, state: proof)
+        } catch {
+            logger.error("[MSG_VM] failed to persist delivery proof: \(error.localizedDescription)")
+        }
+    }
+
+    @MainActor
+    private func takePendingDeliveryProof(for hash: Data) -> LXMessageState? {
+        let hashHex = Self.hexString(hash)
+        pendingOutboundAliases.removeValue(forKey: hashHex)
+        return pendingDeliveryProofs.removeValue(forKey: hashHex)
+    }
+
+    private static func hexString(_ data: Data) -> String {
+        data.map { String(format: "%02x", $0) }.joined()
+    }
+
+    static func visibleMessageID(
+        for realID: String,
+        aliases: [String: String]
+    ) -> String {
+        aliases[realID] ?? realID
     }
 
     static func mergingPendingOutbound(
@@ -549,19 +592,26 @@ public final class MessagingViewModel {
             let sentHash = try Self.queuedHash(from: outcome)
             lxMessage.hash = sentHash
             lxMessage.state = .sent
+            pendingOutboundAliases[Self.hexString(sentHash)] = optimisticId
 
             // Persist so a subsequent loadMessages() doesn't wipe it.
             do {
                 try await persistMessage(lxMessage, replacing: localRetryHash)
+                await reconcilePendingDeliveryProof(for: sentHash)
                 unpersistedOutboundIDs.remove(optimisticId)
                 unsavedFailedOutboundIDs.remove(optimisticId)
+                stagedRetryCleanupHashes.removeValue(forKey: optimisticId)
                 await invalidatePaginationAndRefresh()
             } catch {
                 unsavedFailedOutboundIDs.insert(optimisticId)
-                await removeStagedRetryAfterPersistenceFailure(localRetryHash)
+                let proof = takePendingDeliveryProof(for: sentHash)
+                let cleaned = await removeStagedRetryAfterPersistenceFailure(localRetryHash)
+                if !cleaned, let localRetryHash {
+                    stagedRetryCleanupHashes[optimisticId] = localRetryHash
+                }
                 logger.error("[MSG_VM] saveMessage(outbound) failed: \(error.localizedDescription)")
                 if let index = messages.firstIndex(where: { $0.id == optimisticId }) {
-                    messages[index].deliveryStatus = .failed
+                    messages[index].deliveryStatus = (proof == .delivered) ? .delivered : .failed
                 }
                 errorMessage = "Message was sent, but local confirmation could not be saved. Verify whether it arrived before retrying."
             }
@@ -604,17 +654,24 @@ public final class MessagingViewModel {
                     retryMessage.hash = retryHash
                     retryMessage.state = .sent
                     retryMessage.method = .propagated
+                    pendingOutboundAliases[Self.hexString(retryHash)] = optimisticId
                     do {
                         try await persistMessage(retryMessage, replacing: localRetryHash)
+                        await reconcilePendingDeliveryProof(for: retryHash)
                         unpersistedOutboundIDs.remove(optimisticId)
                         unsavedFailedOutboundIDs.remove(optimisticId)
+                        stagedRetryCleanupHashes.removeValue(forKey: optimisticId)
                         await invalidatePaginationAndRefresh()
                     } catch {
                         unsavedFailedOutboundIDs.insert(optimisticId)
-                        await removeStagedRetryAfterPersistenceFailure(localRetryHash)
+                        let proof = takePendingDeliveryProof(for: retryHash)
+                        let cleaned = await removeStagedRetryAfterPersistenceFailure(localRetryHash)
+                        if !cleaned, let localRetryHash {
+                            stagedRetryCleanupHashes[optimisticId] = localRetryHash
+                        }
                         logger.error("[MSG_VM] saveMessage(retry-relay) failed: \(error.localizedDescription)")
                         if let index = messages.firstIndex(where: { $0.id == optimisticId }) {
-                            messages[index].deliveryStatus = .failed
+                            messages[index].deliveryStatus = (proof == .delivered) ? .delivered : .failed
                         }
                         errorMessage = "Message was relayed, but local confirmation could not be saved. Verify whether it arrived before retrying."
                     }
@@ -634,10 +691,14 @@ public final class MessagingViewModel {
                 persisted = true
                 unpersistedOutboundIDs.remove(optimisticId)
                 unsavedFailedOutboundIDs.remove(optimisticId)
+                stagedRetryCleanupHashes.removeValue(forKey: optimisticId)
                 await invalidatePaginationAndRefresh()
             } catch {
                 unsavedFailedOutboundIDs.insert(optimisticId)
-                await removeStagedRetryAfterPersistenceFailure(localRetryHash)
+                let cleaned = await removeStagedRetryAfterPersistenceFailure(localRetryHash)
+                if !cleaned, let localRetryHash {
+                    stagedRetryCleanupHashes[optimisticId] = localRetryHash
+                }
                 logger.error("[MSG_VM] saveMessage(failed) failed: \(error.localizedDescription)")
             }
 
@@ -685,7 +746,18 @@ public final class MessagingViewModel {
         }
 
         let failedMessage = messages[index]
-        if unsavedFailedOutboundIDs.remove(messageId) != nil {
+        if unsavedFailedOutboundIDs.contains(messageId) {
+            if let stagedHash = stagedRetryCleanupHashes[messageId] {
+                do {
+                    try await repository.deleteMessage(stagedHash)
+                    stagedRetryCleanupHashes.removeValue(forKey: messageId)
+                    await invalidatePaginationAndRefresh()
+                } catch {
+                    errorMessage = "The staged retry could not be cleaned up. Please try again."
+                    return
+                }
+            }
+            unsavedFailedOutboundIDs.remove(messageId)
             unpersistedOutboundIDs.remove(messageId)
             messages.removeAll { $0.id == messageId }
             _ = await sendMessage(
@@ -744,15 +816,29 @@ public final class MessagingViewModel {
     public func deleteMessage(messageId: String, messageHash: Data?) async {
         guard canDeleteMessage(messageId: messageId) else { return }
 
-        let wasUnsavedFailure = unsavedFailedOutboundIDs.remove(messageId) != nil
+        let wasUnsavedFailure = unsavedFailedOutboundIDs.contains(messageId)
+        if wasUnsavedFailure, let stagedHash = stagedRetryCleanupHashes[messageId] {
+            do {
+                try await repository.deleteMessage(stagedHash)
+            } catch {
+                errorMessage = "The staged retry could not be deleted. Please try again."
+                return
+            }
+        }
+
+        unsavedFailedOutboundIDs.remove(messageId)
         unpersistedOutboundIDs.remove(messageId)
+        stagedRetryCleanupHashes.removeValue(forKey: messageId)
 
         // Remove from UI immediately
         withAnimation {
             messages.removeAll { $0.id == messageId }
         }
 
-        guard !wasUnsavedFailure else { return }
+        if wasUnsavedFailure {
+            await invalidatePaginationAndRefresh()
+            return
+        }
 
         // Delete from database if we have the hash
         if let hash = messageHash {

--- a/Sources/ColumbaApp/Views/Messaging/MessageBubble.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageBubble.swift
@@ -441,6 +441,7 @@ public struct Message: Identifiable, Equatable {
             self.messageHash = record.messageId.count == 32 ? record.messageId : nil
             self.isTargetSafe = record.messageId.count == 32
                 && !MessageRepository.isUncertainRetryMarker(record.receivingInterface)
+                && record.receivingInterface != MessageRepository.optimisticOutboundMarker
         }
 
         // Map raw state value to DeliveryStatus

--- a/Sources/ColumbaApp/Views/Messaging/MessageBubble.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageBubble.swift
@@ -294,6 +294,11 @@ public struct Message: Identifiable, Equatable {
     public var rssi: Double?
     public var snr: Double?
     public var messageHash: Data?
+    /// Durable database key. This differs from `messageHash` when a staged
+    /// retry was accepted on the wire but canonical replacement failed.
+    public var storageHash: Data?
+    /// Whether reply/reaction protocols may safely target `messageHash`.
+    public var isTargetSafe: Bool = false
     public var receivedInterface: String?
 
     // Reply & reactions
@@ -335,7 +340,9 @@ public struct Message: Identifiable, Equatable {
         attachments: [FileAttachment]? = nil,
         replyToId: String? = nil,
         replyToPreview: String? = nil,
-        reactions: [ReactionDisplay] = []
+        reactions: [ReactionDisplay] = [],
+        storageHash: Data? = nil,
+        isTargetSafe: Bool = false
     ) {
         self.id = id
         self.content = content
@@ -348,6 +355,8 @@ public struct Message: Identifiable, Equatable {
         self.replyToId = replyToId
         self.replyToPreview = replyToPreview
         self.reactions = reactions
+        self.storageHash = storageHash
+        self.isTargetSafe = isTargetSafe
     }
 
     /// Create from LXMessage.
@@ -357,6 +366,8 @@ public struct Message: Identifiable, Equatable {
         // targets. A 33-byte ID is the local persistence namespace used when an
         // abnormal delivered message arrives without a recoverable wire hash.
         self.messageHash = lxMessage.hash.count == 32 ? lxMessage.hash : nil
+        self.storageHash = lxMessage.hash
+        self.isTargetSafe = lxMessage.hash.count == 32
         self.content = String(data: lxMessage.content, encoding: .utf8) ?? ""
         self.timestamp = Date(timeIntervalSince1970: lxMessage.timestamp)
         self.isFromMe = lxMessage.sourceHash == localHash
@@ -422,7 +433,15 @@ public struct Message: Identifiable, Equatable {
         // message rendered as received. (localHash is still used below for
         // reaction `includesMe`.)
         self.isFromMe = record.direction == .outbound
-        self.messageHash = record.messageId.count == 32 ? record.messageId : nil
+        self.storageHash = record.messageId
+        if let wireHash = MessageRepository.canonicalHashFromUncertainRetryMarker(record.receivingInterface) {
+            self.messageHash = wireHash
+            self.isTargetSafe = false
+        } else {
+            self.messageHash = record.messageId.count == 32 ? record.messageId : nil
+            self.isTargetSafe = record.messageId.count == 32
+                && !MessageRepository.isUncertainRetryMarker(record.receivingInterface)
+        }
 
         // Map raw state value to DeliveryStatus
         switch record.state {

--- a/Sources/ColumbaApp/Views/Messaging/MessageTimelineView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageTimelineView.swift
@@ -44,7 +44,18 @@ struct MessagePageCursor {
     mutating func recordFetchedPage(recordCount: Int) {
         nextOffset += recordCount
     }
+}
 
+struct MessageRefreshWindowPolicy {
+    static func expandedLimit(
+        currentLimit: Int,
+        fetchedCount: Int,
+        containsPriorOldest: Bool,
+        pageSize: Int
+    ) -> Int? {
+        guard fetchedCount == currentLimit, !containsPriorOldest else { return nil }
+        return currentLimit + pageSize
+    }
 }
 
 #if os(iOS)

--- a/Sources/ColumbaApp/Views/Messaging/MessageTimelineView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageTimelineView.swift
@@ -45,9 +45,6 @@ struct MessagePageCursor {
         nextOffset += recordCount
     }
 
-    mutating func recordInsertedAtNewest() {
-        nextOffset += 1
-    }
 }
 
 #if os(iOS)

--- a/Sources/ColumbaApp/Views/Messaging/MessageTimelineView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageTimelineView.swift
@@ -44,6 +44,10 @@ struct MessagePageCursor {
     mutating func recordFetchedPage(recordCount: Int) {
         nextOffset += recordCount
     }
+
+    mutating func recordInsertedAtNewest() {
+        nextOffset += 1
+    }
 }
 
 #if os(iOS)
@@ -283,6 +287,12 @@ final class MessageTimelineViewController: UIViewController, UICollectionViewDat
             self.loadTask = nil
             self.isLoadingMore = false
             self.updateLoadingIndicator()
+            // SwiftUI applies the new message page and exhaustion state on the
+            // next main-loop turn. Re-check after that update so telemetry-only
+            // pages cannot strand the user inside the preload threshold.
+            DispatchQueue.main.async { [weak self] in
+                self?.requestOlderMessagesIfNecessary()
+            }
         }
     }
 

--- a/Sources/ColumbaApp/Views/Messaging/MessageTimelineView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageTimelineView.swift
@@ -262,7 +262,8 @@ final class MessageTimelineViewController: UIViewController, UICollectionViewDat
         cell.backgroundConfiguration = UIBackgroundConfiguration.clear()
         cell.contentConfiguration = UIHostingConfiguration {
             SwipeToReplyContainer(onReply: { [weak self] in
-                guard message.messageHash != nil else { return }
+                guard message.messageHash != nil,
+                      message.isTargetSafe else { return }
                 self?.onReply?(message)
             }) {
                 MessageBubble(

--- a/Sources/ColumbaApp/Views/Messaging/MessageTimelineView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageTimelineView.swift
@@ -56,7 +56,7 @@ struct MessageTimelineView: UIViewControllerRepresentable {
     let messages: [Message]
     let isLoadingMore: Bool
     let allMessagesLoaded: Bool
-    let onLoadOlder: @MainActor () async -> Void
+    let onLoadOlder: @MainActor () async -> Bool
     let onReply: (Message) -> Void
     let onToggleReaction: (Message, String) -> Void
     let onLongPress: (Message) -> Void
@@ -85,7 +85,7 @@ struct MessageTimelineView: UIViewControllerRepresentable {
 
 @available(iOS 17.0, *)
 final class MessageTimelineViewController: UIViewController, UICollectionViewDataSource, UICollectionViewDelegate {
-    var onLoadOlder: (@MainActor () async -> Void)?
+    var onLoadOlder: (@MainActor () async -> Bool)?
     var onReply: ((Message) -> Void)?
     var onToggleReaction: ((Message, String) -> Void)?
     var onLongPress: ((Message) -> Void)?
@@ -282,7 +282,7 @@ final class MessageTimelineViewController: UIViewController, UICollectionViewDat
         isLoadingMore = true
         updateLoadingIndicator()
         loadTask = Task { @MainActor [weak self] in
-            await onLoadOlder()
+            let consumedPage = await onLoadOlder()
             guard let self, !Task.isCancelled else { return }
             self.loadTask = nil
             self.isLoadingMore = false
@@ -290,8 +290,10 @@ final class MessageTimelineViewController: UIViewController, UICollectionViewDat
             // SwiftUI applies the new message page and exhaustion state on the
             // next main-loop turn. Re-check after that update so telemetry-only
             // pages cannot strand the user inside the preload threshold.
-            DispatchQueue.main.async { [weak self] in
-                self?.requestOlderMessagesIfNecessary()
+            if consumedPage {
+                DispatchQueue.main.async { [weak self] in
+                    self?.requestOlderMessagesIfNecessary()
+                }
             }
         }
     }

--- a/Sources/ColumbaApp/Views/Messaging/MessageTimelineView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageTimelineView.swift
@@ -1,0 +1,394 @@
+//
+//  MessageTimelineView.swift
+//  Columba-iOS
+//
+//  UIKit-backed conversation timeline. UIKit owns scrolling, cell reuse,
+//  pagination triggers, and viewport continuity. SwiftUI continues to render
+//  the existing message bubble content inside reusable collection cells.
+//
+
+import SwiftUI
+#if os(iOS)
+import UIKit
+#endif
+
+struct MessageTimelinePaginationPolicy {
+    static func shouldLoadOlder(
+        contentOffsetY: CGFloat,
+        viewportHeight: CGFloat,
+        isLoading: Bool,
+        allHistoryLoaded: Bool
+    ) -> Bool {
+        guard viewportHeight > 0, !isLoading, !allHistoryLoaded else { return false }
+        return contentOffsetY < viewportHeight * 3
+    }
+}
+
+struct MessageTimelineViewportAnchor {
+    static func adjustedContentOffset(
+        previousContentOffset: CGFloat,
+        previousAnchorMinY: CGFloat,
+        updatedAnchorMinY: CGFloat
+    ) -> CGFloat {
+        previousContentOffset + updatedAnchorMinY - previousAnchorMinY
+    }
+}
+
+struct MessagePageCursor {
+    private(set) var nextOffset = 0
+
+    mutating func reset(recordCount: Int) {
+        nextOffset = recordCount
+    }
+
+    mutating func recordFetchedPage(recordCount: Int) {
+        nextOffset += recordCount
+    }
+}
+
+#if os(iOS)
+@available(iOS 17.0, *)
+struct MessageTimelineView: UIViewControllerRepresentable {
+    let messages: [Message]
+    let isLoadingMore: Bool
+    let allMessagesLoaded: Bool
+    let onLoadOlder: @MainActor () async -> Void
+    let onReply: (Message) -> Void
+    let onToggleReaction: (Message, String) -> Void
+    let onLongPress: (Message) -> Void
+
+    func makeUIViewController(context: Context) -> MessageTimelineViewController {
+        let controller = MessageTimelineViewController()
+        controller.onLoadOlder = onLoadOlder
+        controller.onReply = onReply
+        controller.onToggleReaction = onToggleReaction
+        controller.onLongPress = onLongPress
+        return controller
+    }
+
+    func updateUIViewController(_ controller: MessageTimelineViewController, context: Context) {
+        controller.onLoadOlder = onLoadOlder
+        controller.onReply = onReply
+        controller.onToggleReaction = onToggleReaction
+        controller.onLongPress = onLongPress
+        controller.update(
+            messages: messages,
+            isLoadingMore: isLoadingMore,
+            allMessagesLoaded: allMessagesLoaded
+        )
+    }
+}
+
+@available(iOS 17.0, *)
+final class MessageTimelineViewController: UIViewController, UICollectionViewDataSource, UICollectionViewDelegate {
+    var onLoadOlder: (@MainActor () async -> Void)?
+    var onReply: ((Message) -> Void)?
+    var onToggleReaction: ((Message, String) -> Void)?
+    var onLongPress: ((Message) -> Void)?
+
+    private var messages: [Message] = []
+    private var isLoadingMore = false
+    private var allMessagesLoaded = false
+    private var loadTask: Task<Void, Never>?
+    private var needsInitialBottomScroll = false
+    private var hasCompletedInitialPositioning = false
+    private var previousViewportSize = CGSize.zero
+    private var shouldFollowBottomAcrossResize = false
+
+    private lazy var collectionView: UICollectionView = {
+        let layout = UICollectionViewCompositionalLayout { _, _ in
+            let itemSize = NSCollectionLayoutSize(
+                widthDimension: .fractionalWidth(1),
+                heightDimension: .estimated(80)
+            )
+            let item = NSCollectionLayoutItem(layoutSize: itemSize)
+            let groupSize = NSCollectionLayoutSize(
+                widthDimension: .fractionalWidth(1),
+                heightDimension: .estimated(80)
+            )
+            let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
+            let section = NSCollectionLayoutSection(group: group)
+            section.interGroupSpacing = 12
+            section.contentInsets = NSDirectionalEdgeInsets(top: 12, leading: 16, bottom: 12, trailing: 16)
+            return section
+        }
+
+        let view = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = .clear
+        view.alwaysBounceVertical = true
+        view.keyboardDismissMode = .interactive
+        view.dataSource = self
+        view.delegate = self
+        view.register(UICollectionViewCell.self, forCellWithReuseIdentifier: "MessageCell")
+        return view
+    }()
+
+    private let loadingIndicator: UIActivityIndicatorView = {
+        let indicator = UIActivityIndicatorView(style: .medium)
+        indicator.translatesAutoresizingMaskIntoConstraints = false
+        indicator.hidesWhenStopped = true
+        return indicator
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .clear
+        view.addSubview(collectionView)
+        view.addSubview(loadingIndicator)
+        NSLayoutConstraint.activate([
+            collectionView.topAnchor.constraint(equalTo: view.topAnchor),
+            collectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            collectionView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            loadingIndicator.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 8),
+            loadingIndicator.centerXAnchor.constraint(equalTo: view.centerXAnchor)
+        ])
+
+        let dismissKeyboard = UITapGestureRecognizer(target: self, action: #selector(didTapTimeline))
+        dismissKeyboard.cancelsTouchesInView = false
+        collectionView.addGestureRecognizer(dismissKeyboard)
+
+        collectionView.reloadData()
+        needsInitialBottomScroll = !messages.isEmpty
+        updateLoadingIndicator()
+    }
+
+    override func viewWillLayoutSubviews() {
+        super.viewWillLayoutSubviews()
+        if previousViewportSize != .zero, previousViewportSize != view.bounds.size {
+            shouldFollowBottomAcrossResize = isNearBottom
+        }
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+
+        let viewportChanged = previousViewportSize != .zero && previousViewportSize != view.bounds.size
+        previousViewportSize = view.bounds.size
+
+        if needsInitialBottomScroll, !messages.isEmpty, collectionView.bounds.height > 0 {
+            needsInitialBottomScroll = false
+            hasCompletedInitialPositioning = true
+            scrollToBottom(animated: false)
+            requestOlderMessagesIfNecessary()
+        } else if viewportChanged, shouldFollowBottomAcrossResize {
+            shouldFollowBottomAcrossResize = false
+            scrollToBottom(animated: false)
+        }
+    }
+
+    deinit {
+        loadTask?.cancel()
+    }
+
+    func update(messages newMessages: [Message], isLoadingMore: Bool, allMessagesLoaded: Bool) {
+        let oldMessages = messages
+        let anchor = visibleAnchor()
+        let wasNearBottom = self.isNearBottom
+        let oldLastID = oldMessages.last?.id
+
+        messages = deduplicated(newMessages)
+        self.isLoadingMore = isLoadingMore || loadTask != nil
+        self.allMessagesLoaded = allMessagesLoaded
+        updateLoadingIndicator()
+
+        guard isViewLoaded else { return }
+
+        collectionView.reloadData()
+        collectionView.collectionViewLayout.invalidateLayout()
+        collectionView.layoutIfNeeded()
+
+        if oldMessages.isEmpty, !messages.isEmpty {
+            needsInitialBottomScroll = true
+            hasCompletedInitialPositioning = false
+            view.setNeedsLayout()
+        } else if wasNearBottom, oldLastID != messages.last?.id {
+            scrollToBottom(animated: false)
+        } else if let anchor {
+            restore(anchor: anchor)
+        }
+
+        requestOlderMessagesIfNecessary()
+    }
+
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        messages.count
+    }
+
+    func collectionView(
+        _ collectionView: UICollectionView,
+        cellForItemAt indexPath: IndexPath
+    ) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "MessageCell", for: indexPath)
+        guard messages.indices.contains(indexPath.item) else { return cell }
+        let message = messages[indexPath.item]
+
+        cell.backgroundConfiguration = UIBackgroundConfiguration.clear()
+        cell.contentConfiguration = UIHostingConfiguration {
+            SwipeToReplyContainer(onReply: { [weak self] in
+                guard message.messageHash != nil else { return }
+                self?.onReply?(message)
+            }) {
+                MessageBubble(
+                    message: message,
+                    onToggleReaction: { [weak self] emoji in
+                        self?.onToggleReaction?(message, emoji)
+                    },
+                    onTapReplyPreview: { [weak self] replyID in
+                        self?.scrollToMessage(id: replyID)
+                    },
+                    onLongPress: { [weak self] in
+                        self?.onLongPress?(message)
+                    }
+                )
+            }
+        }
+        .margins(.all, 0)
+
+        return cell
+    }
+
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        requestOlderMessagesIfNecessary()
+    }
+
+    private var isNearBottom: Bool {
+        guard collectionView.bounds.height > 0 else { return true }
+        let bottomOffset = max(
+            -collectionView.adjustedContentInset.top,
+            collectionView.contentSize.height
+                - collectionView.bounds.height
+                + collectionView.adjustedContentInset.bottom
+        )
+        return bottomOffset - collectionView.contentOffset.y <= 120
+    }
+
+    private func requestOlderMessagesIfNecessary() {
+        guard isViewLoaded,
+              hasCompletedInitialPositioning,
+              MessageTimelinePaginationPolicy.shouldLoadOlder(
+                contentOffsetY: collectionView.contentOffset.y,
+                viewportHeight: collectionView.bounds.height,
+                isLoading: isLoadingMore || loadTask != nil,
+                allHistoryLoaded: allMessagesLoaded
+              ),
+              let onLoadOlder else { return }
+
+        isLoadingMore = true
+        updateLoadingIndicator()
+        loadTask = Task { @MainActor [weak self] in
+            await onLoadOlder()
+            guard let self, !Task.isCancelled else { return }
+            self.loadTask = nil
+            self.isLoadingMore = false
+            self.updateLoadingIndicator()
+        }
+    }
+
+    private func updateLoadingIndicator() {
+        if isLoadingMore {
+            loadingIndicator.startAnimating()
+        } else {
+            loadingIndicator.stopAnimating()
+        }
+    }
+
+    private struct VisibleAnchor {
+        let messageID: String
+        let minY: CGFloat
+        let contentOffsetY: CGFloat
+    }
+
+    private func visibleAnchor() -> VisibleAnchor? {
+        let visible = collectionView.indexPathsForVisibleItems.compactMap { indexPath -> (IndexPath, UICollectionViewLayoutAttributes)? in
+            guard let attributes = collectionView.layoutAttributesForItem(at: indexPath) else { return nil }
+            return (indexPath, attributes)
+        }
+        guard let top = visible.min(by: { $0.1.frame.minY < $1.1.frame.minY }),
+              messages.indices.contains(top.0.item) else { return nil }
+        let message = messages[top.0.item]
+        return VisibleAnchor(
+            messageID: message.id,
+            minY: top.1.frame.minY,
+            contentOffsetY: collectionView.contentOffset.y
+        )
+    }
+
+    private func restore(anchor: VisibleAnchor) {
+        guard let index = messages.firstIndex(where: { $0.id == anchor.messageID }) else { return }
+        let indexPath = IndexPath(item: index, section: 0)
+        guard let attributes = collectionView.layoutAttributesForItem(at: indexPath) else { return }
+        let targetY = MessageTimelineViewportAnchor.adjustedContentOffset(
+            previousContentOffset: anchor.contentOffsetY,
+            previousAnchorMinY: anchor.minY,
+            updatedAnchorMinY: attributes.frame.minY
+        )
+        collectionView.setContentOffset(
+            CGPoint(x: collectionView.contentOffset.x, y: clampedContentOffsetY(targetY)),
+            animated: false
+        )
+    }
+
+    private func scrollToBottom(animated: Bool) {
+        guard !messages.isEmpty else { return }
+        collectionView.layoutIfNeeded()
+        collectionView.scrollToItem(
+            at: IndexPath(item: messages.count - 1, section: 0),
+            at: .bottom,
+            animated: animated
+        )
+    }
+
+    private func scrollToMessage(id: String) {
+        guard let index = messages.firstIndex(where: { $0.id == id }) else { return }
+        collectionView.scrollToItem(
+            at: IndexPath(item: index, section: 0),
+            at: .centeredVertically,
+            animated: true
+        )
+    }
+
+    private func clampedContentOffsetY(_ proposed: CGFloat) -> CGFloat {
+        let minimum = -collectionView.adjustedContentInset.top
+        let maximum = max(
+            minimum,
+            collectionView.contentSize.height
+                - collectionView.bounds.height
+                + collectionView.adjustedContentInset.bottom
+        )
+        return min(maximum, max(minimum, proposed))
+    }
+
+    private func deduplicated(_ input: [Message]) -> [Message] {
+        var seen = Set<String>()
+        return input.filter { seen.insert($0.id).inserted }
+    }
+
+    var renderedMessageCount: Int {
+        collectionView.numberOfItems(inSection: 0)
+    }
+
+    var visibleMessageCellCount: Int {
+        collectionView.indexPathsForVisibleItems.count
+    }
+
+    func setViewportForTesting(_ size: CGSize) {
+        view.frame = CGRect(origin: .zero, size: size)
+        view.setNeedsLayout()
+        view.layoutIfNeeded()
+    }
+
+    func setContentOffsetForTesting(y: CGFloat) {
+        view.setNeedsLayout()
+        view.layoutIfNeeded()
+        collectionView.setContentOffset(CGPoint(x: 0, y: y), animated: false)
+        scrollViewDidScroll(collectionView)
+    }
+
+    @objc
+    private func didTapTimeline() {
+        view.window?.endEditing(true)
+    }
+}
+#endif

--- a/Sources/ColumbaApp/Views/Messaging/MessageTimelineView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageTimelineView.swift
@@ -51,6 +51,7 @@ struct MessagePageCursor {
 @available(iOS 17.0, *)
 struct MessageTimelineView: UIViewControllerRepresentable {
     let messages: [Message]
+    let messageTextScale: Double
     let isLoadingMore: Bool
     let allMessagesLoaded: Bool
     let onLoadOlder: @MainActor () async -> Bool
@@ -60,6 +61,7 @@ struct MessageTimelineView: UIViewControllerRepresentable {
 
     func makeUIViewController(context: Context) -> MessageTimelineViewController {
         let controller = MessageTimelineViewController()
+        controller.messageTextScale = messageTextScale
         controller.onLoadOlder = onLoadOlder
         controller.onReply = onReply
         controller.onToggleReaction = onToggleReaction
@@ -74,6 +76,7 @@ struct MessageTimelineView: UIViewControllerRepresentable {
         controller.onLongPress = onLongPress
         controller.update(
             messages: messages,
+            messageTextScale: messageTextScale,
             isLoadingMore: isLoadingMore,
             allMessagesLoaded: allMessagesLoaded
         )
@@ -88,6 +91,7 @@ final class MessageTimelineViewController: UIViewController, UICollectionViewDat
     var onLongPress: ((Message) -> Void)?
 
     private var messages: [Message] = []
+    fileprivate var messageTextScale = SettingsRepository.MessageTextScale.defaultValue
     private var isLoadingMore = false
     private var allMessagesLoaded = false
     private var loadTask: Task<Void, Never>?
@@ -183,13 +187,21 @@ final class MessageTimelineViewController: UIViewController, UICollectionViewDat
         loadTask?.cancel()
     }
 
-    func update(messages newMessages: [Message], isLoadingMore: Bool, allMessagesLoaded: Bool) {
+    func update(
+        messages newMessages: [Message],
+        messageTextScale: Double? = nil,
+        isLoadingMore: Bool,
+        allMessagesLoaded: Bool
+    ) {
         let oldMessages = messages
         let anchor = visibleAnchor()
         let wasNearBottom = self.isNearBottom
         let oldLastID = oldMessages.last?.id
 
         messages = deduplicated(newMessages)
+        if let messageTextScale {
+            self.messageTextScale = messageTextScale
+        }
         self.isLoadingMore = isLoadingMore || loadTask != nil
         self.allMessagesLoaded = allMessagesLoaded
         updateLoadingIndicator()
@@ -233,6 +245,7 @@ final class MessageTimelineViewController: UIViewController, UICollectionViewDat
             }) {
                 MessageBubble(
                     message: message,
+                    messageTextScale: messageTextScale,
                     onToggleReaction: { [weak self] emoji in
                         self?.onToggleReaction?(message, emoji)
                     },
@@ -376,6 +389,10 @@ final class MessageTimelineViewController: UIViewController, UICollectionViewDat
 
     var renderedMessageCount: Int {
         collectionView.numberOfItems(inSection: 0)
+    }
+
+    var configuredMessageTextScale: Double {
+        messageTextScale
     }
 
     var visibleMessageCellCount: Int {

--- a/Sources/ColumbaApp/Views/Messaging/MessageTimelineView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageTimelineView.swift
@@ -56,6 +56,17 @@ struct MessageRefreshWindowPolicy {
         guard fetchedCount == currentLimit, !containsPriorOldest else { return nil }
         return currentLimit + pageSize
     }
+
+    static func retainedPrefixCount(
+        recordIDs: [String],
+        priorOldestID: String?
+    ) -> Int {
+        guard let priorOldestID,
+              let index = recordIDs.firstIndex(of: priorOldestID) else {
+            return recordIDs.count
+        }
+        return index + 1
+    }
 }
 
 #if os(iOS)

--- a/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
@@ -82,6 +82,7 @@ struct MessagingView: View {
                 #if os(iOS)
                 MessageTimelineView(
                     messages: vm.messages,
+                    messageTextScale: messageTextScale,
                     isLoadingMore: vm.isLoadingMore,
                     allMessagesLoaded: vm.allMessagesLoaded,
                     onLoadOlder: {

--- a/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
@@ -691,7 +691,12 @@ struct MessagingView: View {
         let image = attachedImage
         let files = attachedFiles
         let replyTarget = viewModel?.replyToMessage
-        let replyToId = replyTarget?.messageHash != nil ? replyTarget?.id : nil
+        let replyToId: String? = {
+            guard let target = replyTarget,
+                  target.isTargetSafe,
+                  let hash = target.messageHash else { return nil }
+            return hash.map { String(format: "%02x", $0) }.joined()
+        }()
 
         guard !text.isEmpty || image != nil || !files.isEmpty else { return }
 

--- a/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
@@ -370,9 +370,9 @@ struct MessagingView: View {
                     onDetails: {
                         detailMessage = msg
                     },
-                    onDelete: {
+                    onDelete: viewModel?.canDeleteMessage(messageId: msg.id) == true ? {
                         deleteConfirmMessage = msg
-                    },
+                    } : nil,
                     onRetry: msg.deliveryStatus == .failed ? {
                         Task { await viewModel?.retryMessage(messageId: msg.id) }
                     } : nil,
@@ -982,7 +982,7 @@ private struct ReactionOverlay: View {
     let onReply: () -> Void
     let onCopy: () -> Void
     let onDetails: () -> Void
-    let onDelete: () -> Void
+    let onDelete: (() -> Void)?
     var onRetry: (() -> Void)?
     let onMoreEmoji: () -> Void
     let onDismiss: () -> Void
@@ -1085,9 +1085,11 @@ private struct ReactionOverlay: View {
                         }
                     }
 
-                    actionButton(icon: "trash", label: "Delete", isDestructive: true) {
-                        onDismiss()
-                        onDelete()
+                    if let onDelete {
+                        actionButton(icon: "trash", label: "Delete", isDestructive: true) {
+                            self.onDismiss()
+                            onDelete()
+                        }
                     }
                 }
                 .padding(.horizontal, 8)

--- a/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
@@ -79,6 +79,85 @@ struct MessagingView: View {
     var body: some View {
         Group {
             if let vm = viewModel {
+                #if os(iOS)
+                MessageTimelineView(
+                    messages: vm.messages,
+                    isLoadingMore: vm.isLoadingMore,
+                    allMessagesLoaded: vm.allMessagesLoaded,
+                    onLoadOlder: {
+                        await vm.loadMoreMessages()
+                    },
+                    onReply: { message in
+                        guard message.messageHash != nil else { return }
+                        withAnimation(.easeInOut(duration: 0.25)) {
+                            vm.replyToMessage = message
+                        }
+                    },
+                    onToggleReaction: { message, emoji in
+                        Task {
+                            await vm.sendReaction(
+                                targetMessageId: message.id,
+                                targetMessageHash: message.messageHash,
+                                emoji: emoji
+                            )
+                        }
+                    },
+                    onLongPress: { message in
+                        withAnimation(.easeInOut(duration: 0.2)) {
+                            reactionModeMessage = message
+                        }
+                    }
+                )
+                .safeAreaInset(edge: .bottom, spacing: 0) {
+                    MessageInputBar(
+                        text: $messageText,
+                        attachedImage: $attachedImage,
+                        attachedFiles: $attachedFiles,
+                        replyToMessage: vm.replyToMessage,
+                        onDismissReply: { withAnimation(.easeInOut(duration: 0.25)) { vm.replyToMessage = nil } },
+                        onSend: sendMessage,
+                        onImagePicker: { showPhotoPicker = true },
+                        onAttachment: { showFilePicker = true }
+                    )
+                    .photosPicker(isPresented: $showPhotoPicker, selection: $selectedPhotoItem, matching: .images)
+                    .onChange(of: selectedPhotoItem) { _, newItem in
+                        guard let newItem else { return }
+                        Task {
+                            do {
+                                if let data = try await newItem.loadTransferable(type: Data.self),
+                                   let image = UIImage(data: data) {
+                                    await MainActor.run {
+                                        pendingRawImage = image
+                                        selectedImagePreset = UserDefaults.standard.string(forKey: "image_quality_preset")
+                                            .flatMap { SettingsViewModel.ImageQualityPreset(rawValue: $0) } ?? .high
+                                        showQualityPicker = true
+                                    }
+                                }
+                            } catch {
+                                logger.error("Failed to load image: \(error)")
+                            }
+                            await MainActor.run {
+                                selectedPhotoItem = nil
+                            }
+                        }
+                    }
+                    .fileImporter(
+                        isPresented: $showFilePicker,
+                        allowedContentTypes: [.data],
+                        allowsMultipleSelection: true
+                    ) { result in
+                        if case .success(let urls) = result {
+                            for url in urls {
+                                guard url.startAccessingSecurityScopedResource() else { continue }
+                                defer { url.stopAccessingSecurityScopedResource() }
+                                if let data = try? Data(contentsOf: url) {
+                                    attachedFiles.append(FileAttachment(name: url.lastPathComponent, data: data))
+                                }
+                            }
+                        }
+                    }
+                }
+                #else
                 ScrollViewReader { proxy in
                     ScrollView {
                         LazyVStack(spacing: 12) {
@@ -253,6 +332,7 @@ struct MessagingView: View {
                     }
                     #endif
                 }
+                #endif
             } else {
                 ProgressView()
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -794,7 +874,7 @@ private class InteractivePopController: UIViewController, UIGestureRecognizerDel
 
 /// Wraps a message bubble to add swipe-right-to-reply gesture.
 @available(iOS 17.0, macOS 14.0, *)
-private struct SwipeToReplyContainer<Content: View>: View {
+struct SwipeToReplyContainer<Content: View>: View {
     let onReply: () -> Void
     @ViewBuilder let content: Content
 

--- a/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
@@ -388,6 +388,7 @@ struct MessagingView: View {
         }
         #if os(iOS)
         .navigationBarBackButtonHidden(true)
+        .navigationBarTitleDisplayMode(.inline)
         .background(InteractivePopGestureEnabler())
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {

--- a/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
@@ -89,12 +89,14 @@ struct MessagingView: View {
                         await vm.loadMoreMessages()
                     },
                     onReply: { message in
-                        guard message.messageHash != nil else { return }
+                        guard message.messageHash != nil,
+                              vm.canTargetMessage(messageId: message.id) else { return }
                         withAnimation(.easeInOut(duration: 0.25)) {
                             vm.replyToMessage = message
                         }
                     },
                     onToggleReaction: { message, emoji in
+                        guard vm.canTargetMessage(messageId: message.id) else { return }
                         Task {
                             await vm.sendReaction(
                                 targetMessageId: message.id,
@@ -176,7 +178,8 @@ struct MessagingView: View {
 
                             ForEach(vm.messages) { message in
                                 SwipeToReplyContainer(onReply: {
-                                    guard message.messageHash != nil else { return }
+                                    guard message.messageHash != nil,
+                                          vm.canTargetMessage(messageId: message.id) else { return }
                                     withAnimation(.easeInOut(duration: 0.25)) {
                                         vm.replyToMessage = message
                                     }
@@ -354,7 +357,8 @@ struct MessagingView: View {
                         }
                     },
                     onReply: {
-                        guard msg.messageHash != nil else { return }
+                        guard msg.messageHash != nil,
+                              viewModel?.canTargetMessage(messageId: msg.id) == true else { return }
                         withAnimation(.easeInOut(duration: 0.25)) {
                             viewModel?.replyToMessage = msg
                         }
@@ -373,6 +377,7 @@ struct MessagingView: View {
                     onDelete: viewModel?.canDeleteMessage(messageId: msg.id) == true ? {
                         deleteConfirmMessage = msg
                     } : nil,
+                    canTarget: viewModel?.canTargetMessage(messageId: msg.id) == true,
                     onRetry: msg.deliveryStatus == .failed ? {
                         Task { await viewModel?.retryMessage(messageId: msg.id) }
                     } : nil,
@@ -983,6 +988,7 @@ private struct ReactionOverlay: View {
     let onCopy: () -> Void
     let onDetails: () -> Void
     let onDelete: (() -> Void)?
+    let canTarget: Bool
     var onRetry: (() -> Void)?
     let onMoreEmoji: () -> Void
     let onDismiss: () -> Void
@@ -998,7 +1004,8 @@ private struct ReactionOverlay: View {
 
             VStack(spacing: 12) {
                 // Inline emoji bar
-                HStack(spacing: 12) {
+                if canTarget {
+                    HStack(spacing: 12) {
                     ForEach(Self.quickEmojis, id: \.self) { emoji in
                         Button {
                             onReact(emoji)
@@ -1023,10 +1030,11 @@ private struct ReactionOverlay: View {
                     }
                     .buttonStyle(.plain)
                 }
-                .padding(.horizontal, 16)
-                .padding(.vertical, 10)
-                .background(.ultraThinMaterial)
-                .clipShape(Capsule())
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 10)
+                    .background(.ultraThinMaterial)
+                    .clipShape(Capsule())
+                }
 
                 // Message preview
                 HStack {
@@ -1061,9 +1069,11 @@ private struct ReactionOverlay: View {
 
                 // Action buttons
                 HStack(spacing: 0) {
-                    actionButton(icon: "arrowshape.turn.up.left", label: "Reply") {
-                        onDismiss()
-                        onReply()
+                    if canTarget {
+                        actionButton(icon: "arrowshape.turn.up.left", label: "Reply") {
+                            onDismiss()
+                            onReply()
+                        }
                     }
 
                     if !message.content.isEmpty {

--- a/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
+++ b/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
@@ -593,21 +593,68 @@ final class MessageRepositoryAtomicReplacementTests: XCTestCase {
         XCTAssertFalse(stillHasUncertainRetry)
     }
 
+    func testDeliveryProofRemovesCanonicalCollisionAliasAndWarning() async throws {
+        let databaseURL = temporaryDatabaseURL()
+        defer { removeDatabase(at: databaseURL) }
+        let repository = try MessageRepository(grdbPath: databaseURL.path)
+        let destination = Data(repeating: 0x7c, count: 16)
+        let storageHash = Data(repeating: 0x7d, count: 32)
+        let canonicalHash = Data(repeating: 0x7e, count: 32)
+
+        let alias = RNSAPI.LXMessage(
+            destinationHash: destination,
+            sourceIdentity: nil,
+            content: Data("uncertain alias".utf8)
+        )
+        alias.hash = storageHash
+        alias.state = .failed
+        alias.receivingInterface = MessageRepository.uncertainRetryMarker(
+            canonicalHash: canonicalHash
+        )
+        try await repository.saveMessage(alias)
+
+        let canonical = RNSAPI.LXMessage(
+            destinationHash: destination,
+            sourceIdentity: nil,
+            content: Data("canonical row".utf8)
+        )
+        canonical.hash = canonicalHash
+        canonical.state = .sent
+        try await repository.saveMessage(canonical)
+
+        let applied = try await repository.applyDeliveryProof(
+            canonicalHash: canonicalHash,
+            state: .delivered
+        )
+
+        XCTAssertTrue(applied)
+        let staleAlias = try await repository.getMessageRecord(id: storageHash)
+        XCTAssertNil(staleAlias)
+        let storedCanonical = try await repository.getMessageRecord(id: canonicalHash)
+        XCTAssertEqual(storedCanonical?.state, LXMessageState.delivered.rawValue)
+        let hasWarning = try await repository.hasUncertainRetry(for: destination)
+        XCTAssertFalse(hasWarning)
+    }
+
     func testReloadedOptimisticFailureIsNotTargetSafeAndCanBeStaged() async throws {
         let databaseURL = temporaryDatabaseURL()
         defer { removeDatabase(at: databaseURL) }
         let repository = try MessageRepository(grdbPath: databaseURL.path)
         let destination = Data(repeating: 0x79, count: 16)
-        let optimisticHash = Data(repeating: 0x7a, count: 32)
+        let oldHash = Data(repeating: 0x7a, count: 32)
+        let optimisticHash = Data(repeating: 0x7b, count: 32)
         let failed = RNSAPI.LXMessage(
             destinationHash: destination,
             sourceIdentity: nil,
             content: Data("never accepted".utf8)
         )
-        failed.hash = optimisticHash
+        failed.hash = oldHash
         failed.state = .failed
-        failed.receivingInterface = MessageRepository.optimisticOutboundMarker
         try await repository.saveMessage(failed)
+
+        failed.hash = optimisticHash
+        failed.receivingInterface = MessageRepository.optimisticOutboundMarker
+        try await repository.replaceMessage(failed, replacing: oldHash)
 
         let storedRecord = try await repository.getMessageRecord(id: optimisticHash)
         let record = try XCTUnwrap(storedRecord)

--- a/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
+++ b/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
@@ -517,6 +517,45 @@ final class MessageRepositoryAtomicReplacementTests: XCTestCase {
         XCTAssertEqual(secondRecoveryCount, 0)
     }
 
+    func testRecoveredCanonicalRetryKeepsStorageIdentityForRetryAndDelete() async throws {
+        let databaseURL = temporaryDatabaseURL()
+        defer { removeDatabase(at: databaseURL) }
+        let repository = try MessageRepository(grdbPath: databaseURL.path)
+        let destination = Data(repeating: 0x73, count: 16)
+        let storageHash = Data(repeating: 0x74, count: 32)
+        let canonicalHash = Data(repeating: 0x75, count: 32)
+        let retry = RNSAPI.LXMessage(
+            destinationHash: destination,
+            sourceIdentity: nil,
+            content: Data("uncertain retry".utf8)
+        )
+        retry.hash = storageHash
+        retry.state = .failed
+        try await repository.saveMessage(retry)
+
+        retry.state = .sending
+        try await repository.stageRetry(retry, replacing: storageHash)
+        try await repository.recoverStagedRetry(storageHash, canonicalHash: canonicalHash)
+
+        let storedRecovered = try await repository.getMessageRecord(id: storageHash)
+        let recoveredRecord = try XCTUnwrap(storedRecovered)
+        let visible = Message(from: recoveredRecord, localHash: Data())
+        XCTAssertEqual(visible.storageHash, storageHash)
+        XCTAssertEqual(visible.messageHash, canonicalHash)
+        XCTAssertFalse(visible.isTargetSafe)
+        XCTAssertEqual(
+            MessageRepository.canonicalHashFromUncertainRetryMarker(recoveredRecord.receivingInterface),
+            canonicalHash
+        )
+
+        retry.state = .sending
+        try await repository.stageRetry(retry, replacing: storageHash)
+        try await repository.recoverStagedRetry(storageHash, canonicalHash: canonicalHash)
+        try await repository.deleteMessage(storageHash)
+        let deleted = try await repository.getMessageRecord(id: storageHash)
+        XCTAssertNil(deleted)
+    }
+
     func testNonAppSendingRowIsNotRecovered() async throws {
         let databaseURL = temporaryDatabaseURL()
         defer { removeDatabase(at: databaseURL) }

--- a/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
+++ b/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
@@ -547,6 +547,8 @@ final class MessageRepositoryAtomicReplacementTests: XCTestCase {
             MessageRepository.canonicalHashFromUncertainRetryMarker(recoveredRecord.receivingInterface),
             canonicalHash
         )
+        let hasCanonicalUncertainRetry = try await repository.hasUncertainRetry(for: destination)
+        XCTAssertTrue(hasCanonicalUncertainRetry)
 
         retry.state = .sending
         try await repository.stageRetry(retry, replacing: storageHash)
@@ -554,6 +556,69 @@ final class MessageRepositoryAtomicReplacementTests: XCTestCase {
         try await repository.deleteMessage(storageHash)
         let deleted = try await repository.getMessageRecord(id: storageHash)
         XCTAssertNil(deleted)
+    }
+
+    func testDeliveryProofRekeysCanonicalUncertainRetryWithoutOpenViewModel() async throws {
+        let databaseURL = temporaryDatabaseURL()
+        defer { removeDatabase(at: databaseURL) }
+        let repository = try MessageRepository(grdbPath: databaseURL.path)
+        let destination = Data(repeating: 0x76, count: 16)
+        let storageHash = Data(repeating: 0x77, count: 32)
+        let canonicalHash = Data(repeating: 0x78, count: 32)
+        let retry = RNSAPI.LXMessage(
+            destinationHash: destination,
+            sourceIdentity: nil,
+            content: Data("late proof".utf8)
+        )
+        retry.hash = storageHash
+        retry.state = .failed
+        try await repository.saveMessage(retry)
+        retry.state = .sending
+        try await repository.stageRetry(retry, replacing: storageHash)
+        try await repository.recoverStagedRetry(storageHash, canonicalHash: canonicalHash)
+
+        let applied = try await repository.applyDeliveryProof(
+            canonicalHash: canonicalHash,
+            state: .delivered
+        )
+
+        XCTAssertTrue(applied)
+        let oldRecord = try await repository.getMessageRecord(id: storageHash)
+        XCTAssertNil(oldRecord)
+        let storedDelivered = try await repository.getMessageRecord(id: canonicalHash)
+        let delivered = try XCTUnwrap(storedDelivered)
+        XCTAssertEqual(delivered.state, LXMessageState.delivered.rawValue)
+        XCTAssertNil(delivered.receivingInterface)
+        let stillHasUncertainRetry = try await repository.hasUncertainRetry(for: destination)
+        XCTAssertFalse(stillHasUncertainRetry)
+    }
+
+    func testReloadedOptimisticFailureIsNotTargetSafeAndCanBeStaged() async throws {
+        let databaseURL = temporaryDatabaseURL()
+        defer { removeDatabase(at: databaseURL) }
+        let repository = try MessageRepository(grdbPath: databaseURL.path)
+        let destination = Data(repeating: 0x79, count: 16)
+        let optimisticHash = Data(repeating: 0x7a, count: 32)
+        let failed = RNSAPI.LXMessage(
+            destinationHash: destination,
+            sourceIdentity: nil,
+            content: Data("never accepted".utf8)
+        )
+        failed.hash = optimisticHash
+        failed.state = .failed
+        failed.receivingInterface = MessageRepository.optimisticOutboundMarker
+        try await repository.saveMessage(failed)
+
+        let storedRecord = try await repository.getMessageRecord(id: optimisticHash)
+        let record = try XCTUnwrap(storedRecord)
+        let visible = Message(from: record, localHash: Data())
+        XCTAssertFalse(visible.isTargetSafe)
+
+        failed.state = .sending
+        try await repository.stageRetry(failed, replacing: optimisticHash)
+        let stagedRecord = try await repository.getMessageRecord(id: optimisticHash)
+        XCTAssertEqual(stagedRecord?.state, LXMessageState.sending.rawValue)
+        XCTAssertEqual(stagedRecord?.receivingInterface, MessageRepository.stagedRetryMarker)
     }
 
     func testNonAppSendingRowIsNotRecovered() async throws {

--- a/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
+++ b/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
@@ -359,6 +359,20 @@ final class MessageTimelinePolicyTests: XCTestCase {
         )
     }
 
+    func testDeliveryProofUsesOptimisticAliasDuringPersistence() {
+        XCTAssertEqual(
+            MessagingViewModel.visibleMessageID(
+                for: "real-hash",
+                aliases: ["real-hash": "optimistic-id"]
+            ),
+            "optimistic-id"
+        )
+        XCTAssertEqual(
+            MessagingViewModel.visibleMessageID(for: "persisted-hash", aliases: [:]),
+            "persisted-hash"
+        )
+    }
+
     func testRefreshPreservesOnlyUnpersistedOutboundRowsInTimelineOrder() {
         let base = Date(timeIntervalSince1970: 1_000)
         let oldest = Message(id: "oldest", content: "Oldest", timestamp: base, isFromMe: false)

--- a/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
+++ b/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
@@ -294,7 +294,21 @@ final class MessageTimelinePolicyTests: XCTestCase {
 
         cursor.recordFetchedPage(recordCount: 50)
         XCTAssertEqual(cursor.nextOffset, 100)
+    }
 
+    func testRefreshPreservesOnlyUnpersistedOutboundRows() {
+        let persisted = Message(id: "persisted", content: "Persisted", isFromMe: true)
+        let pendingA = Message(id: "pending-a", content: "Pending A", isFromMe: true)
+        let pendingB = Message(id: "pending-b", content: "Pending B", isFromMe: true)
+        let stale = Message(id: "stale", content: "Stale", isFromMe: false)
+
+        let merged = MessagingViewModel.mergingPendingOutbound(
+            loaded: [persisted],
+            current: [stale, pendingA, persisted, pendingB],
+            pendingIDs: ["pending-a", "persisted", "pending-b"]
+        )
+
+        XCTAssertEqual(merged.map(\.id), ["persisted", "pending-a", "pending-b"])
     }
 
     @MainActor

--- a/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
+++ b/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
@@ -337,6 +337,7 @@ final class MessageTimelinePolicyTests: XCTestCase {
         controller.onLoadOlder = {
             controller.update(messages: [], isLoadingMore: false, allMessagesLoaded: true)
             requested.fulfill()
+            return true
         }
         controller.loadViewIfNeeded()
         controller.setViewportForTesting(CGSize(width: 390, height: 700))
@@ -350,5 +351,29 @@ final class MessageTimelinePolicyTests: XCTestCase {
 
         controller.setContentOffsetForTesting(y: 0)
         await fulfillment(of: [requested], timeout: 1)
+    }
+
+    @MainActor
+    func testCollectionTimelineDoesNotRetryRejectedHistoryLoad() async {
+        var requestCount = 0
+        let controller = MessageTimelineViewController()
+        controller.onLoadOlder = {
+            requestCount += 1
+            return false
+        }
+        controller.loadViewIfNeeded()
+        controller.setViewportForTesting(CGSize(width: 390, height: 700))
+        controller.update(
+            messages: (0..<50).map {
+                Message(id: "message-\($0)", content: "Message \($0)", isFromMe: false)
+            },
+            isLoadingMore: false,
+            allMessagesLoaded: false
+        )
+
+        controller.setContentOffsetForTesting(y: 0)
+        try? await Task.sleep(for: .milliseconds(100))
+
+        XCTAssertEqual(requestCount, 1)
     }
 }

--- a/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
+++ b/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
@@ -381,6 +381,40 @@ final class MessageTimelinePolicyTests: XCTestCase {
         )
     }
 
+    func testRecoveredRetryRechecksRefreshedDeliveryStateBeforeSending() {
+        let stagedHash = Data(repeating: 0x42, count: 32)
+        let delivered = Message(
+            id: "refreshed-id",
+            content: "already delivered",
+            isFromMe: true,
+            deliveryStatus: .delivered,
+            storageHash: stagedHash
+        )
+        XCTAssertNil(
+            MessagingViewModel.retryableRefreshedMessage(
+                messageId: "stale-id",
+                stagedHash: stagedHash,
+                messages: [delivered]
+            )
+        )
+
+        let failed = Message(
+            id: "refreshed-id",
+            content: "still failed",
+            isFromMe: true,
+            deliveryStatus: .failed,
+            storageHash: stagedHash
+        )
+        XCTAssertEqual(
+            MessagingViewModel.retryableRefreshedMessage(
+                messageId: "stale-id",
+                stagedHash: stagedHash,
+                messages: [failed]
+            )?.content,
+            "still failed"
+        )
+    }
+
     func testRefreshPreservesOnlyUnpersistedOutboundRowsInTimelineOrder() {
         let base = Date(timeIntervalSince1970: 1_000)
         let oldest = Message(id: "oldest", content: "Oldest", timestamp: base, isFromMe: false)

--- a/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
+++ b/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
@@ -381,37 +381,36 @@ final class MessageTimelinePolicyTests: XCTestCase {
         )
     }
 
-    func testRecoveredRetryRechecksRefreshedDeliveryStateBeforeSending() {
-        let stagedHash = Data(repeating: 0x42, count: 32)
-        let delivered = Message(
-            id: "refreshed-id",
-            content: "already delivered",
-            isFromMe: true,
-            deliveryStatus: .delivered,
-            storageHash: stagedHash
-        )
-        XCTAssertNil(
-            MessagingViewModel.retryableRefreshedMessage(
-                messageId: "stale-id",
-                stagedHash: stagedHash,
-                messages: [delivered]
-            )
-        )
-
-        let failed = Message(
-            id: "refreshed-id",
-            content: "still failed",
+    func testPersistedAliasedProofCanonicalizesVisibleIdentityAndActions() {
+        let storageHash = Data(repeating: 0x41, count: 32)
+        let canonicalHash = Data(repeating: 0x42, count: 32)
+        var uncertain = Message(
+            id: storageHash.map { String(format: "%02x", $0) }.joined(),
+            content: "delivered after recovery",
             isFromMe: true,
             deliveryStatus: .failed,
-            storageHash: stagedHash
+            storageHash: storageHash,
+            isTargetSafe: false
         )
-        XCTAssertEqual(
-            MessagingViewModel.retryableRefreshedMessage(
-                messageId: "stale-id",
-                stagedHash: stagedHash,
-                messages: [failed]
-            )?.content,
-            "still failed"
+        uncertain.messageHash = canonicalHash
+
+        let canonical = MessagingViewModel.canonicalizedMessage(
+            uncertain,
+            canonicalHash: canonicalHash,
+            proofState: .delivered
+        )
+
+        let canonicalID = canonicalHash.map { String(format: "%02x", $0) }.joined()
+        XCTAssertEqual(canonical.id, canonicalID)
+        XCTAssertEqual(canonical.storageHash, canonicalHash)
+        XCTAssertEqual(canonical.messageHash, canonicalHash)
+        XCTAssertEqual(canonical.deliveryStatus, .delivered)
+        XCTAssertTrue(canonical.isTargetSafe)
+        XCTAssertTrue(
+            MessagingViewModel.canDeleteMessage(
+                isUnpersisted: false,
+                isUnsavedFailure: false
+            )
         )
     }
 

--- a/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
+++ b/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
@@ -295,8 +295,6 @@ final class MessageTimelinePolicyTests: XCTestCase {
         cursor.recordFetchedPage(recordCount: 50)
         XCTAssertEqual(cursor.nextOffset, 100)
 
-        cursor.recordInsertedAtNewest()
-        XCTAssertEqual(cursor.nextOffset, 101)
     }
 
     @MainActor

--- a/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
+++ b/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
@@ -296,19 +296,58 @@ final class MessageTimelinePolicyTests: XCTestCase {
         XCTAssertEqual(cursor.nextOffset, 100)
     }
 
-    func testRefreshPreservesOnlyUnpersistedOutboundRows() {
-        let persisted = Message(id: "persisted", content: "Persisted", isFromMe: true)
-        let pendingA = Message(id: "pending-a", content: "Pending A", isFromMe: true)
-        let pendingB = Message(id: "pending-b", content: "Pending B", isFromMe: true)
-        let stale = Message(id: "stale", content: "Stale", isFromMe: false)
+    func testRefreshWindowExpandsUntilPriorOldestRecordIsRetained() {
+        XCTAssertEqual(
+            MessageRefreshWindowPolicy.expandedLimit(
+                currentLimit: 51,
+                fetchedCount: 51,
+                containsPriorOldest: false,
+                pageSize: 50
+            ),
+            101
+        )
+        XCTAssertNil(
+            MessageRefreshWindowPolicy.expandedLimit(
+                currentLimit: 101,
+                fetchedCount: 101,
+                containsPriorOldest: true,
+                pageSize: 50
+            )
+        )
+        XCTAssertNil(
+            MessageRefreshWindowPolicy.expandedLimit(
+                currentLimit: 101,
+                fetchedCount: 75,
+                containsPriorOldest: false,
+                pageSize: 50
+            )
+        )
+    }
+
+    func testRefreshPreservesOnlyUnpersistedOutboundRowsInTimelineOrder() {
+        let base = Date(timeIntervalSince1970: 1_000)
+        let oldest = Message(id: "oldest", content: "Oldest", timestamp: base, isFromMe: false)
+        let pendingA = Message(
+            id: "pending-a",
+            content: "Pending A",
+            timestamp: base.addingTimeInterval(1),
+            isFromMe: true
+        )
+        let persistedB = Message(
+            id: "persisted-b",
+            content: "Persisted B",
+            timestamp: base.addingTimeInterval(2),
+            isFromMe: true
+        )
+        let stale = Message(id: "stale", content: "Stale", timestamp: base, isFromMe: false)
 
         let merged = MessagingViewModel.mergingPendingOutbound(
-            loaded: [persisted],
-            current: [stale, pendingA, persisted, pendingB],
-            pendingIDs: ["pending-a", "persisted", "pending-b"]
+            loaded: [oldest, persistedB],
+            current: [stale, pendingA, persistedB],
+            pendingIDs: ["pending-a", "persisted-b"]
         )
 
-        XCTAssertEqual(merged.map(\.id), ["persisted", "pending-a", "pending-b"])
+        XCTAssertEqual(merged.map(\.id), ["oldest", "pending-a", "persisted-b"])
     }
 
     @MainActor

--- a/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
+++ b/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
@@ -371,6 +371,14 @@ final class MessageTimelinePolicyTests: XCTestCase {
             MessagingViewModel.visibleMessageID(for: "persisted-hash", aliases: [:]),
             "persisted-hash"
         )
+        XCTAssertEqual(
+            MessagingViewModel.pendingProof(
+                forVisibleID: "optimistic-id",
+                aliases: ["real-hash": "optimistic-id"],
+                proofs: ["real-hash": .delivered]
+            ),
+            .delivered
+        )
     }
 
     func testRefreshPreservesOnlyUnpersistedOutboundRowsInTimelineOrder() {

--- a/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
+++ b/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
@@ -294,6 +294,9 @@ final class MessageTimelinePolicyTests: XCTestCase {
 
         cursor.recordFetchedPage(recordCount: 50)
         XCTAssertEqual(cursor.nextOffset, 100)
+
+        cursor.recordInsertedAtNewest()
+        XCTAssertEqual(cursor.nextOffset, 101)
     }
 
     @MainActor
@@ -332,6 +335,7 @@ final class MessageTimelinePolicyTests: XCTestCase {
         let requested = expectation(description: "older page requested")
         let controller = MessageTimelineViewController()
         controller.onLoadOlder = {
+            controller.update(messages: [], isLoadingMore: false, allMessagesLoaded: true)
             requested.fulfill()
         }
         controller.loadViewIfNeeded()

--- a/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
+++ b/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
@@ -322,6 +322,41 @@ final class MessageTimelinePolicyTests: XCTestCase {
                 pageSize: 50
             )
         )
+        XCTAssertEqual(
+            MessageRefreshWindowPolicy.retainedPrefixCount(
+                recordIDs: ["new", "prior-oldest", "speculative-older"],
+                priorOldestID: "prior-oldest"
+            ),
+            2
+        )
+        XCTAssertEqual(
+            MessageRefreshWindowPolicy.retainedPrefixCount(
+                recordIDs: ["newest", "middle", "prior-oldest"],
+                priorOldestID: "prior-oldest"
+            ),
+            3
+        )
+    }
+
+    func testDeleteIsUnavailableUntilOutboundPersistenceCompletes() {
+        XCTAssertFalse(
+            MessagingViewModel.canDeleteMessage(
+                isUnpersisted: true,
+                isUnsavedFailure: false
+            )
+        )
+        XCTAssertTrue(
+            MessagingViewModel.canDeleteMessage(
+                isUnpersisted: true,
+                isUnsavedFailure: true
+            )
+        )
+        XCTAssertTrue(
+            MessagingViewModel.canDeleteMessage(
+                isUnpersisted: false,
+                isUnsavedFailure: false
+            )
+        )
     }
 
     func testRefreshPreservesOnlyUnpersistedOutboundRowsInTimelineOrder() {
@@ -333,21 +368,28 @@ final class MessageTimelinePolicyTests: XCTestCase {
             timestamp: base.addingTimeInterval(1),
             isFromMe: true
         )
-        let persistedB = Message(
+        let loadedB = Message(
             id: "persisted-b",
-            content: "Persisted B",
+            content: "Staged database row",
+            timestamp: base.addingTimeInterval(2),
+            isFromMe: true
+        )
+        let pendingB = Message(
+            id: "persisted-b",
+            content: "Current pending row",
             timestamp: base.addingTimeInterval(2),
             isFromMe: true
         )
         let stale = Message(id: "stale", content: "Stale", timestamp: base, isFromMe: false)
 
         let merged = MessagingViewModel.mergingPendingOutbound(
-            loaded: [oldest, persistedB],
-            current: [stale, pendingA, persistedB],
+            loaded: [oldest, loadedB],
+            current: [stale, pendingA, pendingB],
             pendingIDs: ["pending-a", "persisted-b"]
         )
 
         XCTAssertEqual(merged.map(\.id), ["oldest", "pending-a", "persisted-b"])
+        XCTAssertEqual(merged.last?.content, "Current pending row")
     }
 
     @MainActor

--- a/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
+++ b/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
@@ -230,3 +230,121 @@ final class MessageBubbleLayoutTests: XCTestCase {
         )
     }
 }
+
+final class MessageTimelinePolicyTests: XCTestCase {
+
+    func testPaginationStartsBeforeTopWithoutViewLifecycleSentinel() {
+        XCTAssertTrue(
+            MessageTimelinePaginationPolicy.shouldLoadOlder(
+                contentOffsetY: 1_499,
+                viewportHeight: 500,
+                isLoading: false,
+                allHistoryLoaded: false
+            )
+        )
+        XCTAssertFalse(
+            MessageTimelinePaginationPolicy.shouldLoadOlder(
+                contentOffsetY: 1_500,
+                viewportHeight: 500,
+                isLoading: false,
+                allHistoryLoaded: false
+            )
+        )
+    }
+
+    func testPaginationRejectsDuplicateAndExhaustedLoads() {
+        XCTAssertFalse(
+            MessageTimelinePaginationPolicy.shouldLoadOlder(
+                contentOffsetY: 0,
+                viewportHeight: 500,
+                isLoading: true,
+                allHistoryLoaded: false
+            )
+        )
+        XCTAssertFalse(
+            MessageTimelinePaginationPolicy.shouldLoadOlder(
+                contentOffsetY: 0,
+                viewportHeight: 500,
+                isLoading: false,
+                allHistoryLoaded: true
+            )
+        )
+    }
+
+    func testPrependingMessagesPreservesVisibleAnchorOffset() {
+        XCTAssertEqual(
+            MessageTimelineViewportAnchor.adjustedContentOffset(
+                previousContentOffset: 1_200,
+                previousAnchorMinY: 1_260,
+                updatedAnchorMinY: 2_010
+            ),
+            1_950,
+            accuracy: 0.001
+        )
+    }
+
+    func testPaginationCursorUsesFetchedRecordsRatherThanVisibleMessages() {
+        var cursor = MessagePageCursor()
+        cursor.recordFetchedPage(recordCount: 50)
+
+        // A page may contain telemetry records that are intentionally hidden
+        // from the timeline. The next database offset must still skip all 50
+        // records, not the smaller number of visible message bubbles.
+        XCTAssertEqual(cursor.nextOffset, 50)
+
+        cursor.recordFetchedPage(recordCount: 50)
+        XCTAssertEqual(cursor.nextOffset, 100)
+    }
+
+    @MainActor
+    func testCollectionTimelineKeepsRowsRenderedAcrossViewportChanges() {
+        let controller = MessageTimelineViewController()
+        controller.loadViewIfNeeded()
+        controller.setViewportForTesting(CGSize(width: 390, height: 700))
+
+        var messages: [Message] = []
+        for index in 0..<50 {
+            let replyID: String? = index == 0 ? nil : "message-\(index - 1)"
+            let replyPreview: String? = index == 0 ? nil : "Earlier message preview"
+            messages.append(
+                Message(
+                    id: "message-\(index)",
+                    content: String(repeating: "Long timeline content \(index). ", count: 8),
+                    timestamp: Date().addingTimeInterval(TimeInterval(index)),
+                    isFromMe: index.isMultiple(of: 2),
+                    deliveryStatus: .delivered,
+                    replyToId: replyID,
+                    replyToPreview: replyPreview
+                )
+            )
+        }
+
+        controller.update(messages: messages, isLoadingMore: false, allMessagesLoaded: true)
+        controller.setViewportForTesting(CGSize(width: 390, height: 380))
+        controller.setViewportForTesting(CGSize(width: 390, height: 700))
+
+        XCTAssertEqual(controller.renderedMessageCount, 50)
+        XCTAssertGreaterThan(controller.visibleMessageCellCount, 0)
+    }
+
+    @MainActor
+    func testCollectionTimelineRequestsHistoryFromScrollOffset() async {
+        let requested = expectation(description: "older page requested")
+        let controller = MessageTimelineViewController()
+        controller.onLoadOlder = {
+            requested.fulfill()
+        }
+        controller.loadViewIfNeeded()
+        controller.setViewportForTesting(CGSize(width: 390, height: 700))
+        controller.update(
+            messages: (0..<50).map {
+                Message(id: "message-\($0)", content: "Message \($0)", isFromMe: false)
+            },
+            isLoadingMore: false,
+            allMessagesLoaded: false
+        )
+
+        controller.setContentOffsetForTesting(y: 0)
+        await fulfillment(of: [requested], timeout: 1)
+    }
+}

--- a/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
+++ b/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
@@ -320,11 +320,17 @@ final class MessageTimelinePolicyTests: XCTestCase {
             )
         }
 
-        controller.update(messages: messages, isLoadingMore: false, allMessagesLoaded: true)
+        controller.update(
+            messages: messages,
+            messageTextScale: 1.3,
+            isLoadingMore: false,
+            allMessagesLoaded: true
+        )
         controller.setViewportForTesting(CGSize(width: 390, height: 380))
         controller.setViewportForTesting(CGSize(width: 390, height: 700))
 
         XCTAssertEqual(controller.renderedMessageCount, 50)
+        XCTAssertEqual(controller.configuredMessageTextScale, 1.3)
         XCTAssertGreaterThan(controller.visibleMessageCellCount, 0)
     }
 

--- a/Tests/static/test_qr_contact_send_path_contract.py
+++ b/Tests/static/test_qr_contact_send_path_contract.py
@@ -168,7 +168,8 @@ class QRContactSendPathContractTests(unittest.TestCase):
         self.assertIn("Self.stagedRetryMarker", repository)
         self.assertIn("Self.uncertainRetryMarker", repository)
         self.assertIn("message_id = ? AND incoming = 0 AND state = ?", repository)
-        self.assertIn("receiving_interface IS NULL OR receiving_interface = ?", repository)
+        self.assertIn("receiving_interface IS NULL OR receiving_interface LIKE ?", repository)
+        self.assertIn('Self.uncertainRetryMarker + "%"', repository)
         self.assertIn("public func hasUncertainRetry", repository)
 
     def test_existing_qr_contact_can_refresh_peer_identity(self) -> None:

--- a/Tests/static/test_reported_runtime_bugs.py
+++ b/Tests/static/test_reported_runtime_bugs.py
@@ -174,8 +174,9 @@ class ReportedRuntimeBugContracts(unittest.TestCase):
             r"viewModel\?\.canTargetMessage\(messageId: msg\.id\) == true else \{ return \}",
             messaging,
         ))
+        self.assertIn("target.isTargetSafe", messaging)
         self.assertIn(
-            "let replyToId = replyTarget?.messageHash != nil ? replyTarget?.id : nil",
+            'return hash.map { String(format: "%02x", $0) }.joined()',
             messaging,
         )
 

--- a/Tests/static/test_reported_runtime_bugs.py
+++ b/Tests/static/test_reported_runtime_bugs.py
@@ -18,6 +18,7 @@ SETTINGS_VIEW = ROOT / "Sources/ColumbaApp/Views/Settings/SettingsView.swift"
 MAIN_TAB_VIEW = ROOT / "Sources/ColumbaApp/Views/MainTabView.swift"
 MESSAGE_BUBBLE = ROOT / "Sources/ColumbaApp/Views/Messaging/MessageBubble.swift"
 MESSAGING_VIEW = ROOT / "Sources/ColumbaApp/Views/Messaging/MessagingView.swift"
+MESSAGE_TIMELINE_VIEW = ROOT / "Sources/ColumbaApp/Views/Messaging/MessageTimelineView.swift"
 TEXT_SIZE_PICKER = ROOT / "Sources/ColumbaApp/Views/Messaging/TextSizePickerSheet.swift"
 INCOMING_MESSAGE_HANDLER = ROOT / "Sources/ColumbaApp/Services/IncomingMessageHandler.swift"
 LOCATION_SHARING_MANAGER = ROOT / "Sources/ColumbaApp/Services/LocationSharingManager.swift"
@@ -179,6 +180,13 @@ class ReportedRuntimeBugContracts(unittest.TestCase):
             'return hash.map { String(format: "%02x", $0) }.joined()',
             messaging,
         )
+
+        timeline = MESSAGE_TIMELINE_VIEW.read_text()
+        self.assertIsNotNone(re.search(
+            r"guard message\.messageHash != nil,\s+"
+            r"message\.isTargetSafe else \{ return \}",
+            timeline,
+        ))
 
     def test_rnode_cover_dismissal_clears_editing_state(self) -> None:
         settings = SETTINGS_VIEW.read_text()

--- a/Tests/static/test_reported_runtime_bugs.py
+++ b/Tests/static/test_reported_runtime_bugs.py
@@ -164,8 +164,16 @@ class ReportedRuntimeBugContracts(unittest.TestCase):
         )
 
         messaging = MESSAGING_VIEW.read_text()
-        self.assertIn("guard message.messageHash != nil else { return }", messaging)
-        self.assertIn("guard msg.messageHash != nil else { return }", messaging)
+        self.assertIsNotNone(re.search(
+            r"guard message\.messageHash != nil,\s+"
+            r"vm\.canTargetMessage\(messageId: message\.id\) else \{ return \}",
+            messaging,
+        ))
+        self.assertIsNotNone(re.search(
+            r"guard msg\.messageHash != nil,\s+"
+            r"viewModel\?\.canTargetMessage\(messageId: msg\.id\) == true else \{ return \}",
+            messaging,
+        ))
         self.assertIn(
             "let replyToId = replyTarget?.messageHash != nil ? replyTarget?.id : nil",
             messaging,


### PR DESCRIPTION
## Summary

- replace the iOS SwiftUI stack timeline with a UIKit `UICollectionView` embedded through `UIViewControllerRepresentable`
- keep existing SwiftUI message bubbles through `UIHostingConfiguration`, including adjustable message text sizing
- trigger older-history loading from scroll offset and preserve the visible message position when prepending pages
- serialize refresh and pagination state, discard stale offset pages, and preserve concurrent unpersisted outbound rows
- keep outbound send, retry, delete, and delivery-proof identity transitions durable across persistence failures and relaunches
- use an inline navigation-bar title to remove the empty large-title region above the conversation

## Why

On physical iPhone hardware, the lazy SwiftUI timeline could discard every realized row during navigation, keyboard changes, typing, and repository updates while the message model remained populated. It could also fail to trigger or retain older-history pagination. The collection view gives the timeline one explicit owner for cell reuse, pagination, viewport continuity, and keyboard-driven viewport changes.

## Verification

- focused retry, pagination, and timeline policy tests: 23 passed
- full native ColumbaAppTests suite: 190 passed
- adjustable-text static regressions: 7 passed
- full static suite: 223 passed, 1 skipped, 252 subtests passed
- exact-head iPhone build, signature verification, install, launch, and running-process verification passed
- physical iPhone: repeatedly navigated conversation without a black/blank timeline
- physical iPhone: traversed stored history to the oldest available message
- physical iPhone: compact conversation header verified
- physical iPhone: adjustable message text size verified after rebase

No user data was wiped during device verification.