### PR TITLE
feat: render Markdown and safe links in messages

### DIFF
--- a/Columba.xcodeproj/project.pbxproj
+++ b/Columba.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		TSP002 /* TextSizePickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = TSP001 /* TextSizePickerSheet.swift */; };
 		A41F10000000000000000001 /* MessageTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A41F10000000000000000003 /* MessageTimelineView.swift */; };
 		014 /* MessageBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = F014 /* MessageBubble.swift */; };
+		MDB001 /* MessageBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = MDB003 /* MessageBody.swift */; };
 		015 /* MessageInputBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = F015 /* MessageInputBar.swift */; };
 		016 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F016 /* SettingsView.swift */; };
 		017 /* MyIdentityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F017 /* MyIdentityView.swift */; };
@@ -274,6 +275,7 @@
 		C126E88E13D9DB7CCE7AD8A0 /* MicronDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = F07D /* MicronDocument.swift */; };
 		C17B4B4AD850DBC3CD27AEC0 /* JetBrainsMono-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B1AB71D8977FE792BA9B176D /* JetBrainsMono-Bold.ttf */; };
 		C204F5778ABB560C1FD4DC60 /* MessageBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = F014 /* MessageBubble.swift */; };
+		MDB002 /* MessageBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = MDB003 /* MessageBody.swift */; };
 		C2487934101CA21C68F1F458 /* PythonRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0C41F9E953D0445F3C34AE7 /* PythonRuntime.swift */; };
 		C4F369EC98C2B903701CE74A /* SyncStatusBottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67B5525A88EBCEAF05E9DE3F /* SyncStatusBottomSheet.swift */; };
 		C60C9313A6AFB95FCFB8969A /* MessageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = F025 /* MessageRepository.swift */; };
@@ -471,6 +473,7 @@
 		TSP001 /* TextSizePickerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextSizePickerSheet.swift; sourceTree = "<group>"; };
 		A41F10000000000000000003 /* MessageTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageTimelineView.swift; sourceTree = "<group>"; };
 		F014 /* MessageBubble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBubble.swift; sourceTree = "<group>"; };
+		MDB003 /* MessageBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBody.swift; sourceTree = "<group>"; };
 		F015 /* MessageInputBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageInputBar.swift; sourceTree = "<group>"; };
 		F016 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		F017 /* MyIdentityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyIdentityView.swift; sourceTree = "<group>"; };
@@ -847,6 +850,7 @@
 				TSP001 /* TextSizePickerSheet.swift */,
 				A41F10000000000000000003 /* MessageTimelineView.swift */,
 				F014 /* MessageBubble.swift */,
+				MDB003 /* MessageBody.swift */,
 				F015 /* MessageInputBar.swift */,
 				F073 /* MessageDetailView.swift */,
 			);
@@ -1373,6 +1377,7 @@
 				TSP003 /* TextSizePickerSheet.swift in Sources */,
 				A41F10000000000000000002 /* MessageTimelineView.swift in Sources */,
 				C204F5778ABB560C1FD4DC60 /* MessageBubble.swift in Sources */,
+				MDB002 /* MessageBody.swift in Sources */,
 				D93546FFCB0106CF3F68B2C5 /* MessageDetailView.swift in Sources */,
 				D709D8EDF36F85DEB5AABEC4 /* MessageInputBar.swift in Sources */,
 				A48DAD459DFDFDC94AC92B5A /* SettingsView.swift in Sources */,
@@ -1553,6 +1558,7 @@
 				TSP002 /* TextSizePickerSheet.swift in Sources */,
 				A41F10000000000000000001 /* MessageTimelineView.swift in Sources */,
 				014 /* MessageBubble.swift in Sources */,
+				MDB001 /* MessageBody.swift in Sources */,
 				073 /* MessageDetailView.swift in Sources */,
 				015 /* MessageInputBar.swift in Sources */,
 				016 /* SettingsView.swift in Sources */,

--- a/Columba.xcodeproj/project.pbxproj
+++ b/Columba.xcodeproj/project.pbxproj
@@ -276,6 +276,8 @@
 		C17B4B4AD850DBC3CD27AEC0 /* JetBrainsMono-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B1AB71D8977FE792BA9B176D /* JetBrainsMono-Bold.ttf */; };
 		C204F5778ABB560C1FD4DC60 /* MessageBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = F014 /* MessageBubble.swift */; };
 		MDB002 /* MessageBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = MDB003 /* MessageBody.swift */; };
+		MDUIBLD1 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = MDUIPROD1 /* MarkdownUI */; };
+		MDUIBLD2 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = MDUIPROD2 /* MarkdownUI */; };
 		C2487934101CA21C68F1F458 /* PythonRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0C41F9E953D0445F3C34AE7 /* PythonRuntime.swift */; };
 		C4F369EC98C2B903701CE74A /* SyncStatusBottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67B5525A88EBCEAF05E9DE3F /* SyncStatusBottomSheet.swift */; };
 		C60C9313A6AFB95FCFB8969A /* MessageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = F025 /* MessageRepository.swift */; };
@@ -597,6 +599,7 @@
 				876F4CCF3FA441B67D08BBEC /* SwiftBLEBridge in Frameworks */,
 				E34B504A6DCC8F5E7F44E491 /* LXMFSwift in Frameworks */,
 				D4E5F60718293A4B5C6D7E8D /* GRDB in Frameworks */,
+				MDUIBLD2 /* MarkdownUI in Frameworks */,
 				73B2FC9ECC25BA7B4AFF3D96 /* ReticulumSwift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -630,6 +633,7 @@
 				13F299C3C99F5D86B797FA11 /* SwiftBLEBridge in Frameworks */,
 				2F8EC8232FC732AF00235991 /* LXMFSwift in Frameworks */,
 				D4E5F60718293A4B5C6D7E8B /* GRDB in Frameworks */,
+				MDUIBLD1 /* MarkdownUI in Frameworks */,
 				83F513B2A83B444F977E44D9 /* ReticulumSwift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1137,6 +1141,7 @@
 				E0DE32143A4DF2A0284C1911 /* LXMFSwift */,
 				D4E5F60718293A4B5C6D7E8C /* GRDB */,
 				030380C51B178354F4D4E88F /* ReticulumSwift */,
+				MDUIPROD2 /* MarkdownUI */,
 			);
 			productName = ColumbaModelBApp;
 			productReference = E59ED1029D4A906764BC582F /* ColumbaModelBApp.app */;
@@ -1206,6 +1211,7 @@
 				2F8EC8222FC732AF00235991 /* LXMFSwift */,
 				D4E5F60718293A4B5C6D7E8A /* GRDB */,
 				A1380C075A9F67E1B173EA94 /* ReticulumSwift */,
+				MDUIPROD1 /* MarkdownUI */,
 			);
 			productName = ColumbaApp;
 			productReference = PROD /* ColumbaApp.app */;
@@ -1281,6 +1287,7 @@
 				ACEF9566B3811B841D6E5672 /* XCLocalSwiftPackageReference "." */,
 				2F8EC81E2FC7324D00235991 /* XCRemoteSwiftPackageReference "reticulum-swift" */,
 				2F8EC81F2FC7326600235991 /* XCRemoteSwiftPackageReference "LXMF-swift" */,
+				MDUIREF /* XCRemoteSwiftPackageReference "swift-markdown-ui" */,
 			);
 			productRefGroup = PRODS /* Products */;
 			projectDirPath = "";
@@ -2258,6 +2265,14 @@
 				kind = branch;
 			};
 		};
+		MDUIREF /* XCRemoteSwiftPackageReference "swift-markdown-ui" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/gonzalezreal/swift-markdown-ui.git";
+			requirement = {
+				kind = exactVersion;
+				version = 2.4.1;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -2371,6 +2386,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = PKGREF2 /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */;
 			productName = MapLibre;
+		};
+		MDUIPROD1 /* MarkdownUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = MDUIREF /* XCRemoteSwiftPackageReference "swift-markdown-ui" */;
+			productName = MarkdownUI;
+		};
+		MDUIPROD2 /* MarkdownUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = MDUIREF /* XCRemoteSwiftPackageReference "swift-markdown-ui" */;
+			productName = MarkdownUI;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Columba.xcodeproj/project.pbxproj
+++ b/Columba.xcodeproj/project.pbxproj
@@ -278,6 +278,8 @@
 		MDB002 /* MessageBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = MDB003 /* MessageBody.swift */; };
 		MDUIBLD1 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = MDUIPROD1 /* MarkdownUI */; };
 		MDUIBLD2 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = MDUIPROD2 /* MarkdownUI */; };
+		SPLASHBLD1 /* Splash in Frameworks */ = {isa = PBXBuildFile; productRef = SPLASHPROD1 /* Splash */; };
+		SPLASHBLD2 /* Splash in Frameworks */ = {isa = PBXBuildFile; productRef = SPLASHPROD2 /* Splash */; };
 		C2487934101CA21C68F1F458 /* PythonRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0C41F9E953D0445F3C34AE7 /* PythonRuntime.swift */; };
 		C4F369EC98C2B903701CE74A /* SyncStatusBottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67B5525A88EBCEAF05E9DE3F /* SyncStatusBottomSheet.swift */; };
 		C60C9313A6AFB95FCFB8969A /* MessageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = F025 /* MessageRepository.swift */; };
@@ -600,6 +602,7 @@
 				E34B504A6DCC8F5E7F44E491 /* LXMFSwift in Frameworks */,
 				D4E5F60718293A4B5C6D7E8D /* GRDB in Frameworks */,
 				MDUIBLD2 /* MarkdownUI in Frameworks */,
+				SPLASHBLD2 /* Splash in Frameworks */,
 				73B2FC9ECC25BA7B4AFF3D96 /* ReticulumSwift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -634,6 +637,7 @@
 				2F8EC8232FC732AF00235991 /* LXMFSwift in Frameworks */,
 				D4E5F60718293A4B5C6D7E8B /* GRDB in Frameworks */,
 				MDUIBLD1 /* MarkdownUI in Frameworks */,
+				SPLASHBLD1 /* Splash in Frameworks */,
 				83F513B2A83B444F977E44D9 /* ReticulumSwift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1142,6 +1146,7 @@
 				D4E5F60718293A4B5C6D7E8C /* GRDB */,
 				030380C51B178354F4D4E88F /* ReticulumSwift */,
 				MDUIPROD2 /* MarkdownUI */,
+				SPLASHPROD2 /* Splash */,
 			);
 			productName = ColumbaModelBApp;
 			productReference = E59ED1029D4A906764BC582F /* ColumbaModelBApp.app */;
@@ -1212,6 +1217,7 @@
 				D4E5F60718293A4B5C6D7E8A /* GRDB */,
 				A1380C075A9F67E1B173EA94 /* ReticulumSwift */,
 				MDUIPROD1 /* MarkdownUI */,
+				SPLASHPROD1 /* Splash */,
 			);
 			productName = ColumbaApp;
 			productReference = PROD /* ColumbaApp.app */;
@@ -1288,6 +1294,7 @@
 				2F8EC81E2FC7324D00235991 /* XCRemoteSwiftPackageReference "reticulum-swift" */,
 				2F8EC81F2FC7326600235991 /* XCRemoteSwiftPackageReference "LXMF-swift" */,
 				MDUIREF /* XCRemoteSwiftPackageReference "swift-markdown-ui" */,
+				SPLASHREF /* XCRemoteSwiftPackageReference "Splash" */,
 			);
 			productRefGroup = PRODS /* Products */;
 			projectDirPath = "";
@@ -2273,6 +2280,14 @@
 				version = 2.4.1;
 			};
 		};
+		SPLASHREF /* XCRemoteSwiftPackageReference "Splash" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/JohnSundell/Splash";
+			requirement = {
+				kind = exactVersion;
+				version = 0.16.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -2396,6 +2411,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = MDUIREF /* XCRemoteSwiftPackageReference "swift-markdown-ui" */;
 			productName = MarkdownUI;
+		};
+		SPLASHPROD1 /* Splash */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = SPLASHREF /* XCRemoteSwiftPackageReference "Splash" */;
+			productName = Splash;
+		};
+		SPLASHPROD2 /* Splash */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = SPLASHREF /* XCRemoteSwiftPackageReference "Splash" */;
+			productName = Splash;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Columba.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Columba.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "0dc60df1ece66a9258a79fc22638d7b173a5b15313dae679b5e8e6f01b9f15a7",
+  "originHash" : "da644df712faf343b8dbce8a627e757c0abd5d6f35a39de3ac6eaf9c8c559767",
   "pins" : [
     {
       "identity" : "bitbytedata",
@@ -56,6 +56,15 @@
       }
     },
     {
+      "identity" : "networkimage",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gonzalezreal/NetworkImage",
+      "state" : {
+        "revision" : "2849f5323265386e200484b0d0f896e73c3411b9",
+        "version" : "6.0.1"
+      }
+    },
+    {
       "identity" : "reticulum-swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/torlando-tech/reticulum-swift.git",
@@ -71,6 +80,24 @@
       "state" : {
         "revision" : "390e0b0af8dd19a600005a242a89e570ff482e09",
         "version" : "4.8.6"
+      }
+    },
+    {
+      "identity" : "swift-cmark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-cmark",
+      "state" : {
+        "revision" : "924936d0427cb25a61169739a7660230bffa6ea6",
+        "version" : "0.8.0"
+      }
+    },
+    {
+      "identity" : "swift-markdown-ui",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gonzalezreal/swift-markdown-ui.git",
+      "state" : {
+        "revision" : "5f613358148239d0292c0cef674a3c2314737f9e",
+        "version" : "2.4.1"
       }
     }
   ],

--- a/Columba.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Columba.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "da644df712faf343b8dbce8a627e757c0abd5d6f35a39de3ac6eaf9c8c559767",
+  "originHash" : "58ec72628ef9f41eb5d2019a3171fc0bd2a3dfe6c55688c716d13572bb33046f",
   "pins" : [
     {
       "identity" : "bitbytedata",
@@ -71,6 +71,15 @@
       "state" : {
         "branch" : "main",
         "revision" : "52e2a9a5107bf12545a0788ee637686815d47525"
+      }
+    },
+    {
+      "identity" : "splash",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/JohnSundell/Splash",
+      "state" : {
+        "revision" : "7f4df436eb78fe64fe2c32c58006e9949fa28ad8",
+        "version" : "0.16.0"
       }
     },
     {

--- a/Sources/ColumbaApp/ViewModels/NomadNetBrowserViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/NomadNetBrowserViewModel.swift
@@ -110,11 +110,13 @@ public final class NomadNetBrowserViewModel {
     public init(
         nodeHash: Data,
         nodeName: String?,
+        initialPath: String = "/page/index.mu",
         backend: any RnsBackend,
         identity: Identity
     ) {
         self.currentNodeHash = nodeHash
         self.currentNodeName = nodeName
+        self.currentPath = initialPath
         self.browserService = NomadNetBrowserService(
             backend: backend,
             identity: identity

--- a/Sources/ColumbaApp/Views/Messaging/MessageBody.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageBody.swift
@@ -254,6 +254,7 @@ private struct MarkdownMessageText: View {
                         FontFamilyVariant(.monospaced)
                         FontSize(fontSize * 0.82)
                     }
+                    .fixedSize(horizontal: true, vertical: true)
                     .padding(10)
             }
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/Sources/ColumbaApp/Views/Messaging/MessageBody.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageBody.swift
@@ -227,6 +227,15 @@ private struct MarkdownMessageText: View {
             .markdownBlockStyle(\.codeBlock) { configuration in
                 codeBlock(configuration)
             }
+            .markdownBlockStyle(\.heading1) { configuration in
+                configuration.label
+                    .markdownMargin(top: .zero, bottom: .em(0.45))
+                    .markdownTextStyle {
+                        FontWeight(.bold)
+                        FontSize(fontSize * 1.35)
+                    }
+                    .fixedSize(horizontal: false, vertical: true)
+            }
             .markdownTheme(.basic)
             .onChange(of: content) { _, newContent in
                 parsedContent = MarkdownContent(newContent)

--- a/Sources/ColumbaApp/Views/Messaging/MessageBody.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageBody.swift
@@ -1,6 +1,7 @@
 import Foundation
 import MarkdownUI
 import RNSAPI
+import Splash
 import SwiftUI
 
 /// A message link after scheme validation and NomadNet address parsing.
@@ -200,10 +201,47 @@ private struct MarkdownMessageText: View {
             }
             .markdownImageProvider(BlockedMarkdownImageProvider())
             .markdownInlineImageProvider(BlockedMarkdownInlineImageProvider())
+            .markdownCodeSyntaxHighlighter(
+                SplashCodeSyntaxHighlighter(
+                    theme: .wwdc17(withFont: .init(size: fontSize * 0.85))
+                )
+            )
+            .markdownBlockStyle(\.codeBlock) { configuration in
+                codeBlock(configuration)
+            }
             .fixedSize(horizontal: false, vertical: true)
             .onChange(of: content) { _, newContent in
                 parsedContent = MarkdownContent(newContent)
             }
+    }
+
+    private func codeBlock(_ configuration: CodeBlockConfiguration) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if let language = configuration.language, !language.isEmpty {
+                Text(language.uppercased())
+                    .font(.system(
+                        size: max(10, fontSize * 0.65),
+                        weight: .semibold,
+                        design: .monospaced
+                    ))
+                    .foregroundStyle(Color.white.opacity(0.65))
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+            }
+
+            ScrollView(.horizontal) {
+                configuration.label
+                    .relativeLineSpacing(.em(0.2))
+                    .markdownTextStyle {
+                        FontFamilyVariant(.monospaced)
+                        FontSize(fontSize * 0.82)
+                    }
+                    .padding(10)
+            }
+        }
+        .background(Color(red: 0.08, green: 0.09, blue: 0.12))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .markdownMargin(top: .em(0.25), bottom: .em(0.6))
     }
 }
 
@@ -231,5 +269,50 @@ struct BlockedMarkdownInlineImageProvider: InlineImageProvider {
 
     func image(with url: URL, label: String) async throws -> Image {
         throw Blocked.remoteImage
+    }
+}
+
+private struct SplashCodeSyntaxHighlighter: CodeSyntaxHighlighter {
+    private let syntaxHighlighter: SyntaxHighlighter<SplashTextOutputFormat>
+
+    init(theme: Splash.Theme) {
+        syntaxHighlighter = SyntaxHighlighter(format: SplashTextOutputFormat(theme: theme))
+    }
+
+    func highlightCode(_ content: String, language: String?) -> Text {
+        guard language?.lowercased() == "swift" else {
+            return Text(content)
+        }
+        return syntaxHighlighter.highlight(content)
+    }
+}
+
+private struct SplashTextOutputFormat: OutputFormat {
+    let theme: Splash.Theme
+
+    func makeBuilder() -> Builder {
+        Builder(theme: theme)
+    }
+
+    struct Builder: OutputBuilder {
+        let theme: Splash.Theme
+        private var fragments: [Text] = []
+
+        mutating func addToken(_ token: String, ofType type: TokenType) {
+            let tokenColor = theme.tokenColors[type] ?? theme.plainTextColor
+            fragments.append(Text(token).foregroundColor(Color(uiColor: tokenColor)))
+        }
+
+        mutating func addPlainText(_ text: String) {
+            fragments.append(Text(text).foregroundColor(Color(uiColor: theme.plainTextColor)))
+        }
+
+        mutating func addWhitespace(_ whitespace: String) {
+            fragments.append(Text(whitespace))
+        }
+
+        func build() -> Text {
+            fragments.reduce(Text(""), +)
+        }
     }
 }

--- a/Sources/ColumbaApp/Views/Messaging/MessageBody.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageBody.swift
@@ -1,0 +1,131 @@
+import Foundation
+import SwiftUI
+
+/// A message link after scheme validation and NomadNet address parsing.
+enum MessageLinkTarget: Equatable, Hashable {
+    case web(URL)
+    case nomadNet(nodeHash: Data, path: String)
+    case external(URL)
+
+    var url: URL? {
+        switch self {
+        case .web(let url), .external(let url):
+            return url
+        case .nomadNet(let nodeHash, let path):
+            let hash = nodeHash.map { String(format: "%02x", $0) }.joined()
+            return URL(string: "nomadnetwork://\(hash):\(path)")
+        }
+    }
+}
+
+struct MessageLinkMatch: Equatable {
+    let range: NSRange
+    let text: String
+    let target: MessageLinkTarget
+}
+
+/// Detects and validates the exact web and Reticulum links supported in message bodies.
+enum MessageLinkParser {
+    private static let bareNomadNetPattern =
+        #"(?<![0-9a-fA-F])[0-9a-fA-F]{32}:/[^\s,;!?)\]]+(?<![.,;:])"#
+    private static let explicitPattern =
+        #"(?:https?|nomadnetwork|lxma)://[^\s,;!?)\]]+(?<![.,;:])"#
+    private static let anchoredNomadNet = try! NSRegularExpression(
+        pattern: #"^(?:nomadnetwork://)?([0-9a-fA-F]{32}):(/[^\s,;!?)\]]+)$"#,
+        options: [.caseInsensitive]
+    )
+    private static let detectors = [
+        try! NSRegularExpression(pattern: bareNomadNetPattern),
+        try! NSRegularExpression(pattern: explicitPattern, options: [.caseInsensitive]),
+    ]
+
+    static func matches(in text: String) -> [MessageLinkMatch] {
+        let fullRange = NSRange(text.startIndex..<text.endIndex, in: text)
+        var candidates: [MessageLinkMatch] = []
+
+        for detector in detectors {
+            for result in detector.matches(in: text, range: fullRange) {
+                guard let range = Range(result.range, in: text) else { continue }
+                let raw = String(text[range])
+                guard let target = target(for: raw) else { continue }
+                candidates.append(MessageLinkMatch(range: result.range, text: raw, target: target))
+            }
+        }
+
+        candidates.sort {
+            if $0.range.location == $1.range.location {
+                return $0.range.length > $1.range.length
+            }
+            return $0.range.location < $1.range.location
+        }
+
+        var resolved: [MessageLinkMatch] = []
+        var lastEnd = 0
+        for candidate in candidates where candidate.range.location >= lastEnd {
+            resolved.append(candidate)
+            lastEnd = candidate.range.location + candidate.range.length
+        }
+        return resolved
+    }
+
+    static func target(for url: URL) -> MessageLinkTarget? {
+        target(for: url.absoluteString)
+    }
+
+    static func target(for rawValue: String) -> MessageLinkTarget? {
+        let cleaned = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        let range = NSRange(cleaned.startIndex..<cleaned.endIndex, in: cleaned)
+        if let match = anchoredNomadNet.firstMatch(in: cleaned, range: range),
+           let hashRange = Range(match.range(at: 1), in: cleaned),
+           let pathRange = Range(match.range(at: 2), in: cleaned),
+           let hash = Data(hexString: String(cleaned[hashRange])) {
+            return .nomadNet(nodeHash: hash, path: String(cleaned[pathRange]))
+        }
+
+        guard let url = URL(string: cleaned),
+              let scheme = url.scheme?.lowercased() else { return nil }
+        switch scheme {
+        case "http", "https":
+            return .web(url)
+        case "lxma":
+            return .external(url)
+        default:
+            return nil
+        }
+    }
+}
+
+struct PlainMessageText: View {
+    let content: String
+    let color: Color
+    let fontSize: CGFloat
+
+    var body: some View {
+        Text(attributedContent)
+            .font(.system(size: fontSize))
+            .foregroundStyle(color)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    private var attributedContent: AttributedString {
+        var output = AttributedString()
+        let matches = MessageLinkParser.matches(in: content)
+        var cursor = content.startIndex
+
+        for match in matches {
+            guard let range = Range(match.range, in: content) else { continue }
+            if cursor < range.lowerBound {
+                output += AttributedString(content[cursor..<range.lowerBound])
+            }
+            var linked = AttributedString(content[range])
+            linked.link = match.target.url
+            linked.underlineStyle = .single
+            output += linked
+            cursor = range.upperBound
+        }
+        if cursor < content.endIndex {
+            output += AttributedString(content[cursor...])
+        }
+        return output
+    }
+}

--- a/Sources/ColumbaApp/Views/Messaging/MessageBody.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageBody.swift
@@ -100,7 +100,7 @@ enum MessageLinkParser {
 
 struct PlainMessageText: View {
     let content: String
-    let color: Color
+    let color: SwiftUI.Color
     let fontSize: CGFloat
 
     var body: some View {
@@ -136,7 +136,7 @@ struct PlainMessageText: View {
 struct MessageBody: View {
     let content: String
     let renderer: MessageRenderer
-    let color: Color
+    let color: SwiftUI.Color
     let fontSize: CGFloat
     var onOpenLink: ((MessageLinkTarget) -> Void)?
 
@@ -177,11 +177,11 @@ struct MessageBody: View {
 
 private struct MarkdownMessageText: View {
     let content: String
-    let color: Color
+    let color: SwiftUI.Color
     let fontSize: CGFloat
     @State private var parsedContent: MarkdownContent
 
-    init(content: String, color: Color, fontSize: CGFloat) {
+    init(content: String, color: SwiftUI.Color, fontSize: CGFloat) {
         self.content = content
         self.color = color
         self.fontSize = fontSize
@@ -224,7 +224,7 @@ private struct MarkdownMessageText: View {
                         weight: .semibold,
                         design: .monospaced
                     ))
-                    .foregroundStyle(Color.white.opacity(0.65))
+                    .foregroundStyle(SwiftUI.Color.white.opacity(0.65))
                     .padding(.horizontal, 10)
                     .padding(.vertical, 6)
             }
@@ -239,7 +239,7 @@ private struct MarkdownMessageText: View {
                     .padding(10)
             }
         }
-        .background(Color(red: 0.08, green: 0.09, blue: 0.12))
+        .background(SwiftUI.Color(red: 0.08, green: 0.09, blue: 0.12))
         .clipShape(RoundedRectangle(cornerRadius: 8))
         .markdownMargin(top: .em(0.25), bottom: .em(0.6))
     }
@@ -298,13 +298,17 @@ private struct SplashTextOutputFormat: OutputFormat {
         let theme: Splash.Theme
         private var fragments: [Text] = []
 
+        init(theme: Splash.Theme) {
+            self.theme = theme
+        }
+
         mutating func addToken(_ token: String, ofType type: TokenType) {
             let tokenColor = theme.tokenColors[type] ?? theme.plainTextColor
-            fragments.append(Text(token).foregroundColor(Color(uiColor: tokenColor)))
+            fragments.append(Text(token).foregroundColor(SwiftUI.Color(uiColor: tokenColor)))
         }
 
         mutating func addPlainText(_ text: String) {
-            fragments.append(Text(text).foregroundColor(Color(uiColor: theme.plainTextColor)))
+            fragments.append(Text(text).foregroundColor(SwiftUI.Color(uiColor: theme.plainTextColor)))
         }
 
         mutating func addWhitespace(_ whitespace: String) {

--- a/Sources/ColumbaApp/Views/Messaging/MessageBody.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageBody.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MarkdownUI
 import SwiftUI
 
 /// A message link after scheme validation and NomadNet address parsing.
@@ -127,5 +128,107 @@ struct PlainMessageText: View {
             output += AttributedString(content[cursor...])
         }
         return output
+    }
+}
+
+struct MessageBody: View {
+    let content: String
+    let renderer: MessageRenderer
+    let color: Color
+    let fontSize: CGFloat
+    var onOpenLink: ((MessageLinkTarget) -> Void)?
+
+    var body: some View {
+        Group {
+            switch renderer {
+            case .markdown:
+                MarkdownMessageText(
+                    content: content,
+                    color: color,
+                    fontSize: fontSize
+                )
+                .accessibilityIdentifier("bubble_markdown")
+            case .plain:
+                PlainMessageText(
+                    content: content,
+                    color: color,
+                    fontSize: fontSize
+                )
+            }
+        }
+        .accessibilityIdentifier("bubble_text")
+        .environment(\.openURL, OpenURLAction { url in
+            guard let target = MessageLinkParser.target(for: url) else {
+                return .discarded
+            }
+            switch target {
+            case .web, .external:
+                return .systemAction(url)
+            case .nomadNet:
+                guard let onOpenLink else { return .discarded }
+                onOpenLink(target)
+                return .handled
+            }
+        })
+    }
+}
+
+private struct MarkdownMessageText: View {
+    let content: String
+    let color: Color
+    let fontSize: CGFloat
+    @State private var parsedContent: MarkdownContent
+
+    init(content: String, color: Color, fontSize: CGFloat) {
+        self.content = content
+        self.color = color
+        self.fontSize = fontSize
+        _parsedContent = State(initialValue: MarkdownContent(content))
+    }
+
+    var body: some View {
+        Markdown(parsedContent)
+            .markdownTheme(.basic)
+            .markdownTextStyle {
+                FontSize(fontSize)
+                ForegroundColor(color)
+            }
+            .markdownTextStyle(\.link) {
+                ForegroundColor(color)
+                UnderlineStyle(.single)
+            }
+            .markdownImageProvider(BlockedMarkdownImageProvider())
+            .markdownInlineImageProvider(BlockedMarkdownInlineImageProvider())
+            .fixedSize(horizontal: false, vertical: true)
+            .onChange(of: content) { _, newContent in
+                parsedContent = MarkdownContent(newContent)
+            }
+    }
+}
+
+struct BlockedMarkdownImageProvider: ImageProvider {
+    func makeImage(url: URL?) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: "photo.badge.exclamationmark")
+            if let source = url?.host ?? url?.lastPathComponent,
+               !source.isEmpty {
+                Text(source)
+                    .lineLimit(1)
+            }
+        }
+        .font(.caption)
+        .foregroundStyle(.secondary)
+        .padding(6)
+        .background(.secondary.opacity(0.1), in: RoundedRectangle(cornerRadius: 6))
+    }
+}
+
+struct BlockedMarkdownInlineImageProvider: InlineImageProvider {
+    enum Blocked: Error {
+        case remoteImage
+    }
+
+    func image(with url: URL, label: String) async throws -> Image {
+        throw Blocked.remoteImage
     }
 }

--- a/Sources/ColumbaApp/Views/Messaging/MessageBody.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageBody.swift
@@ -101,6 +101,7 @@ enum MessageLinkParser {
 struct PlainMessageText: View {
     let content: String
     let color: SwiftUI.Color
+    let linkColor: SwiftUI.Color
     let fontSize: CGFloat
 
     var body: some View {
@@ -122,6 +123,7 @@ struct PlainMessageText: View {
             }
             var linked = AttributedString(content[range])
             linked.link = match.target.url
+            linked.foregroundColor = linkColor
             linked.underlineStyle = .single
             output += linked
             cursor = range.upperBound
@@ -137,6 +139,7 @@ struct MessageBody: View {
     let content: String
     let renderer: MessageRenderer
     let color: SwiftUI.Color
+    let isOutgoing: Bool
     let fontSize: CGFloat
     var onOpenLink: ((MessageLinkTarget) -> Void)?
 
@@ -147,6 +150,7 @@ struct MessageBody: View {
                 MarkdownMessageText(
                     content: content,
                     color: color,
+                    isOutgoing: isOutgoing,
                     fontSize: fontSize
                 )
                 .accessibilityIdentifier("bubble_markdown")
@@ -154,6 +158,7 @@ struct MessageBody: View {
                 PlainMessageText(
                     content: content,
                     color: color,
+                    linkColor: linkColor,
                     fontSize: fontSize
                 )
             }
@@ -173,31 +178,44 @@ struct MessageBody: View {
             }
         })
     }
+
+    private var linkColor: SwiftUI.Color {
+        isOutgoing
+            ? SwiftUI.Color(red: 0.75, green: 0.91, blue: 1.0)
+            : SwiftUI.Color(red: 0.25, green: 0.65, blue: 1.0)
+    }
 }
 
 private struct MarkdownMessageText: View {
     let content: String
     let color: SwiftUI.Color
+    let isOutgoing: Bool
     let fontSize: CGFloat
     @State private var parsedContent: MarkdownContent
 
-    init(content: String, color: SwiftUI.Color, fontSize: CGFloat) {
+    init(content: String, color: SwiftUI.Color, isOutgoing: Bool, fontSize: CGFloat) {
         self.content = content
         self.color = color
+        self.isOutgoing = isOutgoing
         self.fontSize = fontSize
         _parsedContent = State(initialValue: MarkdownContent(content))
     }
 
     var body: some View {
         Markdown(parsedContent)
-            .markdownTheme(.basic)
             .markdownTextStyle {
                 FontSize(fontSize)
                 ForegroundColor(color)
             }
             .markdownTextStyle(\.link) {
-                ForegroundColor(color)
+                ForegroundColor(linkColor)
                 UnderlineStyle(.single)
+            }
+            .markdownTextStyle(\.code) {
+                FontFamilyVariant(.monospaced)
+                FontSize(fontSize * 0.85)
+                ForegroundColor(color)
+                BackgroundColor(inlineCodeBackground)
             }
             .markdownImageProvider(BlockedMarkdownImageProvider())
             .markdownInlineImageProvider(BlockedMarkdownInlineImageProvider())
@@ -209,6 +227,7 @@ private struct MarkdownMessageText: View {
             .markdownBlockStyle(\.codeBlock) { configuration in
                 codeBlock(configuration)
             }
+            .markdownTheme(.basic)
             .onChange(of: content) { _, newContent in
                 parsedContent = MarkdownContent(newContent)
             }
@@ -239,9 +258,25 @@ private struct MarkdownMessageText: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .background(SwiftUI.Color(red: 0.08, green: 0.09, blue: 0.12))
+        .background(blockCodeBackground)
         .clipShape(RoundedRectangle(cornerRadius: 8))
         .markdownMargin(top: .em(0.25), bottom: .em(0.6))
+    }
+
+    private var linkColor: SwiftUI.Color {
+        isOutgoing
+            ? SwiftUI.Color(red: 0.75, green: 0.91, blue: 1.0)
+            : SwiftUI.Color(red: 0.25, green: 0.65, blue: 1.0)
+    }
+
+    private var inlineCodeBackground: SwiftUI.Color {
+        isOutgoing
+            ? SwiftUI.Color.black.opacity(0.25)
+            : SwiftUI.Color.white.opacity(0.16)
+    }
+
+    private var blockCodeBackground: SwiftUI.Color {
+        SwiftUI.Color(red: 0.19, green: 0.20, blue: 0.23)
     }
 }
 

--- a/Sources/ColumbaApp/Views/Messaging/MessageBody.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageBody.swift
@@ -247,17 +247,15 @@ private struct MarkdownMessageText: View {
                     .padding(.vertical, 6)
             }
 
-            ScrollView(.horizontal) {
-                configuration.label
-                    .relativeLineSpacing(.em(0.2))
-                    .markdownTextStyle {
-                        FontFamilyVariant(.monospaced)
-                        FontSize(fontSize * 0.82)
-                    }
-                    .fixedSize(horizontal: true, vertical: true)
-                    .padding(10)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
+            configuration.label
+                .relativeLineSpacing(.em(0.2))
+                .markdownTextStyle {
+                    FontFamilyVariant(.monospaced)
+                    FontSize(fontSize * 0.82)
+                }
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(10)
+                .frame(maxWidth: .infinity, alignment: .leading)
         }
         .background(blockCodeBackground)
         .clipShape(RoundedRectangle(cornerRadius: 8))

--- a/Sources/ColumbaApp/Views/Messaging/MessageBody.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageBody.swift
@@ -1,5 +1,6 @@
 import Foundation
 import MarkdownUI
+import RNSAPI
 import SwiftUI
 
 /// A message link after scheme validation and NomadNet address parsing.

--- a/Sources/ColumbaApp/Views/Messaging/MessageBody.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageBody.swift
@@ -243,31 +243,18 @@ private struct MarkdownMessageText: View {
     }
 
     private func codeBlock(_ configuration: CodeBlockConfiguration) -> some View {
-        VStack(alignment: .leading, spacing: 0) {
-            if let language = configuration.language, !language.isEmpty {
-                Text(language.uppercased())
-                    .font(.system(
-                        size: max(10, fontSize * 0.65),
-                        weight: .semibold,
-                        design: .monospaced
-                    ))
-                    .foregroundStyle(SwiftUI.Color.white.opacity(0.65))
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 6)
-            }
-
+        ScrollableMarkdownCodeBlock(
+            language: configuration.language,
+            fontSize: fontSize,
+            background: blockCodeBackground
+        ) {
             configuration.label
                 .relativeLineSpacing(.em(0.2))
                 .markdownTextStyle {
                     FontFamilyVariant(.monospaced)
                     FontSize(fontSize * 0.82)
                 }
-                .fixedSize(horizontal: false, vertical: true)
-                .padding(10)
-                .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .background(blockCodeBackground)
-        .clipShape(RoundedRectangle(cornerRadius: 8))
         .markdownMargin(top: .em(0.25), bottom: .em(0.6))
     }
 
@@ -285,6 +272,79 @@ private struct MarkdownMessageText: View {
 
     private var blockCodeBackground: SwiftUI.Color {
         SwiftUI.Color(red: 0.19, green: 0.20, blue: 0.23)
+    }
+}
+
+private struct ScrollableMarkdownCodeBlock<Content: View>: View {
+    let language: String?
+    let fontSize: CGFloat
+    let backgroundColor: SwiftUI.Color
+    let content: Content
+    @State private var measuredContentHeight: CGFloat = 0
+
+    init(
+        language: String?,
+        fontSize: CGFloat,
+        background: SwiftUI.Color,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.language = language
+        self.fontSize = fontSize
+        self.backgroundColor = background
+        self.content = content()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if let language, !language.isEmpty {
+                Text(language.uppercased())
+                    .font(.system(
+                        size: max(10, fontSize * 0.65),
+                        weight: .semibold,
+                        design: .monospaced
+                    ))
+                    .foregroundStyle(SwiftUI.Color.white.opacity(0.65))
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+            }
+
+            GeometryReader { proxy in
+                ScrollView(.horizontal) {
+                    content
+                        .fixedSize(horizontal: true, vertical: true)
+                        .padding(10)
+                        .background {
+                            GeometryReader { contentProxy in
+                                SwiftUI.Color.clear.preference(
+                                    key: CodeContentHeightKey.self,
+                                    value: contentProxy.size.height
+                                )
+                            }
+                        }
+                }
+                .frame(width: proxy.size.width, height: resolvedContentHeight)
+                .accessibilityIdentifier("markdown_code_scroll")
+            }
+            .frame(height: resolvedContentHeight)
+        }
+        .background(backgroundColor)
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .onPreferenceChange(CodeContentHeightKey.self) { height in
+            guard height > 0, abs(height - measuredContentHeight) > 0.5 else { return }
+            measuredContentHeight = height
+        }
+    }
+
+    private var resolvedContentHeight: CGFloat {
+        max(measuredContentHeight, fontSize + 20)
+    }
+}
+
+private struct CodeContentHeightKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
     }
 }
 

--- a/Sources/ColumbaApp/Views/Messaging/MessageBody.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageBody.swift
@@ -209,7 +209,6 @@ private struct MarkdownMessageText: View {
             .markdownBlockStyle(\.codeBlock) { configuration in
                 codeBlock(configuration)
             }
-            .fixedSize(horizontal: false, vertical: true)
             .onChange(of: content) { _, newContent in
                 parsedContent = MarkdownContent(newContent)
             }
@@ -238,6 +237,7 @@ private struct MarkdownMessageText: View {
                     }
                     .padding(10)
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
         .background(SwiftUI.Color(red: 0.08, green: 0.09, blue: 0.12))
         .clipShape(RoundedRectangle(cornerRadius: 8))

--- a/Sources/ColumbaApp/Views/Messaging/MessageBubble.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageBubble.swift
@@ -35,6 +35,8 @@ struct MessageBubble: View {
     var onTapReplyPreview: ((String) -> Void)?
     /// Callback for long-press to enter reaction mode.
     var onLongPress: (() -> Void)?
+    /// Callback for validated in-app message links such as NomadNet pages.
+    var onOpenLink: ((MessageLinkTarget) -> Void)?
 
     // MARK: - Theme (delegates to Theme/ThemeManager)
 
@@ -91,10 +93,13 @@ struct MessageBubble: View {
 
                     // Text content (show if non-empty)
                     if !message.content.isEmpty {
-                        Text(message.content)
-                            .font(.system(size: bodyFontSize * CGFloat(messageTextScale)))
-                            .foregroundStyle(message.isFromMe ? .white : Theme.textPrimary)
-                            .fixedSize(horizontal: false, vertical: true)
+                        MessageBody(
+                            content: message.content,
+                            renderer: message.renderer,
+                            color: message.isFromMe ? .white : Theme.textPrimary,
+                            fontSize: bodyFontSize * CGFloat(messageTextScale),
+                            onOpenLink: onOpenLink
+                        )
                             // The text is already findable via Maestro's
                             // `text:` matcher; the identifier just lets the
                             // harness disambiguate the bubble's text from

--- a/Sources/ColumbaApp/Views/Messaging/MessageBubble.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageBubble.swift
@@ -97,6 +97,7 @@ struct MessageBubble: View {
                             content: message.content,
                             renderer: message.renderer,
                             color: message.isFromMe ? .white : Theme.textPrimary,
+                            isOutgoing: message.isFromMe,
                             fontSize: bodyFontSize * CGFloat(messageTextScale),
                             onOpenLink: onOpenLink
                         )

--- a/Sources/ColumbaApp/Views/Messaging/MessageBubble.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageBubble.swift
@@ -285,6 +285,7 @@ public struct Message: Identifiable, Equatable {
     public let timestamp: Date
     public let isFromMe: Bool
     public var deliveryStatus: DeliveryStatus
+    public var renderer: MessageRenderer
     public var imageData: Data?
     public var imageFormat: String?
     public var attachments: [FileAttachment]?
@@ -335,6 +336,7 @@ public struct Message: Identifiable, Equatable {
         timestamp: Date = Date(),
         isFromMe: Bool,
         deliveryStatus: DeliveryStatus = .sent,
+        renderer: MessageRenderer = .plain,
         imageData: Data? = nil,
         imageFormat: String? = nil,
         attachments: [FileAttachment]? = nil,
@@ -349,6 +351,7 @@ public struct Message: Identifiable, Equatable {
         self.timestamp = timestamp
         self.isFromMe = isFromMe
         self.deliveryStatus = deliveryStatus
+        self.renderer = renderer
         self.imageData = imageData
         self.imageFormat = imageFormat
         self.attachments = attachments
@@ -371,6 +374,7 @@ public struct Message: Identifiable, Equatable {
         self.content = String(data: lxMessage.content, encoding: .utf8) ?? ""
         self.timestamp = Date(timeIntervalSince1970: lxMessage.timestamp)
         self.isFromMe = lxMessage.sourceHash == localHash
+        self.renderer = MessageRenderer(fields: lxMessage.fields)
 
         // Map LXMessage state to DeliveryStatus
         switch lxMessage.state {
@@ -433,6 +437,7 @@ public struct Message: Identifiable, Equatable {
         // message rendered as received. (localHash is still used below for
         // reaction `includesMe`.)
         self.isFromMe = record.direction == .outbound
+        self.renderer = .plain
         self.storageHash = record.messageId
         if let wireHash = MessageRepository.canonicalHashFromUncertainRetryMarker(record.receivingInterface) {
             self.messageHash = wireHash
@@ -506,6 +511,7 @@ public struct Message: Identifiable, Equatable {
         // they were on the wire. See `MessageRecord.packedLxmf` for the
         // codec contract.
         if let fields = LxmfFieldCodec.unpack(record.packedLxmf) {
+            self.renderer = MessageRenderer(fields: fields)
             // FIELD_IMAGE (0x06) = [format_string, image_bytes]
             if let imageField = fields[LXMessage.FIELD_IMAGE] as? [Any],
                imageField.count >= 2,

--- a/Sources/ColumbaApp/Views/Messaging/MessageTimelineView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageTimelineView.swift
@@ -80,6 +80,7 @@ struct MessageTimelineView: UIViewControllerRepresentable {
     let onReply: (Message) -> Void
     let onToggleReaction: (Message, String) -> Void
     let onLongPress: (Message) -> Void
+    let onOpenLink: (MessageLinkTarget) -> Void
 
     func makeUIViewController(context: Context) -> MessageTimelineViewController {
         let controller = MessageTimelineViewController()
@@ -88,6 +89,7 @@ struct MessageTimelineView: UIViewControllerRepresentable {
         controller.onReply = onReply
         controller.onToggleReaction = onToggleReaction
         controller.onLongPress = onLongPress
+        controller.onOpenLink = onOpenLink
         return controller
     }
 
@@ -96,6 +98,7 @@ struct MessageTimelineView: UIViewControllerRepresentable {
         controller.onReply = onReply
         controller.onToggleReaction = onToggleReaction
         controller.onLongPress = onLongPress
+        controller.onOpenLink = onOpenLink
         controller.update(
             messages: messages,
             messageTextScale: messageTextScale,
@@ -111,6 +114,7 @@ final class MessageTimelineViewController: UIViewController, UICollectionViewDat
     var onReply: ((Message) -> Void)?
     var onToggleReaction: ((Message, String) -> Void)?
     var onLongPress: ((Message) -> Void)?
+    var onOpenLink: ((MessageLinkTarget) -> Void)?
 
     private var messages: [Message] = []
     fileprivate var messageTextScale = SettingsRepository.MessageTextScale.defaultValue
@@ -277,6 +281,9 @@ final class MessageTimelineViewController: UIViewController, UICollectionViewDat
                     },
                     onLongPress: { [weak self] in
                         self?.onLongPress?(message)
+                    },
+                    onOpenLink: { [weak self] target in
+                        self?.onOpenLink?(target)
                     }
                 )
             }

--- a/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
@@ -72,6 +72,7 @@ struct MessagingView: View {
     @State private var callUnavailableMessage: String?
     @State private var showTextSizePicker = false
     @State private var messageTextScale = SettingsRepository.MessageTextScale.defaultValue
+    @State private var nomadNetLinkTarget: MessageLinkTarget?
     @Environment(\.dismiss) private var dismiss
 
     // MARK: - Body
@@ -109,7 +110,8 @@ struct MessagingView: View {
                         withAnimation(.easeInOut(duration: 0.2)) {
                             reactionModeMessage = message
                         }
-                    }
+                    },
+                    onOpenLink: openMessageLink
                 )
                 .safeAreaInset(edge: .bottom, spacing: 0) {
                     MessageInputBar(
@@ -205,7 +207,8 @@ struct MessagingView: View {
                                             withAnimation(.easeInOut(duration: 0.2)) {
                                                 reactionModeMessage = message
                                             }
-                                        }
+                                        },
+                                        onOpenLink: openMessageLink
                                     )
                                 }
                                 .id(message.id)
@@ -419,6 +422,9 @@ struct MessagingView: View {
             }
         }
         #endif
+        .navigationDestination(item: $nomadNetLinkTarget) { target in
+            nomadNetDestination(for: target)
+        }
         .sheet(isPresented: $showQualityPicker) {
             ImageQualityPickerSheet(
                 selectedPreset: $selectedImagePreset,
@@ -685,6 +691,41 @@ struct MessagingView: View {
     }
 
     // MARK: - Actions
+
+    private func openMessageLink(_ target: MessageLinkTarget) {
+        guard case .nomadNet = target else { return }
+        nomadNetLinkTarget = target
+    }
+
+    @ViewBuilder
+    private func nomadNetDestination(for target: MessageLinkTarget) -> some View {
+        if case .nomadNet(let nodeHash, let path) = target {
+            #if COLUMBA_NOMADNET_ENABLED
+            if let backend = appServices.backend,
+               let identity = appServices.identity {
+                NomadNetBrowserView(
+                    nodeHash: nodeHash,
+                    nodeName: nil,
+                    initialPath: path,
+                    backend: backend,
+                    identity: identity
+                )
+            } else {
+                ContentUnavailableView(
+                    "Browser Unavailable",
+                    systemImage: "globe",
+                    description: Text("The Reticulum backend is not ready.")
+                )
+            }
+            #else
+            ContentUnavailableView(
+                "Browser Unavailable",
+                systemImage: "globe",
+                description: Text("NomadNet support is not enabled in this build.")
+            )
+            #endif
+        }
+    }
 
     private func sendMessage() {
         let text = messageText.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/ColumbaApp/Views/NomadNet/NomadNetBrowserView.swift
+++ b/Sources/ColumbaApp/Views/NomadNet/NomadNetBrowserView.swift
@@ -7,10 +7,17 @@ import RNSAPI
 struct NomadNetBrowserView: View {
     @State private var viewModel: NomadNetBrowserViewModel
 
-    init(nodeHash: Data, nodeName: String?, backend: any RnsBackend, identity: Identity) {
+    init(
+        nodeHash: Data,
+        nodeName: String?,
+        initialPath: String = "/page/index.mu",
+        backend: any RnsBackend,
+        identity: Identity
+    ) {
         _viewModel = State(initialValue: NomadNetBrowserViewModel(
             nodeHash: nodeHash,
             nodeName: nodeName,
+            initialPath: initialPath,
             backend: backend,
             identity: identity
         ))

--- a/Sources/RNSAPI/Util/LxmfFields.swift
+++ b/Sources/RNSAPI/Util/LxmfFields.swift
@@ -41,6 +41,12 @@ public enum LxmfFields {
     public static let FIELD_AUDIO: UInt8 = 0x07
     /// Command structures (Sideband telemetry-request RPCs).
     public static let FIELD_COMMANDS: UInt8 = 0x09
+    /// Optional content renderer indication from upstream LXMF.
+    public static let FIELD_RENDERER: UInt8 = 0x0F
+    public static let RENDERER_PLAIN = 0x00
+    public static let RENDERER_MICRON = 0x01
+    public static let RENDERER_MARKDOWN = 0x02
+    public static let RENDERER_BBCODE = 0x03
 
     /// Canonical tap-back reaction — `fields[0x40] = {0x00: targetHashBytes,
     /// 0x01: emojiUTF8Bytes}` (standardised upstream in LXMF.py). The reacting
@@ -67,4 +73,50 @@ public enum LxmfFields {
     /// Sideband-compatible `FIELD_TELEMETRY` location share here. (Replaces the
     /// previously-invented 0x70, matching Android's migration.)
     public static let FIELD_CUSTOM_META: UInt8 = 0xFD
+}
+
+/// The message-body presentation Columba currently supports.
+///
+/// Unsupported, absent, and malformed renderer indications deliberately fail
+/// closed to plaintext. Markdown is selected only by an integer wire value 2.
+public enum MessageRenderer: Equatable, Sendable {
+    case plain
+    case markdown
+
+    public init(fields: [UInt8: Any]?) {
+        guard let rawValue = fields?[LxmfFields.FIELD_RENDERER] else {
+            self = .plain
+            return
+        }
+
+        let rendererValue: UInt64?
+        switch rawValue {
+        case let value as Int where value >= 0:
+            rendererValue = UInt64(value)
+        case let value as Int8 where value >= 0:
+            rendererValue = UInt64(value)
+        case let value as Int16 where value >= 0:
+            rendererValue = UInt64(value)
+        case let value as Int32 where value >= 0:
+            rendererValue = UInt64(value)
+        case let value as Int64 where value >= 0:
+            rendererValue = UInt64(value)
+        case let value as UInt:
+            rendererValue = UInt64(value)
+        case let value as UInt8:
+            rendererValue = UInt64(value)
+        case let value as UInt16:
+            rendererValue = UInt64(value)
+        case let value as UInt32:
+            rendererValue = UInt64(value)
+        case let value as UInt64:
+            rendererValue = value
+        default:
+            rendererValue = nil
+        }
+
+        self = rendererValue == UInt64(LxmfFields.RENDERER_MARKDOWN)
+            ? .markdown
+            : .plain
+    }
 }

--- a/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
+++ b/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
@@ -145,6 +145,63 @@ final class MessageBubbleLayoutTests: XCTestCase {
     }
 
     @MainActor
+    func testMarkdownAndPlaintextMessageRenderingProducesVisualEvidence() throws {
+        let markdown = """
+        # Markdown message
+
+        This is **bold**, *emphasized*, and ~~removed~~ text with `inline code`.
+
+        - First item
+        - Second item
+
+        > Authenticated Markdown renderer field
+
+        [HTTPS link](https://example.com/docs) and [NomadNet page](nomadnetwork://9ce92808be498e9e05590ff27cbfdfe4:/page/index.mu)
+
+        ![remote tracking image](https://tracking.example/pixel.png)
+
+        <script>alert('inert')</script>
+        """
+        let messages = [
+            Message(
+                content: markdown,
+                timestamp: Date(),
+                isFromMe: false,
+                deliveryStatus: .delivered,
+                renderer: .markdown
+            ),
+            Message(
+                content: "Plaintext gate: **not bold** https://example.com/docs",
+                timestamp: Date(),
+                isFromMe: true,
+                deliveryStatus: .delivered,
+                renderer: .plain
+            ),
+        ]
+        let view = VStack(spacing: 16) {
+            ForEach(messages) { message in
+                MessageBubble(message: message, onOpenLink: { _ in })
+            }
+        }
+        .frame(width: 390)
+        .padding(.vertical, 20)
+        .background(Color.black)
+        let host = UIHostingController(rootView: view)
+        let fitted = host.sizeThatFits(in: CGSize(width: 390, height: 2_000))
+
+        XCTAssertGreaterThan(fitted.height, 300)
+        XCTAssertLessThan(fitted.height, 1_500)
+
+        let renderer = ImageRenderer(content: view)
+        renderer.scale = 3
+        let image = try XCTUnwrap(renderer.uiImage)
+        let screenshot = XCTAttachment(image: image)
+        screenshot.name = "markdown-and-plaintext-message-bubbles"
+        screenshot.lifetime = .keepAlways
+        add(screenshot)
+    }
+
+    @MainActor
     func testMessageTextScaleChangesRenderedBodyHeight() throws {
         let message = Message(
             content: "A longer message body that wraps across multiple lines so the selected conversation text size has a measurable effect on the rendered bubble height.",

--- a/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
+++ b/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
@@ -151,6 +151,16 @@ final class MessageBubbleLayoutTests: XCTestCase {
 
         This is **bold**, *emphasized*, and ~~removed~~ text with `inline code`.
 
+        ```swift
+        struct Peer {
+            let name: String
+            let isReachable: Bool
+        }
+
+        let peer = Peer(name: "Columba", isReachable: true)
+        print(peer.name)
+        ```
+
         - First item
         - Second item
 

--- a/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
+++ b/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
@@ -165,7 +165,7 @@ final class MessageBubbleLayoutTests: XCTestCase {
 
         let peer = Peer(name: "Columba", isReachable: true)
         print(peer.name)
-        let routeDescription = peers.filter { $0.isReachable }.map { "\($0.name):authenticated-reticulum-route" }.joined(separator: " -> ")
+        let routeDescription = peers.filter { $0.isReachable }.map { "\\($0.name):authenticated-reticulum-route" }.joined(separator: " -> ")
         ```
 
         - First item

--- a/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
+++ b/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
@@ -99,6 +99,12 @@ final class MessageRendererMappingTests: XCTestCase {
 
 final class MessageBubbleLayoutTests: XCTestCase {
 
+    private func descendants<T: UIView>(of type: T.Type, in root: UIView) -> [T] {
+        root.subviews.flatMap { subview in
+            (subview as? T).map { [$0] } ?? [] + descendants(of: type, in: subview)
+        }
+    }
+
     private func visibleContentBounds(in image: UIImage) throws -> CGRect {
         let cgImage = try XCTUnwrap(image.cgImage)
         let width = cgImage.width
@@ -159,6 +165,7 @@ final class MessageBubbleLayoutTests: XCTestCase {
 
         let peer = Peer(name: "Columba", isReachable: true)
         print(peer.name)
+        let routeDescription = peers.filter { $0.isReachable }.map { "\($0.name):authenticated-reticulum-route" }.joined(separator: " -> ")
         ```
 
         - First item
@@ -197,18 +204,30 @@ final class MessageBubbleLayoutTests: XCTestCase {
         .padding(.vertical, 20)
         .background(Color.black)
         let host = UIHostingController(rootView: view)
-        let fitted = host.sizeThatFits(in: CGSize(width: 390, height: 2_000))
+        let initialSize = CGSize(width: 390, height: 2_000)
+        let window = UIWindow(frame: CGRect(origin: .zero, size: initialSize))
+        window.rootViewController = host
+        window.makeKeyAndVisible()
+        defer { window.isHidden = true }
+        host.view.frame = CGRect(origin: .zero, size: initialSize)
+        host.view.layoutIfNeeded()
+        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
 
+        let fitted = host.sizeThatFits(in: initialSize)
         XCTAssertGreaterThan(fitted.height, 300)
         XCTAssertLessThan(fitted.height, 1_500)
 
         let size = CGSize(width: 390, height: ceil(fitted.height))
-        let window = UIWindow(frame: CGRect(origin: .zero, size: size))
-        window.rootViewController = host
-        window.makeKeyAndVisible()
-        defer { window.isHidden = true }
+        window.frame = CGRect(origin: .zero, size: size)
         host.view.frame = CGRect(origin: .zero, size: size)
         host.view.layoutIfNeeded()
+
+        let horizontallyScrollableCodeBlocks = descendants(of: UIScrollView.self, in: host.view)
+            .filter { $0.contentSize.width > $0.bounds.width + 1 }
+        XCTAssertFalse(
+            horizontallyScrollableCodeBlocks.isEmpty,
+            "A code block with one long line must have horizontal scrollable overflow"
+        )
 
         let image = UIGraphicsImageRenderer(size: size).image { _ in
             host.view.drawHierarchy(in: host.view.bounds, afterScreenUpdates: true)

--- a/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
+++ b/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import UIKit
 import XCTest
+import RNSAPI
 @testable import ColumbaApp
 
 final class MessageLinkParserTests: XCTestCase {

--- a/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
+++ b/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
@@ -41,6 +41,22 @@ final class MessageLinkParserTests: XCTestCase {
     func testBareHashWithoutNomadNetPathIsNotLinkified() {
         XCTAssertTrue(MessageLinkParser.matches(in: "identity \(nodeHash)").isEmpty)
     }
+
+    func testInlineMarkdownImagesAreRejectedWithoutLoading() async {
+        let provider = BlockedMarkdownInlineImageProvider()
+
+        do {
+            _ = try await provider.image(
+                with: URL(string: "https://tracking.example/pixel.png")!,
+                label: "tracking pixel"
+            )
+            XCTFail("Expected remote Markdown image to be blocked")
+        } catch is BlockedMarkdownInlineImageProvider.Blocked {
+            // Expected: the provider performs no network operation.
+        } catch {
+            XCTFail("Unexpected image-provider error: \(error)")
+        }
+    }
 }
 
 final class MessageRendererMappingTests: XCTestCase {

--- a/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
+++ b/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
@@ -42,6 +42,44 @@ final class MessageLinkParserTests: XCTestCase {
     }
 }
 
+final class MessageRendererMappingTests: XCTestCase {
+    func testLiveMessageCarriesAuthenticatedMarkdownRenderer() {
+        let lxMessage = LXMessage(
+            destinationHash: Data(repeating: 0x01, count: 16),
+            sourceIdentity: nil,
+            content: Data("**rendered**".utf8),
+            fields: [LxmfFields.FIELD_RENDERER: LxmfFields.RENDERER_MARKDOWN]
+        )
+        lxMessage.hash = Data(repeating: 0x02, count: 32)
+
+        XCTAssertEqual(
+            Message(from: lxMessage, localHash: Data()).renderer,
+            .markdown
+        )
+    }
+
+    func testPersistedMessageRestoresMarkdownRenderer() {
+        let fields: [UInt8: Any] = [
+            LxmfFields.FIELD_RENDERER: LxmfFields.RENDERER_MARKDOWN,
+        ]
+        let record = MessageRecord(
+            id: Data(repeating: 0x03, count: 32),
+            conversationHash: Data(repeating: 0x04, count: 16),
+            content: Data("# Restored".utf8),
+            timestamp: 1,
+            direction: .inbound,
+            state: LXMessageState.received.rawValue,
+            messageId: Data(repeating: 0x03, count: 32),
+            packedLxmf: LxmfFieldCodec.pack(fields)
+        )
+
+        XCTAssertEqual(
+            Message(from: record, localHash: Data()).renderer,
+            .markdown
+        )
+    }
+}
+
 final class MessageBubbleLayoutTests: XCTestCase {
 
     private func visibleContentBounds(in image: UIImage) throws -> CGRect {

--- a/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
+++ b/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
@@ -202,9 +202,17 @@ final class MessageBubbleLayoutTests: XCTestCase {
         XCTAssertGreaterThan(fitted.height, 300)
         XCTAssertLessThan(fitted.height, 1_500)
 
-        let renderer = ImageRenderer(content: view)
-        renderer.scale = 3
-        let image = try XCTUnwrap(renderer.uiImage)
+        let size = CGSize(width: 390, height: ceil(fitted.height))
+        let window = UIWindow(frame: CGRect(origin: .zero, size: size))
+        window.rootViewController = host
+        window.makeKeyAndVisible()
+        defer { window.isHidden = true }
+        host.view.frame = CGRect(origin: .zero, size: size)
+        host.view.layoutIfNeeded()
+
+        let image = UIGraphicsImageRenderer(size: size).image { _ in
+            host.view.drawHierarchy(in: host.view.bounds, afterScreenUpdates: true)
+        }
         let screenshot = XCTAttachment(image: image)
         screenshot.name = "markdown-and-plaintext-message-bubbles"
         screenshot.lifetime = .keepAlways

--- a/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
+++ b/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
@@ -3,6 +3,45 @@ import UIKit
 import XCTest
 @testable import ColumbaApp
 
+final class MessageLinkParserTests: XCTestCase {
+    private let nodeHash = "9ce92808be498e9e05590ff27cbfdfe4"
+
+    func testPlaintextDetectsWebAndBareNomadNetLinksWithoutTrailingPunctuation() {
+        let text = "Open https://example.com/docs, then \(nodeHash):/page/index.mu."
+        let matches = MessageLinkParser.matches(in: text)
+
+        XCTAssertEqual(matches.map(\.text), [
+            "https://example.com/docs",
+            "\(nodeHash):/page/index.mu",
+        ])
+        XCTAssertEqual(matches.map(\.target), [
+            .web(URL(string: "https://example.com/docs")!),
+            .nomadNet(nodeHash: Data(hexString: nodeHash)!, path: "/page/index.mu"),
+        ])
+    }
+
+    func testMarkdownLinkTargetsAllowOnlySupportedSchemes() {
+        XCTAssertEqual(
+            MessageLinkParser.target(for: URL(string: "https://example.com")!),
+            .web(URL(string: "https://example.com")!)
+        )
+        XCTAssertEqual(
+            MessageLinkParser.target(for: URL(string: "nomadnetwork://\(nodeHash):/page/index.mu")!),
+            .nomadNet(nodeHash: Data(hexString: nodeHash)!, path: "/page/index.mu")
+        )
+        XCTAssertNotNil(
+            MessageLinkParser.target(for: URL(string: "lxma://contact?destination=abc")!)
+        )
+        XCTAssertNil(MessageLinkParser.target(for: URL(string: "file:///tmp/private")!))
+        XCTAssertNil(MessageLinkParser.target(for: URL(string: "javascript:alert(1)")!))
+        XCTAssertNil(MessageLinkParser.target(for: URL(string: "data:text/plain,secret")!))
+    }
+
+    func testBareHashWithoutNomadNetPathIsNotLinkified() {
+        XCTAssertTrue(MessageLinkParser.matches(in: "identity \(nodeHash)").isEmpty)
+    }
+}
+
 final class MessageBubbleLayoutTests: XCTestCase {
 
     private func visibleContentBounds(in image: UIImage) throws -> CGRect {

--- a/Tests/RNSAPITests/MessageRendererTests.swift
+++ b/Tests/RNSAPITests/MessageRendererTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+@testable import RNSAPI
+
+final class MessageRendererTests: XCTestCase {
+    func testMarkdownRequiresExactIntegerRendererField() {
+        XCTAssertEqual(
+            MessageRenderer(fields: [LxmfFields.FIELD_RENDERER: 2]),
+            .markdown
+        )
+    }
+
+    func testUnsupportedOrMalformedRendererValuesRemainPlaintext() {
+        let cases: [[UInt8: Any]?] = [
+            nil,
+            [:],
+            [LxmfFields.FIELD_RENDERER: 0],
+            [LxmfFields.FIELD_RENDERER: 1],
+            [LxmfFields.FIELD_RENDERER: 3],
+            [LxmfFields.FIELD_RENDERER: 99],
+            [LxmfFields.FIELD_RENDERER: "2"],
+            [LxmfFields.FIELD_RENDERER: 2.0],
+            [LxmfFields.FIELD_RENDERER: true],
+            [LxmfFields.FIELD_RENDERER: Data([2])],
+        ]
+
+        for fields in cases {
+            XCTAssertEqual(MessageRenderer(fields: fields), .plain)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- render received LXMF Markdown only when authenticated field `0x0F` contains the exact integer renderer value `0x02`
- preserve plaintext for missing, malformed, unsupported, or non-integer renderer indications across live delivery and database reload
- add safe HTTP/S and NomadNet links to Markdown and plaintext message bubbles, with NomadNet pages routed inside Columba
- block remote Markdown images and unsafe URL schemes while keeping raw HTML inert
- add compact chat-bubble Markdown styling, Swift syntax highlighting, and horizontally scrollable code blocks
- pin MarkdownUI 2.4.1 and Splash 0.16.0 without raising the iOS 17 deployment target

## Verification

- `swift test --filter MessageRendererTests` - 2 passed
- full `ColumbaAppTests` on iPhone 17 simulator - 197 passed
- full `ColumbaModelBAppTests` compatibility suite - 21 passed
- static CI contract suite - 92 passed
- shipping and Model B simulator builds succeeded
- Xcode package graph and exact resolved dependency pins verified
- visual XCTest evidence reviewed for Markdown/plaintext gating, link contrast, blocked images, inert HTML, inline code, syntax-highlighted block code, and horizontal overflow

## Risk and rollback

The behavior is receive-only and fails closed to plaintext. Removing the new package products and `MessageBody` integration restores the previous plaintext-only presentation.

Fixes #136
Fixes #141
