### PR TITLE
Persist conversation drafts

### DIFF
--- a/Columba.xcodeproj/project.pbxproj
+++ b/Columba.xcodeproj/project.pbxproj
@@ -251,6 +251,8 @@
 		AC4014BF281AD8BE6FF9E852 /* PeerChildInterfaceRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8A2F8952F6F036C94824552 /* PeerChildInterfaceRegistry.swift */; };
 		ACT02 /* AnnounceClassificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACT01 /* AnnounceClassificationTests.swift */; };
 		DRAFT002 /* DraftMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DRAFT001 /* DraftMessageTests.swift */; };
+		DA143A000000000000000002 /* DraftAutosaveController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA143A000000000000000001 /* DraftAutosaveController.swift */; };
+		DA143A000000000000000003 /* DraftAutosaveController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA143A000000000000000001 /* DraftAutosaveController.swift */; };
 		ADABD423CE22B9E00BC5D7F3 /* BackendPreference.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2569A3C1BFBFDD77F7E639 /* BackendPreference.swift */; };
 		AF0B30F4F05BB35FCC50D99F /* ChatsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F008 /* ChatsView.swift */; };
 		AF6FBB2A1A52C48C0FF27494 /* JetBrainsMono-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = E4AB432DD1264CAE1F35B22A /* JetBrainsMono-Regular.ttf */; };
@@ -440,6 +442,7 @@
 		ACA6D4C7151A87D862FF9B8A /* CodecProfileInfo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CodecProfileInfo.swift; sourceTree = "<group>"; };
 		ACT01 /* AnnounceClassificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnounceClassificationTests.swift; sourceTree = "<group>"; };
 		DRAFT001 /* DraftMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftMessageTests.swift; sourceTree = "<group>"; };
+		DA143A000000000000000001 /* DraftAutosaveController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftAutosaveController.swift; sourceTree = "<group>"; };
 		AD87870C760723D7E77C87E9 /* TCPClientWizardViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TCPClientWizardViewModel.swift; sourceTree = "<group>"; };
 		AGBF /* AppGroupBridgeInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppGroupBridgeInterface.swift; sourceTree = "<group>"; };
 		AGPF /* AppGroupPaths.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppGroupPaths.swift; sourceTree = "<group>"; };
@@ -1065,6 +1068,7 @@
 				F003 /* ChatsViewModel.swift */,
 				F004 /* ContactsViewModel.swift */,
 				F005 /* MessagingViewModel.swift */,
+				DA143A000000000000000001 /* DraftAutosaveController.swift */,
 				F006 /* SettingsViewModel.swift */,
 				F030 /* InterfaceManagementViewModel.swift */,
 				F034 /* NetworkStatusViewModel.swift */,
@@ -1383,6 +1387,7 @@
 				89551A07A2FB8693E6C465FC /* ChatsViewModel.swift in Sources */,
 				35AAE3A0AE037F5B9305CFC1 /* ContactsViewModel.swift in Sources */,
 				3B33F02402537B1825B64EEC /* MessagingViewModel.swift in Sources */,
+				DA143A000000000000000003 /* DraftAutosaveController.swift in Sources */,
 				9673457897893BF9DE512A0F /* SettingsViewModel.swift in Sources */,
 				B71F90BE936BAF660BA0821B /* MainTabView.swift in Sources */,
 				AF0B30F4F05BB35FCC50D99F /* ChatsView.swift in Sources */,
@@ -1564,6 +1569,7 @@
 				003 /* ChatsViewModel.swift in Sources */,
 				004 /* ContactsViewModel.swift in Sources */,
 				005 /* MessagingViewModel.swift in Sources */,
+				DA143A000000000000000002 /* DraftAutosaveController.swift in Sources */,
 				006 /* SettingsViewModel.swift in Sources */,
 				007 /* MainTabView.swift in Sources */,
 				008 /* ChatsView.swift in Sources */,

--- a/Columba.xcodeproj/project.pbxproj
+++ b/Columba.xcodeproj/project.pbxproj
@@ -250,6 +250,7 @@
 		AA9D3715FB399E675BD53B41 /* PythonConfigWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBA4F8C4C9008A06DFF5AC8A /* PythonConfigWriter.swift */; };
 		AC4014BF281AD8BE6FF9E852 /* PeerChildInterfaceRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8A2F8952F6F036C94824552 /* PeerChildInterfaceRegistry.swift */; };
 		ACT02 /* AnnounceClassificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACT01 /* AnnounceClassificationTests.swift */; };
+		DRAFT002 /* DraftMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DRAFT001 /* DraftMessageTests.swift */; };
 		ADABD423CE22B9E00BC5D7F3 /* BackendPreference.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2569A3C1BFBFDD77F7E639 /* BackendPreference.swift */; };
 		AF0B30F4F05BB35FCC50D99F /* ChatsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F008 /* ChatsView.swift */; };
 		AF6FBB2A1A52C48C0FF27494 /* JetBrainsMono-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = E4AB432DD1264CAE1F35B22A /* JetBrainsMono-Regular.ttf */; };
@@ -438,6 +439,7 @@
 		A8A2F8952F6F036C94824552 /* PeerChildInterfaceRegistry.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PeerChildInterfaceRegistry.swift; sourceTree = "<group>"; };
 		ACA6D4C7151A87D862FF9B8A /* CodecProfileInfo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CodecProfileInfo.swift; sourceTree = "<group>"; };
 		ACT01 /* AnnounceClassificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnounceClassificationTests.swift; sourceTree = "<group>"; };
+		DRAFT001 /* DraftMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftMessageTests.swift; sourceTree = "<group>"; };
 		AD87870C760723D7E77C87E9 /* TCPClientWizardViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TCPClientWizardViewModel.swift; sourceTree = "<group>"; };
 		AGBF /* AppGroupBridgeInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppGroupBridgeInterface.swift; sourceTree = "<group>"; };
 		AGPF /* AppGroupPaths.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppGroupPaths.swift; sourceTree = "<group>"; };
@@ -1018,6 +1020,7 @@
 				BC4EF2D71A3D88C71D5BEDAD /* MessageFormattedTimeTests.swift */,
 				A1B2C3D4E5F60718293A4B5D /* MessageBubbleLayoutTests.swift */,
 				ACT01 /* AnnounceClassificationTests.swift */,
+				DRAFT001 /* DraftMessageTests.swift */,
 				EA0AA6C472B1D4EFA2896086 /* RNodeSeamTests.swift */,
 				853F1E1C2B6E5305277FCB2A /* MigrationRoundTripTests.swift */,
 				B1C2D3E4F5061728394A5B6C /* IncomingMessageSizeLimitTests.swift */,
@@ -1695,6 +1698,7 @@
 				9566DCEF56FEFC97BAAA47BA /* MessageFormattedTimeTests.swift in Sources */,
 				A1B2C3D4E5F60718293A4B5E /* MessageBubbleLayoutTests.swift in Sources */,
 				ACT02 /* AnnounceClassificationTests.swift in Sources */,
+				DRAFT002 /* DraftMessageTests.swift in Sources */,
 				0FF6A5C5596A39C092AADA29 /* MigrationRoundTripTests.swift in Sources */,
 				A1B2C3D4E5F60718293A4B5C /* IncomingMessageSizeLimitTests.swift in Sources */,
 				26D564FAEE8E3C750E8E2442 /* PythonConfigWriterTests.swift in Sources */,

--- a/Sources/ColumbaApp/Services/MessageRepository.swift
+++ b/Sources/ColumbaApp/Services/MessageRepository.swift
@@ -234,8 +234,20 @@ public actor MessageRepository {
 
     /// Delete a conversation, its messages, and its app-owned draft.
     public func deleteConversation(_ conversationHash: Data) async throws {
+        try await deleteConversation(conversationHash, afterCanonicalDelete: nil)
+    }
+
+    /// Internal deterministic seam for coordinating work after the canonical
+    /// deletion commits. Production passes no hook and does not suspend here.
+    func deleteConversation(
+        _ conversationHash: Data,
+        afterCanonicalDelete: (@Sendable () async -> Void)?
+    ) async throws {
         try await database.deleteConversation(hash: conversationHash)
-        try clearDraftAndNotify(for: conversationHash)
+        if let afterCanonicalDelete {
+            await afterCanonicalDelete()
+        }
+        try clearOrphanedDraftAndNotify(for: conversationHash)
     }
 
     /// Delete a single message by its ID hash.
@@ -316,6 +328,30 @@ public actor MessageRepository {
             try db.execute(
                 sql: "DELETE FROM columba_drafts WHERE conversation_hash = ?",
                 arguments: [conversationHash]
+            )
+            return db.changesCount > 0
+        }
+        if deleted {
+            postDraftChanged(for: conversationHash)
+        }
+    }
+
+    /// Delete only a draft that is still orphaned after canonical deletion.
+    /// The parent check and deletion share one SQLite statement, so recreation
+    /// and cleanup serialize in commit order across repository instances.
+    private func clearOrphanedDraftAndNotify(for conversationHash: Data) throws {
+        let deleted = try Self.writeDraftSynchronously(to: replacementPool) { db in
+            try db.execute(
+                sql: """
+                    DELETE FROM columba_drafts
+                    WHERE conversation_hash = ?
+                      AND NOT EXISTS (
+                          SELECT 1
+                          FROM conversations
+                          WHERE destination_hash = ?
+                      )
+                    """,
+                arguments: [conversationHash, conversationHash]
             )
             return db.changesCount > 0
         }

--- a/Sources/ColumbaApp/Services/MessageRepository.swift
+++ b/Sources/ColumbaApp/Services/MessageRepository.swift
@@ -186,11 +186,14 @@ public actor MessageRepository {
     /// Nonblank content is persisted exactly as provided.
     public func saveDraft(_ content: String, for conversationHash: Data) async throws {
         if content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            try await clearDraft(for: conversationHash)
+            try clearDraftAndNotify(for: conversationHash)
             return
         }
 
-        try await replacementPool.write { db in
+        // Keep the commit and its notification in one actor-isolated synchronous
+        // operation. Awaiting GRDB here would allow another draft mutation to
+        // commit before this mutation posts its notification.
+        try replacementPool.write { db in
             try db.execute(
                 sql: """
                     INSERT INTO columba_drafts (conversation_hash, content, updated_at)
@@ -236,7 +239,11 @@ public actor MessageRepository {
 
     /// Clear the draft for one conversation.
     public func clearDraft(for conversationHash: Data) async throws {
-        let deleted = try await replacementPool.write { db in
+        try clearDraftAndNotify(for: conversationHash)
+    }
+
+    private func clearDraftAndNotify(for conversationHash: Data) throws {
+        let deleted = try replacementPool.write { db in
             try db.execute(
                 sql: "DELETE FROM columba_drafts WHERE conversation_hash = ?",
                 arguments: [conversationHash]

--- a/Sources/ColumbaApp/Services/MessageRepository.swift
+++ b/Sources/ColumbaApp/Services/MessageRepository.swift
@@ -194,7 +194,7 @@ public actor MessageRepository {
         // synchronous operation. This is a single atomic SQLite statement;
         // awaiting GRDB here would allow another draft mutation to commit before
         // this mutation posts its notification.
-        try replacementPool.writeWithoutTransaction { db in
+        try Self.writeDraftSynchronously(to: replacementPool) { db in
             try db.execute(
                 sql: """
                     INSERT INTO columba_drafts (conversation_hash, content, updated_at)
@@ -244,7 +244,7 @@ public actor MessageRepository {
     }
 
     private func clearDraftAndNotify(for conversationHash: Data) throws {
-        let deleted = try replacementPool.writeWithoutTransaction { db in
+        let deleted = try Self.writeDraftSynchronously(to: replacementPool) { db in
             try db.execute(
                 sql: "DELETE FROM columba_drafts WHERE conversation_hash = ?",
                 arguments: [conversationHash]
@@ -254,6 +254,15 @@ public actor MessageRepository {
         if deleted {
             postDraftChanged(for: conversationHash)
         }
+    }
+
+    /// Resolves GRDB's sync/async overload in a synchronous context so draft
+    /// mutations cannot suspend and re-enter this actor before notification.
+    private static func writeDraftSynchronously<T>(
+        to pool: DatabasePool,
+        _ updates: (Database) throws -> T
+    ) rethrows -> T {
+        try pool.writeWithoutTransaction(updates)
     }
 
     private static func mapDraft(_ row: Row) -> DraftRecord {

--- a/Sources/ColumbaApp/Services/MessageRepository.swift
+++ b/Sources/ColumbaApp/Services/MessageRepository.swift
@@ -33,6 +33,18 @@ import RNSAPI
 import LXMFSwift
 import GRDB
 
+public struct DraftRecord: Equatable, Sendable {
+    public let conversationHash: Data
+    public let content: String
+    public let updatedAt: Date
+
+    public init(conversationHash: Data, content: String, updatedAt: Date) {
+        self.conversationHash = conversationHash
+        self.content = content
+        self.updatedAt = updatedAt
+    }
+}
+
 /// Actor for thread-safe message database operations.
 ///
 /// Wraps the GRDB-backed `LXMFSwift.LXMFDatabase` and exposes RNSAPI Compat
@@ -52,6 +64,9 @@ public actor MessageRepository {
     /// Posted after durable conversation metadata changes without a new message.
     public static let conversationMetadataChangedNotification =
         Notification.Name("network.columba.conversationMetadataChanged")
+    /// Posted after an app-owned conversation draft has committed to storage.
+    public static let draftChangedNotification =
+        Notification.Name("network.columba.draftChanged")
 
     public static let conversationHashUserInfoKey = "conversationHash"
     public static let stagedRetryMarker = "columba-app-retry-staged-v1"
@@ -111,6 +126,16 @@ public actor MessageRepository {
             try db.execute(sql: "PRAGMA busy_timeout=5000")
         }
         self.replacementPool = try DatabasePool(path: grdbPath, configuration: config)
+        try self.replacementPool.write { db in
+            try db.execute(sql: """
+                CREATE TABLE IF NOT EXISTS columba_drafts (
+                    conversation_hash BLOB PRIMARY KEY
+                        REFERENCES conversations(destination_hash) ON DELETE CASCADE,
+                    content TEXT NOT NULL,
+                    updated_at DOUBLE NOT NULL
+                )
+                """)
+        }
     }
 
     // MARK: - Conversation Operations
@@ -153,6 +178,93 @@ public actor MessageRepository {
     /// Ensure a conversation exists for a destination.
     public func ensureConversation(_ conversationHash: Data, displayName: String?) async throws {
         try await database.ensureConversation(hash: conversationHash, displayName: displayName)
+    }
+
+    // MARK: - Draft Operations
+
+    /// Atomically save a draft, or clear it when the content is only whitespace.
+    /// Nonblank content is persisted exactly as provided.
+    public func saveDraft(_ content: String, for conversationHash: Data) async throws {
+        if content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            try await clearDraft(for: conversationHash)
+            return
+        }
+
+        try await replacementPool.write { db in
+            try db.execute(
+                sql: """
+                    INSERT INTO columba_drafts (conversation_hash, content, updated_at)
+                    VALUES (?, ?, ?)
+                    ON CONFLICT(conversation_hash) DO UPDATE SET
+                        content = excluded.content,
+                        updated_at = excluded.updated_at
+                    """,
+                arguments: [conversationHash, content, Date().timeIntervalSince1970]
+            )
+        }
+        postDraftChanged(for: conversationHash)
+    }
+
+    /// Fetch the draft for one conversation.
+    public func fetchDraft(for conversationHash: Data) async throws -> DraftRecord? {
+        try await replacementPool.read { db in
+            try Row.fetchOne(
+                db,
+                sql: """
+                    SELECT conversation_hash, content, updated_at
+                    FROM columba_drafts
+                    WHERE conversation_hash = ?
+                    """,
+                arguments: [conversationHash]
+            ).map(Self.mapDraft)
+        }
+    }
+
+    /// Fetch all drafts in most-recently-updated order.
+    public func fetchDrafts() async throws -> [DraftRecord] {
+        try await replacementPool.read { db in
+            try Row.fetchAll(
+                db,
+                sql: """
+                    SELECT conversation_hash, content, updated_at
+                    FROM columba_drafts
+                    ORDER BY updated_at DESC
+                    """
+            ).map(Self.mapDraft)
+        }
+    }
+
+    /// Clear the draft for one conversation.
+    public func clearDraft(for conversationHash: Data) async throws {
+        let deleted = try await replacementPool.write { db in
+            try db.execute(
+                sql: "DELETE FROM columba_drafts WHERE conversation_hash = ?",
+                arguments: [conversationHash]
+            )
+            return db.changesCount > 0
+        }
+        if deleted {
+            postDraftChanged(for: conversationHash)
+        }
+    }
+
+    private static func mapDraft(_ row: Row) -> DraftRecord {
+        let conversationHash: Data = row["conversation_hash"]
+        let content: String = row["content"]
+        let updatedAt: Double = row["updated_at"]
+        return DraftRecord(
+            conversationHash: conversationHash,
+            content: content,
+            updatedAt: Date(timeIntervalSince1970: updatedAt)
+        )
+    }
+
+    private func postDraftChanged(for conversationHash: Data) {
+        NotificationCenter.default.post(
+            name: Self.draftChangedNotification,
+            object: nil,
+            userInfo: [Self.conversationHashUserInfoKey: conversationHash]
+        )
     }
 
     /// Posted after persisted favorite/contact membership changes.

--- a/Sources/ColumbaApp/Services/MessageRepository.swift
+++ b/Sources/ColumbaApp/Services/MessageRepository.swift
@@ -145,6 +145,20 @@ public actor MessageRepository {
         try await database.getConversations(limit: limit, offset: offset).map(Self.mapConversation)
     }
 
+    /// Fetch conversations by their exact destination hashes without applying
+    /// the paginated conversation-list limit.
+    public func fetchConversations(for conversationHashes: [Data]) async throws -> [RNSAPI.ConversationRecord] {
+        var records: [RNSAPI.ConversationRecord] = []
+        var fetchedHashes = Set<Data>()
+
+        for conversationHash in conversationHashes where fetchedHashes.insert(conversationHash).inserted {
+            if let record = try await database.getConversation(hash: conversationHash) {
+                records.append(Self.mapConversation(record))
+            }
+        }
+        return records
+    }
+
     /// Fetch a single conversation by destination hash.
     public func fetchConversation(_ conversationHash: Data) async throws -> RNSAPI.ConversationRecord? {
         try await database.getConversation(hash: conversationHash).map(Self.mapConversation)

--- a/Sources/ColumbaApp/Services/MessageRepository.swift
+++ b/Sources/ColumbaApp/Services/MessageRepository.swift
@@ -129,7 +129,7 @@ public actor MessageRepository {
         try self.replacementPool.write { db in
             try db.execute(sql: """
                 CREATE TABLE IF NOT EXISTS columba_drafts (
-                    conversation_hash BLOB PRIMARY KEY
+                    conversation_hash BLOB PRIMARY KEY NOT NULL
                         REFERENCES conversations(destination_hash) ON DELETE CASCADE,
                     content TEXT NOT NULL,
                     updated_at DOUBLE NOT NULL
@@ -220,17 +220,17 @@ public actor MessageRepository {
         }
     }
 
-    /// Fetch all drafts in most-recently-updated order.
-    public func fetchDrafts() async throws -> [DraftRecord] {
+    /// Fetch all drafts keyed by conversation hash.
+    public func fetchDrafts() async throws -> [Data: DraftRecord] {
         try await replacementPool.read { db in
-            try Row.fetchAll(
+            let drafts = try Row.fetchAll(
                 db,
                 sql: """
                     SELECT conversation_hash, content, updated_at
                     FROM columba_drafts
-                    ORDER BY updated_at DESC
                     """
             ).map(Self.mapDraft)
+            return Dictionary(uniqueKeysWithValues: drafts.map { ($0.conversationHash, $0) })
         }
     }
 

--- a/Sources/ColumbaApp/Services/MessageRepository.swift
+++ b/Sources/ColumbaApp/Services/MessageRepository.swift
@@ -125,6 +125,7 @@ public actor MessageRepository {
         self.database = try LXMFSwift.LXMFDatabase(path: grdbPath, readonly: false)
         var config = Configuration()
         config.defaultTransactionKind = .immediate
+        config.foreignKeysEnabled = true
         config.observesSuspensionNotifications = true
         config.prepareDatabase { db in
             try db.execute(sql: "PRAGMA busy_timeout=5000")
@@ -231,9 +232,10 @@ public actor MessageRepository {
         try await database.setUnreadCount(hash: conversationHash, count: count)
     }
 
-    /// Delete conversation and all its messages (cascades via FK).
+    /// Delete a conversation, its messages, and its app-owned draft.
     public func deleteConversation(_ conversationHash: Data) async throws {
         try await database.deleteConversation(hash: conversationHash)
+        try clearDraftAndNotify(for: conversationHash)
     }
 
     /// Delete a single message by its ID hash.

--- a/Sources/ColumbaApp/Services/MessageRepository.swift
+++ b/Sources/ColumbaApp/Services/MessageRepository.swift
@@ -190,10 +190,11 @@ public actor MessageRepository {
             return
         }
 
-        // Keep the commit and its notification in one actor-isolated synchronous
-        // operation. Awaiting GRDB here would allow another draft mutation to
-        // commit before this mutation posts its notification.
-        try replacementPool.write { db in
+        // Keep the mutation and its notification in one actor-isolated
+        // synchronous operation. This is a single atomic SQLite statement;
+        // awaiting GRDB here would allow another draft mutation to commit before
+        // this mutation posts its notification.
+        try replacementPool.writeWithoutTransaction { db in
             try db.execute(
                 sql: """
                     INSERT INTO columba_drafts (conversation_hash, content, updated_at)
@@ -243,7 +244,7 @@ public actor MessageRepository {
     }
 
     private func clearDraftAndNotify(for conversationHash: Data) throws {
-        let deleted = try replacementPool.write { db in
+        let deleted = try replacementPool.writeWithoutTransaction { db in
             try db.execute(
                 sql: "DELETE FROM columba_drafts WHERE conversation_hash = ?",
                 arguments: [conversationHash]

--- a/Sources/ColumbaApp/Services/MessageRepository.swift
+++ b/Sources/ColumbaApp/Services/MessageRepository.swift
@@ -51,6 +51,10 @@ public struct DraftRecord: Equatable, Sendable {
 /// types so the existing ViewModels compile unchanged. All operations are
 /// serialized through the underlying GRDB actor.
 public actor MessageRepository {
+    /// Keep set queries comfortably below SQLite's commonly configured bind
+    /// variable limit while still avoiding one read per conversation.
+    private static let conversationQueryChunkSize = 500
+
     /// Posted after a conversation's unread count has been cleared in the
     /// canonical store. The chats list uses this to clear its in-memory badge
     /// while a conversation is open.
@@ -148,20 +152,68 @@ public actor MessageRepository {
     /// Fetch conversations by their exact destination hashes without applying
     /// the paginated conversation-list limit.
     public func fetchConversations(for conversationHashes: [Data]) async throws -> [RNSAPI.ConversationRecord] {
-        var records: [RNSAPI.ConversationRecord] = []
-        var fetchedHashes = Set<Data>()
+        let hashes = Self.sortedUniqueHashes(conversationHashes)
+        guard !hashes.isEmpty else { return [] }
 
-        for conversationHash in conversationHashes where fetchedHashes.insert(conversationHash).inserted {
-            if let record = try await database.getConversation(hash: conversationHash) {
-                records.append(Self.mapConversation(record))
+        return try await replacementPool.read { db in
+            var records: [LXMFSwift.ConversationRecord] = []
+            for start in stride(from: 0, to: hashes.count, by: Self.conversationQueryChunkSize) {
+                let end = min(start + Self.conversationQueryChunkSize, hashes.count)
+                let chunk = Array(hashes[start..<end])
+                let placeholders = Array(repeating: "?", count: chunk.count).joined(separator: ", ")
+                records += try LXMFSwift.ConversationRecord.fetchAll(
+                    db,
+                    sql: """
+                        SELECT *
+                        FROM conversations
+                        WHERE destination_hash IN (\(placeholders))
+                        ORDER BY destination_hash
+                        """,
+                    arguments: StatementArguments(chunk)
+                )
             }
+            return records.map(Self.mapConversation)
         }
-        return records
+    }
+
+    /// Return the requested conversation hashes that have at least one row in
+    /// the canonical messages table. Message preview text cannot provide this
+    /// signal because attachment-only messages legitimately have empty content.
+    public func fetchConversationHashesWithMessages(for conversationHashes: [Data]) async throws -> Set<Data> {
+        let hashes = Self.sortedUniqueHashes(conversationHashes)
+        guard !hashes.isEmpty else { return [] }
+
+        return try await replacementPool.read { db in
+            var result = Set<Data>()
+            for start in stride(from: 0, to: hashes.count, by: Self.conversationQueryChunkSize) {
+                let end = min(start + Self.conversationQueryChunkSize, hashes.count)
+                let chunk = Array(hashes[start..<end])
+                let placeholders = Array(repeating: "?", count: chunk.count).joined(separator: ", ")
+                let rows = try Row.fetchAll(
+                    db,
+                    sql: """
+                        SELECT DISTINCT conversation_hash
+                        FROM messages
+                        WHERE conversation_hash IN (\(placeholders))
+                        """,
+                    arguments: StatementArguments(chunk)
+                )
+                for row in rows {
+                    let conversationHash: Data = row["conversation_hash"]
+                    result.insert(conversationHash)
+                }
+            }
+            return result
+        }
     }
 
     /// Fetch a single conversation by destination hash.
     public func fetchConversation(_ conversationHash: Data) async throws -> RNSAPI.ConversationRecord? {
         try await database.getConversation(hash: conversationHash).map(Self.mapConversation)
+    }
+
+    private static func sortedUniqueHashes(_ hashes: [Data]) -> [Data] {
+        Array(Set(hashes)).sorted { $0.lexicographicallyPrecedes($1) }
     }
 
     /// Mark conversation as read (reset unread count).

--- a/Sources/ColumbaApp/ViewModels/ChatsViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/ChatsViewModel.swift
@@ -12,6 +12,11 @@ import Observation
 
 // MARK: - Conversation Model
 
+public enum ConversationPreviewKind: Equatable, Hashable, Sendable {
+    case message
+    case draft
+}
+
 /// Represents a conversation in the chats list.
 /// Wraps ConversationRecord from LXMFSwift with UI-specific properties.
 public struct Conversation: Identifiable, Equatable, Hashable {
@@ -25,6 +30,9 @@ public struct Conversation: Identifiable, Equatable, Hashable {
     public var iconName: String?
     public var iconFgColor: String?
     public var iconBgColor: String?
+    public var draftText: String?
+    public var draftUpdatedAt: Date?
+    public var previewKind: ConversationPreviewKind
 
     /// Display name with fallback to truncated hash.
     public var peerName: String {
@@ -79,6 +87,9 @@ public struct Conversation: Identifiable, Equatable, Hashable {
         self.iconName = record.iconName
         self.iconFgColor = record.iconFgColor
         self.iconBgColor = record.iconBgColor
+        self.draftText = nil
+        self.draftUpdatedAt = nil
+        self.previewKind = .message
     }
 
     public init(
@@ -88,7 +99,10 @@ public struct Conversation: Identifiable, Equatable, Hashable {
         lastMessageTimestamp: Date,
         lastMessagePreview: String? = nil,
         unreadCount: Int = 0,
-        isFavorite: Bool = false
+        isFavorite: Bool = false,
+        draftText: String? = nil,
+        draftUpdatedAt: Date? = nil,
+        previewKind: ConversationPreviewKind = .message
     ) {
         self.id = id
         self.destinationHash = destinationHash
@@ -97,6 +111,9 @@ public struct Conversation: Identifiable, Equatable, Hashable {
         self.lastMessagePreview = lastMessagePreview
         self.unreadCount = unreadCount
         self.isFavorite = isFavorite
+        self.draftText = draftText
+        self.draftUpdatedAt = draftUpdatedAt
+        self.previewKind = previewKind
     }
 }
 
@@ -152,6 +169,7 @@ public final class ChatsViewModel {
     private var conversationReadObserver: NSObjectProtocol?
     private var conversationActivityObserver: NSObjectProtocol?
     private var conversationMetadataObserver: NSObjectProtocol?
+    private var draftChangedObserver: NSObjectProtocol?
     private var conversationLoadGeneration: UInt64 = 0
     private var activeConversationLoadCount: Int = 0
     private var activeConversationRefreshCount: Int = 0
@@ -218,6 +236,16 @@ public final class ChatsViewModel {
                 await self?.loadConversations()
             }
         }
+
+        draftChangedObserver = NotificationCenter.default.addObserver(
+            forName: MessageRepository.draftChangedNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                await self?.loadConversations()
+            }
+        }
     }
 
     deinit {
@@ -233,6 +261,9 @@ public final class ChatsViewModel {
         if let observer = conversationMetadataObserver {
             NotificationCenter.default.removeObserver(observer)
         }
+        if let observer = draftChangedObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
     }
 
     // MARK: - Public Methods
@@ -244,8 +275,9 @@ public final class ChatsViewModel {
         defer { endLoadingConversations() }
 
         do {
-            let records = try await repository.fetchConversations()
-            var convos = Self.prepareConversations(records)
+            async let records = repository.fetchConversations()
+            async let drafts = repository.fetchDrafts()
+            var convos = try await Self.prepareConversations(records: records, drafts: drafts)
 
             // Backfill display names from path table for conversations that have none
             if let pathTable {
@@ -274,8 +306,9 @@ public final class ChatsViewModel {
         defer { endRefreshingConversations() }
 
         do {
-            let records = try await repository.fetchConversations()
-            var convos = Self.prepareConversations(records)
+            async let records = repository.fetchConversations()
+            async let drafts = repository.fetchDrafts()
+            var convos = try await Self.prepareConversations(records: records, drafts: drafts)
 
             // Backfill display names from path table for conversations that have none
             if let pathTable {
@@ -321,18 +354,43 @@ public final class ChatsViewModel {
         }
     }
 
-    /// Convert persisted records to the visible chat list and enforce newest
-    /// activity first at the UI boundary, independent of database ordering.
-    static func prepareConversations(_ records: [ConversationRecord]) -> [Conversation] {
+    /// Convert persisted records and drafts to the visible chat list and enforce
+    /// newest activity first at the UI boundary, independent of database ordering.
+    static func prepareConversations(
+        records: [ConversationRecord],
+        drafts: [Data: DraftRecord]
+    ) -> [Conversation] {
         records
-            .filter { !$0.lastMessagePreview.isEmpty }
-            .map { Conversation(from: $0) }
+            .compactMap { record in
+                let draft = drafts[record.destinationHash].flatMap { draft in
+                    draft.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : draft
+                }
+                guard !record.lastMessagePreview.isEmpty || draft != nil else { return nil }
+
+                var conversation = Conversation(from: record)
+                if let draft {
+                    conversation.draftText = draft.content
+                    conversation.draftUpdatedAt = draft.updatedAt
+                    conversation.lastMessagePreview = draft.content
+                    conversation.previewKind = .draft
+                    if record.lastMessageAt == nil {
+                        conversation.lastMessageTimestamp = draft.updatedAt
+                    }
+                }
+                return conversation
+            }
             .sorted {
                 if $0.lastMessageTimestamp != $1.lastMessageTimestamp {
                     return $0.lastMessageTimestamp > $1.lastMessageTimestamp
                 }
                 return $0.id < $1.id
             }
+    }
+
+    /// Preserve the original projection call for existing clients while routing
+    /// all list preparation through the draft-aware implementation.
+    static func prepareConversations(_ records: [ConversationRecord]) -> [Conversation] {
+        prepareConversations(records: records, drafts: [:])
     }
 
     /// Start a list refresh. Only the latest generation may replace the

--- a/Sources/ColumbaApp/ViewModels/ChatsViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/ChatsViewModel.swift
@@ -275,22 +275,7 @@ public final class ChatsViewModel {
         defer { endLoadingConversations() }
 
         do {
-            async let records = repository.fetchConversations()
-            async let drafts = repository.fetchDrafts()
-            var convos = try await Self.prepareConversations(records: records, drafts: drafts)
-
-            // Backfill display names from path table for conversations that have none
-            if let pathTable {
-                for i in convos.indices where convos[i].displayName == nil {
-                    if let entry = await pathTable.lookup(destinationHash: convos[i].destinationHash),
-                       !entry.displayName.isEmpty {
-                        convos[i].displayName = entry.displayName
-                        // Persist so we don't need to look up again
-                        try? await repository.ensureConversation(convos[i].destinationHash, displayName: entry.displayName)
-                    }
-                }
-            }
-
+            let convos = try await loadConversationSnapshot()
             applyLoadedConversations(convos, generation: generation)
         } catch {
             if generation == conversationLoadGeneration {
@@ -306,27 +291,54 @@ public final class ChatsViewModel {
         defer { endRefreshingConversations() }
 
         do {
-            async let records = repository.fetchConversations()
-            async let drafts = repository.fetchDrafts()
-            var convos = try await Self.prepareConversations(records: records, drafts: drafts)
-
-            // Backfill display names from path table for conversations that have none
-            if let pathTable {
-                for i in convos.indices where convos[i].displayName == nil {
-                    if let entry = await pathTable.lookup(destinationHash: convos[i].destinationHash),
-                       !entry.displayName.isEmpty {
-                        convos[i].displayName = entry.displayName
-                        try? await repository.ensureConversation(convos[i].destinationHash, displayName: entry.displayName)
-                    }
-                }
-            }
-
+            let convos = try await loadConversationSnapshot()
             applyLoadedConversations(convos, generation: generation)
         } catch {
             if generation == conversationLoadGeneration {
                 errorMessage = error.localizedDescription
             }
         }
+    }
+
+    /// Capture the visible page together with every committed draft and any
+    /// draft parent omitted by that page before projecting one coherent list.
+    @MainActor
+    private func loadConversationSnapshot() async throws -> [Conversation] {
+        async let visibleRecords = repository.fetchConversations()
+        async let drafts = repository.fetchDrafts()
+        let (visible, committedDrafts) = try await (visibleRecords, drafts)
+
+        let visibleHashes = Set(visible.map(\.destinationHash))
+        let missingDraftParentHashes = committedDrafts.keys
+            .filter { !visibleHashes.contains($0) }
+            .sorted { $0.lexicographicallyPrecedes($1) }
+        let missingDraftParents = try await repository.fetchConversations(for: missingDraftParentHashes)
+
+        var recordsByHash: [Data: ConversationRecord] = [:]
+        for record in visible + missingDraftParents where recordsByHash[record.destinationHash] == nil {
+            recordsByHash[record.destinationHash] = record
+        }
+
+        var conversations = Self.prepareConversations(
+            records: Array(recordsByHash.values),
+            drafts: committedDrafts
+        )
+
+        // Backfill display names from path table for conversations that have none.
+        if let pathTable {
+            for i in conversations.indices where conversations[i].displayName == nil {
+                if let entry = await pathTable.lookup(destinationHash: conversations[i].destinationHash),
+                   !entry.displayName.isEmpty {
+                    conversations[i].displayName = entry.displayName
+                    try? await repository.ensureConversation(
+                        conversations[i].destinationHash,
+                        displayName: entry.displayName
+                    )
+                }
+            }
+        }
+
+        return conversations
     }
 
     /// Toggle favorite status for a conversation and persist to database.
@@ -362,10 +374,11 @@ public final class ChatsViewModel {
     ) -> [Conversation] {
         records
             .compactMap { record in
+                let hasMessage = !record.lastMessagePreview.isEmpty
                 let draft = drafts[record.destinationHash].flatMap { draft in
                     draft.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : draft
                 }
-                guard !record.lastMessagePreview.isEmpty || draft != nil else { return nil }
+                guard hasMessage || draft != nil else { return nil }
 
                 var conversation = Conversation(from: record)
                 if let draft {
@@ -373,7 +386,7 @@ public final class ChatsViewModel {
                     conversation.draftUpdatedAt = draft.updatedAt
                     conversation.lastMessagePreview = draft.content
                     conversation.previewKind = .draft
-                    if record.lastMessageAt == nil {
+                    if !hasMessage {
                         conversation.lastMessageTimestamp = draft.updatedAt
                     }
                 }

--- a/Sources/ColumbaApp/ViewModels/ChatsViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/ChatsViewModel.swift
@@ -318,10 +318,14 @@ public final class ChatsViewModel {
         for record in visible + missingDraftParents where recordsByHash[record.destinationHash] == nil {
             recordsByHash[record.destinationHash] = record
         }
+        let messageHashes = try await repository.fetchConversationHashesWithMessages(
+            for: Array(recordsByHash.keys)
+        )
 
         var conversations = Self.prepareConversations(
             records: Array(recordsByHash.values),
-            drafts: committedDrafts
+            drafts: committedDrafts,
+            conversationHashesWithMessages: messageHashes
         )
 
         // Backfill display names from path table for conversations that have none.
@@ -370,11 +374,12 @@ public final class ChatsViewModel {
     /// newest activity first at the UI boundary, independent of database ordering.
     static func prepareConversations(
         records: [ConversationRecord],
-        drafts: [Data: DraftRecord]
+        drafts: [Data: DraftRecord],
+        conversationHashesWithMessages: Set<Data>
     ) -> [Conversation] {
         records
             .compactMap { record in
-                let hasMessage = !record.lastMessagePreview.isEmpty
+                let hasMessage = conversationHashesWithMessages.contains(record.destinationHash)
                 let draft = drafts[record.destinationHash].flatMap { draft in
                     draft.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : draft
                 }
@@ -401,9 +406,20 @@ public final class ChatsViewModel {
     }
 
     /// Preserve the original projection call for existing clients while routing
-    /// all list preparation through the draft-aware implementation.
+    /// all list preparation through the draft-aware implementation. This legacy
+    /// no-draft entry point retains preview-based filtering only for callers that
+    /// do not project drafts; production draft projection always supplies the
+    /// canonical persisted-message set.
     static func prepareConversations(_ records: [ConversationRecord]) -> [Conversation] {
-        prepareConversations(records: records, drafts: [:])
+        prepareConversations(
+            records: records,
+            drafts: [:],
+            conversationHashesWithMessages: Set(
+                records.lazy
+                    .filter { !$0.lastMessagePreview.isEmpty }
+                    .map(\.destinationHash)
+            )
+        )
     }
 
     /// Start a list refresh. Only the latest generation may replace the

--- a/Sources/ColumbaApp/ViewModels/DraftAutosaveController.swift
+++ b/Sources/ColumbaApp/ViewModels/DraftAutosaveController.swift
@@ -104,7 +104,15 @@ private final class DraftMutationPipeline {
 }
 
 @MainActor
-final class DraftAutosaveController {
+protocol DraftAutosaving: AnyObject {
+    func restore() async throws -> String?
+    func textChanged(_ text: String)
+    func flush(_ text: String) async
+    func clearImmediately()
+}
+
+@MainActor
+final class DraftAutosaveController: DraftAutosaving {
     typealias Sleeper = @Sendable (Duration) async throws -> Void
 
     private static let logger = Logger(

--- a/Sources/ColumbaApp/ViewModels/DraftAutosaveController.swift
+++ b/Sources/ColumbaApp/ViewModels/DraftAutosaveController.swift
@@ -1,0 +1,109 @@
+import Foundation
+import OSLog
+
+@MainActor
+final class DraftAutosaveController {
+    typealias Sleeper = @Sendable (Duration) async throws -> Void
+
+    private static let logger = Logger(
+        subsystem: "network.columba.Columba",
+        category: "DraftAutosaveController"
+    )
+
+    private let repository: MessageRepository
+    private let conversationHash: Data
+    private let debounceDuration: Duration
+    private let sleeper: Sleeper
+
+    private var latestText = ""
+    private var generation: UInt64 = 0
+    private var pendingTask: Task<Void, Never>?
+
+    init(
+        repository: MessageRepository,
+        conversationHash: Data,
+        debounceDuration: Duration = .milliseconds(500),
+        sleeper: @escaping Sleeper = { duration in
+            try await Task.sleep(for: duration)
+        }
+    ) {
+        self.repository = repository
+        self.conversationHash = conversationHash
+        self.debounceDuration = debounceDuration
+        self.sleeper = sleeper
+    }
+
+    func restore() async throws -> String? {
+        try await repository.fetchDraft(for: conversationHash)?.content
+    }
+
+    func textChanged(_ text: String) {
+        latestText = text
+        generation += 1
+        let scheduledGeneration = generation
+
+        pendingTask?.cancel()
+        let sleeper = sleeper
+        let debounceDuration = debounceDuration
+        pendingTask = Task { [weak self] in
+            do {
+                try await sleeper(debounceDuration)
+                try Task.checkCancellation()
+            } catch is CancellationError {
+                return
+            } catch {
+                Self.logger.error("Draft debounce failed")
+                return
+            }
+
+            guard let self else { return }
+            guard generation == scheduledGeneration else { return }
+            pendingTask = nil
+
+            do {
+                try await repository.saveDraft(latestText, for: conversationHash)
+            } catch {
+                Self.logger.error("Draft autosave repository mutation failed")
+            }
+        }
+    }
+
+    func flush(_ text: String) async {
+        latestText = text
+        generation += 1
+        pendingTask?.cancel()
+        pendingTask = nil
+
+        do {
+            try await repository.saveDraft(text, for: conversationHash)
+        } catch {
+            Self.logger.error("Draft flush repository mutation failed")
+        }
+    }
+
+    func clearImmediately() {
+        latestText = ""
+        generation += 1
+        pendingTask?.cancel()
+        pendingTask = nil
+
+        let repository = repository
+        let conversationHash = conversationHash
+        Task {
+            do {
+                try await repository.clearDraft(for: conversationHash)
+            } catch {
+                Self.logger.error("Draft clear repository mutation failed")
+            }
+        }
+    }
+
+    func cancel() {
+        pendingTask?.cancel()
+        pendingTask = nil
+    }
+
+    deinit {
+        pendingTask?.cancel()
+    }
+}

--- a/Sources/ColumbaApp/ViewModels/DraftAutosaveController.swift
+++ b/Sources/ColumbaApp/ViewModels/DraftAutosaveController.swift
@@ -1,6 +1,108 @@
 import Foundation
 import OSLog
 
+protocol DraftPersistence: Sendable {
+    func fetchDraftText(for conversationHash: Data) async throws -> String?
+    func saveDraft(_ content: String, for conversationHash: Data) async throws
+    func clearDraft(for conversationHash: Data) async throws
+}
+
+extension MessageRepository: DraftPersistence {
+    func fetchDraftText(for conversationHash: Data) async throws -> String? {
+        try await fetchDraft(for: conversationHash)?.content
+    }
+}
+
+@MainActor
+private final class DraftMutationPipeline {
+    private enum SaveSource {
+        case autosave
+        case flush
+    }
+
+    private enum Mutation {
+        case save(String, SaveSource, CheckedContinuation<Void, Never>?)
+        case clear
+    }
+
+    private static let logger = Logger(
+        subsystem: "network.columba.Columba",
+        category: "DraftAutosaveController"
+    )
+
+    private let persistence: any DraftPersistence
+    private let conversationHash: Data
+    private var mutations: [Mutation?] = []
+    private var nextMutationIndex = 0
+    private var worker: Task<Void, Never>?
+
+    init(persistence: any DraftPersistence, conversationHash: Data) {
+        self.persistence = persistence
+        self.conversationHash = conversationHash
+    }
+
+    func enqueueSave(_ text: String) {
+        enqueue(.save(text, .autosave, nil))
+    }
+
+    func enqueueClear() {
+        enqueue(.clear)
+    }
+
+    func enqueueSaveAndWait(_ text: String) async {
+        await withCheckedContinuation { continuation in
+            enqueue(.save(text, .flush, continuation))
+        }
+    }
+
+    private func enqueue(_ mutation: Mutation) {
+        mutations.append(mutation)
+        guard worker == nil else { return }
+
+        // The worker retains this pipeline, but not its owning controller, until
+        // every already-enqueued durable intent has completed.
+        worker = Task {
+            await drain()
+        }
+    }
+
+    private func drain() async {
+        while nextMutationIndex < mutations.count {
+            guard let mutation = mutations[nextMutationIndex] else {
+                nextMutationIndex += 1
+                continue
+            }
+            mutations[nextMutationIndex] = nil
+            nextMutationIndex += 1
+
+            switch mutation {
+            case let .save(text, source, completion):
+                do {
+                    try await persistence.saveDraft(text, for: conversationHash)
+                } catch {
+                    switch source {
+                    case .autosave:
+                        Self.logger.error("Draft autosave repository mutation failed")
+                    case .flush:
+                        Self.logger.error("Draft flush repository mutation failed")
+                    }
+                }
+                completion?.resume()
+            case .clear:
+                do {
+                    try await persistence.clearDraft(for: conversationHash)
+                } catch {
+                    Self.logger.error("Draft clear repository mutation failed")
+                }
+            }
+        }
+
+        mutations.removeAll(keepingCapacity: true)
+        nextMutationIndex = 0
+        worker = nil
+    }
+}
+
 @MainActor
 final class DraftAutosaveController {
     typealias Sleeper = @Sendable (Duration) async throws -> Void
@@ -10,7 +112,8 @@ final class DraftAutosaveController {
         category: "DraftAutosaveController"
     )
 
-    private let repository: MessageRepository
+    private let persistence: any DraftPersistence
+    private let mutationPipeline: DraftMutationPipeline
     private let conversationHash: Data
     private let debounceDuration: Duration
     private let sleeper: Sleeper
@@ -27,14 +130,34 @@ final class DraftAutosaveController {
             try await Task.sleep(for: duration)
         }
     ) {
-        self.repository = repository
+        self.persistence = repository
         self.conversationHash = conversationHash
+        self.mutationPipeline = DraftMutationPipeline(
+            persistence: repository,
+            conversationHash: conversationHash
+        )
+        self.debounceDuration = debounceDuration
+        self.sleeper = sleeper
+    }
+
+    init(
+        persistence: any DraftPersistence,
+        conversationHash: Data,
+        debounceDuration: Duration,
+        sleeper: @escaping Sleeper
+    ) {
+        self.persistence = persistence
+        self.conversationHash = conversationHash
+        self.mutationPipeline = DraftMutationPipeline(
+            persistence: persistence,
+            conversationHash: conversationHash
+        )
         self.debounceDuration = debounceDuration
         self.sleeper = sleeper
     }
 
     func restore() async throws -> String? {
-        try await repository.fetchDraft(for: conversationHash)?.content
+        try await persistence.fetchDraftText(for: conversationHash)
     }
 
     func textChanged(_ text: String) {
@@ -59,12 +182,7 @@ final class DraftAutosaveController {
             guard let self else { return }
             guard generation == scheduledGeneration else { return }
             pendingTask = nil
-
-            do {
-                try await repository.saveDraft(latestText, for: conversationHash)
-            } catch {
-                Self.logger.error("Draft autosave repository mutation failed")
-            }
+            mutationPipeline.enqueueSave(latestText)
         }
     }
 
@@ -74,11 +192,7 @@ final class DraftAutosaveController {
         pendingTask?.cancel()
         pendingTask = nil
 
-        do {
-            try await repository.saveDraft(text, for: conversationHash)
-        } catch {
-            Self.logger.error("Draft flush repository mutation failed")
-        }
+        await mutationPipeline.enqueueSaveAndWait(text)
     }
 
     func clearImmediately() {
@@ -86,16 +200,7 @@ final class DraftAutosaveController {
         generation += 1
         pendingTask?.cancel()
         pendingTask = nil
-
-        let repository = repository
-        let conversationHash = conversationHash
-        Task {
-            do {
-                try await repository.clearDraft(for: conversationHash)
-            } catch {
-                Self.logger.error("Draft clear repository mutation failed")
-            }
-        }
+        mutationPipeline.enqueueClear()
     }
 
     func cancel() {

--- a/Sources/ColumbaApp/Views/Chats/ConversationRow.swift
+++ b/Sources/ColumbaApp/Views/Chats/ConversationRow.swift
@@ -79,12 +79,7 @@ struct ConversationRow: View {
                 }
 
                 // Message preview
-                if let preview = conversation.lastMessagePreview {
-                    Text(preview)
-                        .font(.system(size: 14))
-                        .foregroundColor(Theme.textSecondary)
-                        .lineLimit(1)
-                }
+                messagePreview
             }
 
             // Favorite button
@@ -135,6 +130,28 @@ struct ConversationRow: View {
     }
 
     // MARK: - Subviews
+
+    @ViewBuilder
+    private var messagePreview: some View {
+        if conversation.previewKind == .draft, let draft = conversation.draftText {
+            (
+                Text("Draft:")
+                    .foregroundColor(.red)
+                + Text(" \(draft)")
+                    .foregroundColor(Theme.textSecondary)
+            )
+            .font(.system(size: 14))
+            .italic()
+            .lineLimit(2)
+            .truncationMode(.tail)
+            .accessibilityIdentifier("conversation_draft_preview")
+        } else if let preview = conversation.lastMessagePreview {
+            Text(preview)
+                .font(.system(size: 14))
+                .foregroundColor(Theme.textSecondary)
+                .lineLimit(1)
+        }
+    }
 
     /// Profile icon with MDI icon or identicon fallback.
     private var avatarView: some View {

--- a/Sources/ColumbaApp/Views/Messaging/MessageInputBar.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageInputBar.swift
@@ -126,6 +126,7 @@ struct MessageInputBar: View {
                         .font(.body)
                         .foregroundStyle(Theme.textPrimary)
                         .lineLimit(1...6)
+                        .accessibilityIdentifier("message_composer")
                         .focused($isFocused)
                         .padding(.horizontal, 12)
                         .padding(.vertical, 10)

--- a/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
@@ -22,6 +22,21 @@ import AppKit
 
 private let logger = Logger(subsystem: "network.columba.Columba", category: "MessagingView")
 
+@MainActor
+enum MessagingDraftBootstrap {
+    static func prepare(
+        loadMessages: () async -> Void,
+        restoreDraft: () async -> String?,
+        applyRestoredText: (String) -> Void,
+        publishConversation: () -> Void
+    ) async {
+        await loadMessages()
+        let restoredText = await restoreDraft() ?? ""
+        applyRestoredText(restoredText)
+        publishConversation()
+    }
+}
+
 /// Main messaging/chat screen view.
 ///
 /// Layout:
@@ -45,6 +60,7 @@ struct MessagingView: View {
     // MARK: - State
 
     @State private var viewModel: MessagingViewModel?
+    @State private var draftController: DraftAutosaveController?
     @State private var messageText = ""
     @State private var showPhotoPicker = false
     @State private var showFilePicker = false
@@ -74,6 +90,7 @@ struct MessagingView: View {
     @State private var messageTextScale = SettingsRepository.MessageTextScale.defaultValue
     @State private var nomadNetLinkTarget: MessageLinkTarget?
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.scenePhase) private var scenePhase
 
     // MARK: - Body
 
@@ -115,7 +132,7 @@ struct MessagingView: View {
                 )
                 .safeAreaInset(edge: .bottom, spacing: 0) {
                     MessageInputBar(
-                        text: $messageText,
+                        text: messageTextBinding,
                         attachedImage: $attachedImage,
                         attachedFiles: $attachedFiles,
                         replyToMessage: vm.replyToMessage,
@@ -251,7 +268,7 @@ struct MessagingView: View {
                     // the keyboard and adjusts the scroll view's visible area to match.
                     .safeAreaInset(edge: .bottom, spacing: 0) {
                         MessageInputBar(
-                            text: $messageText,
+                            text: messageTextBinding,
                             attachedImage: $attachedImage,
                             attachedFiles: $attachedFiles,
                             replyToMessage: vm.replyToMessage,
@@ -535,7 +552,12 @@ struct MessagingView: View {
             .presentationDragIndicator(.visible)
         }
         .onDisappear {
+            flushDraft()
             NotificationService.activeConversationThreadId = nil
+        }
+        .onChange(of: scenePhase) { oldPhase, newPhase in
+            guard oldPhase == .active, newPhase != .active else { return }
+            flushDraft()
         }
         .task {
             messageTextScale = await settingsRepository.getMessageTextScale()
@@ -558,8 +580,27 @@ struct MessagingView: View {
                     appServices: appServices,
                     displayName: conversation.displayName
                 )
-                await vm.loadMessages()
-                viewModel = vm
+                let controller = DraftAutosaveController(
+                    repository: messageRepository,
+                    conversationHash: conversation.destinationHash
+                )
+                await MessagingDraftBootstrap.prepare(
+                    loadMessages: {
+                        await vm.loadMessages()
+                    },
+                    restoreDraft: {
+                        try? await controller.restore()
+                    },
+                    applyRestoredText: { restoredText in
+                        // Programmatic restore intentionally bypasses messageTextBinding.
+                        messageText = restoredText
+                        draftController = controller
+                    },
+                    publishConversation: {
+                        // Publish last so the composer is interactive only after restore.
+                        viewModel = vm
+                    }
+                )
             } else {
                 await viewModel?.loadMessages()
             }
@@ -692,6 +733,24 @@ struct MessagingView: View {
 
     // MARK: - Actions
 
+    private var messageTextBinding: Binding<String> {
+        Binding(
+            get: { messageText },
+            set: { newValue in
+                messageText = newValue
+                draftController?.textChanged(newValue)
+            }
+        )
+    }
+
+    private func flushDraft() {
+        let text = messageText
+        let controller = draftController
+        Task {
+            await controller?.flush(text)
+        }
+    }
+
     private func openMessageLink(_ target: MessageLinkTarget) {
         guard case .nomadNet = target else { return }
         nomadNetLinkTarget = target
@@ -741,6 +800,8 @@ struct MessagingView: View {
 
         guard !text.isEmpty || image != nil || !files.isEmpty else { return }
 
+        draftController?.clearImmediately()
+        // Programmatic send clear intentionally bypasses messageTextBinding.
         messageText = ""
         attachedImage = nil
         attachedFiles = []

--- a/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
@@ -24,29 +24,47 @@ private let logger = Logger(subsystem: "network.columba.Columba", category: "Mes
 
 @MainActor
 enum MessagingDraftBootstrap {
+    enum Outcome {
+        case restored(String)
+        case restoreFailed
+    }
+
     static func prepare(
         loadMessages: () async -> Void,
-        restoreDraft: () async throws -> String?,
-        applyRestoredText: (String) -> Void,
-        handleRestoreFailure: () -> Void,
-        publishConversation: () -> Void
-    ) async throws {
+        restoreDraft: () async throws -> String?
+    ) async throws -> Outcome {
         await loadMessages()
         try Task.checkCancellation()
 
+        let outcome: Outcome
         do {
-            let restoredText = try await restoreDraft()
-            try Task.checkCancellation()
-            applyRestoredText(restoredText ?? "")
+            outcome = .restored(try await restoreDraft() ?? "")
         } catch let error as CancellationError {
             throw error
         } catch {
-            try Task.checkCancellation()
             logger.error("Draft restore failed; persistence remains gated")
-            handleRestoreFailure()
+            outcome = .restoreFailed
         }
 
         try Task.checkCancellation()
+        return outcome
+    }
+
+    static func commit(
+        _ outcome: Outcome,
+        applyRestoredText: (String) -> Void,
+        handleRestoreFailure: () -> Void,
+        publishConversation: () -> Void
+    ) throws {
+        try Task.checkCancellation()
+
+        switch outcome {
+        case .restored(let restoredText):
+            applyRestoredText(restoredText)
+        case .restoreFailed:
+            handleRestoreFailure()
+        }
+
         publishConversation()
     }
 }
@@ -650,13 +668,16 @@ struct MessagingView: View {
                 )
                 let lifecycle = MessagingComposerLifecycle(autosave: controller)
                 do {
-                    try await MessagingDraftBootstrap.prepare(
+                    let outcome = try await MessagingDraftBootstrap.prepare(
                         loadMessages: {
                             await vm.loadMessages()
                         },
                         restoreDraft: {
                             try await lifecycle.restore()
-                        },
+                        }
+                    )
+                    try MessagingDraftBootstrap.commit(
+                        outcome,
                         applyRestoredText: { restoredText in
                             lifecycle.applyProgrammaticRestore(restoredText) {
                                 messageText = $0

--- a/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
@@ -26,14 +26,78 @@ private let logger = Logger(subsystem: "network.columba.Columba", category: "Mes
 enum MessagingDraftBootstrap {
     static func prepare(
         loadMessages: () async -> Void,
-        restoreDraft: () async -> String?,
+        restoreDraft: () async throws -> String?,
         applyRestoredText: (String) -> Void,
+        handleRestoreFailure: () -> Void,
         publishConversation: () -> Void
-    ) async {
+    ) async throws {
         await loadMessages()
-        let restoredText = await restoreDraft() ?? ""
-        applyRestoredText(restoredText)
+        try Task.checkCancellation()
+
+        do {
+            let restoredText = try await restoreDraft()
+            try Task.checkCancellation()
+            applyRestoredText(restoredText ?? "")
+        } catch let error as CancellationError {
+            throw error
+        } catch {
+            try Task.checkCancellation()
+            logger.error("Draft restore failed; persistence remains gated")
+            handleRestoreFailure()
+        }
+
+        try Task.checkCancellation()
         publishConversation()
+    }
+}
+
+/// Production boundary between SwiftUI composer lifecycle events and draft persistence.
+/// Persistence remains gated after a failed restore so an empty lifecycle event cannot
+/// destroy durable text that the screen was unable to read. The first explicit user edit
+/// deliberately supersedes that unknown durable value and opens the gate.
+@MainActor
+final class MessagingComposerLifecycle {
+    private let autosave: any DraftAutosaving
+    private(set) var draftPersistenceReady = false
+
+    init(autosave: any DraftAutosaving) {
+        self.autosave = autosave
+    }
+
+    func restore() async throws -> String? {
+        try await autosave.restore()
+    }
+
+    func applyProgrammaticRestore(_ text: String, applyText: (String) -> Void) {
+        applyText(text)
+        draftPersistenceReady = true
+    }
+
+    func restoreFailed() {
+        draftPersistenceReady = false
+    }
+
+    func userEdited(_ text: String, applyText: (String) -> Void) {
+        applyText(text)
+        draftPersistenceReady = true
+        autosave.textChanged(text)
+    }
+
+    func clearForSend(applyText: () -> Void) {
+        if draftPersistenceReady {
+            autosave.clearImmediately()
+        }
+        applyText()
+    }
+
+    func navigationFlush(_ text: String) async {
+        guard draftPersistenceReady else { return }
+        await autosave.flush(text)
+    }
+
+    func backgroundFlush(_ text: String) async {
+        guard draftPersistenceReady else { return }
+        await autosave.flush(text)
     }
 }
 
@@ -60,7 +124,7 @@ struct MessagingView: View {
     // MARK: - State
 
     @State private var viewModel: MessagingViewModel?
-    @State private var draftController: DraftAutosaveController?
+    @State private var composerLifecycle: MessagingComposerLifecycle?
     @State private var messageText = ""
     @State private var showPhotoPicker = false
     @State private var showFilePicker = false
@@ -552,12 +616,12 @@ struct MessagingView: View {
             .presentationDragIndicator(.visible)
         }
         .onDisappear {
-            flushDraft()
+            flushDraft(for: .navigation)
             NotificationService.activeConversationThreadId = nil
         }
         .onChange(of: scenePhase) { oldPhase, newPhase in
             guard oldPhase == .active, newPhase != .active else { return }
-            flushDraft()
+            flushDraft(for: .background)
         }
         .task {
             messageTextScale = await settingsRepository.getMessageTextScale()
@@ -584,23 +648,35 @@ struct MessagingView: View {
                     repository: messageRepository,
                     conversationHash: conversation.destinationHash
                 )
-                await MessagingDraftBootstrap.prepare(
-                    loadMessages: {
-                        await vm.loadMessages()
-                    },
-                    restoreDraft: {
-                        try? await controller.restore()
-                    },
-                    applyRestoredText: { restoredText in
-                        // Programmatic restore intentionally bypasses messageTextBinding.
-                        messageText = restoredText
-                        draftController = controller
-                    },
-                    publishConversation: {
-                        // Publish last so the composer is interactive only after restore.
-                        viewModel = vm
-                    }
-                )
+                let lifecycle = MessagingComposerLifecycle(autosave: controller)
+                do {
+                    try await MessagingDraftBootstrap.prepare(
+                        loadMessages: {
+                            await vm.loadMessages()
+                        },
+                        restoreDraft: {
+                            try await lifecycle.restore()
+                        },
+                        applyRestoredText: { restoredText in
+                            lifecycle.applyProgrammaticRestore(restoredText) {
+                                messageText = $0
+                            }
+                            composerLifecycle = lifecycle
+                        },
+                        handleRestoreFailure: {
+                            lifecycle.restoreFailed()
+                            composerLifecycle = lifecycle
+                        },
+                        publishConversation: {
+                            // Publish last so the composer is interactive only after restore.
+                            viewModel = vm
+                        }
+                    )
+                } catch is CancellationError {
+                    // A later appearance retries bootstrap because no state was published.
+                } catch {
+                    logger.error("Messaging bootstrap failed")
+                }
             } else {
                 await viewModel?.loadMessages()
             }
@@ -737,17 +813,30 @@ struct MessagingView: View {
         Binding(
             get: { messageText },
             set: { newValue in
-                messageText = newValue
-                draftController?.textChanged(newValue)
+                if let composerLifecycle {
+                    composerLifecycle.userEdited(newValue) { messageText = $0 }
+                } else {
+                    messageText = newValue
+                }
             }
         )
     }
 
-    private func flushDraft() {
+    private enum DraftFlushBoundary {
+        case navigation
+        case background
+    }
+
+    private func flushDraft(for boundary: DraftFlushBoundary) {
         let text = messageText
-        let controller = draftController
+        let lifecycle = composerLifecycle
         Task {
-            await controller?.flush(text)
+            switch boundary {
+            case .navigation:
+                await lifecycle?.navigationFlush(text)
+            case .background:
+                await lifecycle?.backgroundFlush(text)
+            }
         }
     }
 
@@ -800,9 +889,14 @@ struct MessagingView: View {
 
         guard !text.isEmpty || image != nil || !files.isEmpty else { return }
 
-        draftController?.clearImmediately()
-        // Programmatic send clear intentionally bypasses messageTextBinding.
-        messageText = ""
+        if let composerLifecycle {
+            composerLifecycle.clearForSend {
+                // Programmatic send clear intentionally bypasses the user-edit path.
+                messageText = ""
+            }
+        } else {
+            messageText = ""
+        }
         attachedImage = nil
         attachedFiles = []
         withAnimation(.easeInOut(duration: 0.25)) {

--- a/Tests/ColumbaAppTests/DraftMessageTests.swift
+++ b/Tests/ColumbaAppTests/DraftMessageTests.swift
@@ -401,12 +401,17 @@ private final class ControlledDraftSleeper: @unchecked Sendable {
 }
 
 private actor ControlledDraftPersistence: DraftPersistence {
+    enum TestError: Error {
+        case restoreFailed
+    }
+
     enum Mutation: Equatable {
         case save(String)
         case clear
     }
 
     private var draftText: String?
+    private let restoreFails: Bool
     private var mutationsStorage: [Mutation] = []
     private var completedMutationCount = 0
     private var blockNextMutation = false
@@ -414,11 +419,19 @@ private actor ControlledDraftPersistence: DraftPersistence {
     private var blockedWaiters: [CheckedContinuation<Void, Never>] = []
     private var mutationCountWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
 
-    init(draftText: String? = nil) {
+    init(draftText: String? = nil, restoreFails: Bool = false) {
         self.draftText = draftText
+        self.restoreFails = restoreFails
     }
 
     func fetchDraftText(for conversationHash: Data) async throws -> String? {
+        if restoreFails {
+            throw TestError.restoreFailed
+        }
+        return draftText
+    }
+
+    func currentDraftText() -> String? {
         draftText
     }
 
@@ -496,6 +509,40 @@ private final class LockedCancellationResult: @unchecked Sendable {
         lock.lock()
         valueStorage = value
         lock.unlock()
+    }
+}
+
+@MainActor
+private final class RecordingDraftAutosave: DraftAutosaving {
+    enum Event: Equatable {
+        case restore
+        case textChanged(String)
+        case clear
+        case flush(String)
+    }
+
+    private(set) var events: [Event] = []
+    let restoredText: String?
+
+    init(restoredText: String?) {
+        self.restoredText = restoredText
+    }
+
+    func restore() async throws -> String? {
+        events.append(.restore)
+        return restoredText
+    }
+
+    func textChanged(_ text: String) {
+        events.append(.textChanged(text))
+    }
+
+    func flush(_ text: String) async {
+        events.append(.flush(text))
+    }
+
+    func clearImmediately() {
+        events.append(.clear)
     }
 }
 
@@ -797,12 +844,12 @@ final class DraftAutosaveControllerTests: XCTestCase {
         XCTAssertEqual(sleeper.invocationCount, 0)
     }
 
-    func testInitialDraftIsAppliedBeforeConversationBecomesInteractive() async {
+    func testInitialDraftIsAppliedBeforeConversationBecomesInteractive() async throws {
         var events: [String] = []
         var composerText = ""
         var isInteractive = false
 
-        await MessagingDraftBootstrap.prepare(
+        try await MessagingDraftBootstrap.prepare(
             loadMessages: {
                 events.append("messages loaded")
             },
@@ -813,6 +860,9 @@ final class DraftAutosaveControllerTests: XCTestCase {
             applyRestoredText: { restoredText in
                 composerText = restoredText
                 events.append("draft applied")
+            },
+            handleRestoreFailure: {
+                XCTFail("Restore should succeed")
             },
             publishConversation: {
                 isInteractive = true
@@ -828,7 +878,7 @@ final class DraftAutosaveControllerTests: XCTestCase {
         )
     }
 
-    func testProgrammaticRestoreDoesNotScheduleRedundantAutosave() async {
+    func testProgrammaticRestoreDoesNotScheduleRedundantAutosave() async throws {
         let conversationHash = Data(repeating: 0xA9, count: 16)
         let persistence = ControlledDraftPersistence(draftText: "restored without a write")
         let sleeper = ControlledDraftSleeper()
@@ -837,19 +887,60 @@ final class DraftAutosaveControllerTests: XCTestCase {
             conversationHash: conversationHash,
             sleeper: sleeper
         )
+        let lifecycle = MessagingComposerLifecycle(autosave: controller)
         var composerText = ""
 
-        await MessagingDraftBootstrap.prepare(
+        try await MessagingDraftBootstrap.prepare(
             loadMessages: {},
-            restoreDraft: { try? await controller.restore() },
-            applyRestoredText: { composerText = $0 },
+            restoreDraft: { try await lifecycle.restore() },
+            applyRestoredText: {
+                lifecycle.applyProgrammaticRestore($0) { composerText = $0 }
+            },
+            handleRestoreFailure: {
+                XCTFail("Restore should succeed")
+            },
             publishConversation: {}
         )
 
         XCTAssertEqual(composerText, "restored without a write")
+        XCTAssertTrue(lifecycle.draftPersistenceReady)
         XCTAssertEqual(sleeper.invocationCount, 0)
         let mutations = await persistence.mutations()
         XCTAssertTrue(mutations.isEmpty)
+    }
+
+    func testProductionComposerLifecycleRoutesEveryComposerBoundaryInOrder() async throws {
+        let autosave = RecordingDraftAutosave(restoredText: "restored")
+        let lifecycle = MessagingComposerLifecycle(autosave: autosave)
+        var composerText = ""
+
+        let restored = try await lifecycle.restore()
+        lifecycle.applyProgrammaticRestore(restored ?? "") { composerText = $0 }
+        XCTAssertEqual(composerText, "restored")
+        XCTAssertEqual(autosave.events, [.restore])
+
+        lifecycle.userEdited("binding edit") { composerText = $0 }
+        XCTAssertEqual(composerText, "binding edit")
+        XCTAssertEqual(autosave.events, [.restore, .textChanged("binding edit")])
+
+        lifecycle.clearForSend {
+            XCTAssertEqual(autosave.events.last, .clear, "Persistence invalidation must precede UI clear")
+            composerText = ""
+        }
+        XCTAssertEqual(composerText, "")
+
+        await lifecycle.navigationFlush("navigation value")
+        await lifecycle.backgroundFlush("background value")
+        XCTAssertEqual(
+            autosave.events,
+            [
+                .restore,
+                .textChanged("binding edit"),
+                .clear,
+                .flush("navigation value"),
+                .flush("background value")
+            ]
+        )
     }
 
     func testSendClearInvalidatesPendingTypedSave() async {
@@ -863,10 +954,15 @@ final class DraftAutosaveControllerTests: XCTestCase {
             conversationHash: conversationHash,
             sleeper: sleeper
         )
+        let lifecycle = MessagingComposerLifecycle(autosave: controller)
+        lifecycle.applyProgrammaticRestore("previous draft") { _ in }
 
-        controller.textChanged("message being sent")
+        lifecycle.userEdited("message being sent") { _ in }
         await fulfillment(of: [debounceStarted], timeout: 1)
-        controller.clearImmediately()
+        var composerWasCleared = false
+        lifecycle.clearForSend {
+            composerWasCleared = true
+        }
         await persistence.waitForMutationCount(1)
         sleeper.resumeAll()
 
@@ -874,6 +970,7 @@ final class DraftAutosaveControllerTests: XCTestCase {
         let stored = try? await persistence.fetchDraftText(for: conversationHash)
         XCTAssertEqual(mutations, [.clear])
         XCTAssertNil(stored)
+        XCTAssertTrue(composerWasCleared)
     }
 
     func testNavigationFlushUsesLatestComposerValue() async {
@@ -887,10 +984,12 @@ final class DraftAutosaveControllerTests: XCTestCase {
             conversationHash: conversationHash,
             sleeper: sleeper
         )
+        let lifecycle = MessagingComposerLifecycle(autosave: controller)
+        lifecycle.applyProgrammaticRestore("") { _ in }
 
-        controller.textChanged("older value")
+        lifecycle.userEdited("older value") { _ in }
         await fulfillment(of: [debounceStarted], timeout: 1)
-        await controller.flush("latest value at navigation")
+        await lifecycle.navigationFlush("latest value at navigation")
         sleeper.resumeAll()
 
         let mutations = await persistence.mutations()
@@ -910,15 +1009,116 @@ final class DraftAutosaveControllerTests: XCTestCase {
             conversationHash: conversationHash,
             sleeper: sleeper
         )
+        let lifecycle = MessagingComposerLifecycle(autosave: controller)
+        lifecycle.applyProgrammaticRestore("") { _ in }
 
-        controller.textChanged("value before backgrounding")
+        lifecycle.userEdited("value before backgrounding") { _ in }
         await fulfillment(of: [debounceStarted], timeout: 1)
-        await controller.flush("latest value at background")
+        await lifecycle.backgroundFlush("latest value at background")
         sleeper.resumeAll()
 
         let mutations = await persistence.mutations()
         let stored = try? await persistence.fetchDraftText(for: conversationHash)
         XCTAssertEqual(mutations, [.save("latest value at background")])
         XCTAssertEqual(stored, "latest value at background")
+    }
+
+    func testCancelledBootstrapDoesNotApplyOrPublishAndCanRetry() async throws {
+        let conversationHash = Data(repeating: 0xAD, count: 16)
+        let persistence = ControlledDraftPersistence(draftText: "durable draft")
+        let sleeper = ControlledDraftSleeper()
+        let controller = makeController(
+            persistence: persistence,
+            conversationHash: conversationHash,
+            sleeper: sleeper
+        )
+        let lifecycle = MessagingComposerLifecycle(autosave: controller)
+        var composerText = "unchanged"
+        var publishCount = 0
+        var failureCount = 0
+
+        let cancelledAttempt = Task { @MainActor in
+            try await MessagingDraftBootstrap.prepare(
+                loadMessages: {},
+                restoreDraft: {
+                    let restored = try await lifecycle.restore()
+                    withUnsafeCurrentTask { $0?.cancel() }
+                    return restored
+                },
+                applyRestoredText: { composerText = $0 },
+                handleRestoreFailure: { failureCount += 1 },
+                publishConversation: { publishCount += 1 }
+            )
+        }
+
+        do {
+            try await cancelledAttempt.value
+            XCTFail("Cancelled bootstrap should throw CancellationError")
+        } catch is CancellationError {
+            // Expected.
+        }
+        XCTAssertEqual(composerText, "unchanged")
+        XCTAssertEqual(publishCount, 0)
+        XCTAssertEqual(failureCount, 0)
+        XCTAssertFalse(lifecycle.draftPersistenceReady)
+
+        try await MessagingDraftBootstrap.prepare(
+            loadMessages: {},
+            restoreDraft: { try await lifecycle.restore() },
+            applyRestoredText: {
+                lifecycle.applyProgrammaticRestore($0) { composerText = $0 }
+            },
+            handleRestoreFailure: { failureCount += 1 },
+            publishConversation: { publishCount += 1 }
+        )
+
+        XCTAssertEqual(composerText, "durable draft")
+        XCTAssertEqual(publishCount, 1)
+        XCTAssertEqual(failureCount, 0)
+        XCTAssertTrue(lifecycle.draftPersistenceReady)
+    }
+
+    func testRestoreFailureGatesLifecycleClearAndFlushUntilExplicitEdit() async throws {
+        let conversationHash = Data(repeating: 0xAE, count: 16)
+        let persistence = ControlledDraftPersistence(
+            draftText: "unread durable draft",
+            restoreFails: true
+        )
+        let sleeper = ControlledDraftSleeper()
+        let controller = makeController(
+            persistence: persistence,
+            conversationHash: conversationHash,
+            sleeper: sleeper
+        )
+        let lifecycle = MessagingComposerLifecycle(autosave: controller)
+        var composerText = ""
+        var published = false
+
+        try await MessagingDraftBootstrap.prepare(
+            loadMessages: {},
+            restoreDraft: { try await lifecycle.restore() },
+            applyRestoredText: { _ in XCTFail("Failed restore must not apply empty text") },
+            handleRestoreFailure: { lifecycle.restoreFailed() },
+            publishConversation: { published = true }
+        )
+
+        XCTAssertTrue(published)
+        XCTAssertFalse(lifecycle.draftPersistenceReady)
+        await lifecycle.navigationFlush(composerText)
+        await lifecycle.backgroundFlush(composerText)
+        lifecycle.clearForSend { composerText = "" }
+        let gatedMutations = await persistence.mutations()
+        let preservedDraft = await persistence.currentDraftText()
+        XCTAssertEqual(gatedMutations, [])
+        XCTAssertEqual(preservedDraft, "unread durable draft")
+
+        lifecycle.userEdited("explicit replacement") { composerText = $0 }
+        XCTAssertTrue(lifecycle.draftPersistenceReady)
+        await lifecycle.navigationFlush(composerText)
+
+        let replacementMutations = await persistence.mutations()
+        let replacementDraft = await persistence.currentDraftText()
+        XCTAssertEqual(replacementMutations, [.save("explicit replacement")])
+        XCTAssertEqual(replacementDraft, "explicit replacement")
     }
 }

--- a/Tests/ColumbaAppTests/DraftMessageTests.swift
+++ b/Tests/ColumbaAppTests/DraftMessageTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import GRDB
 @testable import ColumbaApp
 
 final class DraftMessageTests: XCTestCase {
@@ -66,7 +67,8 @@ final class DraftMessageTests: XCTestCase {
 
         XCTAssertEqual(replacement.content, "second")
         XCTAssertGreaterThan(replacement.updatedAt, first.updatedAt)
-        XCTAssertEqual(drafts.count, 1)
+        XCTAssertEqual(drafts[conversationHash], replacement)
+        XCTAssertEqual(Set(drafts.keys), Set([conversationHash]))
     }
 
     func testDraftsAreIsolatedByConversation() async throws {
@@ -86,7 +88,27 @@ final class DraftMessageTests: XCTestCase {
         let drafts = try await repository.fetchDrafts()
         XCTAssertEqual(firstDraft?.content, "first conversation")
         XCTAssertEqual(secondDraft?.content, "second conversation")
-        XCTAssertEqual(Set(drafts.map(\.conversationHash)), Set([firstHash, secondHash]))
+        XCTAssertEqual(drafts[firstHash]?.content, "first conversation")
+        XCTAssertEqual(drafts[secondHash]?.content, "second conversation")
+        XCTAssertEqual(Set(drafts.keys), Set([firstHash, secondHash]))
+    }
+
+    func testDraftConversationHashRejectsNull() throws {
+        let databaseURL = temporaryDatabaseURL()
+        defer { removeDatabase(at: databaseURL) }
+        _ = try MessageRepository(grdbPath: databaseURL.path)
+        let database = try DatabaseQueue(path: databaseURL.path)
+
+        XCTAssertThrowsError(
+            try database.write { db in
+                try db.execute(
+                    sql: """
+                        INSERT INTO columba_drafts (conversation_hash, content, updated_at)
+                        VALUES (NULL, 'invalid', 0)
+                        """
+                )
+            }
+        )
     }
 
     func testDraftsAreIsolatedByDatabasePath() async throws {

--- a/Tests/ColumbaAppTests/DraftMessageTests.swift
+++ b/Tests/ColumbaAppTests/DraftMessageTests.swift
@@ -360,11 +360,49 @@ final class ChatsDraftProjectionTests: XCTestCase {
         let storedDraft = try await repository.fetchDraft(for: hash)
         let record = try XCTUnwrap(storedRecord)
         let draft = try XCTUnwrap(storedDraft)
+        let messageHashes = try await repository.fetchConversationHashesWithMessages(for: [hash])
         let projected = ChatsViewModel.prepareConversations(
             records: [record],
-            drafts: [hash: draft]
+            drafts: [hash: draft],
+            conversationHashesWithMessages: messageHashes
         )
         return (record, draft, projected)
+    }
+
+    private func repositoryBackedAttachmentOnlyDraft(
+        at databaseURL: URL
+    ) async throws -> (RNSAPI.ConversationRecord, DraftRecord, Set<Data>, [Conversation]) {
+        let repository = try MessageRepository(grdbPath: databaseURL.path)
+        let hash = conversationHash(0xDA)
+        let messageTimestamp = Date(timeIntervalSince1970: 400)
+        let message = RNSAPI.LXMessage(
+            destinationHash: hash,
+            sourceIdentity: nil,
+            content: Data(),
+            fields: [
+                RNSAPI.LXMessage.FIELD_IMAGE: ["png", Data([0x89, 0x50, 0x4E, 0x47])]
+            ]
+        )
+        message.hash = Data(repeating: 0xDA, count: 32)
+        message.timestamp = messageTimestamp.timeIntervalSince1970
+        message.state = .sent
+        message.method = .opportunistic
+        try await repository.saveMessage(message)
+        try await repository.saveDraft("attachment follow-up", for: hash)
+
+        let storedRecord = try await repository.fetchConversation(hash)
+        let storedDraft = try await repository.fetchDraft(for: hash)
+        let record = try XCTUnwrap(storedRecord)
+        let draft = try XCTUnwrap(storedDraft)
+        let messageHashes = try await repository.fetchConversationHashesWithMessages(
+            for: [hash, hash, conversationHash(0xDB)]
+        )
+        let projected = ChatsViewModel.prepareConversations(
+            records: [record],
+            drafts: [hash: draft],
+            conversationHashesWithMessages: messageHashes
+        )
+        return (record, draft, messageHashes, projected)
     }
 
     private func loadDraftParentBeyondFirstPage(
@@ -404,7 +442,8 @@ final class ChatsDraftProjectionTests: XCTestCase {
         let source = record(hashByte: 0xD1, unreadCount: 4)
         let projected = ChatsViewModel.prepareConversations(
             records: [source],
-            drafts: [source.destinationHash: draft(for: source, content: "unfinished reply")]
+            drafts: [source.destinationHash: draft(for: source, content: "unfinished reply")],
+            conversationHashesWithMessages: [source.destinationHash]
         )
 
         XCTAssertEqual(projected.first?.lastMessagePreview, "unfinished reply")
@@ -418,7 +457,8 @@ final class ChatsDraftProjectionTests: XCTestCase {
 
         let projected = ChatsViewModel.prepareConversations(
             records: [source],
-            drafts: [source.destinationHash: draft(for: source, content: "first message draft")]
+            drafts: [source.destinationHash: draft(for: source, content: "first message draft")],
+            conversationHashesWithMessages: []
         )
 
         XCTAssertEqual(projected.map(\.destinationHash), [source.destinationHash])
@@ -437,7 +477,8 @@ final class ChatsDraftProjectionTests: XCTestCase {
                     content: "timestamped draft",
                     updatedAt: draftTimestamp
                 )
-            ]
+            ],
+            conversationHashesWithMessages: []
         )
 
         XCTAssertEqual(projected.first?.lastMessageTimestamp, draftTimestamp)
@@ -457,9 +498,44 @@ final class ChatsDraftProjectionTests: XCTestCase {
 
         let (record, draft, projected) = snapshot
         XCTAssertNotNil(record.lastMessageAt, "real mapping supplies the conversation creation timestamp")
-        XCTAssertTrue(record.lastMessagePreview.isEmpty, "empty preview is the persisted no-message signal")
+        XCTAssertTrue(record.lastMessagePreview.isEmpty, "new conversation records have no preview")
         XCTAssertEqual(projected.first?.lastMessageTimestamp, draft.updatedAt)
         XCTAssertEqual(projected.first?.draftUpdatedAt, draft.updatedAt)
+    }
+
+    func testAttachmentOnlyMessageWithDraftKeepsMessageTimestamp() async throws {
+        let databaseURL = temporaryDatabaseURL()
+        let snapshot: (RNSAPI.ConversationRecord, DraftRecord, Set<Data>, [Conversation])
+        do {
+            snapshot = try await repositoryBackedAttachmentOnlyDraft(at: databaseURL)
+        } catch {
+            removeDatabase(at: databaseURL)
+            throw error
+        }
+        removeDatabase(at: databaseURL)
+
+        let (record, draft, messageHashes, projected) = snapshot
+        XCTAssertTrue(record.lastMessagePreview.isEmpty, "attachment-only messages have empty text previews")
+        XCTAssertEqual(messageHashes, [record.destinationHash])
+        XCTAssertEqual(projected.first?.lastMessagePreview, draft.content)
+        XCTAssertEqual(projected.first?.lastMessageTimestamp, record.lastMessageAt)
+        XCTAssertNotEqual(projected.first?.lastMessageTimestamp, draft.updatedAt)
+
+        let newerMessage = self.record(
+            hashByte: 0xDC,
+            timestamp: Date(timeIntervalSince1970: 450),
+            preview: "newer message"
+        )
+        let ordered = ChatsViewModel.prepareConversations(
+            records: [record, newerMessage],
+            drafts: [record.destinationHash: draft],
+            conversationHashesWithMessages: messageHashes.union([newerMessage.destinationHash])
+        )
+        XCTAssertEqual(
+            ordered.map(\.destinationHash),
+            [newerMessage.destinationHash, record.destinationHash],
+            "a newer draft must not move an attachment-only conversation ahead of newer messages"
+        )
     }
 
     func testLoadIncludesDraftParentBeyondFirstConversationPage() async throws {
@@ -502,7 +578,8 @@ final class ChatsDraftProjectionTests: XCTestCase {
                     content: "newer draft",
                     updatedAt: Date(timeIntervalSince1970: 500)
                 )
-            ]
+            ],
+            conversationHashesWithMessages: [source.destinationHash]
         )
 
         XCTAssertEqual(projected.first?.lastMessageTimestamp, messageTimestamp)
@@ -523,7 +600,8 @@ final class ChatsDraftProjectionTests: XCTestCase {
             drafts: [
                 blank.destinationHash: draft(for: blank, content: " \t\n "),
                 blankWithoutMessage.destinationHash: malformedBlankDraft
-            ]
+            ],
+            conversationHashesWithMessages: [blank.destinationHash, missing.destinationHash]
         )
 
         XCTAssertEqual(projected.map(\.lastMessagePreview), ["blank draft fallback", "missing draft fallback"])

--- a/Tests/ColumbaAppTests/DraftMessageTests.swift
+++ b/Tests/ColumbaAppTests/DraftMessageTests.swift
@@ -4,6 +4,39 @@ import RNSAPI
 @testable import ColumbaApp
 
 final class DraftMessageTests: XCTestCase {
+    private actor CanonicalDeleteGate {
+        private var reachedCanonicalDelete = false
+        private var released = false
+        private var reachedWaiters: [CheckedContinuation<Void, Never>] = []
+        private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+
+        func pauseAfterCanonicalDelete() async {
+            reachedCanonicalDelete = true
+            let waiters = reachedWaiters
+            reachedWaiters.removeAll()
+            waiters.forEach { $0.resume() }
+
+            guard !released else { return }
+            await withCheckedContinuation { continuation in
+                releaseWaiters.append(continuation)
+            }
+        }
+
+        func waitUntilCanonicalDelete() async {
+            guard !reachedCanonicalDelete else { return }
+            await withCheckedContinuation { continuation in
+                reachedWaiters.append(continuation)
+            }
+        }
+
+        func resumeCleanup() {
+            released = true
+            let waiters = releaseWaiters
+            releaseWaiters.removeAll()
+            waiters.forEach { $0.resume() }
+        }
+    }
+
     private enum DraftSnapshot: Equatable {
         case missing
         case present(String)
@@ -196,6 +229,44 @@ final class DraftMessageTests: XCTestCase {
             let draftAfterRecreatingConversation = try await reopenedRepository.fetchDraft(for: conversationHash)
             XCTAssertNil(draftAfterRecreatingConversation)
         }
+    }
+
+    func testDeletingConversationPreservesDraftSavedAfterSameConversationIsRecreated() async throws {
+        let databaseURL = temporaryDatabaseURL()
+        defer { removeDatabase(at: databaseURL) }
+        let deletingRepository = try MessageRepository(grdbPath: databaseURL.path)
+        let recreatingRepository = try MessageRepository(grdbPath: databaseURL.path)
+        let conversationHash = Data(repeating: 0x78, count: 16)
+        let recreatedDraft = "  exact recreated draft  \n"
+        let gate = CanonicalDeleteGate()
+
+        try await deletingRepository.ensureConversation(conversationHash, displayName: nil)
+        try await deletingRepository.saveDraft("obsolete", for: conversationHash)
+
+        let deletion = Task {
+            try await deletingRepository.deleteConversation(
+                conversationHash,
+                afterCanonicalDelete: {
+                    await gate.pauseAfterCanonicalDelete()
+                }
+            )
+        }
+
+        await gate.waitUntilCanonicalDelete()
+        do {
+            try await recreatingRepository.ensureConversation(conversationHash, displayName: "Recreated")
+            try await recreatingRepository.saveDraft(recreatedDraft, for: conversationHash)
+        } catch {
+            await gate.resumeCleanup()
+            _ = try? await deletion.value
+            throw error
+        }
+        await gate.resumeCleanup()
+        try await deletion.value
+
+        let storedDraft = try await recreatingRepository.fetchDraft(for: conversationHash)
+        XCTAssertEqual(storedDraft?.conversationHash, conversationHash)
+        XCTAssertEqual(storedDraft?.content, recreatedDraft)
     }
 
     func testNotificationIsPostedAfterCommittedDraftIsReadable() async throws {

--- a/Tests/ColumbaAppTests/DraftMessageTests.swift
+++ b/Tests/ColumbaAppTests/DraftMessageTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import GRDB
+import RNSAPI
 @testable import ColumbaApp
 
 final class DraftMessageTests: XCTestCase {
@@ -297,6 +298,160 @@ final class DraftMessageTests: XCTestCase {
 
         NotificationCenter.default.removeObserver(observer)
         await reads.cancelAndWaitForTasks()
+    }
+}
+
+@MainActor
+final class ChatsDraftProjectionTests: XCTestCase {
+    private func record(
+        hashByte: UInt8,
+        timestamp: Date? = Date(timeIntervalSince1970: 100),
+        preview: String? = "last message",
+        unreadCount: Int = 0
+    ) -> RNSAPI.ConversationRecord {
+        RNSAPI.ConversationRecord(
+            hash: Data(repeating: hashByte, count: 16),
+            displayName: "Peer",
+            lastMessageAt: timestamp,
+            lastMessage: preview,
+            unreadCount: unreadCount
+        )
+    }
+
+    private func draft(
+        for record: RNSAPI.ConversationRecord,
+        content: String,
+        updatedAt: Date = Date(timeIntervalSince1970: 200)
+    ) -> DraftRecord {
+        DraftRecord(
+            conversationHash: record.destinationHash,
+            content: content,
+            updatedAt: updatedAt
+        )
+    }
+
+    private func temporaryDatabaseURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("columba-chat-drafts-\(UUID().uuidString).sqlite")
+    }
+
+    private func removeDatabase(at url: URL) {
+        try? FileManager.default.removeItem(at: url)
+        try? FileManager.default.removeItem(atPath: url.path + "-shm")
+        try? FileManager.default.removeItem(atPath: url.path + "-wal")
+    }
+
+    func testDraftOverridesLastMessagePreviewWithoutChangingUnreadCount() {
+        let source = record(hashByte: 0xD1, unreadCount: 4)
+        let projected = ChatsViewModel.prepareConversations(
+            records: [source],
+            drafts: [source.destinationHash: draft(for: source, content: "unfinished reply")]
+        )
+
+        XCTAssertEqual(projected.first?.lastMessagePreview, "unfinished reply")
+        XCTAssertEqual(projected.first?.draftText, "unfinished reply")
+        XCTAssertEqual(projected.first?.previewKind, .draft)
+        XCTAssertEqual(projected.first?.unreadCount, 4)
+    }
+
+    func testConversationWithoutMessageRemainsVisibleWhenDraftExists() {
+        let source = record(hashByte: 0xD2, timestamp: nil, preview: nil)
+
+        let projected = ChatsViewModel.prepareConversations(
+            records: [source],
+            drafts: [source.destinationHash: draft(for: source, content: "first message draft")]
+        )
+
+        XCTAssertEqual(projected.map(\.destinationHash), [source.destinationHash])
+        XCTAssertEqual(projected.first?.previewKind, .draft)
+    }
+
+    func testConversationWithoutMessageUsesDraftTimestampAsFallback() {
+        let source = record(hashByte: 0xD3, timestamp: nil, preview: nil)
+        let draftTimestamp = Date(timeIntervalSince1970: 300)
+
+        let projected = ChatsViewModel.prepareConversations(
+            records: [source],
+            drafts: [
+                source.destinationHash: draft(
+                    for: source,
+                    content: "timestamped draft",
+                    updatedAt: draftTimestamp
+                )
+            ]
+        )
+
+        XCTAssertEqual(projected.first?.lastMessageTimestamp, draftTimestamp)
+        XCTAssertEqual(projected.first?.draftUpdatedAt, draftTimestamp)
+    }
+
+    func testExistingConversationKeepsMessageTimestampWhenDraftExists() {
+        let messageTimestamp = Date(timeIntervalSince1970: 400)
+        let source = record(hashByte: 0xD4, timestamp: messageTimestamp)
+
+        let projected = ChatsViewModel.prepareConversations(
+            records: [source],
+            drafts: [
+                source.destinationHash: draft(
+                    for: source,
+                    content: "newer draft",
+                    updatedAt: Date(timeIntervalSince1970: 500)
+                )
+            ]
+        )
+
+        XCTAssertEqual(projected.first?.lastMessageTimestamp, messageTimestamp)
+    }
+
+    func testBlankOrMissingDraftUsesNormalMessagePreview() {
+        let blank = record(hashByte: 0xD5, preview: "blank draft fallback")
+        let missing = record(hashByte: 0xD6, preview: "missing draft fallback")
+        let blankWithoutMessage = record(hashByte: 0xD7, timestamp: nil, preview: nil)
+        let malformedBlankDraft = DraftRecord(
+            conversationHash: blankWithoutMessage.destinationHash,
+            content: "   ",
+            updatedAt: Date(timeIntervalSince1970: 600)
+        )
+
+        let projected = ChatsViewModel.prepareConversations(
+            records: [blank, missing, blankWithoutMessage],
+            drafts: [
+                blank.destinationHash: draft(for: blank, content: " \t\n "),
+                blankWithoutMessage.destinationHash: malformedBlankDraft
+            ]
+        )
+
+        XCTAssertEqual(projected.map(\.lastMessagePreview), ["blank draft fallback", "missing draft fallback"])
+        XCTAssertTrue(projected.allSatisfy { $0.previewKind == .message })
+        XCTAssertTrue(projected.allSatisfy { $0.draftText == nil && $0.draftUpdatedAt == nil })
+    }
+
+    func testDraftNotificationInvalidatesOlderConversationSnapshot() async throws {
+        let databaseURL = temporaryDatabaseURL()
+        defer { removeDatabase(at: databaseURL) }
+        let repository = try MessageRepository(grdbPath: databaseURL.path)
+        let viewModel = ChatsViewModel(
+            repository: repository,
+            notificationObserver: NotificationObserver()
+        )
+        let hash = Data(repeating: 0xD8, count: 16)
+        try await repository.ensureConversation(hash, displayName: "Peer")
+        let staleSnapshot = Conversation(
+            destinationHash: hash,
+            displayName: "Peer",
+            lastMessageTimestamp: Date(timeIntervalSince1970: 100),
+            lastMessagePreview: "stale preview"
+        )
+        let staleGeneration = viewModel.beginConversationLoad()
+
+        try await repository.saveDraft("committed draft", for: hash)
+        for _ in 0..<100 where viewModel.conversations.first?.draftText != "committed draft" {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        viewModel.applyLoadedConversations([staleSnapshot], generation: staleGeneration)
+
+        XCTAssertEqual(viewModel.conversations.first?.lastMessagePreview, "committed draft")
+        XCTAssertEqual(viewModel.conversations.first?.previewKind, .draft)
     }
 }
 

--- a/Tests/ColumbaAppTests/DraftMessageTests.swift
+++ b/Tests/ColumbaAppTests/DraftMessageTests.swift
@@ -178,15 +178,24 @@ final class DraftMessageTests: XCTestCase {
     func testDeletingConversationCascadesToDraft() async throws {
         let databaseURL = temporaryDatabaseURL()
         defer { removeDatabase(at: databaseURL) }
-        let repository = try MessageRepository(grdbPath: databaseURL.path)
         let conversationHash = Data(repeating: 0x77, count: 16)
 
-        try await repository.ensureConversation(conversationHash, displayName: nil)
-        try await repository.saveDraft("temporary", for: conversationHash)
-        try await repository.deleteConversation(conversationHash)
+        do {
+            let repository = try MessageRepository(grdbPath: databaseURL.path)
+            try await repository.ensureConversation(conversationHash, displayName: nil)
+            try await repository.saveDraft("temporary", for: conversationHash)
+            try await repository.deleteConversation(conversationHash)
+        }
 
-        let storedDraft = try await repository.fetchDraft(for: conversationHash)
-        XCTAssertNil(storedDraft)
+        do {
+            let reopenedRepository = try MessageRepository(grdbPath: databaseURL.path)
+            let draftAfterReopen = try await reopenedRepository.fetchDraft(for: conversationHash)
+            XCTAssertNil(draftAfterReopen)
+
+            try await reopenedRepository.ensureConversation(conversationHash, displayName: nil)
+            let draftAfterRecreatingConversation = try await reopenedRepository.fetchDraft(for: conversationHash)
+            XCTAssertNil(draftAfterRecreatingConversation)
+        }
     }
 
     func testNotificationIsPostedAfterCommittedDraftIsReadable() async throws {

--- a/Tests/ColumbaAppTests/DraftMessageTests.swift
+++ b/Tests/ColumbaAppTests/DraftMessageTests.swift
@@ -301,10 +301,17 @@ final class DraftMessageTests: XCTestCase {
 }
 
 private final class ControlledDraftSleeper: @unchecked Sendable {
+    private enum Registration {
+        case cancelledBeforeRegistration
+        case waiting(CheckedContinuation<Void, Error>)
+        case completed
+    }
+
     private let lock = NSLock()
-    private var continuations: [UUID: CheckedContinuation<Void, Error>] = [:]
+    private var registrations: [UUID: Registration] = [:]
     private var invocationCountStorage = 0
     var onSleep: (() -> Void)?
+    var onBeforeRegistrationLock: (() -> Void)?
 
     var invocationCount: Int {
         lock.lock()
@@ -312,8 +319,15 @@ private final class ControlledDraftSleeper: @unchecked Sendable {
         return invocationCountStorage
     }
 
+    var pendingRegistrationCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return registrations.count
+    }
+
     func sleep(for duration: Duration) async throws {
         let id = UUID()
+        defer { finish(id: id) }
         try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
                 register(continuation, id: id)
@@ -326,24 +340,38 @@ private final class ControlledDraftSleeper: @unchecked Sendable {
     func resumeAll() {
         let pending: [CheckedContinuation<Void, Error>]
         lock.lock()
-        pending = Array(continuations.values)
-        continuations.removeAll()
+        let waitingIDs = registrations.compactMap { id, registration in
+            if case .waiting = registration { return id }
+            return nil
+        }
+        pending = waitingIDs.compactMap { id in
+            guard case let .some(.waiting(continuation)) = registrations[id] else { return nil }
+            registrations[id] = .completed
+            return continuation
+        }
         lock.unlock()
         pending.forEach { $0.resume() }
     }
 
     private func register(_ continuation: CheckedContinuation<Void, Error>, id: UUID) {
-        let isCancelled = Task.isCancelled
+        onBeforeRegistrationLock?()
+
+        let wasCancelled: Bool
+        let onSleep: (() -> Void)?
         lock.lock()
         invocationCountStorage += 1
-        if !isCancelled {
-            continuations[id] = continuation
+        if case .some(.cancelledBeforeRegistration) = registrations[id] {
+            registrations[id] = .completed
+            wasCancelled = true
+        } else {
+            registrations[id] = .waiting(continuation)
+            wasCancelled = false
         }
-        let onSleep = onSleep
+        onSleep = self.onSleep
         lock.unlock()
 
         onSleep?()
-        if isCancelled {
+        if wasCancelled {
             continuation.resume(throwing: CancellationError())
         }
     }
@@ -351,9 +379,123 @@ private final class ControlledDraftSleeper: @unchecked Sendable {
     private func cancel(id: UUID) {
         let continuation: CheckedContinuation<Void, Error>?
         lock.lock()
-        continuation = continuations.removeValue(forKey: id)
+        switch registrations[id] {
+        case let .some(.waiting(waiting)):
+            registrations[id] = .completed
+            continuation = waiting
+        case .some(.completed), .some(.cancelledBeforeRegistration):
+            continuation = nil
+        case .none:
+            registrations[id] = .cancelledBeforeRegistration
+            continuation = nil
+        }
         lock.unlock()
         continuation?.resume(throwing: CancellationError())
+    }
+
+    private func finish(id: UUID) {
+        lock.lock()
+        registrations.removeValue(forKey: id)
+        lock.unlock()
+    }
+}
+
+private actor ControlledDraftPersistence: DraftPersistence {
+    enum Mutation: Equatable {
+        case save(String)
+        case clear
+    }
+
+    private var draftText: String?
+    private var mutationsStorage: [Mutation] = []
+    private var completedMutationCount = 0
+    private var blockNextMutation = false
+    private var blockedMutationContinuation: CheckedContinuation<Void, Never>?
+    private var blockedWaiters: [CheckedContinuation<Void, Never>] = []
+    private var mutationCountWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+
+    init(draftText: String? = nil) {
+        self.draftText = draftText
+    }
+
+    func fetchDraftText(for conversationHash: Data) async throws -> String? {
+        draftText
+    }
+
+    func saveDraft(_ content: String, for conversationHash: Data) async throws {
+        mutationsStorage.append(.save(content))
+        await blockIfRequested()
+        draftText = content
+        notifyMutationCompleted()
+    }
+
+    func clearDraft(for conversationHash: Data) async throws {
+        mutationsStorage.append(.clear)
+        await blockIfRequested()
+        draftText = nil
+        notifyMutationCompleted()
+    }
+
+    func arrangeToBlockNextMutation() {
+        blockNextMutation = true
+    }
+
+    func waitUntilMutationIsBlocked() async {
+        if blockedMutationContinuation != nil { return }
+        await withCheckedContinuation { blockedWaiters.append($0) }
+    }
+
+    func unblockMutation() {
+        let continuation = blockedMutationContinuation
+        blockedMutationContinuation = nil
+        continuation?.resume()
+    }
+
+    func waitForMutationCount(_ count: Int) async {
+        if completedMutationCount >= count { return }
+        await withCheckedContinuation { mutationCountWaiters.append((count, $0)) }
+    }
+
+    func mutations() -> [Mutation] {
+        mutationsStorage
+    }
+
+    private func blockIfRequested() async {
+        guard blockNextMutation else { return }
+        blockNextMutation = false
+        blockedWaiters.forEach { $0.resume() }
+        blockedWaiters.removeAll()
+        await withCheckedContinuation { blockedMutationContinuation = $0 }
+    }
+
+    private func notifyMutationCompleted() {
+        completedMutationCount += 1
+        var remaining: [(Int, CheckedContinuation<Void, Never>)] = []
+        for (count, continuation) in mutationCountWaiters {
+            if completedMutationCount >= count {
+                continuation.resume()
+            } else {
+                remaining.append((count, continuation))
+            }
+        }
+        mutationCountWaiters = remaining
+    }
+}
+
+private final class LockedCancellationResult: @unchecked Sendable {
+    private let lock = NSLock()
+    private var valueStorage: Bool?
+
+    var value: Bool? {
+        lock.lock()
+        defer { lock.unlock() }
+        return valueStorage
+    }
+
+    func store(_ value: Bool) {
+        lock.lock()
+        valueStorage = value
+        lock.unlock()
     }
 }
 
@@ -377,6 +519,19 @@ final class DraftAutosaveControllerTests: XCTestCase {
     ) -> DraftAutosaveController {
         DraftAutosaveController(
             repository: repository,
+            conversationHash: conversationHash,
+            debounceDuration: .seconds(30),
+            sleeper: sleeper.sleep(for:)
+        )
+    }
+
+    private func makeController(
+        persistence: any DraftPersistence,
+        conversationHash: Data,
+        sleeper: ControlledDraftSleeper
+    ) -> DraftAutosaveController {
+        DraftAutosaveController(
+            persistence: persistence,
             conversationHash: conversationHash,
             debounceDuration: .seconds(30),
             sleeper: sleeper.sleep(for:)
@@ -527,6 +682,99 @@ final class DraftAutosaveControllerTests: XCTestCase {
 
         let stored = try await repository.fetchDraft(for: conversationHash)
         XCTAssertEqual(stored?.content, "newer text")
+    }
+
+    func testEnqueuedDelayedSaveCompletesBeforeLaterClear() async throws {
+        let conversationHash = Data(repeating: 0xA7, count: 16)
+        let persistence = ControlledDraftPersistence()
+        let sleeper = ControlledDraftSleeper()
+        let sleepStarted = expectation(description: "Debounce started")
+        sleeper.onSleep = { sleepStarted.fulfill() }
+        let controller = makeController(
+            persistence: persistence,
+            conversationHash: conversationHash,
+            sleeper: sleeper
+        )
+        await persistence.arrangeToBlockNextMutation()
+
+        controller.textChanged("stale but already enqueued")
+        await fulfillment(of: [sleepStarted], timeout: 1)
+        sleeper.resumeAll()
+        await persistence.waitUntilMutationIsBlocked()
+        let mutationsBeforeClear = await persistence.mutations()
+        XCTAssertEqual(mutationsBeforeClear, [.save("stale but already enqueued")])
+
+        controller.clearImmediately()
+        await persistence.unblockMutation()
+        await persistence.waitForMutationCount(2)
+
+        let mutationsAfterClear = await persistence.mutations()
+        let finalDraft = try await persistence.fetchDraftText(for: conversationHash)
+        XCTAssertEqual(mutationsAfterClear, [.save("stale but already enqueued"), .clear])
+        XCTAssertNil(finalDraft)
+    }
+
+    func testClearCompletesBeforeImmediatelyFollowingFlush() async throws {
+        let conversationHash = Data(repeating: 0xA8, count: 16)
+        let persistence = ControlledDraftPersistence(draftText: "existing")
+        let sleeper = ControlledDraftSleeper()
+        let controller = makeController(
+            persistence: persistence,
+            conversationHash: conversationHash,
+            sleeper: sleeper
+        )
+        await persistence.arrangeToBlockNextMutation()
+        let flushed = expectation(description: "Flush completed durably")
+
+        controller.clearImmediately()
+        Task { @MainActor in
+            await controller.flush("newer edit")
+            flushed.fulfill()
+        }
+
+        await persistence.waitUntilMutationIsBlocked()
+        let mutationsWhileClearBlocked = await persistence.mutations()
+        XCTAssertEqual(mutationsWhileClearBlocked, [.clear])
+        await persistence.unblockMutation()
+        await fulfillment(of: [flushed], timeout: 1)
+
+        let finalMutations = await persistence.mutations()
+        let finalDraft = try await persistence.fetchDraftText(for: conversationHash)
+        XCTAssertEqual(finalMutations, [.clear, .save("newer edit")])
+        XCTAssertEqual(finalDraft, "newer edit")
+    }
+
+    func testSleeperCancellationBeforeRegistrationDoesNotHangOrLeak() async {
+        let sleeper = ControlledDraftSleeper()
+        let registrationReached = expectation(description: "Registration race window reached")
+        let sleepFinished = expectation(description: "Cancelled sleep finished")
+        let allowRegistration = DispatchSemaphore(value: 0)
+        let result = LockedCancellationResult()
+        sleeper.onBeforeRegistrationLock = {
+            registrationReached.fulfill()
+            allowRegistration.wait()
+        }
+
+        let task = Task.detached {
+            do {
+                try await sleeper.sleep(for: .seconds(30))
+                result.store(false)
+            } catch is CancellationError {
+                result.store(true)
+            } catch {
+                result.store(false)
+            }
+            sleepFinished.fulfill()
+        }
+
+        await fulfillment(of: [registrationReached], timeout: 1)
+        task.cancel()
+        allowRegistration.signal()
+        await fulfillment(of: [sleepFinished], timeout: 1)
+
+        XCTAssertEqual(result.value, true)
+        XCTAssertEqual(sleeper.invocationCount, 1)
+        XCTAssertEqual(sleeper.pendingRegistrationCount, 0)
     }
 
     func testRestoreReturnsStoredTextWithoutSchedulingAnotherWrite() async throws {

--- a/Tests/ColumbaAppTests/DraftMessageTests.swift
+++ b/Tests/ColumbaAppTests/DraftMessageTests.swift
@@ -849,14 +849,17 @@ final class DraftAutosaveControllerTests: XCTestCase {
         var composerText = ""
         var isInteractive = false
 
-        try await MessagingDraftBootstrap.prepare(
+        let outcome = try await MessagingDraftBootstrap.prepare(
             loadMessages: {
                 events.append("messages loaded")
             },
             restoreDraft: {
                 events.append("draft restored")
                 return "unfinished message"
-            },
+            }
+        )
+        try MessagingDraftBootstrap.commit(
+            outcome,
             applyRestoredText: { restoredText in
                 composerText = restoredText
                 events.append("draft applied")
@@ -890,9 +893,12 @@ final class DraftAutosaveControllerTests: XCTestCase {
         let lifecycle = MessagingComposerLifecycle(autosave: controller)
         var composerText = ""
 
-        try await MessagingDraftBootstrap.prepare(
+        let outcome = try await MessagingDraftBootstrap.prepare(
             loadMessages: {},
-            restoreDraft: { try await lifecycle.restore() },
+            restoreDraft: { try await lifecycle.restore() }
+        )
+        try MessagingDraftBootstrap.commit(
+            outcome,
             applyRestoredText: {
                 lifecycle.applyProgrammaticRestore($0) { composerText = $0 }
             },
@@ -1023,7 +1029,7 @@ final class DraftAutosaveControllerTests: XCTestCase {
         XCTAssertEqual(stored, "latest value at background")
     }
 
-    func testCancelledBootstrapDoesNotApplyOrPublishAndCanRetry() async throws {
+    func testCancellationBeforeBootstrapCommitDoesNotApplyHandleFailureOrPublishAndCanRetry() async throws {
         let conversationHash = Data(repeating: 0xAD, count: 16)
         let persistence = ControlledDraftPersistence(draftText: "durable draft")
         let sleeper = ControlledDraftSleeper()
@@ -1038,13 +1044,13 @@ final class DraftAutosaveControllerTests: XCTestCase {
         var failureCount = 0
 
         let cancelledAttempt = Task { @MainActor in
-            try await MessagingDraftBootstrap.prepare(
+            let outcome = try await MessagingDraftBootstrap.prepare(
                 loadMessages: {},
-                restoreDraft: {
-                    let restored = try await lifecycle.restore()
-                    withUnsafeCurrentTask { $0?.cancel() }
-                    return restored
-                },
+                restoreDraft: { try await lifecycle.restore() }
+            )
+            withUnsafeCurrentTask { $0?.cancel() }
+            try MessagingDraftBootstrap.commit(
+                outcome,
                 applyRestoredText: { composerText = $0 },
                 handleRestoreFailure: { failureCount += 1 },
                 publishConversation: { publishCount += 1 }
@@ -1062,9 +1068,12 @@ final class DraftAutosaveControllerTests: XCTestCase {
         XCTAssertEqual(failureCount, 0)
         XCTAssertFalse(lifecycle.draftPersistenceReady)
 
-        try await MessagingDraftBootstrap.prepare(
+        let retryOutcome = try await MessagingDraftBootstrap.prepare(
             loadMessages: {},
-            restoreDraft: { try await lifecycle.restore() },
+            restoreDraft: { try await lifecycle.restore() }
+        )
+        try MessagingDraftBootstrap.commit(
+            retryOutcome,
             applyRestoredText: {
                 lifecycle.applyProgrammaticRestore($0) { composerText = $0 }
             },
@@ -1076,6 +1085,62 @@ final class DraftAutosaveControllerTests: XCTestCase {
         XCTAssertEqual(publishCount, 1)
         XCTAssertEqual(failureCount, 0)
         XCTAssertTrue(lifecycle.draftPersistenceReady)
+    }
+
+    func testCancellationInsideBootstrapSuccessApplyStillPublishesWholeCommit() async throws {
+        var composerText = "unchanged"
+        var failureCount = 0
+        var publishCount = 0
+        var wasCancelledWhenPublished = false
+
+        let attempt = Task { @MainActor in
+            try MessagingDraftBootstrap.commit(
+                .restored("restored draft"),
+                applyRestoredText: {
+                    composerText = $0
+                    withUnsafeCurrentTask { $0?.cancel() }
+                },
+                handleRestoreFailure: { failureCount += 1 },
+                publishConversation: {
+                    wasCancelledWhenPublished = Task.isCancelled
+                    publishCount += 1
+                }
+            )
+        }
+
+        try await attempt.value
+        XCTAssertEqual(composerText, "restored draft")
+        XCTAssertEqual(failureCount, 0)
+        XCTAssertEqual(publishCount, 1)
+        XCTAssertTrue(wasCancelledWhenPublished)
+    }
+
+    func testCancellationInsideBootstrapFailureHandlerStillPublishesWholeCommit() async throws {
+        var applyCount = 0
+        var failureCount = 0
+        var publishCount = 0
+        var wasCancelledWhenPublished = false
+
+        let attempt = Task { @MainActor in
+            try MessagingDraftBootstrap.commit(
+                .restoreFailed,
+                applyRestoredText: { _ in applyCount += 1 },
+                handleRestoreFailure: {
+                    failureCount += 1
+                    withUnsafeCurrentTask { $0?.cancel() }
+                },
+                publishConversation: {
+                    wasCancelledWhenPublished = Task.isCancelled
+                    publishCount += 1
+                }
+            )
+        }
+
+        try await attempt.value
+        XCTAssertEqual(applyCount, 0)
+        XCTAssertEqual(failureCount, 1)
+        XCTAssertEqual(publishCount, 1)
+        XCTAssertTrue(wasCancelledWhenPublished)
     }
 
     func testRestoreFailureGatesLifecycleClearAndFlushUntilExplicitEdit() async throws {
@@ -1094,9 +1159,12 @@ final class DraftAutosaveControllerTests: XCTestCase {
         var composerText = ""
         var published = false
 
-        try await MessagingDraftBootstrap.prepare(
+        let outcome = try await MessagingDraftBootstrap.prepare(
             loadMessages: {},
-            restoreDraft: { try await lifecycle.restore() },
+            restoreDraft: { try await lifecycle.restore() }
+        )
+        try MessagingDraftBootstrap.commit(
+            outcome,
             applyRestoredText: { _ in XCTFail("Failed restore must not apply empty text") },
             handleRestoreFailure: { lifecycle.restoreFailed() },
             publishConversation: { published = true }

--- a/Tests/ColumbaAppTests/DraftMessageTests.swift
+++ b/Tests/ColumbaAppTests/DraftMessageTests.swift
@@ -299,3 +299,253 @@ final class DraftMessageTests: XCTestCase {
         await reads.cancelAndWaitForTasks()
     }
 }
+
+private final class ControlledDraftSleeper: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuations: [UUID: CheckedContinuation<Void, Error>] = [:]
+    private var invocationCountStorage = 0
+    var onSleep: (() -> Void)?
+
+    var invocationCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return invocationCountStorage
+    }
+
+    func sleep(for duration: Duration) async throws {
+        let id = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                register(continuation, id: id)
+            }
+        } onCancel: {
+            cancel(id: id)
+        }
+    }
+
+    func resumeAll() {
+        let pending: [CheckedContinuation<Void, Error>]
+        lock.lock()
+        pending = Array(continuations.values)
+        continuations.removeAll()
+        lock.unlock()
+        pending.forEach { $0.resume() }
+    }
+
+    private func register(_ continuation: CheckedContinuation<Void, Error>, id: UUID) {
+        let isCancelled = Task.isCancelled
+        lock.lock()
+        invocationCountStorage += 1
+        if !isCancelled {
+            continuations[id] = continuation
+        }
+        let onSleep = onSleep
+        lock.unlock()
+
+        onSleep?()
+        if isCancelled {
+            continuation.resume(throwing: CancellationError())
+        }
+    }
+
+    private func cancel(id: UUID) {
+        let continuation: CheckedContinuation<Void, Error>?
+        lock.lock()
+        continuation = continuations.removeValue(forKey: id)
+        lock.unlock()
+        continuation?.resume(throwing: CancellationError())
+    }
+}
+
+@MainActor
+final class DraftAutosaveControllerTests: XCTestCase {
+    private func temporaryDatabaseURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("columba-autosave-\(UUID().uuidString).sqlite")
+    }
+
+    private func removeDatabase(at url: URL) {
+        try? FileManager.default.removeItem(at: url)
+        try? FileManager.default.removeItem(atPath: url.path + "-shm")
+        try? FileManager.default.removeItem(atPath: url.path + "-wal")
+    }
+
+    private func makeController(
+        repository: MessageRepository,
+        conversationHash: Data,
+        sleeper: ControlledDraftSleeper
+    ) -> DraftAutosaveController {
+        DraftAutosaveController(
+            repository: repository,
+            conversationHash: conversationHash,
+            debounceDuration: .seconds(30),
+            sleeper: sleeper.sleep(for:)
+        )
+    }
+
+    private func draftChangeExpectation(for conversationHash: Data) -> (XCTestExpectation, NSObjectProtocol) {
+        let changed = expectation(description: "Draft mutation committed")
+        changed.assertForOverFulfill = true
+        let observer = NotificationCenter.default.addObserver(
+            forName: MessageRepository.draftChangedNotification,
+            object: nil,
+            queue: nil
+        ) { notification in
+            guard notification.userInfo?[MessageRepository.conversationHashUserInfoKey] as? Data == conversationHash else {
+                return
+            }
+            changed.fulfill()
+        }
+        return (changed, observer)
+    }
+
+    func testRapidEditsPersistOnlyLatestText() async throws {
+        let databaseURL = temporaryDatabaseURL()
+        defer { removeDatabase(at: databaseURL) }
+        let repository = try MessageRepository(grdbPath: databaseURL.path)
+        let conversationHash = Data(repeating: 0xA1, count: 16)
+        let sleeper = ControlledDraftSleeper()
+        let firstSleepStarted = expectation(description: "First debounce started")
+        let secondSleepStarted = expectation(description: "Replacement debounce started")
+        sleeper.onSleep = {
+            if sleeper.invocationCount == 1 {
+                firstSleepStarted.fulfill()
+            } else if sleeper.invocationCount == 2 {
+                secondSleepStarted.fulfill()
+            }
+        }
+        let controller = makeController(
+            repository: repository,
+            conversationHash: conversationHash,
+            sleeper: sleeper
+        )
+        try await repository.ensureConversation(conversationHash, displayName: nil)
+        let (changed, observer) = draftChangeExpectation(for: conversationHash)
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        controller.textChanged("older")
+        await fulfillment(of: [firstSleepStarted], timeout: 1)
+        controller.textChanged("latest")
+        await fulfillment(of: [secondSleepStarted], timeout: 1)
+        sleeper.resumeAll()
+        await fulfillment(of: [changed], timeout: 1)
+
+        let stored = try await repository.fetchDraft(for: conversationHash)
+        XCTAssertEqual(stored?.content, "latest")
+    }
+
+    func testFlushPersistsImmediatelyWithoutWaitingForDebounce() async throws {
+        let databaseURL = temporaryDatabaseURL()
+        defer { removeDatabase(at: databaseURL) }
+        let repository = try MessageRepository(grdbPath: databaseURL.path)
+        let conversationHash = Data(repeating: 0xA2, count: 16)
+        let sleeper = ControlledDraftSleeper()
+        let sleepStarted = expectation(description: "Debounce started")
+        sleeper.onSleep = { sleepStarted.fulfill() }
+        let controller = makeController(
+            repository: repository,
+            conversationHash: conversationHash,
+            sleeper: sleeper
+        )
+        try await repository.ensureConversation(conversationHash, displayName: nil)
+
+        controller.textChanged("pending")
+        await fulfillment(of: [sleepStarted], timeout: 1)
+        await controller.flush("flushed now")
+
+        let stored = try await repository.fetchDraft(for: conversationHash)
+        XCTAssertEqual(stored?.content, "flushed now")
+    }
+
+    func testFlushOfBlankTextDeletesDraft() async throws {
+        let databaseURL = temporaryDatabaseURL()
+        defer { removeDatabase(at: databaseURL) }
+        let repository = try MessageRepository(grdbPath: databaseURL.path)
+        let conversationHash = Data(repeating: 0xA3, count: 16)
+        let sleeper = ControlledDraftSleeper()
+        let controller = makeController(
+            repository: repository,
+            conversationHash: conversationHash,
+            sleeper: sleeper
+        )
+        try await repository.ensureConversation(conversationHash, displayName: nil)
+        try await repository.saveDraft("existing", for: conversationHash)
+
+        await controller.flush(" \t\n ")
+
+        let stored = try await repository.fetchDraft(for: conversationHash)
+        XCTAssertNil(stored)
+    }
+
+    func testClearCancelsPendingSaveAndDraftStaysAbsent() async throws {
+        let databaseURL = temporaryDatabaseURL()
+        defer { removeDatabase(at: databaseURL) }
+        let repository = try MessageRepository(grdbPath: databaseURL.path)
+        let conversationHash = Data(repeating: 0xA4, count: 16)
+        let sleeper = ControlledDraftSleeper()
+        let sleepStarted = expectation(description: "Debounce started")
+        sleeper.onSleep = { sleepStarted.fulfill() }
+        let controller = makeController(
+            repository: repository,
+            conversationHash: conversationHash,
+            sleeper: sleeper
+        )
+        try await repository.ensureConversation(conversationHash, displayName: nil)
+        try await repository.saveDraft("existing", for: conversationHash)
+        let (cleared, observer) = draftChangeExpectation(for: conversationHash)
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        controller.textChanged("must not survive")
+        await fulfillment(of: [sleepStarted], timeout: 1)
+        controller.clearImmediately()
+        await fulfillment(of: [cleared], timeout: 1)
+        sleeper.resumeAll()
+
+        let stored = try await repository.fetchDraft(for: conversationHash)
+        XCTAssertNil(stored)
+    }
+
+    func testOldDelayedSaveCannotOverwriteNewerText() async throws {
+        let databaseURL = temporaryDatabaseURL()
+        defer { removeDatabase(at: databaseURL) }
+        let repository = try MessageRepository(grdbPath: databaseURL.path)
+        let conversationHash = Data(repeating: 0xA5, count: 16)
+        let sleeper = ControlledDraftSleeper()
+        let sleepStarted = expectation(description: "Old debounce started")
+        sleeper.onSleep = { sleepStarted.fulfill() }
+        let controller = makeController(
+            repository: repository,
+            conversationHash: conversationHash,
+            sleeper: sleeper
+        )
+        try await repository.ensureConversation(conversationHash, displayName: nil)
+
+        controller.textChanged("stale delayed text")
+        await fulfillment(of: [sleepStarted], timeout: 1)
+        await controller.flush("newer text")
+        sleeper.resumeAll()
+
+        let stored = try await repository.fetchDraft(for: conversationHash)
+        XCTAssertEqual(stored?.content, "newer text")
+    }
+
+    func testRestoreReturnsStoredTextWithoutSchedulingAnotherWrite() async throws {
+        let databaseURL = temporaryDatabaseURL()
+        defer { removeDatabase(at: databaseURL) }
+        let repository = try MessageRepository(grdbPath: databaseURL.path)
+        let conversationHash = Data(repeating: 0xA6, count: 16)
+        let sleeper = ControlledDraftSleeper()
+        let controller = makeController(
+            repository: repository,
+            conversationHash: conversationHash,
+            sleeper: sleeper
+        )
+        try await repository.ensureConversation(conversationHash, displayName: nil)
+        try await repository.saveDraft("restored exactly", for: conversationHash)
+
+        let restored = try await controller.restore()
+
+        XCTAssertEqual(restored, "restored exactly")
+        XCTAssertEqual(sleeper.invocationCount, 0)
+    }
+}

--- a/Tests/ColumbaAppTests/DraftMessageTests.swift
+++ b/Tests/ColumbaAppTests/DraftMessageTests.swift
@@ -796,4 +796,129 @@ final class DraftAutosaveControllerTests: XCTestCase {
         XCTAssertEqual(restored, "restored exactly")
         XCTAssertEqual(sleeper.invocationCount, 0)
     }
+
+    func testInitialDraftIsAppliedBeforeConversationBecomesInteractive() async {
+        var events: [String] = []
+        var composerText = ""
+        var isInteractive = false
+
+        await MessagingDraftBootstrap.prepare(
+            loadMessages: {
+                events.append("messages loaded")
+            },
+            restoreDraft: {
+                events.append("draft restored")
+                return "unfinished message"
+            },
+            applyRestoredText: { restoredText in
+                composerText = restoredText
+                events.append("draft applied")
+            },
+            publishConversation: {
+                isInteractive = true
+                events.append("conversation published")
+            }
+        )
+
+        XCTAssertEqual(composerText, "unfinished message")
+        XCTAssertTrue(isInteractive)
+        XCTAssertEqual(
+            events,
+            ["messages loaded", "draft restored", "draft applied", "conversation published"]
+        )
+    }
+
+    func testProgrammaticRestoreDoesNotScheduleRedundantAutosave() async {
+        let conversationHash = Data(repeating: 0xA9, count: 16)
+        let persistence = ControlledDraftPersistence(draftText: "restored without a write")
+        let sleeper = ControlledDraftSleeper()
+        let controller = makeController(
+            persistence: persistence,
+            conversationHash: conversationHash,
+            sleeper: sleeper
+        )
+        var composerText = ""
+
+        await MessagingDraftBootstrap.prepare(
+            loadMessages: {},
+            restoreDraft: { try? await controller.restore() },
+            applyRestoredText: { composerText = $0 },
+            publishConversation: {}
+        )
+
+        XCTAssertEqual(composerText, "restored without a write")
+        XCTAssertEqual(sleeper.invocationCount, 0)
+        let mutations = await persistence.mutations()
+        XCTAssertTrue(mutations.isEmpty)
+    }
+
+    func testSendClearInvalidatesPendingTypedSave() async {
+        let conversationHash = Data(repeating: 0xAA, count: 16)
+        let persistence = ControlledDraftPersistence(draftText: "previous draft")
+        let sleeper = ControlledDraftSleeper()
+        let debounceStarted = expectation(description: "Typed autosave is pending")
+        sleeper.onSleep = { debounceStarted.fulfill() }
+        let controller = makeController(
+            persistence: persistence,
+            conversationHash: conversationHash,
+            sleeper: sleeper
+        )
+
+        controller.textChanged("message being sent")
+        await fulfillment(of: [debounceStarted], timeout: 1)
+        controller.clearImmediately()
+        await persistence.waitForMutationCount(1)
+        sleeper.resumeAll()
+
+        let mutations = await persistence.mutations()
+        let stored = try? await persistence.fetchDraftText(for: conversationHash)
+        XCTAssertEqual(mutations, [.clear])
+        XCTAssertNil(stored)
+    }
+
+    func testNavigationFlushUsesLatestComposerValue() async {
+        let conversationHash = Data(repeating: 0xAB, count: 16)
+        let persistence = ControlledDraftPersistence()
+        let sleeper = ControlledDraftSleeper()
+        let debounceStarted = expectation(description: "Older autosave is pending")
+        sleeper.onSleep = { debounceStarted.fulfill() }
+        let controller = makeController(
+            persistence: persistence,
+            conversationHash: conversationHash,
+            sleeper: sleeper
+        )
+
+        controller.textChanged("older value")
+        await fulfillment(of: [debounceStarted], timeout: 1)
+        await controller.flush("latest value at navigation")
+        sleeper.resumeAll()
+
+        let mutations = await persistence.mutations()
+        let stored = try? await persistence.fetchDraftText(for: conversationHash)
+        XCTAssertEqual(mutations, [.save("latest value at navigation")])
+        XCTAssertEqual(stored, "latest value at navigation")
+    }
+
+    func testBackgroundFlushUsesLatestComposerValue() async {
+        let conversationHash = Data(repeating: 0xAC, count: 16)
+        let persistence = ControlledDraftPersistence()
+        let sleeper = ControlledDraftSleeper()
+        let debounceStarted = expectation(description: "Visible-screen autosave is pending")
+        sleeper.onSleep = { debounceStarted.fulfill() }
+        let controller = makeController(
+            persistence: persistence,
+            conversationHash: conversationHash,
+            sleeper: sleeper
+        )
+
+        controller.textChanged("value before backgrounding")
+        await fulfillment(of: [debounceStarted], timeout: 1)
+        await controller.flush("latest value at background")
+        sleeper.resumeAll()
+
+        let mutations = await persistence.mutations()
+        let stored = try? await persistence.fetchDraftText(for: conversationHash)
+        XCTAssertEqual(mutations, [.save("latest value at background")])
+        XCTAssertEqual(stored, "latest value at background")
+    }
 }

--- a/Tests/ColumbaAppTests/DraftMessageTests.swift
+++ b/Tests/ColumbaAppTests/DraftMessageTests.swift
@@ -3,6 +3,50 @@ import GRDB
 @testable import ColumbaApp
 
 final class DraftMessageTests: XCTestCase {
+    private enum DraftSnapshot: Equatable {
+        case missing
+        case present(String)
+        case readFailed
+    }
+
+    private final class NotificationReads: @unchecked Sendable {
+        private let lock = NSLock()
+        private var tasks: [Task<Void, Never>] = []
+        private var snapshots: [Data: [DraftSnapshot]] = [:]
+
+        func track(_ task: Task<Void, Never>) {
+            lock.lock()
+            tasks.append(task)
+            lock.unlock()
+        }
+
+        func append(_ snapshot: DraftSnapshot, for conversationHash: Data) {
+            lock.lock()
+            snapshots[conversationHash, default: []].append(snapshot)
+            lock.unlock()
+        }
+
+        func snapshots(for conversationHash: Data) -> [DraftSnapshot] {
+            lock.lock()
+            defer { lock.unlock() }
+            return snapshots[conversationHash, default: []]
+        }
+
+        private func trackedTasks() -> [Task<Void, Never>] {
+            lock.lock()
+            defer { lock.unlock() }
+            return tasks
+        }
+
+        func cancelAndWaitForTasks() async {
+            let trackedTasks = trackedTasks()
+            trackedTasks.forEach { $0.cancel() }
+            for task in trackedTasks {
+                await task.value
+            }
+        }
+    }
+
     private func temporaryDatabaseURL() -> URL {
         FileManager.default.temporaryDirectory
             .appendingPathComponent("columba-drafts-\(UUID().uuidString).sqlite")
@@ -57,16 +101,14 @@ final class DraftMessageTests: XCTestCase {
 
         try await repository.ensureConversation(conversationHash, displayName: nil)
         try await repository.saveDraft("first", for: conversationHash)
-        let storedFirst = try await repository.fetchDraft(for: conversationHash)
-        let first = try XCTUnwrap(storedFirst)
-        try await Task.sleep(nanoseconds: 1_000_000)
         try await repository.saveDraft("second", for: conversationHash)
         let storedReplacement = try await repository.fetchDraft(for: conversationHash)
         let replacement = try XCTUnwrap(storedReplacement)
         let drafts = try await repository.fetchDrafts()
 
         XCTAssertEqual(replacement.content, "second")
-        XCTAssertGreaterThan(replacement.updatedAt, first.updatedAt)
+        XCTAssertTrue(replacement.updatedAt.timeIntervalSince1970.isFinite)
+        XCTAssertGreaterThan(replacement.updatedAt.timeIntervalSince1970, 0)
         XCTAssertEqual(drafts[conversationHash], replacement)
         XCTAssertEqual(Set(drafts.keys), Set([conversationHash]))
     }
@@ -153,6 +195,7 @@ final class DraftMessageTests: XCTestCase {
         let reader = try MessageRepository(grdbPath: databaseURL.path)
         let conversationHash = Data(repeating: 0x88, count: 16)
         let readable = expectation(description: "Draft is readable when notification arrives")
+        let reads = NotificationReads()
 
         try await writer.ensureConversation(conversationHash, displayName: nil)
         let observer = NotificationCenter.default.addObserver(
@@ -163,16 +206,92 @@ final class DraftMessageTests: XCTestCase {
             guard let notifiedHash = notification.userInfo?[MessageRepository.conversationHashUserInfoKey] as? Data,
                   notifiedHash == conversationHash,
                   notification.userInfo?.count == 1 else { return }
-            Task {
+            let task = Task {
                 if try await reader.fetchDraft(for: conversationHash)?.content == "committed" {
                     readable.fulfill()
                 }
             }
+            reads.track(task)
         }
-        defer { NotificationCenter.default.removeObserver(observer) }
 
-        try await writer.saveDraft("committed", for: conversationHash)
+        do {
+            try await writer.saveDraft("committed", for: conversationHash)
+            await fulfillment(of: [readable], timeout: 1.0)
+        } catch {
+            NotificationCenter.default.removeObserver(observer)
+            await reads.cancelAndWaitForTasks()
+            throw error
+        }
+        NotificationCenter.default.removeObserver(observer)
+        await reads.cancelAndWaitForTasks()
+    }
 
-        await fulfillment(of: [readable], timeout: 1.0)
+    func testOverlappingSaveAndClearNotifyCommittedStateInMutationOrder() async throws {
+        let databaseURL = temporaryDatabaseURL()
+        defer { removeDatabase(at: databaseURL) }
+        let writer = try MessageRepository(grdbPath: databaseURL.path)
+        let reader = try MessageRepository(grdbPath: databaseURL.path)
+        let reads = NotificationReads()
+        let hashes = (0..<12).map { Data(repeating: UInt8(0x90 + $0), count: 16) }
+
+        for conversationHash in hashes {
+            try await writer.ensureConversation(conversationHash, displayName: nil)
+            try await writer.saveDraft("baseline", for: conversationHash)
+        }
+
+        let observer = NotificationCenter.default.addObserver(
+            forName: MessageRepository.draftChangedNotification,
+            object: nil,
+            queue: nil
+        ) { notification in
+            guard let conversationHash = notification.userInfo?[MessageRepository.conversationHashUserInfoKey] as? Data,
+                  hashes.contains(conversationHash) else { return }
+
+            // NotificationCenter invokes this observer synchronously. Waiting on
+            // a distinct repository captures the durable state at notification
+            // time before the writer can begin its next actor-isolated mutation.
+            let finished = DispatchSemaphore(value: 0)
+            let task = Task {
+                do {
+                    let draft = try await reader.fetchDraft(for: conversationHash)
+                    reads.append(draft.map { .present($0.content) } ?? .missing, for: conversationHash)
+                } catch {
+                    reads.append(.readFailed, for: conversationHash)
+                }
+                finished.signal()
+            }
+            reads.track(task)
+            _ = finished.wait(timeout: .now() + 2)
+        }
+
+        do {
+            for (index, conversationHash) in hashes.enumerated() {
+                let replacement = "replacement-\(index)"
+                async let save: Void = writer.saveDraft(replacement, for: conversationHash)
+                async let clear: Void = writer.clearDraft(for: conversationHash)
+                _ = try await (save, clear)
+
+                let snapshots = reads.snapshots(for: conversationHash)
+                let finalDraft = try await writer.fetchDraft(for: conversationHash)
+                let saveThenClear: [DraftSnapshot] = [.present(replacement), .missing]
+                let clearThenSave: [DraftSnapshot] = [.missing, .present(replacement)]
+
+                XCTAssertTrue(
+                    snapshots == saveThenClear || snapshots == clearThenSave,
+                    "Each notification must expose its own committed mutation; got \(snapshots)"
+                )
+                XCTAssertEqual(
+                    snapshots.last,
+                    finalDraft.map { .present($0.content) } ?? .missing
+                )
+            }
+        } catch {
+            NotificationCenter.default.removeObserver(observer)
+            await reads.cancelAndWaitForTasks()
+            throw error
+        }
+
+        NotificationCenter.default.removeObserver(observer)
+        await reads.cancelAndWaitForTasks()
     }
 }

--- a/Tests/ColumbaAppTests/DraftMessageTests.swift
+++ b/Tests/ColumbaAppTests/DraftMessageTests.swift
@@ -206,9 +206,13 @@ final class DraftMessageTests: XCTestCase {
             guard let notifiedHash = notification.userInfo?[MessageRepository.conversationHashUserInfoKey] as? Data,
                   notifiedHash == conversationHash,
                   notification.userInfo?.count == 1 else { return }
-            let task = Task {
-                if try await reader.fetchDraft(for: conversationHash)?.content == "committed" {
-                    readable.fulfill()
+            let task = Task<Void, Never> {
+                do {
+                    if try await reader.fetchDraft(for: conversationHash)?.content == "committed" {
+                        readable.fulfill()
+                    }
+                } catch {
+                    XCTFail("Draft read after notification failed: \(error)")
                 }
             }
             reads.track(task)

--- a/Tests/ColumbaAppTests/DraftMessageTests.swift
+++ b/Tests/ColumbaAppTests/DraftMessageTests.swift
@@ -341,6 +341,65 @@ final class ChatsDraftProjectionTests: XCTestCase {
         try? FileManager.default.removeItem(atPath: url.path + "-wal")
     }
 
+    private func conversationHash(_ index: Int) -> Data {
+        var bytes = [UInt8](repeating: 0, count: 16)
+        bytes[14] = UInt8((index >> 8) & 0xff)
+        bytes[15] = UInt8(index & 0xff)
+        return Data(bytes)
+    }
+
+    private func repositoryBackedNoMessageDraft(
+        at databaseURL: URL
+    ) async throws -> (RNSAPI.ConversationRecord, DraftRecord, [Conversation]) {
+        let repository = try MessageRepository(grdbPath: databaseURL.path)
+        let hash = conversationHash(0xD9)
+        try await repository.ensureConversation(hash, displayName: "Draft parent")
+        try await repository.saveDraft("repository-backed draft", for: hash)
+
+        let storedRecord = try await repository.fetchConversation(hash)
+        let storedDraft = try await repository.fetchDraft(for: hash)
+        let record = try XCTUnwrap(storedRecord)
+        let draft = try XCTUnwrap(storedDraft)
+        let projected = ChatsViewModel.prepareConversations(
+            records: [record],
+            drafts: [hash: draft]
+        )
+        return (record, draft, projected)
+    }
+
+    private func loadDraftParentBeyondFirstPage(
+        at databaseURL: URL
+    ) async throws -> (draftParent: Data, firstPage: [Data], loaded: [Conversation]) {
+        let repository = try MessageRepository(grdbPath: databaseURL.path)
+        let draftParent = conversationHash(0)
+
+        for index in 0...100 {
+            let destinationHash = conversationHash(index)
+            let message = RNSAPI.LXMessage(
+                destinationHash: destinationHash,
+                sourceIdentity: nil,
+                content: Data("message-\(index)".utf8)
+            )
+            var messageID = [UInt8](repeating: 0, count: 32)
+            messageID[30] = UInt8((index >> 8) & 0xff)
+            messageID[31] = UInt8(index & 0xff)
+            message.hash = Data(messageID)
+            message.timestamp = Double(index + 1)
+            message.state = .sent
+            message.method = .opportunistic
+            try await repository.saveMessage(message)
+        }
+        try await repository.saveDraft("old conversation draft", for: draftParent)
+
+        let firstPage = try await repository.fetchConversations().map(\.destinationHash)
+        let viewModel = ChatsViewModel(
+            repository: repository,
+            notificationObserver: NotificationObserver()
+        )
+        await viewModel.loadConversations()
+        return (draftParent, firstPage, viewModel.conversations)
+    }
+
     func testDraftOverridesLastMessagePreviewWithoutChangingUnreadCount() {
         let source = record(hashByte: 0xD1, unreadCount: 4)
         let projected = ChatsViewModel.prepareConversations(
@@ -383,6 +442,52 @@ final class ChatsDraftProjectionTests: XCTestCase {
 
         XCTAssertEqual(projected.first?.lastMessageTimestamp, draftTimestamp)
         XCTAssertEqual(projected.first?.draftUpdatedAt, draftTimestamp)
+    }
+
+    func testRepositoryCreatedConversationWithoutMessageUsesDraftTimestamp() async throws {
+        let databaseURL = temporaryDatabaseURL()
+        let snapshot: (RNSAPI.ConversationRecord, DraftRecord, [Conversation])
+        do {
+            snapshot = try await repositoryBackedNoMessageDraft(at: databaseURL)
+        } catch {
+            removeDatabase(at: databaseURL)
+            throw error
+        }
+        removeDatabase(at: databaseURL)
+
+        let (record, draft, projected) = snapshot
+        XCTAssertNotNil(record.lastMessageAt, "real mapping supplies the conversation creation timestamp")
+        XCTAssertTrue(record.lastMessagePreview.isEmpty, "empty preview is the persisted no-message signal")
+        XCTAssertEqual(projected.first?.lastMessageTimestamp, draft.updatedAt)
+        XCTAssertEqual(projected.first?.draftUpdatedAt, draft.updatedAt)
+    }
+
+    func testLoadIncludesDraftParentBeyondFirstConversationPage() async throws {
+        let databaseURL = temporaryDatabaseURL()
+        let snapshot: (draftParent: Data, firstPage: [Data], loaded: [Conversation])
+        do {
+            snapshot = try await loadDraftParentBeyondFirstPage(at: databaseURL)
+        } catch {
+            removeDatabase(at: databaseURL)
+            throw error
+        }
+        removeDatabase(at: databaseURL)
+
+        XCTAssertEqual(snapshot.firstPage.count, 100)
+        XCTAssertFalse(snapshot.firstPage.contains(snapshot.draftParent))
+        XCTAssertEqual(snapshot.loaded.count, 101)
+        let draftedConversation = try XCTUnwrap(
+            snapshot.loaded.first { $0.destinationHash == snapshot.draftParent }
+        )
+        XCTAssertEqual(draftedConversation.previewKind, .draft)
+        XCTAssertEqual(draftedConversation.draftText, "old conversation draft")
+        XCTAssertEqual(
+            Set(snapshot.loaded.lazy
+                .filter { $0.destinationHash != snapshot.draftParent }
+                .map(\.destinationHash)),
+            Set(snapshot.firstPage),
+            "the existing visible page must remain unchanged for nondraft records"
+        )
     }
 
     func testExistingConversationKeepsMessageTimestampWhenDraftExists() {

--- a/Tests/ColumbaAppTests/DraftMessageTests.swift
+++ b/Tests/ColumbaAppTests/DraftMessageTests.swift
@@ -1,0 +1,156 @@
+import XCTest
+@testable import ColumbaApp
+
+final class DraftMessageTests: XCTestCase {
+    private func temporaryDatabaseURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("columba-drafts-\(UUID().uuidString).sqlite")
+    }
+
+    private func removeDatabase(at url: URL) {
+        try? FileManager.default.removeItem(at: url)
+        try? FileManager.default.removeItem(atPath: url.path + "-shm")
+        try? FileManager.default.removeItem(atPath: url.path + "-wal")
+    }
+
+    func testDraftRoundTripsWithoutChangingWhitespace() async throws {
+        let databaseURL = temporaryDatabaseURL()
+        defer { removeDatabase(at: databaseURL) }
+        let repository = try MessageRepository(grdbPath: databaseURL.path)
+        let conversationHash = Data(repeating: 0x11, count: 16)
+        let content = "  keep this draft exactly  \n"
+
+        try await repository.ensureConversation(conversationHash, displayName: nil)
+        let beforeSave = Date()
+        try await repository.saveDraft(content, for: conversationHash)
+        let storedDraft = try await repository.fetchDraft(for: conversationHash)
+        let draft = try XCTUnwrap(storedDraft)
+
+        XCTAssertEqual(draft.conversationHash, conversationHash)
+        XCTAssertEqual(draft.content, content)
+        XCTAssertGreaterThanOrEqual(draft.updatedAt, beforeSave)
+        XCTAssertLessThanOrEqual(draft.updatedAt, Date())
+    }
+
+    func testWhitespaceOnlyDraftDeletesExistingDraft() async throws {
+        let databaseURL = temporaryDatabaseURL()
+        defer { removeDatabase(at: databaseURL) }
+        let repository = try MessageRepository(grdbPath: databaseURL.path)
+        let conversationHash = Data(repeating: 0x22, count: 16)
+
+        try await repository.ensureConversation(conversationHash, displayName: nil)
+        try await repository.saveDraft("keep me", for: conversationHash)
+        try await repository.saveDraft(" \t\n ", for: conversationHash)
+
+        let storedDraft = try await repository.fetchDraft(for: conversationHash)
+        let drafts = try await repository.fetchDrafts()
+        XCTAssertNil(storedDraft)
+        XCTAssertTrue(drafts.isEmpty)
+    }
+
+    func testSavingAgainReplacesDraftForConversation() async throws {
+        let databaseURL = temporaryDatabaseURL()
+        defer { removeDatabase(at: databaseURL) }
+        let repository = try MessageRepository(grdbPath: databaseURL.path)
+        let conversationHash = Data(repeating: 0x33, count: 16)
+
+        try await repository.ensureConversation(conversationHash, displayName: nil)
+        try await repository.saveDraft("first", for: conversationHash)
+        let storedFirst = try await repository.fetchDraft(for: conversationHash)
+        let first = try XCTUnwrap(storedFirst)
+        try await Task.sleep(nanoseconds: 1_000_000)
+        try await repository.saveDraft("second", for: conversationHash)
+        let storedReplacement = try await repository.fetchDraft(for: conversationHash)
+        let replacement = try XCTUnwrap(storedReplacement)
+        let drafts = try await repository.fetchDrafts()
+
+        XCTAssertEqual(replacement.content, "second")
+        XCTAssertGreaterThan(replacement.updatedAt, first.updatedAt)
+        XCTAssertEqual(drafts.count, 1)
+    }
+
+    func testDraftsAreIsolatedByConversation() async throws {
+        let databaseURL = temporaryDatabaseURL()
+        defer { removeDatabase(at: databaseURL) }
+        let repository = try MessageRepository(grdbPath: databaseURL.path)
+        let firstHash = Data(repeating: 0x44, count: 16)
+        let secondHash = Data(repeating: 0x55, count: 16)
+
+        try await repository.ensureConversation(firstHash, displayName: nil)
+        try await repository.ensureConversation(secondHash, displayName: nil)
+        try await repository.saveDraft("first conversation", for: firstHash)
+        try await repository.saveDraft("second conversation", for: secondHash)
+
+        let firstDraft = try await repository.fetchDraft(for: firstHash)
+        let secondDraft = try await repository.fetchDraft(for: secondHash)
+        let drafts = try await repository.fetchDrafts()
+        XCTAssertEqual(firstDraft?.content, "first conversation")
+        XCTAssertEqual(secondDraft?.content, "second conversation")
+        XCTAssertEqual(Set(drafts.map(\.conversationHash)), Set([firstHash, secondHash]))
+    }
+
+    func testDraftsAreIsolatedByDatabasePath() async throws {
+        let firstURL = temporaryDatabaseURL()
+        let secondURL = temporaryDatabaseURL()
+        defer {
+            removeDatabase(at: firstURL)
+            removeDatabase(at: secondURL)
+        }
+        let firstRepository = try MessageRepository(grdbPath: firstURL.path)
+        let secondRepository = try MessageRepository(grdbPath: secondURL.path)
+        let conversationHash = Data(repeating: 0x66, count: 16)
+
+        try await firstRepository.ensureConversation(conversationHash, displayName: nil)
+        try await secondRepository.ensureConversation(conversationHash, displayName: nil)
+        try await firstRepository.saveDraft("identity one", for: conversationHash)
+
+        let firstDraft = try await firstRepository.fetchDraft(for: conversationHash)
+        let secondDraft = try await secondRepository.fetchDraft(for: conversationHash)
+        XCTAssertEqual(firstDraft?.content, "identity one")
+        XCTAssertNil(secondDraft)
+    }
+
+    func testDeletingConversationCascadesToDraft() async throws {
+        let databaseURL = temporaryDatabaseURL()
+        defer { removeDatabase(at: databaseURL) }
+        let repository = try MessageRepository(grdbPath: databaseURL.path)
+        let conversationHash = Data(repeating: 0x77, count: 16)
+
+        try await repository.ensureConversation(conversationHash, displayName: nil)
+        try await repository.saveDraft("temporary", for: conversationHash)
+        try await repository.deleteConversation(conversationHash)
+
+        let storedDraft = try await repository.fetchDraft(for: conversationHash)
+        XCTAssertNil(storedDraft)
+    }
+
+    func testNotificationIsPostedAfterCommittedDraftIsReadable() async throws {
+        let databaseURL = temporaryDatabaseURL()
+        defer { removeDatabase(at: databaseURL) }
+        let writer = try MessageRepository(grdbPath: databaseURL.path)
+        let reader = try MessageRepository(grdbPath: databaseURL.path)
+        let conversationHash = Data(repeating: 0x88, count: 16)
+        let readable = expectation(description: "Draft is readable when notification arrives")
+
+        try await writer.ensureConversation(conversationHash, displayName: nil)
+        let observer = NotificationCenter.default.addObserver(
+            forName: MessageRepository.draftChangedNotification,
+            object: nil,
+            queue: nil
+        ) { notification in
+            guard let notifiedHash = notification.userInfo?[MessageRepository.conversationHashUserInfoKey] as? Data,
+                  notifiedHash == conversationHash,
+                  notification.userInfo?.count == 1 else { return }
+            Task {
+                if try await reader.fetchDraft(for: conversationHash)?.content == "committed" {
+                    readable.fulfill()
+                }
+            }
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        try await writer.saveDraft("committed", for: conversationHash)
+
+        await fulfillment(of: [readable], timeout: 1.0)
+    }
+}


### PR DESCRIPTION
## Summary

- persist exact text drafts per conversation in the identity-scoped message database
- restore and autosave composer text with race-safe debounce, lifecycle flushes, and send-time clearing
- show committed drafts in Chats with an Android-style `Draft:` preview
- preserve message ordering for attachment-only conversations and include drafted conversations beyond the normal first page
- cascade draft deletion with conversation deletion

Fixes #143

## Verification

- static contracts: 224 passed, 1 skipped
- fresh focused draft tests: 37 passed, 0 failed
- full shipping XCTest target: 234 passed, 0 failed
- shipping `Columba` build: passed
- `Columba-ModelB` compile build: passed
- project reconciler: two-pass idempotent
- exact-head specification audit: passed
- exact-head code-quality audit: approved with no findings
- signed exact-head iPhone build, install, launch, and physical draft smoke test: passed

## Scope

Draft persistence is text-only. Attachments, images, files, and reply context are intentionally not stored as part of drafts.

## Risk and rollback

The schema addition is app-owned and idempotent, with no change to the pinned LXMF package migration chain. Reverting this PR leaves the draft table unused; existing message and conversation data remain unchanged.
