### PR TITLE
Fix composer timeline drift across conversation updates

### DIFF
--- a/Sources/ColumbaApp/Views/Messaging/MessageTimelineView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageTimelineView.swift
@@ -72,6 +72,7 @@ struct MessageRefreshWindowPolicy {
 #if os(iOS)
 @available(iOS 17.0, *)
 struct MessageTimelineView: UIViewControllerRepresentable {
+    let conversationID: String
     let messages: [Message]
     let messageTextScale: Double
     let isLoadingMore: Bool
@@ -100,6 +101,7 @@ struct MessageTimelineView: UIViewControllerRepresentable {
         controller.onLongPress = onLongPress
         controller.onOpenLink = onOpenLink
         controller.update(
+            conversationID: conversationID,
             messages: messages,
             messageTextScale: messageTextScale,
             isLoadingMore: isLoadingMore,
@@ -117,6 +119,7 @@ final class MessageTimelineViewController: UIViewController, UICollectionViewDat
     var onOpenLink: ((MessageLinkTarget) -> Void)?
 
     private var messages: [Message] = []
+    private var conversationID: String?
     fileprivate var messageTextScale = SettingsRepository.MessageTextScale.defaultValue
     private var isLoadingMore = false
     private var allMessagesLoaded = false
@@ -215,23 +218,35 @@ final class MessageTimelineViewController: UIViewController, UICollectionViewDat
     }
 
     func update(
+        conversationID newConversationID: String? = nil,
         messages newMessages: [Message],
         messageTextScale: Double? = nil,
         isLoadingMore: Bool,
         allMessagesLoaded: Bool
     ) {
+        let updatedMessages = deduplicated(newMessages)
+        let updatedMessageTextScale = messageTextScale ?? self.messageTextScale
+        let needsRenderingUpdate = conversationID != newConversationID
+            || messages != updatedMessages
+            || self.messageTextScale != updatedMessageTextScale
+
+        self.isLoadingMore = isLoadingMore || loadTask != nil
+        self.allMessagesLoaded = allMessagesLoaded
+        updateLoadingIndicator()
+
+        guard needsRenderingUpdate else {
+            requestOlderMessagesIfNecessary()
+            return
+        }
+
         let oldMessages = messages
         let anchor = visibleAnchor()
         let wasNearBottom = self.isNearBottom
         let oldLastID = oldMessages.last?.id
 
-        messages = deduplicated(newMessages)
-        if let messageTextScale {
-            self.messageTextScale = messageTextScale
-        }
-        self.isLoadingMore = isLoadingMore || loadTask != nil
-        self.allMessagesLoaded = allMessagesLoaded
-        updateLoadingIndicator()
+        conversationID = newConversationID
+        messages = updatedMessages
+        self.messageTextScale = updatedMessageTextScale
 
         guard isViewLoaded else { return }
 
@@ -425,6 +440,10 @@ final class MessageTimelineViewController: UIViewController, UICollectionViewDat
 
     var configuredMessageTextScale: Double {
         messageTextScale
+    }
+
+    var configuredLoadingState: (isLoadingMore: Bool, allMessagesLoaded: Bool) {
+        (isLoadingMore, allMessagesLoaded)
     }
 
     var visibleMessageCellCount: Int {

--- a/Sources/ColumbaApp/Views/Messaging/MessageTimelineView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageTimelineView.swift
@@ -446,6 +446,14 @@ final class MessageTimelineViewController: UIViewController, UICollectionViewDat
         (isLoadingMore, allMessagesLoaded)
     }
 
+    var hasActiveLoadTaskForTesting: Bool {
+        loadTask != nil
+    }
+
+    var isViewportNearBottomForTesting: Bool {
+        isNearBottom
+    }
+
     var visibleMessageCellCount: Int {
         collectionView.indexPathsForVisibleItems.count
     }

--- a/Sources/ColumbaApp/Views/Messaging/MessageTimelineView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageTimelineView.swift
@@ -234,7 +234,7 @@ final class MessageTimelineViewController: UIViewController, UICollectionViewDat
         if conversationChanged {
             loadTask?.cancel()
             loadTask = nil
-            isLoadingMore = false
+            self.isLoadingMore = false
             needsInitialBottomScroll = !updatedMessages.isEmpty
             hasCompletedInitialPositioning = false
             previousViewportSize = .zero

--- a/Sources/ColumbaApp/Views/Messaging/MessageTimelineView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageTimelineView.swift
@@ -125,6 +125,7 @@ final class MessageTimelineViewController: UIViewController, UICollectionViewDat
     private var hasCompletedInitialPositioning = false
     private var previousViewportSize = CGSize.zero
     private var shouldFollowBottomAcrossResize = false
+    private(set) var timelineReloadCountForTesting = 0
 
     private lazy var collectionView: UICollectionView = {
         let layout = UICollectionViewCompositionalLayout { _, _ in
@@ -234,6 +235,7 @@ final class MessageTimelineViewController: UIViewController, UICollectionViewDat
 
         guard isViewLoaded else { return }
 
+        timelineReloadCountForTesting += 1
         collectionView.reloadData()
         collectionView.collectionViewLayout.invalidateLayout()
         collectionView.layoutIfNeeded()
@@ -427,6 +429,23 @@ final class MessageTimelineViewController: UIViewController, UICollectionViewDat
 
     var visibleMessageCellCount: Int {
         collectionView.indexPathsForVisibleItems.count
+    }
+
+    struct ViewportSnapshot: Equatable {
+        let anchorMessageID: String
+        let anchorViewportMinY: CGFloat
+        let contentOffsetY: CGFloat
+    }
+
+    func viewportSnapshotForTesting() -> ViewportSnapshot? {
+        view.setNeedsLayout()
+        view.layoutIfNeeded()
+        guard let anchor = visibleAnchor() else { return nil }
+        return ViewportSnapshot(
+            anchorMessageID: anchor.messageID,
+            anchorViewportMinY: anchor.minY - anchor.contentOffsetY,
+            contentOffsetY: anchor.contentOffsetY
+        )
     }
 
     func setViewportForTesting(_ size: CGSize) {

--- a/Sources/ColumbaApp/Views/Messaging/MessageTimelineView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageTimelineView.swift
@@ -226,9 +226,20 @@ final class MessageTimelineViewController: UIViewController, UICollectionViewDat
     ) {
         let updatedMessages = deduplicated(newMessages)
         let updatedMessageTextScale = messageTextScale ?? self.messageTextScale
-        let needsRenderingUpdate = conversationID != newConversationID
+        let conversationChanged = conversationID != newConversationID
+        let needsRenderingUpdate = conversationChanged
             || messages != updatedMessages
             || self.messageTextScale != updatedMessageTextScale
+
+        if conversationChanged {
+            loadTask?.cancel()
+            loadTask = nil
+            isLoadingMore = false
+            needsInitialBottomScroll = !updatedMessages.isEmpty
+            hasCompletedInitialPositioning = false
+            previousViewportSize = .zero
+            shouldFollowBottomAcrossResize = false
+        }
 
         self.isLoadingMore = isLoadingMore || loadTask != nil
         self.allMessagesLoaded = allMessagesLoaded
@@ -240,8 +251,8 @@ final class MessageTimelineViewController: UIViewController, UICollectionViewDat
         }
 
         let oldMessages = messages
-        let anchor = visibleAnchor()
-        let wasNearBottom = self.isNearBottom
+        let anchor = conversationChanged ? nil : visibleAnchor()
+        let wasNearBottom = conversationChanged ? false : self.isNearBottom
         let oldLastID = oldMessages.last?.id
 
         conversationID = newConversationID
@@ -255,7 +266,9 @@ final class MessageTimelineViewController: UIViewController, UICollectionViewDat
         collectionView.collectionViewLayout.invalidateLayout()
         collectionView.layoutIfNeeded()
 
-        if oldMessages.isEmpty, !messages.isEmpty {
+        if conversationChanged {
+            view.setNeedsLayout()
+        } else if oldMessages.isEmpty, !messages.isEmpty {
             needsInitialBottomScroll = true
             hasCompletedInitialPositioning = false
             view.setNeedsLayout()

--- a/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
@@ -181,6 +181,7 @@ struct MessagingView: View {
             if let vm = viewModel {
                 #if os(iOS)
                 MessageTimelineView(
+                    conversationID: conversation.id,
                     messages: vm.messages,
                     messageTextScale: messageTextScale,
                     isLoadingMore: vm.isLoadingMore,

--- a/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
+++ b/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
@@ -673,6 +673,51 @@ final class MessageTimelinePolicyTests: XCTestCase {
     }
 
     @MainActor
+    func testIdenticalTimelineUpdatesPreserveViewportWithoutReloading() throws {
+        let controller = MessageTimelineViewController()
+        controller.loadViewIfNeeded()
+        controller.setViewportForTesting(CGSize(width: 390, height: 500))
+        let messages = (0..<50).map { index in
+            Message(
+                id: "message-\(index)",
+                content: String(repeating: "Variable-height message \(index). ", count: index % 5 + 1),
+                timestamp: Date(timeIntervalSince1970: TimeInterval(index)),
+                isFromMe: index.isMultiple(of: 2),
+                deliveryStatus: .delivered
+            )
+        }
+        controller.update(
+            messages: messages,
+            messageTextScale: 1.0,
+            isLoadingMore: false,
+            allMessagesLoaded: true
+        )
+        controller.setContentOffsetForTesting(y: 1_000)
+
+        let initialViewport = try XCTUnwrap(controller.viewportSnapshotForTesting())
+        let initialReloadCount = controller.timelineReloadCountForTesting
+
+        for _ in 0..<10 {
+            controller.update(
+                messages: messages,
+                messageTextScale: 1.0,
+                isLoadingMore: false,
+                allMessagesLoaded: true
+            )
+        }
+
+        let finalViewport = try XCTUnwrap(controller.viewportSnapshotForTesting())
+        XCTAssertEqual(finalViewport.anchorMessageID, initialViewport.anchorMessageID)
+        XCTAssertEqual(finalViewport.anchorViewportMinY, initialViewport.anchorViewportMinY, accuracy: 0.001)
+        XCTAssertEqual(finalViewport.contentOffsetY, initialViewport.contentOffsetY, accuracy: 0.001)
+        XCTAssertEqual(
+            controller.timelineReloadCountForTesting,
+            initialReloadCount,
+            "An unchanged SwiftUI update must not reload or restore the collection timeline"
+        )
+    }
+
+    @MainActor
     func testCollectionTimelineRequestsHistoryFromScrollOffset() async {
         let requested = expectation(description: "older page requested")
         let controller = MessageTimelineViewController()

--- a/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
+++ b/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
@@ -755,6 +755,142 @@ final class MessageTimelinePolicyTests: XCTestCase {
     }
 
     @MainActor
+    func testConversationTransitionPositionsNewTimelineAtBottomWithoutRestoringOldViewport() throws {
+        let controller = MessageTimelineViewController()
+        controller.loadViewIfNeeded()
+        controller.setViewportForTesting(CGSize(width: 390, height: 500))
+        let messagesA = timelineMessages(prefix: "a", count: 60)
+        let messagesB = timelineMessages(prefix: "b", count: 60)
+
+        controller.update(
+            conversationID: "conversation-a",
+            messages: messagesA,
+            isLoadingMore: false,
+            allMessagesLoaded: true
+        )
+        controller.setContentOffsetForTesting(y: 1_000)
+        let oldViewport = try XCTUnwrap(controller.viewportSnapshotForTesting())
+        XCTAssertTrue(oldViewport.anchorMessageID.hasPrefix("a-"))
+        XCTAssertFalse(controller.isViewportNearBottomForTesting)
+
+        controller.update(
+            conversationID: "conversation-b",
+            messages: messagesB,
+            isLoadingMore: false,
+            allMessagesLoaded: true
+        )
+
+        let newViewport = try XCTUnwrap(controller.viewportSnapshotForTesting())
+        XCTAssertTrue(newViewport.anchorMessageID.hasPrefix("b-"))
+        XCTAssertTrue(
+            controller.isViewportNearBottomForTesting,
+            "A reused controller must initially position the new conversation at its bottom"
+        )
+        XCTAssertGreaterThan(
+            newViewport.contentOffsetY,
+            oldViewport.contentOffsetY + 500,
+            "The new conversation must not inherit the old conversation's numeric offset"
+        )
+    }
+
+    @MainActor
+    func testConversationTransitionCancelsOlderHistoryLoadAndRejectsItsCompletion() async {
+        let gate = TimelineLoadGate()
+        let oldLoadReturned = expectation(description: "old load callback returned")
+        let controller = MessageTimelineViewController()
+        controller.onLoadOlder = {
+            await gate.wait()
+            oldLoadReturned.fulfill()
+            return true
+        }
+        controller.loadViewIfNeeded()
+        controller.setViewportForTesting(CGSize(width: 390, height: 500))
+        controller.update(
+            conversationID: "conversation-a",
+            messages: timelineMessages(prefix: "a", count: 60),
+            isLoadingMore: false,
+            allMessagesLoaded: false
+        )
+        controller.setContentOffsetForTesting(y: 0)
+        await gate.waitUntilBlocked()
+        XCTAssertTrue(controller.hasActiveLoadTaskForTesting)
+
+        var newConversationLoadCount = 0
+        controller.onLoadOlder = {
+            newConversationLoadCount += 1
+            return false
+        }
+        controller.update(
+            conversationID: "conversation-b",
+            messages: timelineMessages(prefix: "b", count: 60),
+            isLoadingMore: false,
+            allMessagesLoaded: false
+        )
+
+        XCTAssertFalse(
+            controller.hasActiveLoadTaskForTesting,
+            "Conversation B must not remain owned by conversation A's pagination task"
+        )
+        XCTAssertFalse(controller.configuredLoadingState.isLoadingMore)
+        XCTAssertTrue(controller.isViewportNearBottomForTesting)
+
+        controller.update(
+            conversationID: "conversation-b",
+            messages: timelineMessages(prefix: "b", count: 60),
+            isLoadingMore: true,
+            allMessagesLoaded: false
+        )
+        await gate.open()
+        await fulfillment(of: [oldLoadReturned], timeout: 1)
+        await Task.yield()
+
+        XCTAssertTrue(
+            controller.configuredLoadingState.isLoadingMore,
+            "A stale completion must not clear conversation B's externally owned loading state"
+        )
+        XCTAssertEqual(newConversationLoadCount, 0)
+    }
+
+    @MainActor
+    func testNoOpTimelineUpdateUsesFreshPaginationCallbackWithoutReloading() async {
+        let controller = MessageTimelineViewController()
+        var staleCallbackCount = 0
+        controller.onLoadOlder = {
+            staleCallbackCount += 1
+            return false
+        }
+        controller.loadViewIfNeeded()
+        controller.setViewportForTesting(CGSize(width: 390, height: 500))
+        let messages = timelineMessages(prefix: "callback", count: 60)
+        controller.update(
+            conversationID: "conversation",
+            messages: messages,
+            isLoadingMore: false,
+            allMessagesLoaded: true
+        )
+        controller.setContentOffsetForTesting(y: 2_000)
+        let reloadCount = controller.timelineReloadCountForTesting
+
+        let freshCallbackCalled = expectation(description: "fresh pagination callback called")
+        controller.onLoadOlder = {
+            freshCallbackCalled.fulfill()
+            return false
+        }
+        controller.update(
+            conversationID: "conversation",
+            messages: messages,
+            isLoadingMore: false,
+            allMessagesLoaded: false
+        )
+        XCTAssertEqual(controller.timelineReloadCountForTesting, reloadCount)
+
+        controller.setContentOffsetForTesting(y: 0)
+        await fulfillment(of: [freshCallbackCalled], timeout: 1)
+        XCTAssertEqual(staleCallbackCount, 0)
+        XCTAssertEqual(controller.timelineReloadCountForTesting, reloadCount)
+    }
+
+    @MainActor
     func testCollectionTimelineRequestsHistoryFromScrollOffset() async {
         let requested = expectation(description: "older page requested")
         let controller = MessageTimelineViewController()
@@ -799,5 +935,38 @@ final class MessageTimelinePolicyTests: XCTestCase {
         try? await Task.sleep(for: .milliseconds(100))
 
         XCTAssertEqual(requestCount, 1)
+    }
+
+    private func timelineMessages(prefix: String, count: Int) -> [Message] {
+        (0..<count).map { index in
+            Message(
+                id: "\(prefix)-\(index)",
+                content: String(repeating: "Variable timeline row \(prefix)-\(index). ", count: index % 5 + 1),
+                timestamp: Date(timeIntervalSince1970: TimeInterval(index)),
+                isFromMe: index.isMultiple(of: 2),
+                deliveryStatus: .delivered
+            )
+        }
+    }
+}
+
+private actor TimelineLoadGate {
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func wait() async {
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func waitUntilBlocked() async {
+        while continuation == nil {
+            await Task.yield()
+        }
+    }
+
+    func open() {
+        continuation?.resume()
+        continuation = nil
     }
 }

--- a/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
+++ b/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
@@ -715,6 +715,43 @@ final class MessageTimelinePolicyTests: XCTestCase {
             initialReloadCount,
             "An unchanged SwiftUI update must not reload or restore the collection timeline"
         )
+
+        controller.update(
+            messages: messages,
+            messageTextScale: 1.0,
+            isLoadingMore: true,
+            allMessagesLoaded: false
+        )
+        XCTAssertTrue(controller.configuredLoadingState.isLoadingMore)
+        XCTAssertFalse(controller.configuredLoadingState.allMessagesLoaded)
+        XCTAssertEqual(controller.timelineReloadCountForTesting, initialReloadCount)
+
+        var changedMessages = messages
+        changedMessages[20].content = "Updated delivery content"
+        controller.update(
+            messages: changedMessages,
+            messageTextScale: 1.0,
+            isLoadingMore: false,
+            allMessagesLoaded: true
+        )
+        XCTAssertEqual(controller.timelineReloadCountForTesting, initialReloadCount + 1)
+
+        controller.update(
+            messages: changedMessages,
+            messageTextScale: 1.3,
+            isLoadingMore: false,
+            allMessagesLoaded: true
+        )
+        XCTAssertEqual(controller.timelineReloadCountForTesting, initialReloadCount + 2)
+
+        controller.update(
+            conversationID: "different-conversation",
+            messages: changedMessages,
+            messageTextScale: 1.3,
+            isLoadingMore: false,
+            allMessagesLoaded: true
+        )
+        XCTAssertEqual(controller.timelineReloadCountForTesting, initialReloadCount + 3)
     }
 
     @MainActor

--- a/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
+++ b/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
@@ -832,6 +832,7 @@ final class MessageTimelinePolicyTests: XCTestCase {
             "Conversation B must not remain owned by conversation A's pagination task"
         )
         XCTAssertFalse(controller.configuredLoadingState.isLoadingMore)
+        XCTAssertNotNil(controller.viewportSnapshotForTesting())
         XCTAssertTrue(controller.isViewportNearBottomForTesting)
 
         controller.update(


### PR DESCRIPTION
## Summary

When the composer updates its conversation after sending, the timeline could reload an unchanged collection, restore viewport state owned by the previous conversation, or leave loading state attached to a superseded request. This caused visible timeline drift and incorrect positioning.

This change:
- skips reloads when the timeline identity is unchanged while refreshing pagination callbacks;
- resets viewport and loading ownership when the conversation changes;
- rejects completion from an older conversation load;
- keeps the new conversation positioned at the bottom.

## Verification

- TDD red/green coverage for no-op updates, conversation transitions, stale load completion, and callback refresh
- Focused iOS tests: 3 passed, 0 failed
- Timeline policy group: 16 passed, 0 failed
- Full iOS app suite: 239 passed, 0 failed
- Static CI contract suite: 92 passed, 0 failed
- The behavior-identical source patch previously passed physical device build, signing, installation, launch, and hands-on acceptance
- Rebased five-commit stack is patch-identical to the accepted source and changes only the two messaging views plus their timeline tests

## Risk and rollback

Risk is limited to message timeline reload and conversation-transition state. The regression suite covers unchanged updates, callback replacement, transition positioning, and stale async completion. Rollback is a revert of this five-commit stack.
