### PR TITLE
Complete NomadNet navigation and canonical Micron rendering

### DIFF
--- a/Sources/ColumbaApp/Models/MicronDocument.swift
+++ b/Sources/ColumbaApp/Models/MicronDocument.swift
@@ -20,9 +20,9 @@ public struct MicronDocument: Sendable, Equatable {
 public struct MicronPageHeaders: Sendable, Equatable {
     /// Cache duration in seconds. nil = default (12h), 0 = no cache.
     public var cacheSeconds: Int?
-    /// Background color as 3- or 6-digit hex (e.g. "222" or "282828").
+    /// Background color as legacy 3-digit hex (for example, "222").
     public var backgroundColor: String?
-    /// Foreground color as 3- or 6-digit hex (e.g. "fff" or "c9d1d9").
+    /// Foreground color as legacy 3-digit hex (for example, "fff").
     public var foregroundColor: String?
 
     public init(cacheSeconds: Int? = nil, backgroundColor: String? = nil, foregroundColor: String? = nil) {

--- a/Sources/ColumbaApp/Models/MicronDocument.swift
+++ b/Sources/ColumbaApp/Models/MicronDocument.swift
@@ -44,10 +44,23 @@ public struct MicronPageHeaders: Sendable, Equatable {
 public enum MicronElement: Sendable, Equatable {
     case heading(level: Int, spans: [MicronSpan], alignment: MicronAlignment)
     case paragraph(spans: [MicronSpan], alignment: MicronAlignment, indentLevel: Int)
-    case divider(character: Character?)
-    case literalBlock(text: String)
-    case formField(MicronFormField)
-    case partial(MicronPartial)
+    case divider(character: Character?, indentLevel: Int)
+    case literalBlock(text: String, indentLevel: Int)
+    case formField(MicronFormField, indentLevel: Int)
+    case partial(MicronPartial, indentLevel: Int)
+
+    public var sectionIndent: Int {
+        switch self {
+        case .heading(let level, _, _):
+            return max(0, (level - 1) * 2)
+        case .paragraph(_, _, let indentLevel),
+             .divider(_, let indentLevel),
+             .literalBlock(_, let indentLevel),
+             .formField(_, let indentLevel),
+             .partial(_, let indentLevel):
+            return indentLevel
+        }
+    }
 }
 
 // MARK: - Partials

--- a/Sources/ColumbaApp/Models/MicronDocument.swift
+++ b/Sources/ColumbaApp/Models/MicronDocument.swift
@@ -147,18 +147,20 @@ public enum MicronURL: Sendable, Equatable, Hashable {
 // MARK: - Color Helpers
 
 extension MicronTextStyle {
-    /// Convert legacy 3-digit or true-color 6-digit hex to a SwiftUI Color.
-    public static func colorFromHex(_ hex: String) -> Color? {
-        let expanded: String
-        switch hex.count {
-        case 3:
-            expanded = hex.map { String(repeating: $0, count: 2) }.joined()
-        case 6:
-            expanded = hex
-        default:
-            return nil
-        }
+    /// Convert a legacy Micron 3-digit color to a SwiftUI Color.
+    public static func colorFrom3Hex(_ hex: String) -> Color? {
+        guard hex.count == 3 else { return nil }
+        return colorFromExpandedHex(hex.map { String(repeating: $0, count: 2) }.joined())
+    }
 
+    /// Convert a parsed inline style color, including `FT`/`BT` true color.
+    public static func colorFromStyleHex(_ hex: String) -> Color? {
+        if hex.count == 3 { return colorFrom3Hex(hex) }
+        guard hex.count == 6 else { return nil }
+        return colorFromExpandedHex(hex)
+    }
+
+    private static func colorFromExpandedHex(_ expanded: String) -> Color? {
         guard expanded.allSatisfy(\.isHexDigit),
               let value = UInt32(expanded, radix: 16) else { return nil }
         let r = (value >> 16) & 0xFF

--- a/Sources/ColumbaApp/Models/MicronDocument.swift
+++ b/Sources/ColumbaApp/Models/MicronDocument.swift
@@ -20,9 +20,9 @@ public struct MicronDocument: Sendable, Equatable {
 public struct MicronPageHeaders: Sendable, Equatable {
     /// Cache duration in seconds. nil = default (12h), 0 = no cache.
     public var cacheSeconds: Int?
-    /// Background color as 3-digit hex (e.g. "222").
+    /// Background color as 3- or 6-digit hex (e.g. "222" or "282828").
     public var backgroundColor: String?
-    /// Foreground color as 3-digit hex (e.g. "fff").
+    /// Foreground color as 3- or 6-digit hex (e.g. "fff" or "c9d1d9").
     public var foregroundColor: String?
 
     public init(cacheSeconds: Int? = nil, backgroundColor: String? = nil, foregroundColor: String? = nil) {
@@ -147,13 +147,23 @@ public enum MicronURL: Sendable, Equatable, Hashable {
 // MARK: - Color Helpers
 
 extension MicronTextStyle {
-    /// Expand 3-digit hex to Color (each digit doubled: "d2f" → #DD22FF).
-    public static func colorFrom3Hex(_ hex: String) -> Color? {
-        guard hex.count == 3 else { return nil }
-        let chars = Array(hex)
-        guard let r = Int(String(repeating: chars[0], count: 2), radix: 16),
-              let g = Int(String(repeating: chars[1], count: 2), radix: 16),
-              let b = Int(String(repeating: chars[2], count: 2), radix: 16) else { return nil }
+    /// Convert legacy 3-digit or true-color 6-digit hex to a SwiftUI Color.
+    public static func colorFromHex(_ hex: String) -> Color? {
+        let expanded: String
+        switch hex.count {
+        case 3:
+            expanded = hex.map { String(repeating: $0, count: 2) }.joined()
+        case 6:
+            expanded = hex
+        default:
+            return nil
+        }
+
+        guard expanded.allSatisfy(\.isHexDigit),
+              let value = UInt32(expanded, radix: 16) else { return nil }
+        let r = (value >> 16) & 0xFF
+        let g = (value >> 8) & 0xFF
+        let b = value & 0xFF
         return Color(
             red: Double(r) / 255.0,
             green: Double(g) / 255.0,

--- a/Sources/ColumbaApp/Models/MicronParser.swift
+++ b/Sources/ColumbaApp/Models/MicronParser.swift
@@ -15,7 +15,7 @@ public struct MicronParser {
         var currentIndent = 0
         var currentAlignment: MicronAlignment = .left
         // Formatting state persists across lines (matches python NomadNet's
-        // MicronParser, where `!/`*/`_/`Fxxx/`Bxxx are document-scoped until
+        // MicronParser, where `!/`*/`_/`Fxxx/`FTxxxxxx/`Bxxx/`BTxxxxxx are document-scoped until
         // toggled off or reset). Without this the chat-room page's
         // `F0ff`B52f preamble drops its colors before the ASCII art.
         var currentStyle: MicronTextStyle = .plain
@@ -233,26 +233,27 @@ public struct MicronParser {
                     continue
                 }
 
-                // Foreground color
+                // Foreground color: Fxxx (3-digit) or FTxxxxxx (true color)
                 if cmd == "F" || cmd == "f" {
                     flushBuffer()
                     if cmd == "f" {
                         style.foregroundColor = nil
                         i = text.index(after: next)
                     } else {
-                        // Read 3 hex digits
                         let colorStart = text.index(after: next)
-                        if let colorEnd = text.index(colorStart, offsetBy: 3, limitedBy: text.endIndex) {
-                            style.foregroundColor = String(text[colorStart..<colorEnd])
-                            i = colorEnd
+                        if let parsed = parseColor(in: text, from: colorStart) {
+                            style.foregroundColor = parsed.value
+                            i = parsed.endIndex
                         } else {
-                            i = text.index(after: next)
+                            // Consume only the command. Preserve malformed or
+                            // truncated payload text and leave the style intact.
+                            i = colorStart
                         }
                     }
                     continue
                 }
 
-                // Background color
+                // Background color: Bxxx (3-digit) or BTxxxxxx (true color)
                 if cmd == "B" || cmd == "b" {
                     flushBuffer()
                     if cmd == "b" {
@@ -260,11 +261,11 @@ public struct MicronParser {
                         i = text.index(after: next)
                     } else {
                         let colorStart = text.index(after: next)
-                        if let colorEnd = text.index(colorStart, offsetBy: 3, limitedBy: text.endIndex) {
-                            style.backgroundColor = String(text[colorStart..<colorEnd])
-                            i = colorEnd
+                        if let parsed = parseColor(in: text, from: colorStart) {
+                            style.backgroundColor = parsed.value
+                            i = parsed.endIndex
                         } else {
-                            i = text.index(after: next)
+                            i = colorStart
                         }
                     }
                     continue
@@ -337,6 +338,29 @@ public struct MicronParser {
 
         flushBuffer()
         return (spans, alignment, formFields, style)
+    }
+
+    private struct ParsedColor {
+        let value: String
+        let endIndex: String.Index
+    }
+
+    /// Parse a Micron color payload starting immediately after F/B.
+    /// `T` selects six-digit true color; otherwise the legacy three-digit
+    /// form is used. Invalid payloads are rejected without consuming them.
+    private static func parseColor(in text: String, from start: String.Index) -> ParsedColor? {
+        guard start < text.endIndex else { return nil }
+
+        let isTrueColor = text[start] == "T"
+        let valueStart = isTrueColor ? text.index(after: start) : start
+        let length = isTrueColor ? 6 : 3
+        guard let valueEnd = text.index(valueStart, offsetBy: length, limitedBy: text.endIndex) else {
+            return nil
+        }
+
+        let value = String(text[valueStart..<valueEnd])
+        guard value.count == length, value.allSatisfy(\.isHexDigit) else { return nil }
+        return ParsedColor(value: value.lowercased(), endIndex: valueEnd)
     }
 
     // MARK: - Form Field Parsing

--- a/Sources/ColumbaApp/Models/MicronParser.swift
+++ b/Sources/ColumbaApp/Models/MicronParser.swift
@@ -69,6 +69,15 @@ public struct MicronParser {
                 if line.isEmpty { continue lineLoop }
             }
 
+            // A heading containing fields is treated as a regular content line
+            // by canonical NomadNet so heading styling cannot interfere with
+            // interactive controls.
+            if line.first == ">" && line.contains("`<") {
+                line.removeFirst(line.prefix(while: { $0 == ">" }).count)
+            }
+
+            // Heading sanitization changes the block-leading character, so all
+            // block classification below must inspect the sanitized remainder.
             let firstChar = line.first!
 
             // Comment
@@ -76,17 +85,10 @@ public struct MicronParser {
                 continue
             }
 
-            // A heading containing fields is treated as a regular content line
-            // by canonical NomadNet so heading styling cannot interfere with
-            // interactive controls.
-            if firstChar == ">" && line.contains("`<") {
-                line.removeFirst(line.prefix(while: { $0 == ">" }).count)
-            }
-
             // Heading
             if line.first == ">" {
                 let level = line.prefix(while: { $0 == ">" }).count
-                currentIndent = level
+                currentIndent = max(0, (level - 1) * 2)
                 let content = String(line.dropFirst(level))
                 if content.isEmpty {
                     continue
@@ -126,7 +128,7 @@ public struct MicronParser {
             // Escaped line
             if firstChar == "\\" {
                 let text = String(line.dropFirst())
-                elements.append(.paragraph(spans: [.text(text, .plain)], alignment: currentAlignment, indentLevel: currentIndent))
+                elements.append(.paragraph(spans: [.text(text, currentStyle)], alignment: currentAlignment, indentLevel: currentIndent))
                 continue
             }
 

--- a/Sources/ColumbaApp/Models/MicronParser.swift
+++ b/Sources/ColumbaApp/Models/MicronParser.swift
@@ -32,12 +32,12 @@ public struct MicronParser {
         }
 
         // Process remaining lines
-        while lineIndex < lines.count {
-            let line = lines[lineIndex]
+        lineLoop: while lineIndex < lines.count {
+            var line = lines[lineIndex]
             lineIndex += 1
 
             // Literal block toggle
-            if line.hasPrefix("`=") {
+            if line == "`=" {
                 if inLiteral {
                     elements.append(.literalBlock(text: literalLines.joined(separator: "\n")))
                     literalLines = []
@@ -59,6 +59,16 @@ public struct MicronParser {
                 continue
             }
 
+            // `<` resets section depth, then canonical NomadNet recursively
+            // classifies the remainder of the same line. rngit relies on this
+            // when its template's trailing `<` is joined directly to a README
+            // heading, producing lines such as `<>Title`.
+            while line.first == "<" {
+                currentIndent = 0
+                line.removeFirst()
+                if line.isEmpty { continue lineLoop }
+            }
+
             let firstChar = line.first!
 
             // Comment
@@ -66,19 +76,27 @@ public struct MicronParser {
                 continue
             }
 
+            // A heading containing fields is treated as a regular content line
+            // by canonical NomadNet so heading styling cannot interfere with
+            // interactive controls.
+            if firstChar == ">" && line.contains("`<") {
+                line.removeFirst(line.prefix(while: { $0 == ">" }).count)
+            }
+
             // Heading
-            if firstChar == ">" {
+            if line.first == ">" {
                 let level = line.prefix(while: { $0 == ">" }).count
-                let headingLevel = min(level, 3)
-                currentIndent = headingLevel
-                let content = String(line.dropFirst(level)).trimmingCharacters(in: .whitespaces)
+                currentIndent = level
+                let content = String(line.dropFirst(level))
                 if content.isEmpty {
                     continue
                 }
-                let (spans, alignment, fields, updatedStyle) = parseInline(content, currentStyle: currentStyle, currentAlignment: currentAlignment)
-                currentStyle = updatedStyle
+                // Heading palette state is temporary in NomadNet. Inline
+                // formatting may style the heading and change alignment, but
+                // it must not inherit or mutate document text formatting.
+                let (spans, alignment, fields, _) = parseInline(content, currentStyle: .plain, currentAlignment: currentAlignment)
                 if let alignment = alignment { currentAlignment = alignment }
-                elements.append(.heading(level: headingLevel, spans: spans, alignment: currentAlignment))
+                elements.append(.heading(level: level, spans: spans, alignment: currentAlignment))
                 for field in fields { elements.append(.formField(field)) }
                 continue
             }
@@ -86,25 +104,14 @@ public struct MicronParser {
             // Divider
             if firstChar == "-" {
                 let rest = line.dropFirst()
-                let divChar: Character? = rest.isEmpty ? nil : rest.first
-                elements.append(.divider(character: divChar))
-                continue
-            }
-
-            // Reset indent — also resets formatting state to plain, matching
-            // python NomadNet's `<` semantics where the line restarts parsing
-            // from a default state.
-            if firstChar == "<" {
-                currentIndent = 0
-                currentStyle = .plain
-                let rest = String(line.dropFirst())
-                if !rest.isEmpty {
-                    let (spans, alignment, fields, updatedStyle) = parseInline(rest, currentStyle: currentStyle, currentAlignment: currentAlignment)
-                    currentStyle = updatedStyle
-                    if let alignment = alignment { currentAlignment = alignment }
-                    elements.append(.paragraph(spans: spans, alignment: currentAlignment, indentLevel: currentIndent))
-                    for field in fields { elements.append(.formField(field)) }
+                let requested = line.count == 2 ? rest.first : nil
+                let divChar: Character?
+                if let requested, requested.asciiValue.map({ $0 < 32 }) != true {
+                    divChar = requested
+                } else {
+                    divChar = nil
                 }
+                elements.append(.divider(character: divChar))
                 continue
             }
 

--- a/Sources/ColumbaApp/Models/MicronParser.swift
+++ b/Sources/ColumbaApp/Models/MicronParser.swift
@@ -37,9 +37,10 @@ public struct MicronParser {
             var line = lines[lineIndex]
             lineIndex += 1
 
-            // Literal block toggle
-            if line == "`=" {
-                if inLiteral {
+            // Literal content is opaque. Only an exact toggle closes the block;
+            // reset and heading markers inside it remain literal text.
+            if inLiteral {
+                if line == "`=" {
                     elements.append(.literalBlock(
                         text: literalLines.joined(separator: "\n"),
                         indentLevel: literalIndent
@@ -47,105 +48,126 @@ public struct MicronParser {
                     literalLines = []
                     inLiteral = false
                 } else {
+                    literalLines.append(line)
+                }
+                continue
+            }
+
+            // Canonical NomadNet recursively reparses a line whenever a reset or
+            // field-bearing heading sanitization exposes a new block control.
+            classificationLoop: while true {
+                while line.first == "<" {
+                    currentIndent = 0
+                    line.removeFirst()
+                    if line.isEmpty { continue lineLoop }
+                }
+
+                // A reset can expose a literal toggle, for example `<`=`.
+                if line == "`=" {
                     inLiteral = true
                     literalIndent = currentIndent
+                    continue lineLoop
                 }
-                continue
-            }
 
-            if inLiteral {
-                literalLines.append(line)
-                continue
-            }
-
-            // Empty line
-            if line.isEmpty {
-                elements.append(.paragraph(spans: [.text("", .plain)], alignment: currentAlignment, indentLevel: currentIndent))
-                continue
-            }
-
-            // `<` resets section depth, then canonical NomadNet recursively
-            // classifies the remainder of the same line. rngit relies on this
-            // when its template's trailing `<` is joined directly to a README
-            // heading, producing lines such as `<>Title`.
-            while line.first == "<" {
-                currentIndent = 0
-                line.removeFirst()
-                if line.isEmpty { continue lineLoop }
-            }
-
-            // A heading containing fields is treated as a regular content line
-            // by canonical NomadNet so heading styling cannot interfere with
-            // interactive controls.
-            if line.first == ">" && line.contains("`<") {
-                line.removeFirst(line.prefix(while: { $0 == ">" }).count)
-            }
-
-            // Heading sanitization changes the block-leading character, so all
-            // block classification below must inspect the sanitized remainder.
-            let firstChar = line.first!
-
-            // Comment
-            if firstChar == "#" {
-                continue
-            }
-
-            // Heading
-            if line.first == ">" {
-                let level = line.prefix(while: { $0 == ">" }).count
-                currentIndent = max(0, (level - 1) * 2)
-                let content = String(line.dropFirst(level))
-                if content.isEmpty {
-                    continue
+                // Empty line
+                if line.isEmpty {
+                    elements.append(.paragraph(
+                        spans: [.text("", .plain)],
+                        alignment: currentAlignment,
+                        indentLevel: currentIndent
+                    ))
+                    continue lineLoop
                 }
-                // Heading palette state is temporary in NomadNet. Inline
-                // formatting may style the heading and change alignment, but
-                // it must not inherit or mutate document text formatting.
-                let (spans, alignment, fields, _) = parseInline(content, currentStyle: .plain, currentAlignment: currentAlignment)
+
+                // A heading containing fields is treated as a regular content
+                // line. Stripping the heading markers can expose any other block
+                // control, so restart classification from the beginning.
+                if line.first == ">" && line.contains("`<") {
+                    line.removeFirst(line.prefix(while: { $0 == ">" }).count)
+                    continue classificationLoop
+                }
+
+                let firstChar = line.first!
+
+                // Comment
+                if firstChar == "#" {
+                    continue lineLoop
+                }
+
+                // Heading
+                if firstChar == ">" {
+                    let level = line.prefix(while: { $0 == ">" }).count
+                    currentIndent = max(0, (level - 1) * 2)
+                    let content = String(line.dropFirst(level))
+                    if content.isEmpty {
+                        continue lineLoop
+                    }
+                    // Heading palette state is temporary in NomadNet. Inline
+                    // formatting may style the heading and change alignment, but
+                    // it must not inherit or mutate document text formatting.
+                    let (spans, alignment, fields, _) = parseInline(
+                        content,
+                        currentStyle: .plain,
+                        currentAlignment: currentAlignment
+                    )
+                    if let alignment = alignment { currentAlignment = alignment }
+                    elements.append(.heading(level: level, spans: spans, alignment: currentAlignment))
+                    for field in fields {
+                        elements.append(.formField(field, indentLevel: currentIndent))
+                    }
+                    continue lineLoop
+                }
+
+                // Divider
+                if firstChar == "-" {
+                    let rest = line.dropFirst()
+                    let requested = line.count == 2 ? rest.first : nil
+                    let divChar: Character?
+                    if let requested, requested.asciiValue.map({ $0 < 32 }) != true {
+                        divChar = requested
+                    } else {
+                        divChar = nil
+                    }
+                    elements.append(.divider(character: divChar, indentLevel: currentIndent))
+                    continue lineLoop
+                }
+
+                // Partial include: `{url`refresh`fields}
+                if line.hasPrefix("`{") {
+                    if let partial = parsePartial(line) {
+                        elements.append(.partial(partial, indentLevel: currentIndent))
+                    }
+                    continue lineLoop
+                }
+
+                // Escaped line
+                if firstChar == "\\" {
+                    let text = String(line.dropFirst())
+                    elements.append(.paragraph(
+                        spans: [.text(text, currentStyle)],
+                        alignment: currentAlignment,
+                        indentLevel: currentIndent
+                    ))
+                    continue lineLoop
+                }
+
+                // Regular paragraph - parse inline formatting
+                let (spans, alignment, fields, updatedStyle) = parseInline(
+                    line,
+                    currentStyle: currentStyle,
+                    currentAlignment: currentAlignment
+                )
+                currentStyle = updatedStyle
                 if let alignment = alignment { currentAlignment = alignment }
-                elements.append(.heading(level: level, spans: spans, alignment: currentAlignment))
+                elements.append(.paragraph(
+                    spans: spans,
+                    alignment: currentAlignment,
+                    indentLevel: currentIndent
+                ))
                 for field in fields {
                     elements.append(.formField(field, indentLevel: currentIndent))
                 }
-                continue
-            }
-
-            // Divider
-            if firstChar == "-" {
-                let rest = line.dropFirst()
-                let requested = line.count == 2 ? rest.first : nil
-                let divChar: Character?
-                if let requested, requested.asciiValue.map({ $0 < 32 }) != true {
-                    divChar = requested
-                } else {
-                    divChar = nil
-                }
-                elements.append(.divider(character: divChar, indentLevel: currentIndent))
-                continue
-            }
-
-            // Partial include: `{url`refresh`fields}
-            if line.hasPrefix("`{") {
-                if let partial = parsePartial(line) {
-                    elements.append(.partial(partial, indentLevel: currentIndent))
-                }
-                continue
-            }
-
-            // Escaped line
-            if firstChar == "\\" {
-                let text = String(line.dropFirst())
-                elements.append(.paragraph(spans: [.text(text, currentStyle)], alignment: currentAlignment, indentLevel: currentIndent))
-                continue
-            }
-
-            // Regular paragraph — parse inline formatting
-            let (spans, alignment, fields, updatedStyle) = parseInline(line, currentStyle: currentStyle, currentAlignment: currentAlignment)
-            currentStyle = updatedStyle
-            if let alignment = alignment { currentAlignment = alignment }
-            elements.append(.paragraph(spans: spans, alignment: currentAlignment, indentLevel: currentIndent))
-            for field in fields {
-                elements.append(.formField(field, indentLevel: currentIndent))
+                continue lineLoop
             }
         }
 

--- a/Sources/ColumbaApp/Models/MicronParser.swift
+++ b/Sources/ColumbaApp/Models/MicronParser.swift
@@ -12,6 +12,7 @@ public struct MicronParser {
         var lineIndex = 0
         var inLiteral = false
         var literalLines: [String] = []
+        var literalIndent = 0
         var currentIndent = 0
         var currentAlignment: MicronAlignment = .left
         // Formatting state persists across lines (matches python NomadNet's
@@ -39,11 +40,15 @@ public struct MicronParser {
             // Literal block toggle
             if line == "`=" {
                 if inLiteral {
-                    elements.append(.literalBlock(text: literalLines.joined(separator: "\n")))
+                    elements.append(.literalBlock(
+                        text: literalLines.joined(separator: "\n"),
+                        indentLevel: literalIndent
+                    ))
                     literalLines = []
                     inLiteral = false
                 } else {
                     inLiteral = true
+                    literalIndent = currentIndent
                 }
                 continue
             }
@@ -99,7 +104,9 @@ public struct MicronParser {
                 let (spans, alignment, fields, _) = parseInline(content, currentStyle: .plain, currentAlignment: currentAlignment)
                 if let alignment = alignment { currentAlignment = alignment }
                 elements.append(.heading(level: level, spans: spans, alignment: currentAlignment))
-                for field in fields { elements.append(.formField(field)) }
+                for field in fields {
+                    elements.append(.formField(field, indentLevel: currentIndent))
+                }
                 continue
             }
 
@@ -113,14 +120,14 @@ public struct MicronParser {
                 } else {
                     divChar = nil
                 }
-                elements.append(.divider(character: divChar))
+                elements.append(.divider(character: divChar, indentLevel: currentIndent))
                 continue
             }
 
             // Partial include: `{url`refresh`fields}
             if line.hasPrefix("`{") {
                 if let partial = parsePartial(line) {
-                    elements.append(.partial(partial))
+                    elements.append(.partial(partial, indentLevel: currentIndent))
                 }
                 continue
             }
@@ -137,12 +144,17 @@ public struct MicronParser {
             currentStyle = updatedStyle
             if let alignment = alignment { currentAlignment = alignment }
             elements.append(.paragraph(spans: spans, alignment: currentAlignment, indentLevel: currentIndent))
-            for field in fields { elements.append(.formField(field)) }
+            for field in fields {
+                elements.append(.formField(field, indentLevel: currentIndent))
+            }
         }
 
         // Close unclosed literal block
         if inLiteral && !literalLines.isEmpty {
-            elements.append(.literalBlock(text: literalLines.joined(separator: "\n")))
+            elements.append(.literalBlock(
+                text: literalLines.joined(separator: "\n"),
+                indentLevel: literalIndent
+            ))
         }
 
         return MicronDocument(headers: headers, elements: elements)

--- a/Sources/ColumbaApp/Services/NomadNetBrowserService.swift
+++ b/Sources/ColumbaApp/Services/NomadNetBrowserService.swift
@@ -103,24 +103,19 @@ public actor NomadNetBrowserService {
         return (document, markup)
     }
 
-    /// Submit form data to a NomadNet node page.
-    public func submitForm(
+    /// Submit already encoded request fields and variables to a page.
+    public func submitRequest(
         destinationHash: Data,
         path: String,
-        fields: [String: String]
+        requestData: [String: String]
     ) async throws -> (MicronDocument, String) {
         statusMessage = "Submitting form..."
-
-        // NomadNet's node app expects form fields keyed with a "field_"
-        // prefix. The Python bridge msgpack-packs the dict on its side.
-        var prefixed: [String: String] = [:]
-        for (k, v) in fields { prefixed["field_\(k)"] = v }
 
         let result = try await backend.fetchNomadNetPage(
             destHashHex: destinationHash.toHex(),
             path: path,
             timeout: 30.0,
-            formFields: prefixed
+            formFields: requestData
         )
         try ensureSuccess(result)
 

--- a/Sources/ColumbaApp/Services/NomadNetBrowserService.swift
+++ b/Sources/ColumbaApp/Services/NomadNetBrowserService.swift
@@ -22,8 +22,7 @@ public actor NomadNetBrowserService {
 
     // MARK: - Dependencies
 
-    private let backend: any RnsBackend
-    private let localIdentity: Identity
+    private let backend: any RnsNomadnet
 
     // MARK: - Page Cache
 
@@ -44,7 +43,10 @@ public actor NomadNetBrowserService {
 
     public init(backend: any RnsBackend, identity: Identity) {
         self.backend = backend
-        self.localIdentity = identity
+    }
+
+    init(backend: any RnsNomadnet) {
+        self.backend = backend
     }
 
     // MARK: - Page Fetching

--- a/Sources/ColumbaApp/ViewModels/NomadNetBrowserViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/NomadNetBrowserViewModel.swift
@@ -76,6 +76,33 @@ struct NomadNetLocation: Sendable, Equatable {
     var path: String
     var requestContext: NomadNetRequestContext
 
+    init(nodeHash: Data, path: String, requestContext: NomadNetRequestContext) {
+        self.nodeHash = nodeHash
+        self.path = path
+        self.requestContext = requestContext
+    }
+
+    init(nodeHash: Data, addressPath: String) {
+        let components = addressPath.split(
+            separator: "`",
+            maxSplits: 1,
+            omittingEmptySubsequences: false
+        ).map(String.init)
+        let fieldEntries = components.count == 2
+            ? components[1].split(separator: "|").map(String.init)
+            : []
+        self.init(
+            nodeHash: nodeHash,
+            path: components[0],
+            requestContext: NomadNetRequestContext.build(
+                fieldEntries: fieldEntries,
+                formFields: [:],
+                checkboxFields: [:],
+                radioFields: [:]
+            )
+        )
+    }
+
     var address: String {
         let hashHex = nodeHash.map { String(format: "%02x", $0) }.joined()
         let variables = requestContext.requestVariables
@@ -217,9 +244,11 @@ public final class NomadNetBrowserViewModel {
         backend: any RnsBackend,
         identity: Identity
     ) {
-        self.currentNodeHash = nodeHash
+        let initialLocation = NomadNetLocation(nodeHash: nodeHash, addressPath: initialPath)
+        self.currentNodeHash = initialLocation.nodeHash
         self.currentNodeName = nodeName
-        self.currentPath = initialPath
+        self.currentPath = initialLocation.path
+        self.currentRequestContext = initialLocation.requestContext
         self.browserService = NomadNetBrowserService(
             backend: backend,
             identity: identity

--- a/Sources/ColumbaApp/ViewModels/NomadNetBrowserViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/NomadNetBrowserViewModel.swift
@@ -3,6 +3,98 @@ import Foundation
 import RNSAPI
 import SwiftUI
 
+/// Exact request data attached to a NomadNet location.
+///
+/// `requestData` is ready for the wire (`field_` and `var_` prefixes included).
+/// Only request variables are retained separately for safe address sharing;
+/// user-entered form fields, including passwords, are never serialized into URLs.
+struct NomadNetRequestContext: Sendable, Equatable {
+    var requestData: [String: String]
+    var requestVariables: [String: String]
+
+    static let empty = NomadNetRequestContext(requestData: [:], requestVariables: [:])
+
+    static func build(
+        fieldEntries: [String],
+        formFields: [String: String],
+        checkboxFields: [String: Bool],
+        radioFields: [String: String]
+    ) -> NomadNetRequestContext {
+        var availableFields = formFields
+        var selectedCheckboxes: [String: [String]] = [:]
+        for (key, checked) in checkboxFields where checked {
+            let parts = key.split(separator: ":", maxSplits: 1).map(String.init)
+            guard parts.count == 2 else { continue }
+            selectedCheckboxes[parts[0], default: []].append(parts[1])
+        }
+        for (name, values) in selectedCheckboxes {
+            availableFields[name] = values.sorted().joined(separator: ",")
+        }
+        for (name, value) in radioFields {
+            availableFields[name] = value
+        }
+
+        var requestData: [String: String] = [:]
+        var requestVariables: [String: String] = [:]
+        let submitAll = fieldEntries.contains("*")
+
+        for entry in fieldEntries where entry != "*" {
+            if let separator = entry.firstIndex(of: "=") {
+                let rawName = String(entry[..<separator])
+                let rawValue = String(entry[entry.index(after: separator)...])
+                guard !rawName.isEmpty else { continue }
+                let name = decodeFormComponent(rawName)
+                let value = decodeFormComponent(rawValue)
+                requestData["var_\(name)"] = value
+                requestVariables[name] = value
+            } else {
+                requestData["field_\(entry)"] = availableFields[entry] ?? ""
+            }
+        }
+
+        if submitAll {
+            for (name, value) in availableFields {
+                requestData["field_\(name)"] = value
+            }
+        }
+
+        return NomadNetRequestContext(
+            requestData: requestData,
+            requestVariables: requestVariables
+        )
+    }
+
+    private static func decodeFormComponent(_ value: String) -> String {
+        value.replacingOccurrences(of: "+", with: " ").removingPercentEncoding ?? value
+    }
+}
+
+/// A complete browser location, including the request variables needed to
+/// reproduce dynamic pages such as rngit's group and repository views.
+struct NomadNetLocation: Sendable, Equatable {
+    var nodeHash: Data
+    var path: String
+    var requestContext: NomadNetRequestContext
+
+    var address: String {
+        let hashHex = nodeHash.map { String(format: "%02x", $0) }.joined()
+        let variables = requestContext.requestVariables
+            .sorted { $0.key < $1.key }
+            .map { "\(Self.encodeFormComponent($0.key))=\(Self.encodeFormComponent($0.value))" }
+            .joined(separator: "|")
+        return variables.isEmpty ? "\(hashHex):\(path)" : "\(hashHex):\(path)`\(variables)"
+    }
+
+    var shareableAddress: String { "nomadnetwork://\(address)" }
+
+    private static func encodeFormComponent(_ value: String) -> String {
+        var allowed = CharacterSet.alphanumerics
+        allowed.insert(charactersIn: "-._~")
+        return (value.addingPercentEncoding(withAllowedCharacters: allowed) ?? value)
+            .replacingOccurrences(of: "%20", with: "+")
+    }
+}
+
 /// Rendering mode for NomadNet pages.
 public enum NomadNetRenderingMode: String, Sendable, CaseIterable {
     /// Monospace font with horizontal+vertical scroll, square line height, pinch zoom.
@@ -37,6 +129,7 @@ public struct NomadNetNavigationEntry: Sendable {
     public let nodeHash: Data
     public let path: String
     public let document: MicronDocument?
+    let requestContext: NomadNetRequestContext
 }
 
 /// ViewModel for the NomadNet node page browser.
@@ -92,13 +185,23 @@ public final class NomadNetBrowserViewModel {
 
     private var navigationHistory: [NomadNetNavigationEntry] = []
     private static let maxHistorySize = 50
+    private var currentRequestContext: NomadNetRequestContext = .empty
 
     public var canGoBack: Bool { !navigationHistory.isEmpty }
 
-    /// URL display string: "hashPrefix:/path"
+    /// Complete address, including request variables required to reproduce the page.
     public var displayURL: String {
-        let hashHex = currentNodeHash.map { String(format: "%02x", $0) }.joined()
-        return "\(hashHex):\(currentPath)"
+        currentLocation.address
+    }
+
+    public var shareableAddress: String { currentLocation.shareableAddress }
+
+    private var currentLocation: NomadNetLocation {
+        NomadNetLocation(
+            nodeHash: currentNodeHash,
+            path: currentPath,
+            requestContext: currentRequestContext
+        )
     }
 
     // MARK: - Dependencies
@@ -132,10 +235,18 @@ public final class NomadNetBrowserViewModel {
         errorMessage = nil
 
         do {
-            let (document, _) = try await browserService.fetchPage(
-                destinationHash: currentNodeHash,
-                path: currentPath
-            )
+            let (document, _) = if currentRequestContext.requestData.isEmpty {
+                try await browserService.fetchPage(
+                    destinationHash: currentNodeHash,
+                    path: currentPath
+                )
+            } else {
+                try await browserService.submitRequest(
+                    destinationHash: currentNodeHash,
+                    path: currentPath,
+                    requestData: currentRequestContext.requestData
+                )
+            }
             currentDocument = document
             partialDocuments.removeAll()
             initializeFormDefaults(from: document)
@@ -161,6 +272,7 @@ public final class NomadNetBrowserViewModel {
             }
             pushHistory()
             currentPath = path
+            currentRequestContext = .empty
             await loadPage()
 
         case .remoteNode(let hash, let path):
@@ -178,6 +290,7 @@ public final class NomadNetBrowserViewModel {
             currentNodeHash = hashData
             currentNodeName = nil
             currentPath = path
+            currentRequestContext = .empty
             await loadPage()
 
         case .lxmf:
@@ -218,6 +331,7 @@ public final class NomadNetBrowserViewModel {
         cancelPartialRefreshTasks()
         currentNodeHash = previous.nodeHash
         currentPath = previous.path
+        currentRequestContext = previous.requestContext
 
         if let doc = previous.document {
             currentDocument = doc
@@ -259,7 +373,12 @@ public final class NomadNetBrowserViewModel {
 
     /// Submit form fields to a page.
     public func submitForm(url: MicronURL, fieldNames: [String]) async {
-        let fields = collectFormFields(fieldNames: fieldNames)
+        let requestContext = NomadNetRequestContext.build(
+            fieldEntries: fieldNames,
+            formFields: formFields,
+            checkboxFields: checkboxFields,
+            radioFields: radioFields
+        )
 
         // Resolve target node hash and path from the URL. Reject LXMF targets
         // (no form submission semantics) and bail on invalid remote hashes
@@ -288,14 +407,15 @@ public final class NomadNetBrowserViewModel {
             currentNodeName = nil
         }
         currentPath = targetPath
+        currentRequestContext = requestContext
         isLoading = true
         errorMessage = nil
 
         do {
-            let (document, _) = try await browserService.submitForm(
+            let (document, _) = try await browserService.submitRequest(
                 destinationHash: targetHash,
                 path: targetPath,
-                fields: fields
+                requestData: requestContext.requestData
             )
             currentDocument = document
             initializeFormDefaults(from: document)
@@ -387,49 +507,14 @@ public final class NomadNetBrowserViewModel {
         }
     }
 
-    /// Collect form field values for submission.
-    private func collectFormFields(fieldNames: [String]) -> [String: String] {
-        var result: [String: String] = [:]
-        let submitAll = fieldNames.contains("*")
-
-        for (name, value) in formFields {
-            if submitAll || fieldNames.contains(name) {
-                result[name] = value
-            }
-        }
-
-        // Collect checked checkboxes — concatenate values with same name
-        var checkboxValues: [String: [String]] = [:]
-        for (key, checked) in checkboxFields where checked {
-            let parts = key.split(separator: ":", maxSplits: 1)
-            guard parts.count == 2 else { continue }
-            let name = String(parts[0])
-            let value = String(parts[1])
-            if submitAll || fieldNames.contains(name) {
-                checkboxValues[name, default: []].append(value)
-            }
-        }
-        for (name, values) in checkboxValues {
-            result[name] = values.joined(separator: ",")
-        }
-
-        // Collect radio selections
-        for (name, value) in radioFields {
-            if submitAll || fieldNames.contains(name) {
-                result[name] = value
-            }
-        }
-
-        return result
-    }
-
     // MARK: - History
 
     private func pushHistory() {
         let entry = NomadNetNavigationEntry(
             nodeHash: currentNodeHash,
             path: currentPath,
-            document: currentDocument
+            document: currentDocument,
+            requestContext: currentRequestContext
         )
         navigationHistory.append(entry)
         if navigationHistory.count > Self.maxHistorySize {

--- a/Sources/ColumbaApp/ViewModels/NomadNetBrowserViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/NomadNetBrowserViewModel.swift
@@ -40,11 +40,9 @@ struct NomadNetRequestContext: Sendable, Equatable {
 
         for entry in fieldEntries where entry != "*" {
             if let separator = entry.firstIndex(of: "=") {
-                let rawName = String(entry[..<separator])
-                let rawValue = String(entry[entry.index(after: separator)...])
-                guard !rawName.isEmpty else { continue }
-                let name = decodeFormComponent(rawName)
-                let value = decodeFormComponent(rawValue)
+                let name = String(entry[..<separator])
+                let value = String(entry[entry.index(after: separator)...])
+                guard !name.isEmpty else { continue }
                 requestData["var_\(name)"] = value
                 requestVariables[name] = value
             } else {
@@ -64,9 +62,6 @@ struct NomadNetRequestContext: Sendable, Equatable {
         )
     }
 
-    private static func decodeFormComponent(_ value: String) -> String {
-        value.replacingOccurrences(of: "+", with: " ").removingPercentEncoding ?? value
-    }
 }
 
 /// A complete browser location, including the request variables needed to
@@ -88,17 +83,26 @@ struct NomadNetLocation: Sendable, Equatable {
             maxSplits: 1,
             omittingEmptySubsequences: false
         ).map(String.init)
-        let fieldEntries = components.count == 2
-            ? components[1].split(separator: "|").map(String.init)
-            : []
+        var requestData: [String: String] = [:]
+        var requestVariables: [String: String] = [:]
+        if components.count == 2 {
+            for entry in components[1].split(separator: "|").map(String.init) {
+                guard let separator = entry.firstIndex(of: "=") else { continue }
+                let encodedName = String(entry[..<separator])
+                let encodedValue = String(entry[entry.index(after: separator)...])
+                let name = Self.decodeAddressComponent(encodedName)
+                guard !name.isEmpty else { continue }
+                let value = Self.decodeAddressComponent(encodedValue)
+                requestData["var_\(name)"] = value
+                requestVariables[name] = value
+            }
+        }
         self.init(
             nodeHash: nodeHash,
             path: components[0],
-            requestContext: NomadNetRequestContext.build(
-                fieldEntries: fieldEntries,
-                formFields: [:],
-                checkboxFields: [:],
-                radioFields: [:]
+            requestContext: NomadNetRequestContext(
+                requestData: requestData,
+                requestVariables: requestVariables
             )
         )
     }
@@ -119,6 +123,11 @@ struct NomadNetLocation: Sendable, Equatable {
         allowed.insert(charactersIn: "-._~")
         return (value.addingPercentEncoding(withAllowedCharacters: allowed) ?? value)
             .replacingOccurrences(of: "%20", with: "+")
+    }
+
+    private static func decodeAddressComponent(_ value: String) -> String {
+        let withSpaces = value.replacingOccurrences(of: "+", with: " ")
+        return withSpaces.removingPercentEncoding ?? withSpaces
     }
 }
 
@@ -237,22 +246,33 @@ public final class NomadNetBrowserViewModel {
 
     // MARK: - Init
 
-    public init(
+    public convenience init(
         nodeHash: Data,
         nodeName: String?,
         initialPath: String = "/page/index.mu",
         backend: any RnsBackend,
         identity: Identity
     ) {
+        self.init(
+            nodeHash: nodeHash,
+            nodeName: nodeName,
+            initialPath: initialPath,
+            browserService: NomadNetBrowserService(backend: backend, identity: identity)
+        )
+    }
+
+    init(
+        nodeHash: Data,
+        nodeName: String?,
+        initialPath: String = "/page/index.mu",
+        browserService: NomadNetBrowserService
+    ) {
         let initialLocation = NomadNetLocation(nodeHash: nodeHash, addressPath: initialPath)
         self.currentNodeHash = initialLocation.nodeHash
         self.currentNodeName = nodeName
         self.currentPath = initialLocation.path
         self.currentRequestContext = initialLocation.requestContext
-        self.browserService = NomadNetBrowserService(
-            backend: backend,
-            identity: identity
-        )
+        self.browserService = browserService
     }
 
     // MARK: - Page Loading

--- a/Sources/ColumbaApp/ViewModels/NomadNetBrowserViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/NomadNetBrowserViewModel.swift
@@ -491,7 +491,12 @@ public final class NomadNetBrowserViewModel {
 
     /// Load a single partial.
     public func loadPartial(_ partial: MicronPartial) async {
+        await loadPartial(partial, ancestry: [])
+    }
+
+    private func loadPartial(_ partial: MicronPartial, ancestry: Set<String>) async {
         let key = partial.partialId ?? partial.url
+        guard !ancestry.contains(key) else { return }
         loadingPartials.insert(key)
 
         do {
@@ -500,6 +505,13 @@ public final class NomadNetBrowserViewModel {
                 path: partial.url
             )
             partialDocuments[key] = document
+            mergeFormDefaults(from: document)
+
+            let nestedAncestry = ancestry.union([key])
+            for element in document.elements {
+                guard case .partial(let nestedPartial, _) = element else { continue }
+                await loadPartial(nestedPartial, ancestry: nestedAncestry)
+            }
         } catch {
             // Partials fail silently — show empty content
         }
@@ -539,17 +551,22 @@ public final class NomadNetBrowserViewModel {
         checkboxFields.removeAll()
         radioFields.removeAll()
 
+        mergeFormDefaults(from: document)
+    }
+
+    private func mergeFormDefaults(from document: MicronDocument) {
         for element in document.elements {
             guard case .formField(let field, _) = element else { continue }
             switch field {
             case .textInput(_, let name, let defaultValue):
-                formFields[name] = defaultValue
+                if formFields[name] == nil { formFields[name] = defaultValue }
             case .passwordInput(let name, let defaultValue):
-                formFields[name] = defaultValue
+                if formFields[name] == nil { formFields[name] = defaultValue }
             case .checkbox(let name, let value, _, let checked):
-                checkboxFields["\(name):\(value)"] = checked
+                let key = "\(name):\(value)"
+                if checkboxFields[key] == nil { checkboxFields[key] = checked }
             case .radio(let name, let value, _, let selected):
-                if selected {
+                if selected && radioFields[name] == nil {
                     radioFields[name] = value
                 }
             }

--- a/Sources/ColumbaApp/ViewModels/NomadNetBrowserViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/NomadNetBrowserViewModel.swift
@@ -484,7 +484,7 @@ public final class NomadNetBrowserViewModel {
     public func loadPartials() async {
         guard let document = currentDocument else { return }
         for element in document.elements {
-            guard case .partial(let partial) = element else { continue }
+            guard case .partial(let partial, _) = element else { continue }
             await loadPartial(partial)
         }
     }
@@ -540,7 +540,7 @@ public final class NomadNetBrowserViewModel {
         radioFields.removeAll()
 
         for element in document.elements {
-            guard case .formField(let field) = element else { continue }
+            guard case .formField(let field, _) = element else { continue }
             switch field {
             case .textInput(_, let name, let defaultValue):
                 formFields[name] = defaultValue

--- a/Sources/ColumbaApp/Views/Messaging/MessageBody.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageBody.swift
@@ -72,7 +72,10 @@ enum MessageLinkParser {
     }
 
     static func target(for url: URL) -> MessageLinkTarget? {
-        target(for: url.absoluteString)
+        if url.scheme?.lowercased() == "nomadnetwork" {
+            return target(for: url.absoluteString.removingPercentEncoding ?? url.absoluteString)
+        }
+        return target(for: url.absoluteString)
     }
 
     static func target(for rawValue: String) -> MessageLinkTarget? {

--- a/Sources/ColumbaApp/Views/Messaging/MessageBody.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageBody.swift
@@ -73,7 +73,11 @@ enum MessageLinkParser {
 
     static func target(for url: URL) -> MessageLinkTarget? {
         if url.scheme?.lowercased() == "nomadnetwork" {
-            return target(for: url.absoluteString.removingPercentEncoding ?? url.absoluteString)
+            guard let host = url.host,
+                  let hash = Data(hexString: host),
+                  hash.count == 16,
+                  url.path.hasPrefix("/") else { return nil }
+            return .nomadNet(nodeHash: hash, path: url.path)
         }
         return target(for: url.absoluteString)
     }

--- a/Sources/ColumbaApp/Views/NomadNet/MicronDocumentView.swift
+++ b/Sources/ColumbaApp/Views/NomadNet/MicronDocumentView.swift
@@ -368,10 +368,10 @@ struct MicronSpansText: View {
             piece.font = .body.italic()
         }
         if style.underline { piece.underlineStyle = .single }
-        if let fg = style.foregroundColor, let color = MicronTextStyle.colorFrom3Hex(fg) {
+        if let fg = style.foregroundColor, let color = MicronTextStyle.colorFromHex(fg) {
             piece.foregroundColor = color
         }
-        if let bg = style.backgroundColor, let color = MicronTextStyle.colorFrom3Hex(bg) {
+        if let bg = style.backgroundColor, let color = MicronTextStyle.colorFromHex(bg) {
             piece.backgroundColor = color
         }
         return piece

--- a/Sources/ColumbaApp/Views/NomadNet/MicronDocumentView.swift
+++ b/Sources/ColumbaApp/Views/NomadNet/MicronDocumentView.swift
@@ -5,6 +5,7 @@ import RNSAPI
 /// Renders a parsed MicronDocument as SwiftUI views.
 @available(iOS 17.0, macOS 14.0, *)
 struct MicronDocumentView: View {
+    @Environment(\.colorScheme) private var colorScheme
     let document: MicronDocument
     @Binding var formFields: [String: String]
     @Binding var checkboxFields: [String: Bool]
@@ -49,6 +50,7 @@ struct MicronDocumentView: View {
     private func renderElement(_ element: MicronElement, index: Int) -> some View {
         switch element {
         case .heading(let level, let spans, let alignment):
+            let palette = MicronHeadingPalette.style(level: level, colorScheme: colorScheme)
             if isScrollMode {
                 // UIKit-backed line with strict paragraph line-height so block chars stack tight
                 MonospaceLineView(
@@ -57,14 +59,18 @@ struct MicronDocumentView: View {
                     cellHeight: cellHeight,
                     alignment: alignment,
                     bold: true,
+                    defaultForegroundColor: palette.foreground,
                     onLinkTapped: onLinkTapped
                 )
                 .frame(minWidth: viewportWidth, alignment: alignment.swiftUI)
+                .background(palette.background)
             } else {
                 renderSpans(spans, onLinkTapped: onLinkTapped)
                     .font(headingFont(level: level))
                     .bold()
+                    .foregroundStyle(palette.foreground)
                     .frame(maxWidth: .infinity, alignment: alignment.swiftUI)
+                    .background(palette.background)
                     .padding(.top, level == 1 ? 12 : 8)
                     .padding(.bottom, 4)
             }
@@ -266,16 +272,20 @@ private struct MicronPartialView: View {
 /// Simplified element renderer for partial content (no form fields or nested partials).
 @available(iOS 17.0, macOS 14.0, *)
 private struct MicronSimpleElementView: View {
+    @Environment(\.colorScheme) private var colorScheme
     let element: MicronElement
     var onLinkTapped: ((MicronLink) -> Void)?
 
     var body: some View {
         switch element {
-        case .heading(_, let spans, let alignment):
+        case .heading(let level, let spans, let alignment):
+            let palette = MicronHeadingPalette.style(level: level, colorScheme: colorScheme)
             renderSpans(spans, onLinkTapped: onLinkTapped)
                 .font(.headline)
                 .bold()
+                .foregroundStyle(palette.foreground)
                 .frame(maxWidth: .infinity, alignment: alignment.swiftUI)
+                .background(palette.background)
         case .paragraph(let spans, let alignment, let indentLevel):
             renderSpans(spans, onLinkTapped: onLinkTapped)
                 .font(.system(.body, design: .monospaced))
@@ -292,6 +302,27 @@ private struct MicronSimpleElementView: View {
         case .formField, .partial:
             EmptyView()
         }
+    }
+}
+
+private enum MicronHeadingPalette {
+    static func style(level: Int, colorScheme: ColorScheme) -> (foreground: Color, background: Color) {
+        let paletteLevel = min(max(level, 1), 3)
+        let foregroundHex: String
+        let backgroundHex: String
+
+        if colorScheme == .dark {
+            foregroundHex = ["222", "111", "000"][paletteLevel - 1]
+            backgroundHex = ["bbb", "999", "777"][paletteLevel - 1]
+        } else {
+            foregroundHex = ["000", "111", "222"][paletteLevel - 1]
+            backgroundHex = ["777", "aaa", "ccc"][paletteLevel - 1]
+        }
+
+        return (
+            MicronTextStyle.colorFrom3Hex(foregroundHex) ?? .primary,
+            MicronTextStyle.colorFrom3Hex(backgroundHex) ?? .clear
+        )
     }
 }
 

--- a/Sources/ColumbaApp/Views/NomadNet/MicronDocumentView.swift
+++ b/Sources/ColumbaApp/Views/NomadNet/MicronDocumentView.swift
@@ -368,10 +368,10 @@ struct MicronSpansText: View {
             piece.font = .body.italic()
         }
         if style.underline { piece.underlineStyle = .single }
-        if let fg = style.foregroundColor, let color = MicronTextStyle.colorFromHex(fg) {
+        if let fg = style.foregroundColor, let color = MicronTextStyle.colorFromStyleHex(fg) {
             piece.foregroundColor = color
         }
-        if let bg = style.backgroundColor, let color = MicronTextStyle.colorFromHex(bg) {
+        if let bg = style.backgroundColor, let color = MicronTextStyle.colorFromStyleHex(bg) {
             piece.backgroundColor = color
         }
         return piece

--- a/Sources/ColumbaApp/Views/NomadNet/MicronDocumentView.swift
+++ b/Sources/ColumbaApp/Views/NomadNet/MicronDocumentView.swift
@@ -60,15 +60,22 @@ struct MicronDocumentView: View {
                     alignment: alignment,
                     bold: true,
                     defaultForegroundColor: palette.foreground,
+                    linkForegroundColor: palette.foreground,
                     onLinkTapped: onLinkTapped
                 )
+                .padding(.leading, headingIndentWidth(level: level))
                 .frame(minWidth: viewportWidth, alignment: alignment.swiftUI)
                 .background(palette.background)
             } else {
-                renderSpans(spans, onLinkTapped: onLinkTapped)
+                renderSpans(
+                    spans,
+                    onLinkTapped: onLinkTapped,
+                    linkForegroundColor: palette.foreground
+                )
                     .font(headingFont(level: level))
                     .bold()
                     .foregroundStyle(palette.foreground)
+                    .padding(.leading, headingIndentWidth(level: level))
                     .frame(maxWidth: .infinity, alignment: alignment.swiftUI)
                     .background(palette.background)
                     .padding(.top, level == 1 ? 12 : 8)
@@ -92,7 +99,7 @@ struct MicronDocumentView: View {
                     .font(bodyFont)
                     .lineLimit(nil)
                     .frame(maxWidth: .infinity, alignment: alignment.swiftUI)
-                    .padding(.leading, CGFloat(indentLevel) * 16)
+                    .padding(.leading, indentationWidth(columns: indentLevel))
             }
 
         case .divider(let character):
@@ -236,6 +243,14 @@ struct MicronDocumentView: View {
         default: return .title3
         }
     }
+
+    private func indentationWidth(columns: Int) -> CGFloat {
+        CGFloat(columns) * (style.usesMonospace ? style.approxCharWidth : 8)
+    }
+
+    private func headingIndentWidth(level: Int) -> CGFloat {
+        indentationWidth(columns: max(0, (level - 1) * 2))
+    }
 }
 
 // MARK: - Partial View
@@ -280,17 +295,22 @@ private struct MicronSimpleElementView: View {
         switch element {
         case .heading(let level, let spans, let alignment):
             let palette = MicronHeadingPalette.style(level: level, colorScheme: colorScheme)
-            renderSpans(spans, onLinkTapped: onLinkTapped)
+            renderSpans(
+                spans,
+                onLinkTapped: onLinkTapped,
+                linkForegroundColor: palette.foreground
+            )
                 .font(.headline)
                 .bold()
                 .foregroundStyle(palette.foreground)
+                .padding(.leading, CGFloat(max(0, (level - 1) * 2)) * 8)
                 .frame(maxWidth: .infinity, alignment: alignment.swiftUI)
                 .background(palette.background)
         case .paragraph(let spans, let alignment, let indentLevel):
             renderSpans(spans, onLinkTapped: onLinkTapped)
                 .font(.system(.body, design: .monospaced))
                 .frame(maxWidth: .infinity, alignment: alignment.swiftUI)
-                .padding(.leading, CGFloat(indentLevel) * 16)
+                .padding(.leading, CGFloat(indentLevel) * 8)
         case .divider:
             Divider().padding(.vertical, 4)
         case .literalBlock(let text):
@@ -335,14 +355,23 @@ private enum MicronHeadingPalette {
 /// custom URL scheme (`micron-link://<index>`) that `OpenURLAction` maps
 /// back to the originating `MicronLink`.
 @available(iOS 17.0, macOS 14.0, *)
-func renderSpans(_ spans: [MicronSpan], onLinkTapped: ((MicronLink) -> Void)?) -> some View {
-    MicronSpansText(spans: spans, onLinkTapped: onLinkTapped)
+func renderSpans(
+    _ spans: [MicronSpan],
+    onLinkTapped: ((MicronLink) -> Void)?,
+    linkForegroundColor: Color? = nil
+) -> some View {
+    MicronSpansText(
+        spans: spans,
+        onLinkTapped: onLinkTapped,
+        linkForegroundColor: linkForegroundColor
+    )
 }
 
 @available(iOS 17.0, macOS 14.0, *)
 struct MicronSpansText: View {
     let spans: [MicronSpan]
     var onLinkTapped: ((MicronLink) -> Void)?
+    var linkForegroundColor: Color? = nil
 
     var body: some View {
         Text(buildAttributed())
@@ -377,7 +406,7 @@ struct MicronSpansText: View {
                 result.append(styledAttributed(content, style: style))
             case .link(let link):
                 var piece = AttributedString(link.label)
-                piece.foregroundColor = .accentColor
+                piece.foregroundColor = linkForegroundColor ?? .accentColor
                 piece.underlineStyle = .single
                 if let url = URL(string: "micron-link://\(linkIndex)") {
                     piece.link = url

--- a/Sources/ColumbaApp/Views/NomadNet/MicronDocumentView.swift
+++ b/Sources/ColumbaApp/Views/NomadNet/MicronDocumentView.swift
@@ -92,8 +92,11 @@ struct MicronDocumentView: View {
                     bold: false,
                     onLinkTapped: onLinkTapped
                 )
-                .frame(minWidth: viewportWidth, alignment: alignment.swiftUI)
-                .padding(.horizontal, CGFloat(indentLevel) * style.approxCharWidth)
+                .frame(
+                    minWidth: sectionViewportWidth(columns: indentLevel),
+                    alignment: alignment.swiftUI
+                )
+                .padding(.horizontal, indentationWidth(columns: indentLevel))
             } else {
                 renderSpans(spans, onLinkTapped: onLinkTapped)
                     .font(bodyFont)
@@ -106,15 +109,22 @@ struct MicronDocumentView: View {
             if isScrollMode {
                 // Use a full-width horizontal line character for scroll mode
                 let divChar = character.map(String.init) ?? "─"
+                let dividerCount = max(
+                    1,
+                    Int(sectionViewportWidth(columns: indentLevel) / style.approxCharWidth)
+                )
                 MonospaceLineView(
-                    spans: [.text(String(repeating: divChar, count: 80), .plain)],
+                    spans: [.text(String(repeating: divChar, count: dividerCount), .plain)],
                     fontSize: style.fontSize,
                     cellHeight: cellHeight,
                     alignment: .left,
                     bold: false,
                     onLinkTapped: nil
                 )
-                .frame(minWidth: viewportWidth, alignment: .leading)
+                .frame(
+                    minWidth: sectionViewportWidth(columns: indentLevel),
+                    alignment: .leading
+                )
                 .padding(.horizontal, indentationWidth(columns: indentLevel))
             } else if let ch = character {
                 Text(String(repeating: ch, count: 40))
@@ -257,6 +267,10 @@ struct MicronDocumentView: View {
 
     private func headingIndentWidth(level: Int) -> CGFloat {
         indentationWidth(columns: max(0, (level - 1) * 2))
+    }
+
+    private func sectionViewportWidth(columns: Int) -> CGFloat {
+        max(0, viewportWidth - (2 * indentationWidth(columns: columns)))
     }
 }
 

--- a/Sources/ColumbaApp/Views/NomadNet/MicronDocumentView.swift
+++ b/Sources/ColumbaApp/Views/NomadNet/MicronDocumentView.swift
@@ -22,6 +22,8 @@ struct MicronDocumentView: View {
     /// whitespace line) sets the VStack width and centered shorter rows end up
     /// scrolled offscreen-right.
     var viewportWidth: CGFloat = 0
+    var appliesDocumentPadding = true
+    var partialAncestry: Set<String> = []
 
     var body: some View {
         VStack(alignment: .leading, spacing: isScrollMode ? 0 : 2) {
@@ -29,8 +31,8 @@ struct MicronDocumentView: View {
                 renderElement(element, index: index)
             }
         }
-        .padding(.horizontal, isScrollMode ? 0 : 12)
-        .padding(.vertical, isScrollMode ? 0 : 8)
+        .padding(.horizontal, appliesDocumentPadding && !isScrollMode ? 12 : 0)
+        .padding(.vertical, appliesDocumentPadding && !isScrollMode ? 8 : 0)
     }
 
     private var isScrollMode: Bool { style == .monospaceScroll }
@@ -109,10 +111,9 @@ struct MicronDocumentView: View {
             if isScrollMode {
                 // Use a full-width horizontal line character for scroll mode
                 let divChar = character.map(String.init) ?? "─"
-                let dividerCount = max(
-                    1,
-                    Int(sectionViewportWidth(columns: indentLevel) / style.approxCharWidth)
-                )
+                let dividerCount = viewportWidth > 0
+                    ? max(1, Int(sectionViewportWidth(columns: indentLevel) / style.approxCharWidth))
+                    : 80
                 MonospaceLineView(
                     spans: [.text(String(repeating: divChar, count: dividerCount), .plain)],
                     fontSize: style.fontSize,
@@ -183,12 +184,37 @@ struct MicronDocumentView: View {
     @ViewBuilder
     private func renderPartial(_ partial: MicronPartial) -> some View {
         let key = partial.partialId ?? partial.url
-        MicronPartialView(
-            partialKey: key,
-            partialDocuments: partialDocuments,
-            loadingPartials: loadingPartials,
-            onLinkTapped: onLinkTapped
-        )
+        if let partialDocument = partialDocuments[key], !partialAncestry.contains(key) {
+            AnyView(
+                MicronDocumentView(
+                    document: partialDocument,
+                    formFields: $formFields,
+                    checkboxFields: $checkboxFields,
+                    radioFields: $radioFields,
+                    partialDocuments: partialDocuments,
+                    loadingPartials: loadingPartials,
+                    onLinkTapped: onLinkTapped,
+                    style: style,
+                    viewportWidth: viewportWidth,
+                    appliesDocumentPadding: false,
+                    partialAncestry: partialAncestry.union([key])
+                )
+            )
+        } else if loadingPartials.contains(key) {
+            HStack(spacing: 6) {
+                ProgressView()
+                    .scaleEffect(0.7)
+                Text("Loading...")
+                    .font(
+                        .system(
+                            size: style.fontSize,
+                            design: style.usesMonospace ? .monospaced : .default
+                        )
+                    )
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.vertical, 4)
+        }
     }
 
     // MARK: - Form Field Rendering
@@ -198,13 +224,15 @@ struct MicronDocumentView: View {
         switch field {
         case .textInput(let width, let name, _):
             TextField(name, text: binding(for: name))
-                .font(.system(.body, design: .monospaced))
+                .font(bodyFont)
                 .textFieldStyle(.roundedBorder)
-                .frame(maxWidth: CGFloat(width) * 10)
+                .frame(
+                    maxWidth: CGFloat(width) * (style.usesMonospace ? style.approxCharWidth : 10)
+                )
 
         case .passwordInput(let name, _):
             SecureField(name, text: binding(for: name))
-                .font(.system(.body, design: .monospaced))
+                .font(bodyFont)
                 .textFieldStyle(.roundedBorder)
                 .frame(maxWidth: 240)
 
@@ -217,7 +245,7 @@ struct MicronDocumentView: View {
                     Image(systemName: (checkboxFields[key] ?? false) ? "checkmark.square.fill" : "square")
                         .foregroundColor((checkboxFields[key] ?? false) ? .accentColor : .secondary)
                     Text(label)
-                        .font(.system(.body, design: .monospaced))
+                        .font(bodyFont)
                         .foregroundStyle(.primary)
                 }
             }
@@ -231,7 +259,7 @@ struct MicronDocumentView: View {
                     Image(systemName: radioFields[name] == value ? "circle.inset.filled" : "circle")
                         .foregroundColor(radioFields[name] == value ? .accentColor : .secondary)
                     Text(label)
-                        .font(.system(.body, design: .monospaced))
+                        .font(bodyFont)
                         .foregroundStyle(.primary)
                 }
             }
@@ -271,81 +299,6 @@ struct MicronDocumentView: View {
 
     private func sectionViewportWidth(columns: Int) -> CGFloat {
         max(0, viewportWidth - (2 * indentationWidth(columns: columns)))
-    }
-}
-
-// MARK: - Partial View
-
-/// Renders a loaded partial document inline, or a loading indicator.
-@available(iOS 17.0, macOS 14.0, *)
-private struct MicronPartialView: View {
-    let partialKey: String
-    let partialDocuments: [String: MicronDocument]
-    let loadingPartials: Set<String>
-    var onLinkTapped: ((MicronLink) -> Void)?
-
-    var body: some View {
-        if let partialDoc = partialDocuments[partialKey] {
-            // Render partial content as simple text spans (no nested form/partial support)
-            VStack(alignment: .leading, spacing: 2) {
-                ForEach(Array(partialDoc.elements.enumerated()), id: \.offset) { _, element in
-                    MicronSimpleElementView(element: element, onLinkTapped: onLinkTapped)
-                }
-            }
-        } else if loadingPartials.contains(partialKey) {
-            HStack(spacing: 6) {
-                ProgressView()
-                    .scaleEffect(0.7)
-                Text("Loading...")
-                    .font(.system(.caption, design: .monospaced))
-                    .foregroundStyle(.secondary)
-            }
-            .padding(.vertical, 4)
-        }
-    }
-}
-
-/// Simplified element renderer for partial content (no form fields or nested partials).
-@available(iOS 17.0, macOS 14.0, *)
-private struct MicronSimpleElementView: View {
-    @Environment(\.colorScheme) private var colorScheme
-    let element: MicronElement
-    var onLinkTapped: ((MicronLink) -> Void)?
-
-    var body: some View {
-        switch element {
-        case .heading(let level, let spans, let alignment):
-            let palette = MicronHeadingPalette.style(level: level, colorScheme: colorScheme)
-            renderSpans(
-                spans,
-                onLinkTapped: onLinkTapped,
-                linkForegroundColor: palette.foreground
-            )
-                .font(.headline)
-                .bold()
-                .foregroundStyle(palette.foreground)
-                .padding(.leading, CGFloat(max(0, (level - 1) * 2)) * 8)
-                .frame(maxWidth: .infinity, alignment: alignment.swiftUI)
-                .background(palette.background)
-        case .paragraph(let spans, let alignment, let indentLevel):
-            renderSpans(spans, onLinkTapped: onLinkTapped)
-                .font(.system(.body, design: .monospaced))
-                .frame(maxWidth: .infinity, alignment: alignment.swiftUI)
-                .padding(.horizontal, CGFloat(indentLevel) * 8)
-        case .divider(_, let indentLevel):
-            Divider()
-                .padding(.vertical, 4)
-                .padding(.horizontal, CGFloat(indentLevel) * 8)
-        case .literalBlock(let text, let indentLevel):
-            Text(text)
-                .font(.system(.body, design: .monospaced))
-                .padding(8)
-                .background(Color.platformSystemGray6)
-                .cornerRadius(6)
-                .padding(.horizontal, CGFloat(indentLevel) * 8)
-        case .formField, .partial:
-            EmptyView()
-        }
     }
 }
 

--- a/Sources/ColumbaApp/Views/NomadNet/MicronDocumentView.swift
+++ b/Sources/ColumbaApp/Views/NomadNet/MicronDocumentView.swift
@@ -41,11 +41,7 @@ struct MicronDocumentView: View {
     private var cellHeight: CGFloat { style.approxCharWidth * 2 }
 
     private var bodyFont: Font {
-        if style.usesMonospace {
-            return .system(size: style.fontSize, design: .monospaced)
-        } else {
-            return .system(size: style.fontSize)
-        }
+        style.swiftUIFont
     }
 
     @ViewBuilder
@@ -129,7 +125,7 @@ struct MicronDocumentView: View {
                 .padding(.horizontal, indentationWidth(columns: indentLevel))
             } else if let ch = character {
                 Text(String(repeating: ch, count: 40))
-                    .font(.system(size: style.fontSize, design: .monospaced))
+                    .font(bodyFont)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -159,7 +155,7 @@ struct MicronDocumentView: View {
                 .padding(.horizontal, indentationWidth(columns: indentLevel))
             } else {
                 Text(text)
-                    .font(.system(size: style.fontSize, design: .monospaced))
+                    .font(bodyFont)
                     .padding(8)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .background(Color.platformSystemGray6)
@@ -174,7 +170,7 @@ struct MicronDocumentView: View {
                 .padding(.horizontal, indentationWidth(columns: indentLevel))
 
         case .partial(let partial, let indentLevel):
-            renderPartial(partial)
+            renderPartial(partial, indentLevel: indentLevel)
                 .padding(.horizontal, indentationWidth(columns: indentLevel))
         }
     }
@@ -182,7 +178,7 @@ struct MicronDocumentView: View {
     // MARK: - Partial Rendering
 
     @ViewBuilder
-    private func renderPartial(_ partial: MicronPartial) -> some View {
+    private func renderPartial(_ partial: MicronPartial, indentLevel: Int) -> some View {
         let key = partial.partialId ?? partial.url
         if let partialDocument = partialDocuments[key], !partialAncestry.contains(key) {
             AnyView(
@@ -195,7 +191,7 @@ struct MicronDocumentView: View {
                     loadingPartials: loadingPartials,
                     onLinkTapped: onLinkTapped,
                     style: style,
-                    viewportWidth: viewportWidth,
+                    viewportWidth: sectionViewportWidth(columns: indentLevel),
                     appliesDocumentPadding: false,
                     partialAncestry: partialAncestry.union([key])
                 )
@@ -205,12 +201,7 @@ struct MicronDocumentView: View {
                 ProgressView()
                     .scaleEffect(0.7)
                 Text("Loading...")
-                    .font(
-                        .system(
-                            size: style.fontSize,
-                            design: style.usesMonospace ? .monospaced : .default
-                        )
-                    )
+                    .font(bodyFont)
                     .foregroundStyle(.secondary)
             }
             .padding(.vertical, 4)
@@ -397,13 +388,10 @@ struct MicronSpansText: View {
 
     private func styledAttributed(_ content: String, style: MicronTextStyle) -> AttributedString {
         var piece = AttributedString(content)
-        if style.bold && style.italic {
-            piece.font = .body.bold().italic()
-        } else if style.bold {
-            piece.font = .body.bold()
-        } else if style.italic {
-            piece.font = .body.italic()
-        }
+        var intents: InlinePresentationIntent = []
+        if style.bold { intents.insert(.stronglyEmphasized) }
+        if style.italic { intents.insert(.emphasized) }
+        if !intents.isEmpty { piece.inlinePresentationIntent = intents }
         if style.underline { piece.underlineStyle = .single }
         if let fg = style.foregroundColor, let color = MicronTextStyle.colorFromStyleHex(fg) {
             piece.foregroundColor = color

--- a/Sources/ColumbaApp/Views/NomadNet/MicronDocumentView.swift
+++ b/Sources/ColumbaApp/Views/NomadNet/MicronDocumentView.swift
@@ -92,17 +92,17 @@ struct MicronDocumentView: View {
                     bold: false,
                     onLinkTapped: onLinkTapped
                 )
-                .padding(.leading, CGFloat(indentLevel) * style.approxCharWidth)
                 .frame(minWidth: viewportWidth, alignment: alignment.swiftUI)
+                .padding(.horizontal, CGFloat(indentLevel) * style.approxCharWidth)
             } else {
                 renderSpans(spans, onLinkTapped: onLinkTapped)
                     .font(bodyFont)
                     .lineLimit(nil)
                     .frame(maxWidth: .infinity, alignment: alignment.swiftUI)
-                    .padding(.leading, indentationWidth(columns: indentLevel))
+                    .padding(.horizontal, indentationWidth(columns: indentLevel))
             }
 
-        case .divider(let character):
+        case .divider(let character, let indentLevel):
             if isScrollMode {
                 // Use a full-width horizontal line character for scroll mode
                 let divChar = character.map(String.init) ?? "─"
@@ -115,6 +115,7 @@ struct MicronDocumentView: View {
                     onLinkTapped: nil
                 )
                 .frame(minWidth: viewportWidth, alignment: .leading)
+                .padding(.horizontal, indentationWidth(columns: indentLevel))
             } else if let ch = character {
                 Text(String(repeating: ch, count: 40))
                     .font(.system(size: style.fontSize, design: .monospaced))
@@ -122,12 +123,14 @@ struct MicronDocumentView: View {
                     .lineLimit(1)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.vertical, 4)
+                    .padding(.horizontal, indentationWidth(columns: indentLevel))
             } else {
                 Divider()
                     .padding(.vertical, 4)
+                    .padding(.horizontal, indentationWidth(columns: indentLevel))
             }
 
-        case .literalBlock(let text):
+        case .literalBlock(let text, let indentLevel):
             if isScrollMode {
                 // Split literal blocks into individual lines so each gets exact cell height
                 VStack(alignment: .leading, spacing: 0) {
@@ -142,6 +145,7 @@ struct MicronDocumentView: View {
                         )
                     }
                 }
+                .padding(.horizontal, indentationWidth(columns: indentLevel))
             } else {
                 Text(text)
                     .font(.system(size: style.fontSize, design: .monospaced))
@@ -150,14 +154,17 @@ struct MicronDocumentView: View {
                     .background(Color.platformSystemGray6)
                     .cornerRadius(6)
                     .padding(.vertical, 4)
+                    .padding(.horizontal, indentationWidth(columns: indentLevel))
             }
 
-        case .formField(let field):
+        case .formField(let field, let indentLevel):
             renderFormField(field)
                 .padding(.vertical, 2)
+                .padding(.horizontal, indentationWidth(columns: indentLevel))
 
-        case .partial(let partial):
+        case .partial(let partial, let indentLevel):
             renderPartial(partial)
+                .padding(.horizontal, indentationWidth(columns: indentLevel))
         }
     }
 
@@ -310,15 +317,18 @@ private struct MicronSimpleElementView: View {
             renderSpans(spans, onLinkTapped: onLinkTapped)
                 .font(.system(.body, design: .monospaced))
                 .frame(maxWidth: .infinity, alignment: alignment.swiftUI)
-                .padding(.leading, CGFloat(indentLevel) * 8)
-        case .divider:
-            Divider().padding(.vertical, 4)
-        case .literalBlock(let text):
+                .padding(.horizontal, CGFloat(indentLevel) * 8)
+        case .divider(_, let indentLevel):
+            Divider()
+                .padding(.vertical, 4)
+                .padding(.horizontal, CGFloat(indentLevel) * 8)
+        case .literalBlock(let text, let indentLevel):
             Text(text)
                 .font(.system(.body, design: .monospaced))
                 .padding(8)
                 .background(Color.platformSystemGray6)
                 .cornerRadius(6)
+                .padding(.horizontal, CGFloat(indentLevel) * 8)
         case .formField, .partial:
             EmptyView()
         }

--- a/Sources/ColumbaApp/Views/NomadNet/MicronRenderContainer.swift
+++ b/Sources/ColumbaApp/Views/NomadNet/MicronRenderContainer.swift
@@ -156,6 +156,19 @@ public enum MicronRenderStyle: Sendable, Equatable {
         }
     }
 
+    var swiftUIFont: Font {
+        guard usesMonospace else {
+            return .system(size: fontSize)
+        }
+        #if os(iOS)
+        let resolved = Self.uiMonospaceFont(fontSize: fontSize)
+        if resolved.fontName.hasPrefix("JetBrainsMono") {
+            return .custom(resolved.fontName, size: fontSize)
+        }
+        #endif
+        return .system(size: fontSize, design: .monospaced)
+    }
+
     /// Measured width of a single character in the monospace font at this style's font size.
     /// Used to compute square line height for block-drawing characters (▀▄█ etc.).
     public var approxCharWidth: CGFloat {

--- a/Sources/ColumbaApp/Views/NomadNet/MicronRenderContainer.swift
+++ b/Sources/ColumbaApp/Views/NomadNet/MicronRenderContainer.swift
@@ -170,10 +170,23 @@ public enum MicronRenderStyle: Sendable, Equatable {
     /// Cached so we don't re-measure every frame.
     private static var charWidthCache: [CGFloat: CGFloat] = [:]
 
+    #if os(iOS)
+    static func uiMonospaceFont(fontSize: CGFloat, bold: Bool = false) -> UIFont {
+        let name = bold ? "JetBrainsMono-Bold" : "JetBrainsMono-Regular"
+        if let custom = UIFont(name: name, size: fontSize) {
+            return custom
+        }
+        return UIFont.monospacedSystemFont(
+            ofSize: fontSize,
+            weight: bold ? .bold : .regular
+        )
+    }
+    #endif
+
     private static func measureMonospaceCharWidth(fontSize: CGFloat) -> CGFloat {
         if let cached = charWidthCache[fontSize] { return cached }
         #if os(iOS)
-        let font = UIFont.monospacedSystemFont(ofSize: fontSize, weight: .regular)
+        let font = uiMonospaceFont(fontSize: fontSize)
         let width = ("M" as NSString).size(withAttributes: [.font: font]).width
         #elseif os(macOS)
         let font = NSFont.monospacedSystemFont(ofSize: fontSize, weight: .regular)

--- a/Sources/ColumbaApp/Views/NomadNet/MonospaceLineView.swift
+++ b/Sources/ColumbaApp/Views/NomadNet/MonospaceLineView.swift
@@ -20,6 +20,7 @@ struct MonospaceLineView: View {
     let cellHeight: CGFloat
     let alignment: MicronAlignment
     let bold: Bool
+    var defaultForegroundColor: Color? = nil
     /// Force the UIKit label to be at least this wide so center/right alignment
     /// resolves against the visible viewport, not just the text's intrinsic width.
     /// Pass 0 to opt out (label sizes to its own intrinsic only).
@@ -92,6 +93,8 @@ struct MonospaceLineView: View {
                 if let fg = style.foregroundColor,
                    let color = MicronTextStyle.colorFromStyleHex(fg) {
                     attrs[.foregroundColor] = UIColor(color)
+                } else if let defaultForegroundColor {
+                    attrs[.foregroundColor] = UIColor(defaultForegroundColor)
                 } else {
                     attrs[.foregroundColor] = UIColor.label
                 }

--- a/Sources/ColumbaApp/Views/NomadNet/MonospaceLineView.swift
+++ b/Sources/ColumbaApp/Views/NomadNet/MonospaceLineView.swift
@@ -109,14 +109,12 @@ struct MonospaceLineView: View {
                 result.append(NSAttributedString(string: text, attributes: attrs))
 
             case .link(let link):
-                var attrs: [NSAttributedString.Key: Any] = [
+                let attrs: [NSAttributedString.Key: Any] = [
                     .font: baseFont,
                     .paragraphStyle: paragraph,
                     .foregroundColor: UIColor(linkForegroundColor ?? .accentColor),
                     .underlineStyle: NSUnderlineStyle.single.rawValue,
-                    .link: "columba-micron://link/\(result.length)",
                 ]
-                _ = attrs // mark the attribute so we can map back to MicronLink
                 result.append(NSAttributedString(string: link.label, attributes: attrs))
             }
         }

--- a/Sources/ColumbaApp/Views/NomadNet/MonospaceLineView.swift
+++ b/Sources/ColumbaApp/Views/NomadNet/MonospaceLineView.swift
@@ -90,13 +90,13 @@ struct MonospaceLineView: View {
                     .paragraphStyle: paragraph,
                 ]
                 if let fg = style.foregroundColor,
-                   let color = MicronTextStyle.colorFromHex(fg) {
+                   let color = MicronTextStyle.colorFromStyleHex(fg) {
                     attrs[.foregroundColor] = UIColor(color)
                 } else {
                     attrs[.foregroundColor] = UIColor.label
                 }
                 if let bg = style.backgroundColor,
-                   let color = MicronTextStyle.colorFromHex(bg) {
+                   let color = MicronTextStyle.colorFromStyleHex(bg) {
                     attrs[.backgroundColor] = UIColor(color)
                 }
                 if style.underline {

--- a/Sources/ColumbaApp/Views/NomadNet/MonospaceLineView.swift
+++ b/Sources/ColumbaApp/Views/NomadNet/MonospaceLineView.swift
@@ -66,23 +66,10 @@ struct MonospaceLineView: View {
         // trailing-whitespace stripping under .center / .right alignment.
         paragraph.alignment = .left
 
-        // Prefer bundled JetBrains Mono — its Unicode block-drawing glyphs are
-        // truly cell-uniform with ASCII spaces, which the iOS system monospaced
-        // font (SF Mono) is not. SF Mono renders ▗▄▖█ at slightly different
-        // pixel widths than space, so a row of mixed box-chars + spaces ends
-        // up at a different intrinsic width than the next row, breaking
-        // column alignment in NomadNet ASCII art (e.g. fr33n0w/thechatroom).
-        // Falls back to the system font if the bundled font fails to load.
-        let baseFont: UIFont = {
-            let name = bold ? "JetBrainsMono-Bold" : "JetBrainsMono-Regular"
-            if let custom = UIFont(name: name, size: fontSize) {
-                return custom
-            }
-            if bold {
-                return UIFont.monospacedSystemFont(ofSize: fontSize, weight: .bold)
-            }
-            return UIFont.monospacedSystemFont(ofSize: fontSize, weight: .regular)
-        }()
+        let baseFont = MicronRenderStyle.uiMonospaceFont(
+            fontSize: fontSize,
+            bold: bold
+        )
 
         for span in spans {
             switch span {
@@ -124,8 +111,10 @@ struct MonospaceLineView: View {
     private func font(for style: MicronTextStyle, base: UIFont) -> UIFont {
         var font = base
         if style.bold {
-            font = UIFont(name: "JetBrainsMono-Bold", size: base.pointSize)
-                ?? UIFont.monospacedSystemFont(ofSize: base.pointSize, weight: .bold)
+            font = MicronRenderStyle.uiMonospaceFont(
+                fontSize: base.pointSize,
+                bold: true
+            )
         }
         if style.italic,
            let desc = font.fontDescriptor.withSymbolicTraits(.traitItalic) {

--- a/Sources/ColumbaApp/Views/NomadNet/MonospaceLineView.swift
+++ b/Sources/ColumbaApp/Views/NomadNet/MonospaceLineView.swift
@@ -21,6 +21,7 @@ struct MonospaceLineView: View {
     let alignment: MicronAlignment
     let bold: Bool
     var defaultForegroundColor: Color? = nil
+    var linkForegroundColor: Color? = nil
     /// Force the UIKit label to be at least this wide so center/right alignment
     /// resolves against the visible viewport, not just the text's intrinsic width.
     /// Pass 0 to opt out (label sizes to its own intrinsic only).
@@ -111,7 +112,7 @@ struct MonospaceLineView: View {
                 var attrs: [NSAttributedString.Key: Any] = [
                     .font: baseFont,
                     .paragraphStyle: paragraph,
-                    .foregroundColor: UIColor.tintColor,
+                    .foregroundColor: UIColor(linkForegroundColor ?? .accentColor),
                     .underlineStyle: NSUnderlineStyle.single.rawValue,
                     .link: "columba-micron://link/\(result.length)",
                 ]

--- a/Sources/ColumbaApp/Views/NomadNet/MonospaceLineView.swift
+++ b/Sources/ColumbaApp/Views/NomadNet/MonospaceLineView.swift
@@ -90,13 +90,13 @@ struct MonospaceLineView: View {
                     .paragraphStyle: paragraph,
                 ]
                 if let fg = style.foregroundColor,
-                   let color = MicronTextStyle.colorFrom3Hex(fg) {
+                   let color = MicronTextStyle.colorFromHex(fg) {
                     attrs[.foregroundColor] = UIColor(color)
                 } else {
                     attrs[.foregroundColor] = UIColor.label
                 }
                 if let bg = style.backgroundColor,
-                   let color = MicronTextStyle.colorFrom3Hex(bg) {
+                   let color = MicronTextStyle.colorFromHex(bg) {
                     attrs[.backgroundColor] = UIColor(color)
                 }
                 if style.underline {

--- a/Sources/ColumbaApp/Views/NomadNet/NomadNetBrowserView.swift
+++ b/Sources/ColumbaApp/Views/NomadNet/NomadNetBrowserView.swift
@@ -169,7 +169,7 @@ struct NomadNetBrowserView: View {
     @ViewBuilder
     private var pageBackground: some View {
         if let bgHex = viewModel.currentDocument?.headers.backgroundColor,
-           let color = MicronTextStyle.colorFrom3Hex(bgHex) {
+           let color = MicronTextStyle.colorFromHex(bgHex) {
             color
         } else {
             Color.platformSystemBackground

--- a/Sources/ColumbaApp/Views/NomadNet/NomadNetBrowserView.swift
+++ b/Sources/ColumbaApp/Views/NomadNet/NomadNetBrowserView.swift
@@ -211,7 +211,7 @@ struct NomadNetBrowserView: View {
     @ViewBuilder
     private var pageBackground: some View {
         if let bgHex = viewModel.currentDocument?.headers.backgroundColor,
-           let color = MicronTextStyle.colorFromHex(bgHex) {
+           let color = MicronTextStyle.colorFrom3Hex(bgHex) {
             color
         } else {
             Color.platformSystemBackground

--- a/Sources/ColumbaApp/Views/NomadNet/NomadNetBrowserView.swift
+++ b/Sources/ColumbaApp/Views/NomadNet/NomadNetBrowserView.swift
@@ -1,11 +1,17 @@
 #if COLUMBA_NOMADNET_ENABLED
 import SwiftUI
 import RNSAPI
+#if canImport(UIKit)
+import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
 
 /// Main browser view for browsing NomadNet node pages.
 @available(iOS 17.0, macOS 14.0, *)
 struct NomadNetBrowserView: View {
     @State private var viewModel: NomadNetBrowserViewModel
+    @State private var showingAddressShareSheet = false
 
     init(
         nodeHash: Data,
@@ -83,6 +89,9 @@ struct NomadNetBrowserView: View {
                 ShareSheet(items: [url])
             }
         }
+        .sheet(isPresented: $showingAddressShareSheet) {
+            ShareSheet(items: [viewModel.shareableAddress])
+        }
         #endif
         .alert("Error", isPresented: .init(
             get: { viewModel.errorMessage != nil },
@@ -106,6 +115,13 @@ struct NomadNetBrowserView: View {
             .truncationMode(.middle)
             .foregroundStyle(.secondary)
             .frame(maxWidth: 220)
+            .contextMenu {
+                Button {
+                    copyAddress()
+                } label: {
+                    Label("Copy Address", systemImage: "doc.on.doc")
+                }
+            }
     }
 
     @ViewBuilder
@@ -135,6 +151,22 @@ struct NomadNetBrowserView: View {
 
             Divider()
 
+            Button {
+                copyAddress()
+            } label: {
+                Label("Copy Address", systemImage: "doc.on.doc")
+            }
+
+            #if os(iOS)
+            Button {
+                showingAddressShareSheet = true
+            } label: {
+                Label("Share Address", systemImage: "square.and.arrow.up")
+            }
+            #endif
+
+            Divider()
+
             Menu {
                 ForEach(NomadNetRenderingMode.allCases, id: \.self) { mode in
                     Button {
@@ -153,6 +185,16 @@ struct NomadNetBrowserView: View {
         } label: {
             Image(systemName: "ellipsis.circle")
         }
+    }
+
+    private func copyAddress() {
+        #if canImport(UIKit)
+        UIPasteboard.general.string = viewModel.shareableAddress
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+        #elseif canImport(AppKit)
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(viewModel.shareableAddress, forType: .string)
+        #endif
     }
 
     private var loadingOverlay: some View {

--- a/Sources/RNSAPI/Protocols/RnsNomadnet.swift
+++ b/Sources/RNSAPI/Protocols/RnsNomadnet.swift
@@ -12,8 +12,9 @@ import Foundation
 public protocol RnsNomadnet: AnyObject, Sendable {
 
     /// One-shot NomadNet page fetch over a fresh RNS Link. `formFields`, when
-    /// present, are submitted as the request's MessagePack map (caller prefixes
-    /// `field_` per NomadNet's node-app convention).
+    /// present, are submitted as the request's MessagePack map. Callers provide
+    /// exact NomadNet keys: `field_` for user-entered fields and `var_` for
+    /// inline request variables.
     func fetchNomadNetPage(
         destHashHex: String,
         path: String,

--- a/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
+++ b/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
@@ -38,6 +38,19 @@ final class MessageLinkParserTests: XCTestCase {
         XCTAssertNil(MessageLinkParser.target(for: URL(string: "data:text/plain,secret")!))
     }
 
+    func testSharedNomadNetAddressPreservesEncodedRequestVariables() throws {
+        let address = "nomadnetwork://\(nodeHash):/page/group.mu`g=reticulum|topic=hello+world"
+        let url = try XCTUnwrap(URL(string: address))
+
+        XCTAssertEqual(
+            MessageLinkParser.target(for: url),
+            .nomadNet(
+                nodeHash: Data(hexString: nodeHash)!,
+                path: "/page/group.mu`g=reticulum|topic=hello+world"
+            )
+        )
+    }
+
     func testBareHashWithoutNomadNetPathIsNotLinkified() {
         XCTAssertTrue(MessageLinkParser.matches(in: "identity \(nodeHash)").isEmpty)
     }

--- a/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
+++ b/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
@@ -39,14 +39,14 @@ final class MessageLinkParserTests: XCTestCase {
     }
 
     func testSharedNomadNetAddressPreservesEncodedRequestVariables() throws {
-        let address = "nomadnetwork://\(nodeHash):/page/group.mu`g=reticulum|topic=hello+world"
+        let address = "nomadnetwork://\(nodeHash):/page/group.mu`g=reticulum|delimiter=a%7Cb|equals=a%3Db|plus=a%2Bb|percent=a%25b"
         let url = try XCTUnwrap(URL(string: address))
 
         XCTAssertEqual(
             MessageLinkParser.target(for: url),
             .nomadNet(
                 nodeHash: Data(hexString: nodeHash)!,
-                path: "/page/group.mu`g=reticulum|topic=hello+world"
+                path: "/page/group.mu`g=reticulum|delimiter=a%7Cb|equals=a%3Db|plus=a%2Bb|percent=a%25b"
             )
         )
     }

--- a/Tests/ColumbaAppTests/MicronParserTests.swift
+++ b/Tests/ColumbaAppTests/MicronParserTests.swift
@@ -850,6 +850,13 @@ final class MicronParserTests: XCTestCase {
         }
     }
 
+    func testScrollMetricsUseRenderedMonospaceFont() {
+        let style = MicronRenderStyle.monospaceScroll
+        let font = MicronRenderStyle.uiMonospaceFont(fontSize: style.fontSize)
+        let renderedWidth = ("M" as NSString).size(withAttributes: [.font: font]).width
+        XCTAssertEqual(style.approxCharWidth, renderedWidth, accuracy: 0.001)
+    }
+
     @MainActor
     func testZeroViewportScrollDividerKeepsIntrinsicFallbackWidth() {
         let document = MicronDocument(elements: [.divider(character: "=", indentLevel: 2)])

--- a/Tests/ColumbaAppTests/MicronParserTests.swift
+++ b/Tests/ColumbaAppTests/MicronParserTests.swift
@@ -569,7 +569,7 @@ final class MicronParserTests: XCTestCase {
                 formFields: .constant([:]),
                 checkboxFields: .constant([:]),
                 radioFields: .constant([:]),
-                style: .monospaceScroll,
+                style: .proportional,
                 viewportWidth: 320
             )
             .frame(width: 320, alignment: .leading)

--- a/Tests/ColumbaAppTests/MicronParserTests.swift
+++ b/Tests/ColumbaAppTests/MicronParserTests.swift
@@ -968,19 +968,18 @@ final class MicronParserTests: XCTestCase {
         ])
         let innerDocument = MicronParser.parse(">>Nested Partial")
         let partials = [outer.url: outerDocument, inner.url: innerDocument]
-        let styles: [MicronRenderStyle] = [.monospaceScroll, .monospaceCompact, .proportional]
+        let modes: [NomadNetRenderingMode] = [.monospaceScroll, .monospaceZoom, .proportionalWrap]
 
-        for style in styles {
+        for mode in modes {
             let size = CGSize(width: 340, height: 180)
             let host = UIHostingController(
-                rootView: MicronDocumentView(
+                rootView: MicronRenderContainer(
                     document: rootDocument,
+                    mode: mode,
                     formFields: .constant([:]),
                     checkboxFields: .constant([:]),
                     radioFields: .constant([:]),
-                    partialDocuments: partials,
-                    style: style,
-                    viewportWidth: 320
+                    partialDocuments: partials
                 )
                 .frame(width: 320, alignment: .leading)
                 .environment(\.colorScheme, .light)
@@ -996,11 +995,11 @@ final class MicronParserTests: XCTestCase {
             host.view.layoutIfNeeded()
 
             let textFields = descendants(of: host.view, matching: UITextField.self)
-            XCTAssertEqual(textFields.count, 1, "style: \(style)")
+            XCTAssertEqual(textFields.count, 1, "mode: \(mode)")
             if let textField = textFields.first {
                 let fieldFrame = textField.convert(textField.bounds, to: host.view)
-                XCTAssertGreaterThan(fieldFrame.minX, 30, "style: \(style)")
-                XCTAssertGreaterThan(size.width - fieldFrame.maxX, 20, "style: \(style)")
+                XCTAssertGreaterThan(fieldFrame.minX, 30, "mode: \(mode)")
+                XCTAssertGreaterThan(size.width - fieldFrame.maxX, 20, "mode: \(mode)")
             }
             let image = UIGraphicsImageRenderer(size: size).image { _ in
                 host.view.drawHierarchy(in: host.view.bounds, afterScreenUpdates: true)
@@ -1008,20 +1007,20 @@ final class MicronParserTests: XCTestCase {
             XCTAssertGreaterThan(
                 pixelCount(in: image, near: (0xaa, 0xaa, 0xaa), tolerance: 4),
                 100,
-                "style: \(style)"
+                "mode: \(mode)"
             )
             let headingBounds = dominantBandBounds(
                 in: image,
                 near: (0xaa, 0xaa, 0xaa),
                 tolerance: 4
             )
-            XCTAssertNotNil(headingBounds, "style: \(style)")
+            XCTAssertNotNil(headingBounds, "mode: \(mode)")
             if let headingBounds {
-                XCTAssertGreaterThan(headingBounds.minX / image.scale, 20, "style: \(style)")
+                XCTAssertGreaterThan(headingBounds.minX / image.scale, 20, "mode: \(mode)")
                 XCTAssertGreaterThan(
                     (CGFloat(image.cgImage?.width ?? 0) - headingBounds.maxX) / image.scale,
                     20,
-                    "style: \(style)"
+                    "mode: \(mode)"
                 )
             }
             window.isHidden = true

--- a/Tests/ColumbaAppTests/MicronParserTests.swift
+++ b/Tests/ColumbaAppTests/MicronParserTests.swift
@@ -136,6 +136,42 @@ final class MicronParserTests: XCTestCase {
         XCTAssertEqual(text, "The Non-linear Task Manager")
     }
 
+    func testSectionIndentUsesCanonicalTwoCellsPerNestedLevel() {
+        let doc = MicronParser.parse("""
+        >Top
+        top body
+        >>Nested
+        nested body
+        >>>>Deep
+        deep body
+        """)
+
+        let paragraphIndents = doc.elements.compactMap { element -> Int? in
+            guard case .paragraph(_, _, let indent) = element else { return nil }
+            return indent
+        }
+        XCTAssertEqual(paragraphIndents, [0, 2, 6])
+    }
+
+    func testSectionResetEscapedRemainderPreservesFormattingState() {
+        let doc = MicronParser.parse("`!bold\n<\\>literal")
+
+        guard case .paragraph(let spans, _, let indent) = doc.elements.last,
+              case .text(let text, let style) = spans.first else {
+            XCTFail("Expected escaped reset remainder")
+            return
+        }
+
+        XCTAssertEqual(text, ">literal")
+        XCTAssertEqual(indent, 0)
+        XCTAssertTrue(style.bold)
+    }
+
+    func testFieldBearingHeadingSanitizationRestartsBlockClassification() {
+        let doc = MicronParser.parse(">># hidden `<name`value>")
+        XCTAssertTrue(doc.elements.isEmpty)
+    }
+
     // MARK: - Dividers
 
     func testDefaultDivider() {
@@ -601,6 +637,89 @@ final class MicronParserTests: XCTestCase {
         attachment.name = "nomadnet-canonical-dark-section-headings"
         attachment.lifetime = .keepAlways
         add(attachment)
+    }
+
+    @MainActor
+    func testMonospaceHeadingLinkInheritsCanonicalForeground() {
+        let document = MicronParser.parse(">>`[Key Features`:/page/features.mu]")
+        let size = CGSize(width: 340, height: 100)
+        let host = UIHostingController(
+            rootView: MicronDocumentView(
+                document: document,
+                formFields: .constant([:]),
+                checkboxFields: .constant([:]),
+                radioFields: .constant([:]),
+                style: .monospaceScroll,
+                viewportWidth: 320
+            )
+            .frame(width: 320, alignment: .leading)
+            .environment(\.colorScheme, .dark)
+            .padding(10)
+            .frame(width: size.width, height: size.height, alignment: .topLeading)
+            .background(Color.black)
+            .ignoresSafeArea()
+        )
+        let window = UIWindow(frame: CGRect(origin: .zero, size: size))
+        window.rootViewController = host
+        window.makeKeyAndVisible()
+        defer { window.isHidden = true }
+
+        host.view.frame = CGRect(origin: .zero, size: size)
+        host.view.layoutIfNeeded()
+        let image = UIGraphicsImageRenderer(size: size).image { _ in
+            host.view.drawHierarchy(in: host.view.bounds, afterScreenUpdates: true)
+        }
+
+        XCTAssertGreaterThan(pixelCount(in: image, near: (0x99, 0x99, 0x99), tolerance: 4), 500)
+        XCTAssertGreaterThan(pixelCount(in: image, near: (0x11, 0x11, 0x11), tolerance: 8), 5)
+
+        let attachment = XCTAttachment(image: image)
+        attachment.name = "nomadnet-monospace-heading-link"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+
+    @MainActor
+    func testLightPartialHeadingUsesCanonicalPalette() {
+        let partial = MicronPartial(
+            url: "/page/partial.mu",
+            refreshInterval: nil,
+            partialId: nil,
+            fieldNames: nil
+        )
+        let document = MicronDocument(elements: [.partial(partial)])
+        let partialDocument = MicronParser.parse(">>Partial Heading")
+        let size = CGSize(width: 340, height: 120)
+        let host = UIHostingController(
+            rootView: MicronDocumentView(
+                document: document,
+                formFields: .constant([:]),
+                checkboxFields: .constant([:]),
+                radioFields: .constant([:]),
+                partialDocuments: [partial.url: partialDocument],
+                style: .proportional,
+                viewportWidth: 320
+            )
+            .frame(width: 320, alignment: .leading)
+            .environment(\.colorScheme, .light)
+            .padding(10)
+            .frame(width: size.width, height: size.height, alignment: .topLeading)
+            .background(Color.white)
+            .ignoresSafeArea()
+        )
+        let window = UIWindow(frame: CGRect(origin: .zero, size: size))
+        window.rootViewController = host
+        window.makeKeyAndVisible()
+        defer { window.isHidden = true }
+
+        host.view.frame = CGRect(origin: .zero, size: size)
+        host.view.layoutIfNeeded()
+        let image = UIGraphicsImageRenderer(size: size).image { _ in
+            host.view.drawHierarchy(in: host.view.bounds, afterScreenUpdates: true)
+        }
+
+        XCTAssertGreaterThan(pixelCount(in: image, near: (0xaa, 0xaa, 0xaa), tolerance: 4), 500)
+        XCTAssertGreaterThan(pixelCount(in: image, near: (0x11, 0x11, 0x11), tolerance: 8), 5)
     }
 
     private func pixelCount(

--- a/Tests/ColumbaAppTests/MicronParserTests.swift
+++ b/Tests/ColumbaAppTests/MicronParserTests.swift
@@ -172,6 +172,28 @@ final class MicronParserTests: XCTestCase {
         XCTAssertTrue(doc.elements.isEmpty)
     }
 
+    func testNestedBlocksCarryCanonicalSectionIndent() {
+        let doc = MicronParser.parse("""
+        >>Nested
+        -X
+        `=
+        literal
+        `=
+        `<12|name`value>
+        `{/page/partial.mu}
+        """)
+
+        let nestedBlockIndents = doc.elements.compactMap { element -> Int? in
+            switch element {
+            case .divider, .literalBlock, .formField, .partial:
+                return element.sectionIndent
+            case .heading, .paragraph:
+                return nil
+            }
+        }
+        XCTAssertEqual(nestedBlockIndents, [2, 2, 2, 2])
+    }
+
     // MARK: - Dividers
 
     func testDefaultDivider() {
@@ -595,7 +617,7 @@ final class MicronParserTests: XCTestCase {
     func testCanonicalDarkSectionHeadingsRenderPaletteBackgrounds() {
         let document = MicronParser.parse("""
         <>The Non-linear Task Manager
-        >>Key Features
+        >>`[Key Features`:/page/features.mu]
         >>>Installation
         """)
         let size = CGSize(width: 340, height: 360)
@@ -632,6 +654,52 @@ final class MicronParserTests: XCTestCase {
         XCTAssertGreaterThan(pixelCount(in: image, near: (0xbb, 0xbb, 0xbb), tolerance: 4), 500)
         XCTAssertGreaterThan(pixelCount(in: image, near: (0x99, 0x99, 0x99), tolerance: 4), 500)
         XCTAssertGreaterThan(pixelCount(in: image, near: (0x77, 0x77, 0x77), tolerance: 4), 500)
+        XCTAssertLessThan(blueDominantPixelCount(in: image), 5)
+
+        let level1Background = pixelBounds(in: image, near: (0xbb, 0xbb, 0xbb), tolerance: 4)
+        let level2Background = pixelBounds(in: image, near: (0x99, 0x99, 0x99), tolerance: 4)
+        let level3Background = pixelBounds(in: image, near: (0x77, 0x77, 0x77), tolerance: 4)
+        XCTAssertNotNil(level1Background)
+        XCTAssertNotNil(level2Background)
+        XCTAssertNotNil(level3Background)
+        if let level1Background, let level2Background, let level3Background {
+            XCTAssertEqual(level1Background.minX, level2Background.minX, accuracy: 4)
+            XCTAssertEqual(level2Background.minX, level3Background.minX, accuracy: 4)
+            XCTAssertEqual(level1Background.maxX, level2Background.maxX, accuracy: 4)
+            XCTAssertEqual(level2Background.maxX, level3Background.maxX, accuracy: 4)
+
+            let level1Text = pixelBounds(
+                in: image,
+                near: (0x22, 0x22, 0x22),
+                tolerance: 8,
+                inside: level1Background
+            )
+            let level2Text = pixelBounds(
+                in: image,
+                near: (0x11, 0x11, 0x11),
+                tolerance: 8,
+                inside: level2Background
+            )
+            let level3Text = pixelBounds(
+                in: image,
+                near: (0x00, 0x00, 0x00),
+                tolerance: 4,
+                inside: level3Background
+            )
+            XCTAssertNotNil(level1Text)
+            XCTAssertNotNil(level2Text)
+            XCTAssertNotNil(level3Text)
+            if let level1Text, let level2Text, let level3Text {
+                XCTAssertGreaterThan(level2Text.minX - level1Text.minX, 30)
+                XCTAssertGreaterThan(level3Text.minX - level2Text.minX, 30)
+                XCTAssertGreaterThanOrEqual(level1Text.minY, level1Background.minY)
+                XCTAssertLessThanOrEqual(level1Text.maxY, level1Background.maxY)
+                XCTAssertGreaterThanOrEqual(level2Text.minY, level2Background.minY)
+                XCTAssertLessThanOrEqual(level2Text.maxY, level2Background.maxY)
+                XCTAssertGreaterThanOrEqual(level3Text.minY, level3Background.minY)
+                XCTAssertLessThanOrEqual(level3Text.maxY, level3Background.maxY)
+            }
+        }
 
         let attachment = XCTAttachment(image: image)
         attachment.name = "nomadnet-canonical-dark-section-headings"
@@ -689,7 +757,7 @@ final class MicronParserTests: XCTestCase {
             fieldNames: nil
         )
         let document = MicronDocument(elements: [.partial(partial)])
-        let partialDocument = MicronParser.parse(">>Partial Heading")
+        let partialDocument = MicronParser.parse(">>`[Partial Heading`:/page/target.mu]")
         let size = CGSize(width: 340, height: 120)
         let host = UIHostingController(
             rootView: MicronDocumentView(
@@ -721,6 +789,7 @@ final class MicronParserTests: XCTestCase {
 
         XCTAssertGreaterThan(pixelCount(in: image, near: (0xaa, 0xaa, 0xaa), tolerance: 4), 500)
         XCTAssertGreaterThan(pixelCount(in: image, near: (0x11, 0x11, 0x11), tolerance: 8), 5)
+        XCTAssertLessThan(blueDominantPixelCount(in: image), 5)
     }
 
     private func pixelCount(
@@ -779,6 +848,53 @@ final class MicronParserTests: XCTestCase {
                 count += 1
             }
         }
+    }
+
+    private func pixelBounds(
+        in image: UIImage,
+        near expected: (UInt8, UInt8, UInt8),
+        tolerance: Int,
+        inside region: CGRect? = nil
+    ) -> CGRect? {
+        guard let source = image.cgImage else { return nil }
+        let width = source.width
+        let height = source.height
+        var pixels = [UInt8](repeating: 0, count: width * height * 4)
+        guard let context = CGContext(
+            data: &pixels,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: width * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else { return nil }
+        context.draw(source, in: CGRect(x: 0, y: 0, width: width, height: height))
+
+        let canvas = CGRect(x: 0, y: 0, width: width, height: height)
+        let search = region?.integral.intersection(canvas) ?? canvas
+        var minX = width
+        var minY = height
+        var maxX = -1
+        var maxY = -1
+        for y in Int(search.minY)..<Int(search.maxY) {
+            for x in Int(search.minX)..<Int(search.maxX) {
+                let index = (y * width + x) * 4
+                let red = Int(pixels[index])
+                let green = Int(pixels[index + 1])
+                let blue = Int(pixels[index + 2])
+                if abs(red - Int(expected.0)) <= tolerance,
+                   abs(green - Int(expected.1)) <= tolerance,
+                   abs(blue - Int(expected.2)) <= tolerance {
+                    minX = min(minX, x)
+                    minY = min(minY, y)
+                    maxX = max(maxX, x)
+                    maxY = max(maxY, y)
+                }
+            }
+        }
+        guard maxX >= minX, maxY >= minY else { return nil }
+        return CGRect(x: minX, y: minY, width: maxX - minX + 1, height: maxY - minY + 1)
     }
     #endif
 

--- a/Tests/ColumbaAppTests/MicronParserTests.swift
+++ b/Tests/ColumbaAppTests/MicronParserTests.swift
@@ -447,7 +447,7 @@ final class MicronParserTests: XCTestCase {
 
     #if canImport(UIKit)
     func testTrueColorConvertsToExactRGBComponents() throws {
-        let color = try XCTUnwrap(MicronTextStyle.colorFromHex("8b949e"))
+        let color = try XCTUnwrap(MicronTextStyle.colorFromStyleHex("8b949e"))
         let uiColor = UIColor(color)
         var red: CGFloat = 0
         var green: CGFloat = 0
@@ -458,6 +458,11 @@ final class MicronParserTests: XCTestCase {
         XCTAssertEqual(green, 0x94 / 255.0, accuracy: 0.001)
         XCTAssertEqual(blue, 0x9e / 255.0, accuracy: 0.001)
         XCTAssertEqual(alpha, 1, accuracy: 0.001)
+    }
+
+    func testPageHeaderColorRemainsLegacyThreeDigitOnly() {
+        XCTAssertNotNil(MicronTextStyle.colorFrom3Hex("abc"))
+        XCTAssertNil(MicronTextStyle.colorFrom3Hex("aabbcc"))
     }
 
     @MainActor

--- a/Tests/ColumbaAppTests/MicronParserTests.swift
+++ b/Tests/ColumbaAppTests/MicronParserTests.swift
@@ -684,7 +684,7 @@ final class MicronParserTests: XCTestCase {
                 in: image,
                 near: (0x00, 0x00, 0x00),
                 tolerance: 4,
-                inside: level3Background
+                inside: level3Background.insetBy(dx: 30, dy: 4)
             )
             XCTAssertNotNil(level1Text)
             XCTAssertNotNil(level2Text)

--- a/Tests/ColumbaAppTests/MicronParserTests.swift
+++ b/Tests/ColumbaAppTests/MicronParserTests.swift
@@ -901,7 +901,11 @@ final class MicronParserTests: XCTestCase {
             )
             .frame(width: 200, height: 40, alignment: .leading)
         )
-        host.view.frame = CGRect(x: 0, y: 0, width: 200, height: 40)
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 200, height: 40))
+        window.rootViewController = host
+        window.makeKeyAndVisible()
+        defer { window.isHidden = true }
+        host.view.frame = window.bounds
         host.view.layoutIfNeeded()
 
         guard let label = descendants(of: host.view, matching: UILabel.self).first,

--- a/Tests/ColumbaAppTests/MicronParserTests.swift
+++ b/Tests/ColumbaAppTests/MicronParserTests.swift
@@ -2,6 +2,9 @@ import XCTest
 @testable import ColumbaApp
 import RNSAPI
 import LXMFSwift
+#if canImport(UIKit)
+import UIKit
+#endif
 
 private actor ReactionGateProbe {
     private var active = 0
@@ -384,6 +387,86 @@ final class MicronParserTests: XCTestCase {
             XCTAssertEqual(t, "blue")
             XCTAssertEqual(s.backgroundColor, "00f")
         } else { XCTFail("Expected text") }
+    }
+
+    func testRngitTrueColorsRenderWithoutLeakingControlPayloads() {
+        let markup = """
+        `BT282828`Fddd`FT8b949e# Add tasks`f
+        `FTc9d1d9nt add `FTa5d6ff"Buy groceries"`f`b
+        """
+
+        let doc = MicronParser.parse(markup)
+        let renderedText = doc.elements.compactMap { element -> String? in
+            guard case .paragraph(let spans, _, _) = element else { return nil }
+            return spans.compactMap { span -> String? in
+                guard case .text(let text, _) = span else { return nil }
+                return text
+            }.joined()
+        }.joined(separator: "\n")
+
+        XCTAssertEqual(renderedText, "# Add tasks\nnt add \"Buy groceries\"")
+
+        guard case .paragraph(let commentSpans, _, _) = doc.elements[0],
+              case .text(_, let commentStyle) = commentSpans.first,
+              case .paragraph(let commandSpans, _, _) = doc.elements[1],
+              case .text(_, let commandStyle) = commandSpans[0],
+              case .text(_, let argumentStyle) = commandSpans[1] else {
+            XCTFail("Expected rngit true-color text spans")
+            return
+        }
+
+        XCTAssertEqual(commentStyle.foregroundColor, "8b949e")
+        XCTAssertEqual(commentStyle.backgroundColor, "282828")
+        XCTAssertEqual(commandStyle.foregroundColor, "c9d1d9")
+        XCTAssertEqual(commandStyle.backgroundColor, "282828")
+        XCTAssertEqual(argumentStyle.foregroundColor, "a5d6ff")
+        XCTAssertEqual(argumentStyle.backgroundColor, "282828")
+    }
+
+    func testMalformedAndTruncatedTrueColorsDoNotChangeStyle() {
+        let foreground = MicronParser.parse("`FT12")
+        let background = MicronParser.parse("`BT12")
+        let malformedForeground = MicronParser.parse("`FTzzzzzztext")
+        let malformedBackground = MicronParser.parse("`BTggggggtext")
+
+        let foregroundText = singleText(from: foreground)
+        let backgroundText = singleText(from: background)
+        let malformedForegroundText = singleText(from: malformedForeground)
+        let malformedBackgroundText = singleText(from: malformedBackground)
+
+        XCTAssertEqual(foregroundText.0, "T12")
+        XCTAssertEqual(foregroundText.1, .plain)
+        XCTAssertEqual(backgroundText.0, "T12")
+        XCTAssertEqual(backgroundText.1, .plain)
+        XCTAssertEqual(malformedForegroundText.0, "Tzzzzzztext")
+        XCTAssertEqual(malformedForegroundText.1, .plain)
+        XCTAssertEqual(malformedBackgroundText.0, "Tggggggtext")
+        XCTAssertEqual(malformedBackgroundText.1, .plain)
+    }
+
+    #if canImport(UIKit)
+    func testTrueColorConvertsToExactRGBComponents() throws {
+        let color = try XCTUnwrap(MicronTextStyle.colorFromHex("8b949e"))
+        let uiColor = UIColor(color)
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        XCTAssertTrue(uiColor.getRed(&red, green: &green, blue: &blue, alpha: &alpha))
+        XCTAssertEqual(red, 0x8b / 255.0, accuracy: 0.001)
+        XCTAssertEqual(green, 0x94 / 255.0, accuracy: 0.001)
+        XCTAssertEqual(blue, 0x9e / 255.0, accuracy: 0.001)
+        XCTAssertEqual(alpha, 1, accuracy: 0.001)
+    }
+    #endif
+
+    private func singleText(from document: MicronDocument) -> (String, MicronTextStyle) {
+        guard case .paragraph(let spans, _, _) = document.elements.first,
+              case .text(let text, let style) = spans.first else {
+            XCTFail("Expected one text span")
+            return ("", .plain)
+        }
+        return (text, style)
     }
 
     // MARK: - Alignment

--- a/Tests/ColumbaAppTests/MicronParserTests.swift
+++ b/Tests/ColumbaAppTests/MicronParserTests.swift
@@ -700,10 +700,26 @@ final class MicronParserTests: XCTestCase {
         XCTAssertNotNil(level2Background)
         XCTAssertNotNil(level3Background)
         if let level1Background, let level2Background, let level3Background {
-            XCTAssertEqual(level1Background.minX, level2Background.minX, accuracy: 4)
-            XCTAssertEqual(level2Background.minX, level3Background.minX, accuracy: 4)
-            XCTAssertEqual(level1Background.maxX, level2Background.maxX, accuracy: 4)
-            XCTAssertEqual(level2Background.maxX, level3Background.maxX, accuracy: 4)
+            XCTAssertEqual(
+                level1Background.minX / image.scale,
+                level2Background.minX / image.scale,
+                accuracy: 1.5
+            )
+            XCTAssertEqual(
+                level2Background.minX / image.scale,
+                level3Background.minX / image.scale,
+                accuracy: 1.5
+            )
+            XCTAssertEqual(
+                level1Background.maxX / image.scale,
+                level2Background.maxX / image.scale,
+                accuracy: 1.5
+            )
+            XCTAssertEqual(
+                level2Background.maxX / image.scale,
+                level3Background.maxX / image.scale,
+                accuracy: 1.5
+            )
 
             let level1Text = pixelBounds(
                 in: image,
@@ -721,7 +737,7 @@ final class MicronParserTests: XCTestCase {
                 in: image,
                 near: (0x00, 0x00, 0x00),
                 tolerance: 4,
-                inside: level3Background.insetBy(dx: 30, dy: 4)
+                inside: level3Background.insetBy(dx: 10 * image.scale, dy: image.scale)
             )
             XCTAssertNotNil(level1Text)
             XCTAssertNotNil(level2Text)
@@ -872,10 +888,30 @@ final class MicronParserTests: XCTestCase {
         }
     }
 
+    @MainActor
     func testScrollMetricsUseRenderedMonospaceFont() {
         let style = MicronRenderStyle.monospaceScroll
-        let font = MicronRenderStyle.uiMonospaceFont(fontSize: style.fontSize)
-        let renderedWidth = ("M" as NSString).size(withAttributes: [.font: font]).width
+        let host = UIHostingController(
+            rootView: MonospaceLineView(
+                spans: [.text("MMMM", .plain)],
+                fontSize: style.fontSize,
+                cellHeight: style.approxCharWidth * 2,
+                alignment: .left,
+                bold: false
+            )
+            .frame(width: 200, height: 40, alignment: .leading)
+        )
+        host.view.frame = CGRect(x: 0, y: 0, width: 200, height: 40)
+        host.view.layoutIfNeeded()
+
+        guard let label = descendants(of: host.view, matching: UILabel.self).first,
+              let attributed = label.attributedText,
+              attributed.length > 0,
+              let renderedFont = attributed.attribute(.font, at: 0, effectiveRange: nil) as? UIFont else {
+            XCTFail("Expected a rendered monospace UILabel font")
+            return
+        }
+        let renderedWidth = ("M" as NSString).size(withAttributes: [.font: renderedFont]).width
         XCTAssertEqual(style.approxCharWidth, renderedWidth, accuracy: 0.001)
     }
 
@@ -921,7 +957,7 @@ final class MicronParserTests: XCTestCase {
     func testLoadedPartialRecursivelyRendersFormsAndNestedPartialsInEveryMode() {
         let outer = MicronPartial(url: "/outer.mu", refreshInterval: nil, partialId: nil, fieldNames: nil)
         let inner = MicronPartial(url: "/inner.mu", refreshInterval: nil, partialId: nil, fieldNames: nil)
-        let rootDocument = MicronDocument(elements: [.partial(outer, indentLevel: 0)])
+        let rootDocument = MicronDocument(elements: [.partial(outer, indentLevel: 2)])
         let outerDocument = MicronDocument(elements: [
             .formField(.textInput(width: 12, name: "nested", defaultValue: "value"), indentLevel: 2),
             .partial(inner, indentLevel: 2),
@@ -955,7 +991,13 @@ final class MicronParserTests: XCTestCase {
             host.view.frame = CGRect(origin: .zero, size: size)
             host.view.layoutIfNeeded()
 
-            XCTAssertEqual(descendants(of: host.view, matching: UITextField.self).count, 1, "style: \(style)")
+            let textFields = descendants(of: host.view, matching: UITextField.self)
+            XCTAssertEqual(textFields.count, 1, "style: \(style)")
+            if let textField = textFields.first {
+                let fieldFrame = textField.convert(textField.bounds, to: host.view)
+                XCTAssertGreaterThan(fieldFrame.minX, 30, "style: \(style)")
+                XCTAssertGreaterThan(size.width - fieldFrame.maxX, 20, "style: \(style)")
+            }
             let image = UIGraphicsImageRenderer(size: size).image { _ in
                 host.view.drawHierarchy(in: host.view.bounds, afterScreenUpdates: true)
             }
@@ -964,6 +1006,63 @@ final class MicronParserTests: XCTestCase {
                 100,
                 "style: \(style)"
             )
+            let headingBounds = dominantBandBounds(
+                in: image,
+                near: (0xaa, 0xaa, 0xaa),
+                tolerance: 4
+            )
+            XCTAssertNotNil(headingBounds, "style: \(style)")
+            if let headingBounds {
+                XCTAssertGreaterThan(headingBounds.minX / image.scale, 20, "style: \(style)")
+                XCTAssertGreaterThan(
+                    (CGFloat(image.cgImage?.width ?? 0) - headingBounds.maxX) / image.scale,
+                    20,
+                    "style: \(style)"
+                )
+            }
+            window.isHidden = true
+        }
+    }
+
+    @MainActor
+    func testNestedLiteralAppliesSectionGeometryInEveryMode() {
+        let document = MicronDocument(elements: [
+            .literalBlock(text: "MMMM", indentLevel: 2),
+        ])
+        let styles: [MicronRenderStyle] = [.monospaceScroll, .monospaceCompact, .proportional]
+
+        for style in styles {
+            let size = CGSize(width: 340, height: 100)
+            let host = UIHostingController(
+                rootView: MicronDocumentView(
+                    document: document,
+                    formFields: .constant([:]),
+                    checkboxFields: .constant([:]),
+                    radioFields: .constant([:]),
+                    style: style,
+                    viewportWidth: 320
+                )
+                .frame(width: 320, alignment: .leading)
+                .environment(\.colorScheme, .light)
+                .padding(10)
+                .frame(width: size.width, height: size.height, alignment: .topLeading)
+                .background(Color.white)
+                .ignoresSafeArea()
+            )
+            let window = UIWindow(frame: CGRect(origin: .zero, size: size))
+            window.rootViewController = host
+            window.makeKeyAndVisible()
+            host.view.frame = CGRect(origin: .zero, size: size)
+            host.view.layoutIfNeeded()
+
+            let image = UIGraphicsImageRenderer(size: size).image { _ in
+                host.view.drawHierarchy(in: host.view.bounds, afterScreenUpdates: true)
+            }
+            let textBounds = pixelBounds(in: image, near: (0x00, 0x00, 0x00), tolerance: 24)
+            XCTAssertNotNil(textBounds, "style: \(style)")
+            if let textBounds {
+                XCTAssertGreaterThan(textBounds.minX / image.scale, 20, "style: \(style)")
+            }
             window.isHidden = true
         }
     }

--- a/Tests/ColumbaAppTests/MicronParserTests.swift
+++ b/Tests/ColumbaAppTests/MicronParserTests.swift
@@ -809,7 +809,7 @@ final class MicronParserTests: XCTestCase {
         XCTAssertEqual(requests.last?.requestData?["var_g"], "reticulum")
 
         await viewModel.navigateTo(url: MicronURL.samePage(path: "/page/index.mu"))
-        viewModel.goBack()
+        await viewModel.goBack()
         await viewModel.refresh()
         requests = await backend.requests()
         XCTAssertEqual(requests.last?.path, "/page/group.mu")

--- a/Tests/ColumbaAppTests/MicronParserTests.swift
+++ b/Tests/ColumbaAppTests/MicronParserTests.swift
@@ -789,11 +789,12 @@ final class MicronParserTests: XCTestCase {
         viewModel.formFields["password"] = "never-share-this"
 
         await viewModel.handleLinkTap(MicronLink(
-            text: "reticulum",
+            label: "reticulum",
             url: .samePage(path: "/page/group.mu"),
             fieldNames: ["g=reticulum", "password"]
         ))
-        XCTAssertEqual((await backend.requests()).last?.requestData, [
+        var requests = await backend.requests()
+        XCTAssertEqual(requests.last?.requestData, [
             "var_g": "reticulum",
             "field_password": "never-share-this",
         ])
@@ -804,13 +805,15 @@ final class MicronParserTests: XCTestCase {
         XCTAssertFalse(viewModel.shareableAddress.contains("never-share-this"))
 
         await viewModel.refresh()
-        XCTAssertEqual((await backend.requests()).last?.requestData?["var_g"], "reticulum")
+        requests = await backend.requests()
+        XCTAssertEqual(requests.last?.requestData?["var_g"], "reticulum")
 
-        await viewModel.navigateTo(url: .samePage(path: "/page/index.mu"))
+        await viewModel.navigateTo(url: MicronURL.samePage(path: "/page/index.mu"))
         viewModel.goBack()
         await viewModel.refresh()
-        XCTAssertEqual((await backend.requests()).last?.path, "/page/group.mu")
-        XCTAssertEqual((await backend.requests()).last?.requestData?["var_g"], "reticulum")
+        requests = await backend.requests()
+        XCTAssertEqual(requests.last?.path, "/page/group.mu")
+        XCTAssertEqual(requests.last?.requestData?["var_g"], "reticulum")
 
         let reopened = NomadNetBrowserViewModel(
             nodeHash: hash,
@@ -819,8 +822,9 @@ final class MicronParserTests: XCTestCase {
             browserService: service
         )
         await reopened.loadPage()
-        XCTAssertEqual((await backend.requests()).last?.path, "/page/repo.mu")
-        XCTAssertEqual((await backend.requests()).last?.requestData, [
+        requests = await backend.requests()
+        XCTAssertEqual(requests.last?.path, "/page/repo.mu")
+        XCTAssertEqual(requests.last?.requestData, [
             "var_g": "reticulum",
             "var_r": "lxmf",
             "var_path": "docs%2Fmanual",

--- a/Tests/ColumbaAppTests/MicronParserTests.swift
+++ b/Tests/ColumbaAppTests/MicronParserTests.swift
@@ -574,7 +574,7 @@ final class MicronParserTests: XCTestCase {
             )
             .frame(width: 320, alignment: .leading)
             .background(Color.black)
-            .preferredColorScheme(.dark)
+            .environment(\.colorScheme, .dark)
             .padding(10)
             .frame(width: size.width, height: size.height, alignment: .topLeading)
             .background(Color.black)

--- a/Tests/ColumbaAppTests/MicronParserTests.swift
+++ b/Tests/ColumbaAppTests/MicronParserTests.swift
@@ -7,6 +7,37 @@ import SwiftUI
 import UIKit
 #endif
 
+private actor RecordingNomadNetBackend: RnsNomadnet {
+    struct Request: Sendable, Equatable {
+        let destinationHash: String
+        let path: String
+        let requestData: [String: String]?
+    }
+
+    private var recordedRequests: [Request] = []
+
+    func fetchNomadNetPage(
+        destHashHex: String,
+        path: String,
+        timeout: TimeInterval,
+        formFields: [String: String]?
+    ) async throws -> NomadNetFetchResult {
+        recordedRequests.append(Request(
+            destinationHash: destHashHex,
+            path: path,
+            requestData: formFields
+        ))
+        return NomadNetFetchResult(
+            ok: true,
+            status: .ok,
+            data: Data("# response for \(path)".utf8),
+            contentType: "text/x-micron"
+        )
+    }
+
+    func requests() -> [Request] { recordedRequests }
+}
+
 private actor ReactionGateProbe {
     private var active = 0
     private var maximumActive = 0
@@ -638,14 +669,39 @@ final class MicronParserTests: XCTestCase {
 
         XCTAssertEqual(context.requestData, [
             "var_g": "reticulum",
-            "var_path": "docs/manual",
-            "var_query": "hello world",
+            "var_path": "docs%2Fmanual",
+            "var_query": "hello+world",
             "field_username": "torlando",
         ])
         XCTAssertEqual(context.requestVariables, [
             "g": "reticulum",
-            "path": "docs/manual",
-            "query": "hello world",
+            "path": "docs%2Fmanual",
+            "query": "hello+world",
+        ])
+    }
+
+    func testInlineMicronVariablesRemainByteForByteEquivalentStrings() {
+        let context = NomadNetRequestContext.build(
+            fieldEntries: [
+                "plus=a+b",
+                "encodedPlus=%2B",
+                "percent=%25",
+                "slash=%2F",
+                "delimiter=%7C",
+                "equals=%3D",
+            ],
+            formFields: [:],
+            checkboxFields: [:],
+            radioFields: [:]
+        )
+
+        XCTAssertEqual(context.requestData, [
+            "var_plus": "a+b",
+            "var_encodedPlus": "%2B",
+            "var_percent": "%25",
+            "var_slash": "%2F",
+            "var_delimiter": "%7C",
+            "var_equals": "%3D",
         ])
     }
 
@@ -689,6 +745,86 @@ final class MicronParserTests: XCTestCase {
             addressPath: "/page/group.mu`g=reticulum|topic=hello+world"
         )
         XCTAssertEqual(reopened, location)
+    }
+
+    func testNomadNetAddressRoundTripsReservedVariableCharacters() {
+        let variables = [
+            "delimiter": "a|b",
+            "equals": "a=b",
+            "plus": "a+b",
+            "percent": "a%b",
+            "slash": "a/b",
+        ]
+        let location = NomadNetLocation(
+            nodeHash: Data(repeating: 0xcd, count: 16),
+            path: "/page/repo.mu",
+            requestContext: NomadNetRequestContext(
+                requestData: Dictionary(uniqueKeysWithValues: variables.map { ("var_\($0.key)", $0.value) }),
+                requestVariables: variables
+            )
+        )
+
+        XCTAssertEqual(
+            location.address,
+            "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd:/page/repo.mu`delimiter=a%7Cb|equals=a%3Db|percent=a%25b|plus=a%2Bb|slash=a%2Fb"
+        )
+        let addressPath = String(location.address.dropFirst(33))
+        XCTAssertEqual(
+            NomadNetLocation(nodeHash: location.nodeHash, addressPath: addressPath),
+            location
+        )
+    }
+
+    @MainActor
+    func testRngitNavigationRefreshBackAndReopenSendExactVariablesWithoutSharingPassword() async throws {
+        let backend = RecordingNomadNetBackend()
+        let service = NomadNetBrowserService(backend: backend)
+        let hash = Data(repeating: 0xef, count: 16)
+        let viewModel = NomadNetBrowserViewModel(
+            nodeHash: hash,
+            nodeName: "rngit",
+            initialPath: "/page/index.mu",
+            browserService: service
+        )
+        viewModel.formFields["password"] = "never-share-this"
+
+        await viewModel.handleLinkTap(MicronLink(
+            text: "reticulum",
+            url: .samePage(path: "/page/group.mu"),
+            fieldNames: ["g=reticulum", "password"]
+        ))
+        XCTAssertEqual((await backend.requests()).last?.requestData, [
+            "var_g": "reticulum",
+            "field_password": "never-share-this",
+        ])
+        XCTAssertEqual(
+            viewModel.shareableAddress,
+            "nomadnetwork://efefefefefefefefefefefefefefefef:/page/group.mu`g=reticulum"
+        )
+        XCTAssertFalse(viewModel.shareableAddress.contains("never-share-this"))
+
+        await viewModel.refresh()
+        XCTAssertEqual((await backend.requests()).last?.requestData?["var_g"], "reticulum")
+
+        await viewModel.navigateTo(url: .samePage(path: "/page/index.mu"))
+        viewModel.goBack()
+        await viewModel.refresh()
+        XCTAssertEqual((await backend.requests()).last?.path, "/page/group.mu")
+        XCTAssertEqual((await backend.requests()).last?.requestData?["var_g"], "reticulum")
+
+        let reopened = NomadNetBrowserViewModel(
+            nodeHash: hash,
+            nodeName: nil,
+            initialPath: "/page/repo.mu`g=reticulum|r=lxmf|path=docs%252Fmanual",
+            browserService: service
+        )
+        await reopened.loadPage()
+        XCTAssertEqual((await backend.requests()).last?.path, "/page/repo.mu")
+        XCTAssertEqual((await backend.requests()).last?.requestData, [
+            "var_g": "reticulum",
+            "var_r": "lxmf",
+            "var_path": "docs%2Fmanual",
+        ])
     }
 
     func testLinkWithSurroundingText() {

--- a/Tests/ColumbaAppTests/MicronParserTests.swift
+++ b/Tests/ColumbaAppTests/MicronParserTests.swift
@@ -656,9 +656,9 @@ final class MicronParserTests: XCTestCase {
         XCTAssertGreaterThan(pixelCount(in: image, near: (0x77, 0x77, 0x77), tolerance: 4), 500)
         XCTAssertLessThan(blueDominantPixelCount(in: image), 5)
 
-        let level1Background = pixelBounds(in: image, near: (0xbb, 0xbb, 0xbb), tolerance: 4)
-        let level2Background = pixelBounds(in: image, near: (0x99, 0x99, 0x99), tolerance: 4)
-        let level3Background = pixelBounds(in: image, near: (0x77, 0x77, 0x77), tolerance: 4)
+        let level1Background = dominantBandBounds(in: image, near: (0xbb, 0xbb, 0xbb), tolerance: 4)
+        let level2Background = dominantBandBounds(in: image, near: (0x99, 0x99, 0x99), tolerance: 4)
+        let level3Background = dominantBandBounds(in: image, near: (0x77, 0x77, 0x77), tolerance: 4)
         XCTAssertNotNil(level1Background)
         XCTAssertNotNil(level2Background)
         XCTAssertNotNil(level3Background)
@@ -848,6 +848,51 @@ final class MicronParserTests: XCTestCase {
                 count += 1
             }
         }
+    }
+
+    private func dominantBandBounds(
+        in image: UIImage,
+        near expected: (UInt8, UInt8, UInt8),
+        tolerance: Int
+    ) -> CGRect? {
+        guard let source = image.cgImage else { return nil }
+        let width = source.width
+        let height = source.height
+        var pixels = [UInt8](repeating: 0, count: width * height * 4)
+        guard let context = CGContext(
+            data: &pixels,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: width * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else { return nil }
+        context.draw(source, in: CGRect(x: 0, y: 0, width: width, height: height))
+
+        func matches(_ index: Int) -> Bool {
+            abs(Int(pixels[index]) - Int(expected.0)) <= tolerance
+                && abs(Int(pixels[index + 1]) - Int(expected.1)) <= tolerance
+                && abs(Int(pixels[index + 2]) - Int(expected.2)) <= tolerance
+        }
+
+        let dominantRows = (0..<height).filter { y in
+            (0..<width).reduce(into: 0) { count, x in
+                if matches((y * width + x) * 4) { count += 1 }
+            } > width / 2
+        }
+        guard let minY = dominantRows.first, let maxY = dominantRows.last else { return nil }
+
+        var minX = width
+        var maxX = -1
+        for y in dominantRows {
+            for x in 0..<width where matches((y * width + x) * 4) {
+                minX = min(minX, x)
+                maxX = max(maxX, x)
+            }
+        }
+        guard maxX >= minX else { return nil }
+        return CGRect(x: minX, y: minY, width: maxX - minX + 1, height: maxY - minY + 1)
     }
 
     private func pixelBounds(

--- a/Tests/ColumbaAppTests/MicronParserTests.swift
+++ b/Tests/ColumbaAppTests/MicronParserTests.swift
@@ -562,7 +562,7 @@ final class MicronParserTests: XCTestCase {
         >>Key Features
         >>>Installation
         """)
-        let size = CGSize(width: 340, height: 180)
+        let size = CGSize(width: 340, height: 360)
         let host = UIHostingController(
             rootView: MicronDocumentView(
                 document: document,

--- a/Tests/ColumbaAppTests/MicronParserTests.swift
+++ b/Tests/ColumbaAppTests/MicronParserTests.swift
@@ -678,6 +678,12 @@ final class MicronParserTests: XCTestCase {
             location.shareableAddress,
             "nomadnetwork://abababababababababababababababab:/page/group.mu`g=reticulum|topic=hello+world"
         )
+
+        let reopened = NomadNetLocation(
+            nodeHash: location.nodeHash,
+            addressPath: "/page/group.mu`g=reticulum|topic=hello+world"
+        )
+        XCTAssertEqual(reopened, location)
     }
 
     func testLinkWithSurroundingText() {

--- a/Tests/ColumbaAppTests/MicronParserTests.swift
+++ b/Tests/ColumbaAppTests/MicronParserTests.swift
@@ -38,6 +38,28 @@ private actor RecordingNomadNetBackend: RnsNomadnet {
     func requests() -> [Request] { recordedRequests }
 }
 
+private actor MappedNomadNetBackend: RnsNomadnet {
+    private let responses: [String: String]
+
+    init(responses: [String: String]) {
+        self.responses = responses
+    }
+
+    func fetchNomadNetPage(
+        destHashHex: String,
+        path: String,
+        timeout: TimeInterval,
+        formFields: [String: String]?
+    ) async throws -> NomadNetFetchResult {
+        NomadNetFetchResult(
+            ok: true,
+            status: .ok,
+            data: Data((responses[path] ?? "").utf8),
+            contentType: "text/x-micron"
+        )
+    }
+}
+
 private actor ReactionGateProbe {
     private var active = 0
     private var maximumActive = 0
@@ -1306,6 +1328,33 @@ final class MicronParserTests: XCTestCase {
             NomadNetLocation(nodeHash: location.nodeHash, addressPath: addressPath),
             location
         )
+    }
+
+    @MainActor
+    func testLoadedPartialRecursivelyFetchesNestedPartialsAndInitializesFields() async {
+        let backend = MappedNomadNetBackend(responses: [
+            "/outer.mu": "`{/inner.mu}",
+            "/inner.mu": "`<12|nested`default>",
+        ])
+        let service = NomadNetBrowserService(backend: backend)
+        let viewModel = NomadNetBrowserViewModel(
+            nodeHash: Data(repeating: 0xab, count: 16),
+            nodeName: "nested",
+            initialPath: "/page/index.mu",
+            browserService: service
+        )
+        let outer = MicronPartial(
+            url: "/outer.mu",
+            refreshInterval: nil,
+            partialId: nil,
+            fieldNames: nil
+        )
+
+        await viewModel.loadPartial(outer)
+
+        XCTAssertNotNil(viewModel.partialDocuments["/outer.mu"])
+        XCTAssertNotNil(viewModel.partialDocuments["/inner.mu"])
+        XCTAssertEqual(viewModel.formFields["nested"], "default")
     }
 
     @MainActor

--- a/Tests/ColumbaAppTests/MicronParserTests.swift
+++ b/Tests/ColumbaAppTests/MicronParserTests.swift
@@ -113,12 +113,27 @@ final class MicronParserTests: XCTestCase {
         XCTAssertEqual(level, 3)
     }
 
-    func testHeadingLevelCappedAt3() {
+    func testSectionDepthIsNotCappedByThreeHeadingPaletteStyles() {
         let doc = MicronParser.parse(">>>>TooDeep")
         guard case .heading(let level, _, _) = doc.elements.first else {
             XCTFail("Expected heading"); return
         }
-        XCTAssertEqual(level, 3)
+        XCTAssertEqual(level, 4)
+    }
+
+    func testRngitResetImmediatelyFollowedByReadmeHeadingReparsesRemainder() {
+        // Current rngit repo pages join the template's trailing `<` directly
+        // to a converted Markdown heading, producing this exact line shape.
+        let doc = MicronParser.parse("<>The Non-linear Task Manager")
+
+        guard case .heading(let level, let spans, _) = doc.elements.first,
+              case .text(let text, _) = spans.first else {
+            XCTFail("Expected reset remainder to be parsed as a heading")
+            return
+        }
+
+        XCTAssertEqual(level, 1)
+        XCTAssertEqual(text, "The Non-linear Task Manager")
     }
 
     // MARK: - Dividers
@@ -379,8 +394,9 @@ final class MicronParserTests: XCTestCase {
         XCTAssertEqual(resetSpans.count, 0)
     }
 
-    func testIndentResetClearsStyle() {
-        // `< at line-start resets formatting state in addition to indent.
+    func testSectionResetPreservesFormattingState() {
+        // Canonical NomadNet uses `<` only to reset section depth. Formatting
+        // remains document-scoped until its own reset command is encountered.
         let doc = MicronParser.parse("`!bold-line\n<plain-after-reset")
         XCTAssertEqual(doc.elements.count, 2)
 
@@ -390,7 +406,7 @@ final class MicronParserTests: XCTestCase {
         XCTAssertEqual(line2Spans.count, 1)
         if case .text(let t, let s) = line2Spans[0] {
             XCTAssertEqual(t, "plain-after-reset")
-            XCTAssertFalse(s.bold) // `< wiped the persisted bold from line 1
+            XCTAssertTrue(s.bold)
         } else { XCTFail("Expected text") }
     }
 
@@ -535,6 +551,54 @@ final class MicronParserTests: XCTestCase {
 
         let attachment = XCTAttachment(image: image)
         attachment.name = "nomadnet-rngit-true-color-line"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+
+    @MainActor
+    func testCanonicalDarkSectionHeadingsRenderPaletteBackgrounds() {
+        let document = MicronParser.parse("""
+        <>The Non-linear Task Manager
+        >>Key Features
+        >>>Installation
+        """)
+        let size = CGSize(width: 340, height: 180)
+        let host = UIHostingController(
+            rootView: MicronDocumentView(
+                document: document,
+                formFields: .constant([:]),
+                checkboxFields: .constant([:]),
+                radioFields: .constant([:]),
+                style: .monospaceScroll,
+                viewportWidth: 320
+            )
+            .frame(width: 320, alignment: .leading)
+            .background(Color.black)
+            .preferredColorScheme(.dark)
+            .padding(10)
+            .frame(width: size.width, height: size.height, alignment: .topLeading)
+            .background(Color.black)
+            .ignoresSafeArea()
+        )
+        let window = UIWindow(frame: CGRect(origin: .zero, size: size))
+        window.rootViewController = host
+        window.makeKeyAndVisible()
+        defer { window.isHidden = true }
+
+        host.view.frame = CGRect(origin: .zero, size: size)
+        host.view.layoutIfNeeded()
+        let image = UIGraphicsImageRenderer(size: size).image { _ in
+            host.view.drawHierarchy(in: host.view.bounds, afterScreenUpdates: true)
+        }
+
+        // Canonical NomadNet dark heading backgrounds: level 1 = bbb,
+        // level 2 = 999, level 3 (and deeper) = 777.
+        XCTAssertGreaterThan(pixelCount(in: image, near: (0xbb, 0xbb, 0xbb), tolerance: 4), 500)
+        XCTAssertGreaterThan(pixelCount(in: image, near: (0x99, 0x99, 0x99), tolerance: 4), 500)
+        XCTAssertGreaterThan(pixelCount(in: image, near: (0x77, 0x77, 0x77), tolerance: 4), 500)
+
+        let attachment = XCTAttachment(image: image)
+        attachment.name = "nomadnet-canonical-dark-section-headings"
         attachment.lifetime = .keepAlways
         add(attachment)
     }

--- a/Tests/ColumbaAppTests/MicronParserTests.swift
+++ b/Tests/ColumbaAppTests/MicronParserTests.swift
@@ -172,6 +172,21 @@ final class MicronParserTests: XCTestCase {
         XCTAssertTrue(doc.elements.isEmpty)
     }
 
+    func testResetRemainderCanOpenLiteralBlock() {
+        let doc = MicronParser.parse("<`=\n<`=\n`=")
+        guard case .literalBlock(let text, let indentLevel) = doc.elements.first else {
+            XCTFail("Expected reset remainder to open a literal block")
+            return
+        }
+        XCTAssertEqual(text, "<`=")
+        XCTAssertEqual(indentLevel, 0)
+    }
+
+    func testFieldBearingHeadingSanitizationReclassifiesExposedReset() {
+        let doc = MicronParser.parse("><# hidden `<name`value>")
+        XCTAssertTrue(doc.elements.isEmpty)
+    }
+
     func testNestedBlocksCarryCanonicalSectionIndent() {
         let doc = MicronParser.parse("""
         >>Nested
@@ -690,8 +705,8 @@ final class MicronParserTests: XCTestCase {
             XCTAssertNotNil(level2Text)
             XCTAssertNotNil(level3Text)
             if let level1Text, let level2Text, let level3Text {
-                XCTAssertGreaterThan(level2Text.minX - level1Text.minX, 30)
-                XCTAssertGreaterThan(level3Text.minX - level2Text.minX, 30)
+                XCTAssertGreaterThan((level2Text.minX - level1Text.minX) / image.scale, 10)
+                XCTAssertGreaterThan((level3Text.minX - level2Text.minX) / image.scale, 10)
                 XCTAssertGreaterThanOrEqual(level1Text.minY, level1Background.minY)
                 XCTAssertLessThanOrEqual(level1Text.maxY, level1Background.maxY)
                 XCTAssertGreaterThanOrEqual(level2Text.minY, level2Background.minY)
@@ -827,8 +842,108 @@ final class MicronParserTests: XCTestCase {
         let bounds = pixelBounds(in: image, near: (0xff, 0x00, 0x00), tolerance: 4)
         XCTAssertNotNil(bounds)
         if let bounds {
-            XCTAssertGreaterThan(bounds.minX, 100)
-            XCTAssertLessThan(bounds.maxX, CGFloat(image.cgImage?.width ?? 0) - 100)
+            XCTAssertGreaterThan(bounds.minX / image.scale, 30)
+            XCTAssertGreaterThan(
+                (CGFloat(image.cgImage?.width ?? 0) - bounds.maxX) / image.scale,
+                30
+            )
+        }
+    }
+
+    @MainActor
+    func testZeroViewportScrollDividerKeepsIntrinsicFallbackWidth() {
+        let document = MicronDocument(elements: [.divider(character: "=", indentLevel: 2)])
+        let size = CGSize(width: 340, height: 80)
+        let host = UIHostingController(
+            rootView: MicronDocumentView(
+                document: document,
+                formFields: .constant([:]),
+                checkboxFields: .constant([:]),
+                radioFields: .constant([:]),
+                style: .monospaceScroll
+            )
+            .frame(width: 320, alignment: .leading)
+            .environment(\.colorScheme, .light)
+            .padding(10)
+            .frame(width: size.width, height: size.height, alignment: .topLeading)
+            .background(Color.white)
+            .ignoresSafeArea()
+        )
+        let window = UIWindow(frame: CGRect(origin: .zero, size: size))
+        window.rootViewController = host
+        window.makeKeyAndVisible()
+        defer { window.isHidden = true }
+
+        host.view.frame = CGRect(origin: .zero, size: size)
+        host.view.layoutIfNeeded()
+        let image = UIGraphicsImageRenderer(size: size).image { _ in
+            host.view.drawHierarchy(in: host.view.bounds, afterScreenUpdates: true)
+        }
+
+        let bounds = pixelBounds(in: image, near: (0x00, 0x00, 0x00), tolerance: 24)
+        XCTAssertNotNil(bounds)
+        if let bounds {
+            XCTAssertGreaterThan(bounds.width / image.scale, 200)
+            XCTAssertGreaterThan(bounds.minX / image.scale, 20)
+        }
+    }
+
+    @MainActor
+    func testLoadedPartialRecursivelyRendersFormsAndNestedPartialsInEveryMode() {
+        let outer = MicronPartial(url: "/outer.mu", refreshInterval: nil, partialId: nil, fieldNames: nil)
+        let inner = MicronPartial(url: "/inner.mu", refreshInterval: nil, partialId: nil, fieldNames: nil)
+        let rootDocument = MicronDocument(elements: [.partial(outer, indentLevel: 0)])
+        let outerDocument = MicronDocument(elements: [
+            .formField(.textInput(width: 12, name: "nested", defaultValue: "value"), indentLevel: 2),
+            .partial(inner, indentLevel: 2),
+        ])
+        let innerDocument = MicronParser.parse(">>Nested Partial")
+        let partials = [outer.url: outerDocument, inner.url: innerDocument]
+        let styles: [MicronRenderStyle] = [.monospaceScroll, .monospaceCompact, .proportional]
+
+        for style in styles {
+            let size = CGSize(width: 340, height: 180)
+            let host = UIHostingController(
+                rootView: MicronDocumentView(
+                    document: rootDocument,
+                    formFields: .constant([:]),
+                    checkboxFields: .constant([:]),
+                    radioFields: .constant([:]),
+                    partialDocuments: partials,
+                    style: style,
+                    viewportWidth: 320
+                )
+                .frame(width: 320, alignment: .leading)
+                .environment(\.colorScheme, .light)
+                .padding(10)
+                .frame(width: size.width, height: size.height, alignment: .topLeading)
+                .background(Color.white)
+                .ignoresSafeArea()
+            )
+            let window = UIWindow(frame: CGRect(origin: .zero, size: size))
+            window.rootViewController = host
+            window.makeKeyAndVisible()
+            host.view.frame = CGRect(origin: .zero, size: size)
+            host.view.layoutIfNeeded()
+
+            XCTAssertEqual(descendants(of: host.view, matching: UITextField.self).count, 1, "style: \(style)")
+            let image = UIGraphicsImageRenderer(size: size).image { _ in
+                host.view.drawHierarchy(in: host.view.bounds, afterScreenUpdates: true)
+            }
+            XCTAssertGreaterThan(
+                pixelCount(in: image, near: (0xaa, 0xaa, 0xaa), tolerance: 4),
+                100,
+                "style: \(style)"
+            )
+            window.isHidden = true
+        }
+    }
+
+    private func descendants<T: UIView>(of root: UIView, matching type: T.Type) -> [T] {
+        root.subviews.flatMap { child in
+            var matches = (child as? T).map { [$0] } ?? []
+            matches.append(contentsOf: descendants(of: child, matching: type))
+            return matches
         }
     }
 

--- a/Tests/ColumbaAppTests/MicronParserTests.swift
+++ b/Tests/ColumbaAppTests/MicronParserTests.swift
@@ -792,6 +792,46 @@ final class MicronParserTests: XCTestCase {
         XCTAssertLessThan(blueDominantPixelCount(in: image), 5)
     }
 
+    @MainActor
+    func testNestedWrappedParagraphReservesBothSectionMargins() {
+        let content = "`Bf00" + String(repeating: "M ", count: 80)
+        let document = MicronParser.parse(">>Nested\n\(content)")
+        let size = CGSize(width: 340, height: 220)
+        let host = UIHostingController(
+            rootView: MicronDocumentView(
+                document: document,
+                formFields: .constant([:]),
+                checkboxFields: .constant([:]),
+                radioFields: .constant([:]),
+                style: .proportional,
+                viewportWidth: 320
+            )
+            .frame(width: 320, alignment: .leading)
+            .environment(\.colorScheme, .light)
+            .padding(10)
+            .frame(width: size.width, height: size.height, alignment: .topLeading)
+            .background(Color.white)
+            .ignoresSafeArea()
+        )
+        let window = UIWindow(frame: CGRect(origin: .zero, size: size))
+        window.rootViewController = host
+        window.makeKeyAndVisible()
+        defer { window.isHidden = true }
+
+        host.view.frame = CGRect(origin: .zero, size: size)
+        host.view.layoutIfNeeded()
+        let image = UIGraphicsImageRenderer(size: size).image { _ in
+            host.view.drawHierarchy(in: host.view.bounds, afterScreenUpdates: true)
+        }
+
+        let bounds = pixelBounds(in: image, near: (0xff, 0x00, 0x00), tolerance: 4)
+        XCTAssertNotNil(bounds)
+        if let bounds {
+            XCTAssertGreaterThan(bounds.minX, 100)
+            XCTAssertLessThan(bounds.maxX, CGFloat(image.cgImage?.width ?? 0) - 100)
+        }
+    }
+
     private func pixelCount(
         in image: UIImage,
         near expected: (UInt8, UInt8, UInt8),

--- a/Tests/ColumbaAppTests/MicronParserTests.swift
+++ b/Tests/ColumbaAppTests/MicronParserTests.swift
@@ -535,6 +535,75 @@ final class MicronParserTests: XCTestCase {
         XCTAssertEqual(link.fieldNames, ["username", "password"])
     }
 
+    func testRngitGroupLinkPreservesInlineVariable() {
+        let doc = MicronParser.parse("`[reticulum`:/page/group.mu`g=reticulum]")
+        guard case .paragraph(let spans, _, _) = doc.elements.first,
+              case .link(let link) = spans.first else {
+            XCTFail("Expected rngit group link")
+            return
+        }
+
+        XCTAssertEqual(link.url, .samePage(path: "/page/group.mu"))
+        XCTAssertEqual(link.fieldNames, ["g=reticulum"])
+    }
+
+    func testRngitInlineVariablesAndFormFieldsEncodeForNomadNetRequest() {
+        let context = NomadNetRequestContext.build(
+            fieldEntries: ["g=reticulum", "path=docs%2Fmanual", "query=hello+world", "username"],
+            formFields: ["username": "torlando"],
+            checkboxFields: [:],
+            radioFields: [:]
+        )
+
+        XCTAssertEqual(context.requestData, [
+            "var_g": "reticulum",
+            "var_path": "docs/manual",
+            "var_query": "hello world",
+            "field_username": "torlando",
+        ])
+        XCTAssertEqual(context.requestVariables, [
+            "g": "reticulum",
+            "path": "docs/manual",
+            "query": "hello world",
+        ])
+    }
+
+    func testSubmitAllIncludesTextCheckboxAndRadioFields() {
+        let context = NomadNetRequestContext.build(
+            fieldEntries: ["*"],
+            formFields: ["username": "torlando"],
+            checkboxFields: ["features:mail": true, "features:voice": false],
+            radioFields: ["theme": "dark"]
+        )
+
+        XCTAssertEqual(context.requestData, [
+            "field_username": "torlando",
+            "field_features": "mail",
+            "field_theme": "dark",
+        ])
+        XCTAssertTrue(context.requestVariables.isEmpty)
+    }
+
+    func testNomadNetAddressPreservesSortedRequestVariables() {
+        let location = NomadNetLocation(
+            nodeHash: Data(repeating: 0xab, count: 16),
+            path: "/page/group.mu",
+            requestContext: NomadNetRequestContext(
+                requestData: ["var_topic": "hello world", "var_g": "reticulum"],
+                requestVariables: ["topic": "hello world", "g": "reticulum"]
+            )
+        )
+
+        XCTAssertEqual(
+            location.address,
+            "abababababababababababababababab:/page/group.mu`g=reticulum|topic=hello+world"
+        )
+        XCTAssertEqual(
+            location.shareableAddress,
+            "nomadnetwork://abababababababababababababababab:/page/group.mu`g=reticulum|topic=hello+world"
+        )
+    }
+
     func testLinkWithSurroundingText() {
         let doc = MicronParser.parse("Click `[here`/page/info.mu] for info")
         guard case .paragraph(let spans, _, _) = doc.elements.first else {

--- a/Tests/ColumbaAppTests/MicronParserTests.swift
+++ b/Tests/ColumbaAppTests/MicronParserTests.swift
@@ -672,6 +672,7 @@ final class MicronParserTests: XCTestCase {
 
         XCTAssertGreaterThan(pixelCount(in: image, near: (0x99, 0x99, 0x99), tolerance: 4), 500)
         XCTAssertGreaterThan(pixelCount(in: image, near: (0x11, 0x11, 0x11), tolerance: 8), 5)
+        XCTAssertLessThan(pixelCount(in: image, near: (0x3a, 0x82, 0xf7), tolerance: 4), 5)
 
         let attachment = XCTAttachment(image: image)
         attachment.name = "nomadnet-monospace-heading-link"

--- a/Tests/ColumbaAppTests/MicronParserTests.swift
+++ b/Tests/ColumbaAppTests/MicronParserTests.swift
@@ -198,7 +198,7 @@ final class MicronParserTests: XCTestCase {
 
     func testDefaultDivider() {
         let doc = MicronParser.parse("-")
-        guard case .divider(let ch) = doc.elements.first else {
+        guard case .divider(let ch, _) = doc.elements.first else {
             XCTFail("Expected divider"); return
         }
         XCTAssertNil(ch)
@@ -206,7 +206,7 @@ final class MicronParserTests: XCTestCase {
 
     func testCustomDivider() {
         let doc = MicronParser.parse("-=")
-        guard case .divider(let ch) = doc.elements.first else {
+        guard case .divider(let ch, _) = doc.elements.first else {
             XCTFail("Expected divider"); return
         }
         XCTAssertEqual(ch, "=")
@@ -229,7 +229,7 @@ final class MicronParserTests: XCTestCase {
 
     func testLiteralBlock() {
         let doc = MicronParser.parse("`=\nfoo\nbar\n`=")
-        guard case .literalBlock(let text) = doc.elements.first else {
+        guard case .literalBlock(let text, _) = doc.elements.first else {
             XCTFail("Expected literal block"); return
         }
         XCTAssertEqual(text, "foo\nbar")
@@ -237,7 +237,7 @@ final class MicronParserTests: XCTestCase {
 
     func testUnclosedLiteralBlock() {
         let doc = MicronParser.parse("`=\nsome code")
-        guard case .literalBlock(let text) = doc.elements.first else {
+        guard case .literalBlock(let text, _) = doc.elements.first else {
             XCTFail("Expected literal block"); return
         }
         XCTAssertEqual(text, "some code")
@@ -756,7 +756,7 @@ final class MicronParserTests: XCTestCase {
             partialId: nil,
             fieldNames: nil
         )
-        let document = MicronDocument(elements: [.partial(partial)])
+        let document = MicronDocument(elements: [.partial(partial, indentLevel: 0)])
         let partialDocument = MicronParser.parse(">>`[Partial Heading`:/page/target.mu]")
         let size = CGSize(width: 340, height: 120)
         let host = UIHostingController(
@@ -1230,7 +1230,7 @@ final class MicronParserTests: XCTestCase {
         let doc = MicronParser.parse("`<24|username`admin>")
         let formElements = doc.elements.filter { if case .formField = $0 { return true }; return false }
         XCTAssertEqual(formElements.count, 1)
-        guard case .formField(let field) = formElements[0] else { XCTFail("Expected form field"); return }
+        guard case .formField(let field, _) = formElements[0] else { XCTFail("Expected form field"); return }
         guard case .textInput(let width, let name, let defaultValue) = field else {
             XCTFail("Expected text input"); return
         }
@@ -1243,7 +1243,7 @@ final class MicronParserTests: XCTestCase {
         let doc = MicronParser.parse("`<!|password`>")
         let formElements = doc.elements.filter { if case .formField = $0 { return true }; return false }
         XCTAssertEqual(formElements.count, 1)
-        guard case .formField(let field) = formElements[0] else { XCTFail("Expected form field"); return }
+        guard case .formField(let field, _) = formElements[0] else { XCTFail("Expected form field"); return }
         guard case .passwordInput(let name, _) = field else {
             XCTFail("Expected password input"); return
         }
@@ -1254,7 +1254,7 @@ final class MicronParserTests: XCTestCase {
         let doc = MicronParser.parse("`<?|option|yes`>Accept terms")
         let formElements = doc.elements.filter { if case .formField = $0 { return true }; return false }
         XCTAssertEqual(formElements.count, 1)
-        guard case .formField(let field) = formElements[0] else { XCTFail("Expected form field"); return }
+        guard case .formField(let field, _) = formElements[0] else { XCTFail("Expected form field"); return }
         guard case .checkbox(let name, let value, let label, let checked) = field else {
             XCTFail("Expected checkbox"); return
         }
@@ -1267,7 +1267,7 @@ final class MicronParserTests: XCTestCase {
     func testCheckboxPrechecked() {
         let doc = MicronParser.parse("`<?|option|yes|*`>Accept terms")
         let formElements = doc.elements.filter { if case .formField = $0 { return true }; return false }
-        guard case .formField(let field) = formElements[0] else { XCTFail("Expected form field"); return }
+        guard case .formField(let field, _) = formElements[0] else { XCTFail("Expected form field"); return }
         guard case .checkbox(_, _, _, let checked) = field else {
             XCTFail("Expected checkbox"); return
         }
@@ -1278,7 +1278,7 @@ final class MicronParserTests: XCTestCase {
         let doc = MicronParser.parse("`<^|choice|a`>Option A")
         let formElements = doc.elements.filter { if case .formField = $0 { return true }; return false }
         XCTAssertEqual(formElements.count, 1)
-        guard case .formField(let field) = formElements[0] else { XCTFail("Expected form field"); return }
+        guard case .formField(let field, _) = formElements[0] else { XCTFail("Expected form field"); return }
         guard case .radio(let name, let value, let label, let selected) = field else {
             XCTFail("Expected radio"); return
         }
@@ -1291,7 +1291,7 @@ final class MicronParserTests: XCTestCase {
     func testRadioPreselected() {
         let doc = MicronParser.parse("`<^|choice|b|*`>Option B")
         let formElements = doc.elements.filter { if case .formField = $0 { return true }; return false }
-        guard case .formField(let field) = formElements[0] else { XCTFail("Expected form field"); return }
+        guard case .formField(let field, _) = formElements[0] else { XCTFail("Expected form field"); return }
         guard case .radio(_, _, _, let selected) = field else {
             XCTFail("Expected radio"); return
         }
@@ -1304,7 +1304,7 @@ final class MicronParserTests: XCTestCase {
         let doc = MicronParser.parse("`{/page/status.mu}")
         let partials = doc.elements.filter { if case .partial = $0 { return true }; return false }
         XCTAssertEqual(partials.count, 1)
-        guard case .partial(let p) = partials[0] else { XCTFail("Expected partial"); return }
+        guard case .partial(let p, _) = partials[0] else { XCTFail("Expected partial"); return }
         XCTAssertEqual(p.url, "/page/status.mu")
         XCTAssertNil(p.refreshInterval)
         XCTAssertNil(p.partialId)
@@ -1312,7 +1312,7 @@ final class MicronParserTests: XCTestCase {
 
     func testPartialWithRefresh() {
         let doc = MicronParser.parse("`{/page/status.mu`5}")
-        guard case .partial(let p) = doc.elements.first(where: { if case .partial = $0 { return true }; return false }) else {
+        guard case .partial(let p, _) = doc.elements.first(where: { if case .partial = $0 { return true }; return false }) else {
             XCTFail("Expected partial"); return
         }
         XCTAssertEqual(p.url, "/page/status.mu")
@@ -1321,7 +1321,7 @@ final class MicronParserTests: XCTestCase {
 
     func testPartialWithIdAndFields() {
         let doc = MicronParser.parse("`{/page/widget.mu`10`pid=status|username}")
-        guard case .partial(let p) = doc.elements.first(where: { if case .partial = $0 { return true }; return false }) else {
+        guard case .partial(let p, _) = doc.elements.first(where: { if case .partial = $0 { return true }; return false }) else {
             XCTFail("Expected partial"); return
         }
         XCTAssertEqual(p.url, "/page/widget.mu")

--- a/Tests/ColumbaAppTests/MicronParserTests.swift
+++ b/Tests/ColumbaAppTests/MicronParserTests.swift
@@ -468,7 +468,7 @@ final class MicronParserTests: XCTestCase {
             return
         }
 
-        let size = CGSize(width: 320, height: 60)
+        let size = CGSize(width: 320, height: 160)
         let host = UIHostingController(
             rootView: MonospaceLineView(
                 spans: spans,
@@ -479,7 +479,9 @@ final class MicronParserTests: XCTestCase {
             )
             .frame(width: 300, height: 32, alignment: .leading)
             .padding(10)
+            .frame(width: size.width, height: size.height, alignment: .center)
             .background(Color.white)
+            .ignoresSafeArea()
         )
         let window = UIWindow(frame: CGRect(origin: .zero, size: size))
         window.rootViewController = host

--- a/Tests/ColumbaAppTests/MicronParserTests.swift
+++ b/Tests/ColumbaAppTests/MicronParserTests.swift
@@ -672,7 +672,7 @@ final class MicronParserTests: XCTestCase {
 
         XCTAssertGreaterThan(pixelCount(in: image, near: (0x99, 0x99, 0x99), tolerance: 4), 500)
         XCTAssertGreaterThan(pixelCount(in: image, near: (0x11, 0x11, 0x11), tolerance: 8), 5)
-        XCTAssertLessThan(pixelCount(in: image, near: (0x3a, 0x82, 0xf7), tolerance: 4), 5)
+        XCTAssertLessThan(blueDominantPixelCount(in: image), 5)
 
         let attachment = XCTAttachment(image: image)
         attachment.name = "nomadnet-monospace-heading-link"
@@ -750,6 +750,32 @@ final class MicronParserTests: XCTestCase {
             if abs(red - Int(expected.0)) <= tolerance,
                abs(green - Int(expected.1)) <= tolerance,
                abs(blue - Int(expected.2)) <= tolerance {
+                count += 1
+            }
+        }
+    }
+
+    private func blueDominantPixelCount(in image: UIImage) -> Int {
+        guard let source = image.cgImage else { return 0 }
+        let width = source.width
+        let height = source.height
+        var pixels = [UInt8](repeating: 0, count: width * height * 4)
+        guard let context = CGContext(
+            data: &pixels,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: width * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else { return 0 }
+        context.draw(source, in: CGRect(x: 0, y: 0, width: width, height: height))
+
+        return stride(from: 0, to: pixels.count, by: 4).reduce(into: 0) { count, index in
+            let red = Int(pixels[index])
+            let green = Int(pixels[index + 1])
+            let blue = Int(pixels[index + 2])
+            if blue > red + 50, blue > green + 50 {
                 count += 1
             }
         }

--- a/Tests/ColumbaAppTests/MicronParserTests.swift
+++ b/Tests/ColumbaAppTests/MicronParserTests.swift
@@ -2,6 +2,7 @@ import XCTest
 @testable import ColumbaApp
 import RNSAPI
 import LXMFSwift
+import SwiftUI
 #if canImport(UIKit)
 import UIKit
 #endif
@@ -457,6 +458,79 @@ final class MicronParserTests: XCTestCase {
         XCTAssertEqual(green, 0x94 / 255.0, accuracy: 0.001)
         XCTAssertEqual(blue, 0x9e / 255.0, accuracy: 0.001)
         XCTAssertEqual(alpha, 1, accuracy: 0.001)
+    }
+
+    @MainActor
+    func testRngitTrueColorsReachMonospaceRenderer() throws {
+        let document = MicronParser.parse("`BT282828`FT8b949e# Add tasks")
+        guard case .paragraph(let spans, _, _) = document.elements.first else {
+            XCTFail("Expected rngit paragraph")
+            return
+        }
+
+        let size = CGSize(width: 320, height: 60)
+        let host = UIHostingController(
+            rootView: MonospaceLineView(
+                spans: spans,
+                fontSize: 18,
+                cellHeight: 32,
+                alignment: .left,
+                bold: false
+            )
+            .frame(width: 300, height: 32, alignment: .leading)
+            .padding(10)
+            .background(Color.white)
+        )
+        let window = UIWindow(frame: CGRect(origin: .zero, size: size))
+        window.rootViewController = host
+        window.makeKeyAndVisible()
+        defer { window.isHidden = true }
+
+        host.view.frame = CGRect(origin: .zero, size: size)
+        host.view.layoutIfNeeded()
+        let image = UIGraphicsImageRenderer(size: size).image { _ in
+            host.view.drawHierarchy(in: host.view.bounds, afterScreenUpdates: true)
+        }
+
+        XCTAssertGreaterThan(pixelCount(in: image, near: (0x28, 0x28, 0x28), tolerance: 8), 100)
+        XCTAssertGreaterThan(pixelCount(in: image, near: (0x8b, 0x94, 0x9e), tolerance: 12), 5)
+
+        let attachment = XCTAttachment(image: image)
+        attachment.name = "nomadnet-rngit-true-color-line"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+
+    private func pixelCount(
+        in image: UIImage,
+        near expected: (UInt8, UInt8, UInt8),
+        tolerance: Int
+    ) -> Int {
+        guard let source = image.cgImage else { return 0 }
+        let width = source.width
+        let height = source.height
+        var pixels = [UInt8](repeating: 0, count: width * height * 4)
+        guard let context = CGContext(
+            data: &pixels,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: width * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else { return 0 }
+        context.draw(source, in: CGRect(x: 0, y: 0, width: width, height: height))
+
+        return stride(from: 0, to: pixels.count, by: 4).reduce(into: 0) { count, index in
+            let red = Int(pixels[index])
+            let green = Int(pixels[index + 1])
+            let blue = Int(pixels[index + 2])
+            if abs(red - Int(expected.0)) <= tolerance,
+               abs(green - Int(expected.1)) <= tolerance,
+               abs(blue - Int(expected.2)) <= tolerance {
+                count += 1
+            }
+        }
     }
     #endif
 

--- a/Tests/static/test_nomadnet_request_payload.py
+++ b/Tests/static/test_nomadnet_request_payload.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Behavioral regression for NomadNet request-data framing."""
+
+import ast
+from pathlib import Path
+import sys
+import threading
+import types
+from typing import Any
+import unittest
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[2]
+BRIDGE = ROOT / "app/rns_bridge.py"
+
+
+class NomadNetRequestPayloadTests(unittest.TestCase):
+    def _load_fetch(self):
+        tree = ast.parse(BRIDGE.read_text())
+        function = next(
+            node
+            for node in tree.body
+            if isinstance(node, ast.FunctionDef) and node.name == "fetch_nomadnet_page"
+        )
+
+        class FakeIdentity:
+            @staticmethod
+            def recall(_destination_hash):
+                return object()
+
+        class FakeDestination:
+            OUT = 1
+            SINGLE = 2
+
+            def __init__(self, *_args):
+                pass
+
+        class FakeLink:
+            last_request_data = None
+
+            def __init__(self, _destination, established_callback, closed_callback):
+                established_callback(self)
+
+            def identify(self, _identity):
+                pass
+
+            def request(
+                self,
+                _path,
+                data,
+                response_callback,
+                failed_callback,
+                timeout,
+            ):
+                del failed_callback, timeout
+                type(self).last_request_data = data
+                response_callback(types.SimpleNamespace(response=b"ok"))
+                return object()
+
+            def teardown(self):
+                pass
+
+        fake_rns = types.SimpleNamespace(
+            Identity=FakeIdentity,
+            Destination=FakeDestination,
+            Link=FakeLink,
+            Transport=types.SimpleNamespace(request_path=lambda _hash: None),
+        )
+        namespace = {
+            "Any": Any,
+            "RNS": fake_rns,
+            "threading": threading,
+            "_lock": threading.Lock(),
+            "_state": {"started": True, "identity": object()},
+            "_balanced_runtime_teardown": lambda fn: fn,
+        }
+        exec(
+            compile(ast.Module(body=[function], type_ignores=[]), str(BRIDGE), "exec"),
+            namespace,
+        )
+        return namespace["fetch_nomadnet_page"], FakeLink
+
+    def test_link_request_receives_mapping_not_prepacked_bytes(self):
+        fetch, fake_link = self._load_fetch()
+        fake_vendor = types.ModuleType("RNS.vendor")
+        setattr(
+            fake_vendor,
+            "umsgpack",
+            types.SimpleNamespace(packb=lambda _value: b"prematurely-packed"),
+        )
+
+        with mock.patch.dict(sys.modules, {"RNS.vendor": fake_vendor}):
+            result = fetch(
+                "35de95d657469cead07d870fa4080573",
+                "/page/group.mu",
+                form_fields={"var_g": "alephgit_mirrors"},
+            )
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(
+            {"var_g": "alephgit_mirrors"},
+            fake_link.last_request_data,
+            "RNS.Link.request must receive the request-data map and own MessagePack framing",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tests/static/test_nomadnet_request_payload.py
+++ b/Tests/static/test_nomadnet_request_payload.py
@@ -16,18 +16,48 @@ BRIDGE = ROOT / "app/rns_bridge.py"
 
 
 class NomadNetRequestPayloadTests(unittest.TestCase):
-    def _load_fetch(self):
+    def _load_fetch(self, *, initially_resolved: bool = True):
         tree = ast.parse(BRIDGE.read_text())
+        resolve_function = next(
+            node
+            for node in tree.body
+            if isinstance(node, ast.FunctionDef) and node.name == "resolve_path"
+        )
         function = next(
             node
             for node in tree.body
             if isinstance(node, ast.FunctionDef) and node.name == "fetch_nomadnet_page"
         )
 
+        resolution = {"ready": initially_resolved}
+
         class FakeIdentity:
             @staticmethod
             def recall(_destination_hash):
-                return object()
+                return object() if resolution["ready"] else None
+
+        class FakeTransport:
+            requests = 0
+
+            @classmethod
+            def has_path(cls, _destination_hash):
+                return resolution["ready"]
+
+            @classmethod
+            def request_path(cls, _destination_hash):
+                cls.requests += 1
+
+        class FakeTime:
+            now = 0.0
+
+            @classmethod
+            def monotonic(cls):
+                return cls.now
+
+            @classmethod
+            def sleep(cls, seconds):
+                cls.now += seconds
+                resolution["ready"] = True
 
         class FakeDestination:
             OUT = 1
@@ -65,24 +95,29 @@ class NomadNetRequestPayloadTests(unittest.TestCase):
             Identity=FakeIdentity,
             Destination=FakeDestination,
             Link=FakeLink,
-            Transport=types.SimpleNamespace(request_path=lambda _hash: None),
+            Transport=FakeTransport,
         )
         namespace = {
             "Any": Any,
             "RNS": fake_rns,
             "threading": threading,
+            "time": FakeTime,
             "_lock": threading.Lock(),
             "_state": {"started": True, "identity": object()},
             "_balanced_runtime_teardown": lambda fn: fn,
         }
         exec(
-            compile(ast.Module(body=[function], type_ignores=[]), str(BRIDGE), "exec"),
+            compile(
+                ast.Module(body=[resolve_function, function], type_ignores=[]),
+                str(BRIDGE),
+                "exec",
+            ),
             namespace,
         )
-        return namespace["fetch_nomadnet_page"], FakeLink
+        return namespace["fetch_nomadnet_page"], FakeLink, FakeTransport
 
     def test_link_request_receives_mapping_not_prepacked_bytes(self):
-        fetch, fake_link = self._load_fetch()
+        fetch, fake_link, _ = self._load_fetch()
         fake_vendor = types.ModuleType("RNS.vendor")
         setattr(
             fake_vendor,
@@ -103,6 +138,20 @@ class NomadNetRequestPayloadTests(unittest.TestCase):
             fake_link.last_request_data,
             "RNS.Link.request must receive the request-data map and own MessagePack framing",
         )
+
+    def test_cold_first_fetch_waits_for_requested_path(self):
+        fetch, fake_link, fake_transport = self._load_fetch(initially_resolved=False)
+
+        result = fetch(
+            "35de95d657469cead07d870fa4080573",
+            "/page/index.mu",
+            timeout=1.0,
+        )
+
+        self.assertTrue(result["ok"], result)
+        self.assertEqual("ok", result["status"])
+        self.assertEqual(1, fake_transport.requests)
+        self.assertIsNone(fake_link.last_request_data)
 
 
 if __name__ == "__main__":

--- a/Tests/static/test_nomadnet_request_payload.py
+++ b/Tests/static/test_nomadnet_request_payload.py
@@ -57,7 +57,8 @@ class NomadNetRequestPayloadTests(unittest.TestCase):
             @classmethod
             def sleep(cls, seconds):
                 cls.now += seconds
-                resolution["ready"] = True
+                if FakeTransport.requests > 0:
+                    resolution["ready"] = True
 
         class FakeDestination:
             OUT = 1
@@ -67,7 +68,10 @@ class NomadNetRequestPayloadTests(unittest.TestCase):
                 pass
 
         class FakeLink:
-            last_request_data = None
+            unrequested = object()
+            last_request_data = unrequested
+            last_request_path = None
+            request_count = 0
 
             def __init__(self, _destination, established_callback, closed_callback):
                 established_callback(self)
@@ -77,13 +81,15 @@ class NomadNetRequestPayloadTests(unittest.TestCase):
 
             def request(
                 self,
-                _path,
+                path,
                 data,
                 response_callback,
                 failed_callback,
                 timeout,
             ):
                 del failed_callback, timeout
+                type(self).request_count += 1
+                type(self).last_request_path = path
                 type(self).last_request_data = data
                 response_callback(types.SimpleNamespace(response=b"ok"))
                 return object()
@@ -151,6 +157,8 @@ class NomadNetRequestPayloadTests(unittest.TestCase):
         self.assertTrue(result["ok"], result)
         self.assertEqual("ok", result["status"])
         self.assertEqual(1, fake_transport.requests)
+        self.assertEqual(1, fake_link.request_count)
+        self.assertEqual("/page/index.mu", fake_link.last_request_path)
         self.assertIsNone(fake_link.last_request_data)
 
 

--- a/app/rns_bridge.py
+++ b/app/rns_bridge.py
@@ -1550,14 +1550,11 @@ def fetch_nomadnet_page(
         empty bytes on failure
       - content_type: optional mime hint when the server provides one
 
-    `form_fields` is a `dict[str, str]` (form name -> value) for
-    POST-style submissions; pass `None` for a plain GET-equivalent
-    fetch. Form values are passed as msgpack to match Reticulum's
-    convention. Link is established fresh each call and closed
-    before return — no link caching on the Python side yet (Swift's
-    NomadNetBrowserService used to cache, but with this simplified
-    bridge we trade a few hundred ms of re-establishment for a much
-    smaller API surface)."""
+    `form_fields` is a `dict[str, str]` (exact `field_*` / `var_*` keys)
+    for POST-style submissions; pass `None` for a plain GET-equivalent
+    fetch. The mapping is passed directly to `RNS.Link.request`, which owns
+    request framing. Pre-packing it turns the server-side request data into
+    bytes instead of a dict, so node apps such as rngit reject the request."""
     with _lock:
         if not _state["started"]:
             return {"ok": False, "status": "not-started", "data": b"", "content_type": ""}
@@ -1642,16 +1639,9 @@ def fetch_nomadnet_page(
     except Exception:
         pass
 
-    # Pack form fields as msgpack when present (Reticulum/LXMF convention).
-    request_data: Any = None
-    if form_fields:
-        try:
-            from RNS.vendor import umsgpack
-            request_data = umsgpack.packb(dict(form_fields))
-        except Exception:
-            # Fall back to nothing — better to send the request unform'd
-            # than to fail outright.
-            request_data = None
+    # RNS.Link.request owns request-data framing. Pass the mapping directly so
+    # the remote path handler receives a dict rather than pre-packed bytes.
+    request_data: Any = dict(form_fields) if form_fields else None
 
     try:
         link.request(

--- a/app/rns_bridge.py
+++ b/app/rns_bridge.py
@@ -1563,15 +1563,18 @@ def fetch_nomadnet_page(
     except ValueError:
         return {"ok": False, "status": "bad-hash", "data": b"", "content_type": ""}
 
-    # Recall the remote identity. If we haven't received an announce yet,
-    # kick off a request_path and bail — caller can retry once the path
-    # arrives. (Mirrors send_opportunistic's behavior.)
+    # Resolve both the route and announced node identity before opening the
+    # link. A cold first request must wait for the path response instead of
+    # merely triggering discovery and requiring the user to retry manually.
+    path_result = resolve_path(
+        dest_hash_hex,
+        timeout_seconds=min(15.0, max(0.0, float(timeout))),
+    )
+    if not path_result["ok"]:
+        return {"ok": False, "status": "no-path", "data": b"", "content_type": ""}
+
     peer_identity = RNS.Identity.recall(dest_hash)
     if peer_identity is None:
-        try:
-            RNS.Transport.request_path(dest_hash)
-        except Exception:
-            pass
         return {"ok": False, "status": "no-path", "data": b"", "content_type": ""}
 
     peer_dest = RNS.Destination(


### PR DESCRIPTION
## Summary

- add complete NomadNet `rngit` request-link navigation with canonical `var_` request semantics while excluding user-entered `field_` values from reusable addresses
- preserve complete destination/path/variable addresses across copy, share, reopen, refresh, and browser history
- align Micron rendering with canonical NomadNet behavior for true colors, resets, section palettes, arbitrary nesting, bilateral margins, link color inheritance, and block reclassification
- recursively load partials and forms with first-wins defaults, cycle protection, active viewport/font metrics, and zero-width divider fallback
- make the first cold NomadNet request wait boundedly for path resolution instead of requiring a manual retry

## Authority and development approach

Behavior is aligned with canonical NomadNet request and Micron semantics. The feature was developed through red/green regression coverage spanning parser, rendering, request framing, address round trips, recursive document loading, viewport geometry, and cold-path resolution.

## Verification

- static contracts on the exact head: 226 passed, 1 skipped
- focused cold-path regression on the exact head: 100/100 deterministic passes
- full iOS suite on the production-source parent: 264/264; the exact head differs only by additional Python static assertions
- earlier exact Micron feature head: 264/264
- exact production and test-hardening reviews: approved
- physical signed-device verification confirmed that the first cold request succeeds

Physical verification used a local integration artifact that also contained the separate accepted composer fix from PR #147. This PR excludes PR #147 and contains only the complete NomadNet feature stack described above.

## Risk and rollback

Primary risk is behavioral compatibility across complex Micron nesting/render modes and NomadNet address/request edge cases. Regression coverage exercises canonical colors, reset behavior, recursive partials, history/reopen semantics, request payload ownership, and cold resolution. Rollback is a normal revert of this feature branch; there are no data migrations or generated artifacts.
