### PR TITLE
Fix asynchronous Retry via Relay fallback

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,6 +74,7 @@ jobs:
             Tests.static.test_fetch_python_resilience \
             Tests.static.test_migration_export_flow \
             Tests.static.test_ios_stamp_runtime_hardening \
+            Tests.static.test_async_propagation_fallback \
             Tests.static.test_ui_screenshotter_readiness \
             Tests.static.test_collect_maestro_screenshots
 

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -2926,7 +2926,7 @@ public final class AppServices {
                 userInfo: [
                     "messageHash": hashData,
                     "state": state,
-                    "deliveryMethod": acceptedMethod == .propagated ? "propagated" : "",
+                    "deliveryMethod": acceptedMethod?.rawValue ?? "",
                     "persisted": proofPersisted,
                 ]
             )

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -2893,15 +2893,25 @@ public final class AppServices {
         case .delivery(let messageHash, let state, _):
             DiagLog.log("[RNS] delivery \(messageHash.prefix(16)) state=\(state)")
             guard let hashData = Data(hexString: messageHash) else { return }
-            let newState: LXMessageState = (state == "delivered") ? .delivered : .failed
+            let newState: LXMessageState
+            switch state {
+            case "sent": newState = .sent
+            case "delivered": newState = .delivered
+            case "failed": newState = .failed
+            default:
+                logger.warning("Ignoring unknown delivery state: \(state, privacy: .public)")
+                return
+            }
             // Update the GRDB canonical store (where outbound messages are
             // persisted and the UI reads from), via the shared repository's
             // RNSAPI-typed method — not the Compat `database`.
             var proofPersisted = false
+            let acceptedMethod: LXDeliveryMethod? = (state == "sent") ? .propagated : nil
             if let repo = self.messageRepository {
                 proofPersisted = (try? await repo.applyDeliveryProof(
                     canonicalHash: hashData,
-                    state: newState
+                    state: newState,
+                    method: acceptedMethod
                 )) ?? false
             }
             // Notify the open chat so it can flip the bubble's indicator
@@ -2912,6 +2922,7 @@ public final class AppServices {
                 userInfo: [
                     "messageHash": hashData,
                     "state": state,
+                    "deliveryMethod": acceptedMethod == .propagated ? "propagated" : "",
                     "persisted": proofPersisted,
                 ]
             )

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -2890,7 +2890,7 @@ public final class AppServices {
         case .state(let value, _):
             DiagLog.log("[RNS] state \(value)")
             logger.info("Python state: \(value, privacy: .public)")
-        case .delivery(let messageHash, let state, _):
+        case .delivery(let messageHash, let state, let method, _):
             DiagLog.log("[RNS] delivery \(messageHash.prefix(16)) state=\(state)")
             guard let hashData = Data(hexString: messageHash) else { return }
             let newState: LXMessageState
@@ -2906,7 +2906,11 @@ public final class AppServices {
             // persisted and the UI reads from), via the shared repository's
             // RNSAPI-typed method — not the Compat `database`.
             var proofPersisted = false
-            let acceptedMethod: LXDeliveryMethod? = (state == "sent") ? .propagated : nil
+            // Transport and lifecycle are independent. A propagated fallback
+            // can report recipient proof without a separately observed `sent`
+            // event, so persist the backend's effective method on every state.
+            // Retain the old sent-state inference for legacy event producers.
+            let acceptedMethod = method ?? ((state == "sent") ? .propagated : nil)
             if let repo = self.messageRepository {
                 proofPersisted = (try? await repo.applyDeliveryProof(
                     canonicalHash: hashData,

--- a/Sources/ColumbaApp/Services/MessageRepository.swift
+++ b/Sources/ColumbaApp/Services/MessageRepository.swift
@@ -730,17 +730,20 @@ public actor MessageRepository {
     @discardableResult
     public func applyDeliveryProof(
         canonicalHash: Data,
-        state: RNSAPI.LXMessageState
+        state: RNSAPI.LXMessageState,
+        method: RNSAPI.LXDeliveryMethod? = nil
     ) async throws -> Bool {
         try await replacementPool.write { db in
             let mappedState = Self.mapStateToGRDB(state).rawValue
+            let mappedMethod = method.map { Self.mapMethodToGRDB($0).rawValue }
             let now = Date().timeIntervalSince1970
             try db.execute(
                 sql: """
-                    UPDATE messages SET state = ?, updated_at = ?
+                    UPDATE messages
+                    SET state = ?, method = COALESCE(?, method), updated_at = ?
                     WHERE message_id = ?
                     """,
-                arguments: [mappedState, now, canonicalHash]
+                arguments: [mappedState, mappedMethod, now, canonicalHash]
             )
             if db.changesCount == 1 {
                 try db.execute(
@@ -760,13 +763,15 @@ public actor MessageRepository {
             try db.execute(
                 sql: """
                     UPDATE messages
-                    SET message_id = ?, state = ?, receiving_interface = NULL,
+                    SET message_id = ?, state = ?, method = COALESCE(?, method),
+                        receiving_interface = NULL,
                         updated_at = ?
                     WHERE incoming = 0 AND receiving_interface = ?
                     """,
                 arguments: [
                     canonicalHash,
                     mappedState,
+                    mappedMethod,
                     now,
                     Self.uncertainRetryMarker(canonicalHash: canonicalHash),
                 ]

--- a/Sources/ColumbaApp/Services/MessageRepository.swift
+++ b/Sources/ColumbaApp/Services/MessageRepository.swift
@@ -718,9 +718,41 @@ public actor MessageRepository {
         try await database.hasMessage(id: id)
     }
 
-    /// Update message delivery state.
-    public func updateMessageState(id: Data, state: RNSAPI.LXMessageState) async throws {
-        try await database.updateMessageState(id: id, state: Self.mapStateToGRDB(state))
+    /// Update message delivery state and optional effective transport without
+    /// allowing stale evidence to downgrade authoritative recipient delivery.
+    public func updateMessageState(
+        id: Data,
+        state: RNSAPI.LXMessageState,
+        method: RNSAPI.LXDeliveryMethod? = nil
+    ) async throws {
+        try await replacementPool.write { db in
+            let incomingState = Int(Self.mapStateToGRDB(state).rawValue)
+            let existingState = try Int.fetchOne(
+                db,
+                sql: "SELECT state FROM messages WHERE message_id = ?",
+                arguments: [id]
+            )
+            let persistedState = Self.monotonicDeliveryState(
+                existing: existingState,
+                incoming: incomingState
+            )
+            let persistedMethod = persistedState == incomingState
+                ? method.map { Self.mapMethodToGRDB($0).rawValue }
+                : nil
+            try db.execute(
+                sql: """
+                    UPDATE messages
+                    SET state = ?, method = COALESCE(?, method), updated_at = ?
+                    WHERE message_id = ?
+                    """,
+                arguments: [
+                    persistedState,
+                    persistedMethod,
+                    Date().timeIntervalSince1970,
+                    id,
+                ]
+            )
+        }
     }
 
     /// Persist an authoritative backend delivery proof. If canonical message

--- a/Sources/ColumbaApp/Services/MessageRepository.swift
+++ b/Sources/ColumbaApp/Services/MessageRepository.swift
@@ -720,11 +720,12 @@ public actor MessageRepository {
 
     /// Update message delivery state and optional effective transport without
     /// allowing stale evidence to downgrade authoritative recipient delivery.
+    @discardableResult
     public func updateMessageState(
         id: Data,
         state: RNSAPI.LXMessageState,
         method: RNSAPI.LXDeliveryMethod? = nil
-    ) async throws {
+    ) async throws -> Bool {
         try await replacementPool.write { db in
             let incomingState = Int(Self.mapStateToGRDB(state).rawValue)
             let existingState = try Int.fetchOne(
@@ -752,6 +753,7 @@ public actor MessageRepository {
                     id,
                 ]
             )
+            return db.changesCount > 0
         }
     }
 

--- a/Sources/ColumbaApp/Services/MessageRepository.swift
+++ b/Sources/ColumbaApp/Services/MessageRepository.swift
@@ -727,6 +727,12 @@ public actor MessageRepository {
     /// persistence previously failed during a retry, atomically resolve the
     /// durable storage-key row through its canonical uncertainty marker and
     /// rekey it to the wire hash. This path works without an open chat view.
+    static func monotonicDeliveryState(existing: Int?, incoming: Int) -> Int {
+        guard let existing else { return incoming }
+        let delivered = Int(LXMFSwift.LXMessageState.delivered.rawValue)
+        return existing == delivered ? existing : incoming
+    }
+
     @discardableResult
     public func applyDeliveryProof(
         canonicalHash: Data,
@@ -734,16 +740,26 @@ public actor MessageRepository {
         method: RNSAPI.LXDeliveryMethod? = nil
     ) async throws -> Bool {
         try await replacementPool.write { db in
-            let mappedState = Self.mapStateToGRDB(state).rawValue
+            let incomingState = Int(Self.mapStateToGRDB(state).rawValue)
             let mappedMethod = method.map { Self.mapMethodToGRDB($0).rawValue }
             let now = Date().timeIntervalSince1970
+            let existingCanonicalState = try Int.fetchOne(
+                db,
+                sql: "SELECT state FROM messages WHERE message_id = ?",
+                arguments: [canonicalHash]
+            )
+            let canonicalState = Self.monotonicDeliveryState(
+                existing: existingCanonicalState,
+                incoming: incomingState
+            )
+            let canonicalMethod = canonicalState == incomingState ? mappedMethod : nil
             try db.execute(
                 sql: """
                     UPDATE messages
                     SET state = ?, method = COALESCE(?, method), updated_at = ?
                     WHERE message_id = ?
                     """,
-                arguments: [mappedState, mappedMethod, now, canonicalHash]
+                arguments: [canonicalState, canonicalMethod, now, canonicalHash]
             )
             if db.changesCount == 1 {
                 try db.execute(
@@ -760,6 +776,17 @@ public actor MessageRepository {
                 return true
             }
 
+            let uncertaintyMarker = Self.uncertainRetryMarker(canonicalHash: canonicalHash)
+            let existingAliasState = try Int.fetchOne(
+                db,
+                sql: "SELECT state FROM messages WHERE incoming = 0 AND receiving_interface = ?",
+                arguments: [uncertaintyMarker]
+            )
+            let aliasState = Self.monotonicDeliveryState(
+                existing: existingAliasState,
+                incoming: incomingState
+            )
+            let aliasMethod = aliasState == incomingState ? mappedMethod : nil
             try db.execute(
                 sql: """
                     UPDATE messages
@@ -770,10 +797,10 @@ public actor MessageRepository {
                     """,
                 arguments: [
                     canonicalHash,
-                    mappedState,
-                    mappedMethod,
+                    aliasState,
+                    aliasMethod,
                     now,
-                    Self.uncertainRetryMarker(canonicalHash: canonicalHash),
+                    uncertaintyMarker,
                 ]
             )
             return db.changesCount == 1

--- a/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
@@ -63,6 +63,7 @@ public final class MessagingViewModel {
     private var unsavedFailedOutboundIDs: Set<String> = []
     private var stagedRetryRecoveryHashes: [String: Data] = [:]
     private var pendingOutboundAliases: [String: String] = [:]
+    private var canonicalizedOutboundAliases: [String: String] = [:]
     private var pendingDeliveryProofs: [String: LXMessageState] = [:]
 
     // MARK: - Initialization
@@ -143,6 +144,7 @@ public final class MessagingViewModel {
                     if let deliveryMethod, !deliveryMethod.isEmpty {
                         self.messages[index].deliveryMethod = deliveryMethod
                     }
+                    self.canonicalizedOutboundAliases[visibleID] = hashHex
                     self.pendingOutboundAliases.removeValue(forKey: hashHex)
                     self.pendingDeliveryProofs.removeValue(forKey: hashHex)
                     await self.invalidatePaginationAndRefresh()
@@ -439,6 +441,30 @@ public final class MessagingViewModel {
         aliases: [String: String]
     ) -> String {
         aliases[realID] ?? realID
+    }
+
+    func currentMessage(for selected: Message) -> Message {
+        Self.resolveCurrentMessage(
+            selected,
+            messages: messages,
+            pendingAliases: pendingOutboundAliases,
+            canonicalizedAliases: canonicalizedOutboundAliases
+        )
+    }
+
+    static func resolveCurrentMessage(
+        _ selected: Message,
+        messages: [Message],
+        pendingAliases: [String: String],
+        canonicalizedAliases: [String: String]
+    ) -> Message {
+        if let exact = messages.first(where: { $0.id == selected.id }) {
+            return exact
+        }
+        let canonicalID = canonicalizedAliases[selected.id]
+            ?? pendingAliases.first(where: { $0.value == selected.id })?.key
+        guard let canonicalID else { return selected }
+        return messages.first(where: { $0.id == canonicalID }) ?? selected
     }
 
     static func pendingProof(

--- a/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
@@ -19,6 +19,22 @@ import os.log
 @available(iOS 17.0, macOS 14.0, *)
 @Observable
 public final class MessagingViewModel {
+    struct OutboundSendRequest {
+        let destHashHex: String
+        let content: String
+        let method: RNSAPI.LXDeliveryMethod
+        let failureFallbackMethod: RNSAPI.LXDeliveryMethod?
+        let imageData: Data?
+        let imageFormat: String?
+        let fileAttachments: [RnsFileAttachment]?
+        let iconAppearance: IconAppearance?
+        let replyToMessageHashHex: String?
+        let replyQuotedContent: String?
+        let extraFields: [UInt8: Data]?
+    }
+
+    typealias OutboundSendOperation = @MainActor (OutboundSendRequest) async throws -> SendOutcome
+
     struct PendingDeliveryProof: Equatable {
         let state: LXMessageState
         let method: RNSAPI.LXDeliveryMethod?
@@ -57,6 +73,8 @@ public final class MessagingViewModel {
     private let appServices: AppServices
     private let settingsRepository = SettingsRepository()
     private let displayName: String?
+    private var identityOverride: Identity?
+    private var outboundSendOperation: OutboundSendOperation?
     private let logger = Logger(subsystem: "network.columba.Columba", category: "MessagingViewModel")
 
     /// Observation token for incoming message notifications.
@@ -137,7 +155,7 @@ public final class MessagingViewModel {
                     for: hashHex,
                     aliases: self.pendingOutboundAliases
                 )
-                if wasAliased && !proofPersisted {
+                if !proofPersisted {
                     self.pendingDeliveryProofs[hashHex] = PendingDeliveryProof(
                         state: proofState,
                         method: proofMethod
@@ -168,6 +186,22 @@ public final class MessagingViewModel {
                 }
             }
         }
+    }
+
+    convenience init(
+        conversationHash: Data,
+        repository: MessageRepository,
+        appServices: AppServices,
+        identity: Identity,
+        outboundSendOperation: @escaping OutboundSendOperation
+    ) {
+        self.init(
+            conversationHash: conversationHash,
+            repository: repository,
+            appServices: appServices
+        )
+        self.identityOverride = identity
+        self.outboundSendOperation = outboundSendOperation
     }
 
     deinit {
@@ -447,6 +481,10 @@ public final class MessagingViewModel {
     }
 
     @MainActor
+    func hasPendingDeliveryProof(for hash: Data) -> Bool {
+        pendingDeliveryProofs[Self.hexString(hash)] != nil
+    }
+
     private func pendingDeliveryProof(for hash: Data) -> PendingDeliveryProof? {
         let hashHex = Self.hexString(hash)
         return pendingDeliveryProofs[hashHex]
@@ -657,6 +695,32 @@ public final class MessagingViewModel {
         )
     }
 
+    @MainActor
+    private func sendOutbound(
+        _ request: OutboundSendRequest,
+        backend: (any RnsBackend)?
+    ) async throws -> SendOutcome {
+        if let outboundSendOperation {
+            return try await outboundSendOperation(request)
+        }
+        guard let backend else {
+            throw NSError(domain: "MessagingViewModel", code: 1)
+        }
+        return try await backend.lxmf.sendLxmfMessage(
+            destHashHex: request.destHashHex,
+            content: request.content,
+            method: request.method,
+            failureFallbackMethod: request.failureFallbackMethod,
+            imageData: request.imageData,
+            imageFormat: request.imageFormat,
+            fileAttachments: request.fileAttachments,
+            iconAppearance: request.iconAppearance,
+            replyToMessageHashHex: request.replyToMessageHashHex,
+            replyQuotedContent: request.replyQuotedContent,
+            extraFields: request.extraFields
+        )
+    }
+
     private static func failureCategory(_ error: Error) -> String {
         (error as? SendFailure)?.category ?? "backend-error"
     }
@@ -699,12 +763,13 @@ public final class MessagingViewModel {
             return false
         }
 
-        guard let identity = appServices.identity else {
+        guard let identity = identityOverride ?? appServices.identity else {
             errorMessage = "Identity not initialized"
             return false
         }
 
-        guard let backend = appServices.backend else {
+        let backend = appServices.backend
+        guard backend != nil || outboundSendOperation != nil else {
             errorMessage = "Backend not initialized"
             return false
         }
@@ -820,14 +885,24 @@ public final class MessagingViewModel {
             // Compat router + sendHook path, which dropped all fields on the
             // wire.) Nothing persists the outbound message to the local DB, so
             // we save explicitly below once `lxMessage.hash` is stamped.
-            let outcome = try await backend.lxmf.sendLxmfMessage(
-                destHashHex: conversationHash.map { String(format: "%02x", $0) }.joined(),
-                content: trimmedText, method: .opportunistic,
-                failureFallbackMethod: retryViaRelay ? .propagated : nil,
-                imageData: imageData, imageFormat: imageFormat,
-                fileAttachments: attachments?.map { RnsFileAttachment(name: $0.name, data: $0.data) },
-                iconAppearance: icon,
-                replyToMessageHashHex: replyToId, replyQuotedContent: replyPreview, extraFields: nil)
+            let outcome = try await sendOutbound(
+                OutboundSendRequest(
+                    destHashHex: Self.hexString(conversationHash),
+                    content: trimmedText,
+                    method: .opportunistic,
+                    failureFallbackMethod: retryViaRelay ? .propagated : nil,
+                    imageData: imageData,
+                    imageFormat: imageFormat,
+                    fileAttachments: attachments?.map {
+                        RnsFileAttachment(name: $0.name, data: $0.data)
+                    },
+                    iconAppearance: icon,
+                    replyToMessageHashHex: replyToId,
+                    replyQuotedContent: replyPreview,
+                    extraFields: nil
+                ),
+                backend: backend
+            )
             let sentHash = try Self.queuedHash(from: outcome)
             lxMessage.hash = sentHash
             lxMessage.state = .sent
@@ -893,13 +968,24 @@ public final class MessagingViewModel {
 
                 do {
                     // Relay retry through the neutral facet (propagated method).
-                    let retryOutcome = try await backend.lxmf.sendLxmfMessage(
-                        destHashHex: conversationHash.map { String(format: "%02x", $0) }.joined(),
-                        content: trimmedText, method: .propagated,
-                        imageData: imageData, imageFormat: imageFormat,
-                        fileAttachments: attachments?.map { RnsFileAttachment(name: $0.name, data: $0.data) },
-                        iconAppearance: icon,
-                        replyToMessageHashHex: replyToId, replyQuotedContent: replyPreview, extraFields: nil)
+                    let retryOutcome = try await sendOutbound(
+                        OutboundSendRequest(
+                            destHashHex: Self.hexString(conversationHash),
+                            content: trimmedText,
+                            method: .propagated,
+                            failureFallbackMethod: nil,
+                            imageData: imageData,
+                            imageFormat: imageFormat,
+                            fileAttachments: attachments?.map {
+                                RnsFileAttachment(name: $0.name, data: $0.data)
+                            },
+                            iconAppearance: icon,
+                            replyToMessageHashHex: replyToId,
+                            replyQuotedContent: replyPreview,
+                            extraFields: nil
+                        ),
+                        backend: backend
+                    )
                     let retryHash = try Self.queuedHash(from: retryOutcome)
                     retryMessage.hash = retryHash
                     retryMessage.state = .sent

--- a/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
@@ -144,8 +144,11 @@ public final class MessagingViewModel {
                     if let deliveryMethod, !deliveryMethod.isEmpty {
                         self.messages[index].deliveryMethod = deliveryMethod
                     }
-                    self.canonicalizedOutboundAliases[visibleID] = hashHex
-                    self.pendingOutboundAliases.removeValue(forKey: hashHex)
+                    Self.recordCanonicalAlias(
+                        canonicalID: hashHex,
+                        pendingAliases: &self.pendingOutboundAliases,
+                        canonicalizedAliases: &self.canonicalizedOutboundAliases
+                    )
                     self.pendingDeliveryProofs.removeValue(forKey: hashHex)
                     await self.invalidatePaginationAndRefresh()
                 } else {
@@ -248,7 +251,7 @@ public final class MessagingViewModel {
                     aliases: pendingOutboundAliases,
                     proofs: pendingDeliveryProofs
                 ) {
-                    resolvedMessages[i].deliveryStatus = (proof == .delivered) ? .delivered : .failed
+                    resolvedMessages[i].deliveryStatus = Self.deliveryStatus(for: proof)
                 }
             }
             await reconcileAliasedDeliveryProofs(in: resolvedMessages)
@@ -372,7 +375,11 @@ public final class MessagingViewModel {
     @MainActor
     private func reconcilePendingDeliveryProof(for hash: Data) async {
         let hashHex = Self.hexString(hash)
-        pendingOutboundAliases.removeValue(forKey: hashHex)
+        Self.recordCanonicalAlias(
+            canonicalID: hashHex,
+            pendingAliases: &pendingOutboundAliases,
+            canonicalizedAliases: &canonicalizedOutboundAliases
+        )
         guard let proof = pendingDeliveryProofs[hashHex] else { return }
         do {
             try await repository.updateMessageState(id: hash, state: proof)
@@ -430,6 +437,7 @@ public final class MessagingViewModel {
             pendingOutboundAliases.removeValue(forKey: hash)
             pendingDeliveryProofs.removeValue(forKey: hash)
         }
+        canonicalizedOutboundAliases.removeValue(forKey: visibleID)
     }
 
     private static func hexString(_ data: Data) -> String {
@@ -441,6 +449,15 @@ public final class MessagingViewModel {
         aliases: [String: String]
     ) -> String {
         aliases[realID] ?? realID
+    }
+
+    static func recordCanonicalAlias(
+        canonicalID: String,
+        pendingAliases: inout [String: String],
+        canonicalizedAliases: inout [String: String]
+    ) {
+        guard let optimisticID = pendingAliases.removeValue(forKey: canonicalID) else { return }
+        canonicalizedAliases[optimisticID] = canonicalID
     }
 
     func currentMessage(for selected: Message) -> Message {
@@ -790,7 +807,7 @@ public final class MessagingViewModel {
                 logger.error("[MSG_VM] saveMessage(outbound) failed: \(error.localizedDescription)")
                 if let index = messages.firstIndex(where: { $0.id == optimisticId }) {
                     messages[index].messageHash = sentHash
-                    messages[index].deliveryStatus = (proof == .delivered) ? .delivered : .failed
+                    messages[index].deliveryStatus = proof.map(Self.deliveryStatus(for:)) ?? .failed
                 }
                 errorMessage = "Message was sent, but local confirmation could not be saved. Verify whether it arrived before retrying."
             }
@@ -858,7 +875,7 @@ public final class MessagingViewModel {
                         logger.error("[MSG_VM] saveMessage(retry-relay) failed: \(error.localizedDescription)")
                         if let index = messages.firstIndex(where: { $0.id == optimisticId }) {
                             messages[index].messageHash = retryHash
-                            messages[index].deliveryStatus = (proof == .delivered) ? .delivered : .failed
+                            messages[index].deliveryStatus = proof.map(Self.deliveryStatus(for:)) ?? .failed
                         }
                         errorMessage = "Message was relayed, but local confirmation could not be saved. Verify whether it arrived before retrying."
                     }

--- a/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
@@ -113,9 +113,18 @@ public final class MessagingViewModel {
                   let hashData = notification.userInfo?["messageHash"] as? Data,
                   let state = notification.userInfo?["state"] as? String else { return }
             let proofPersisted = notification.userInfo?["persisted"] as? Bool ?? false
+            let deliveryMethod = notification.userInfo?["deliveryMethod"] as? String
             let hashHex = hashData.map { String(format: "%02x", $0) }.joined()
             Task { @MainActor in
-                let proofState: LXMessageState = (state == "delivered") ? .delivered : .failed
+                let proofState: LXMessageState
+                switch state {
+                case "sent": proofState = .sent
+                case "delivered": proofState = .delivered
+                case "failed": proofState = .failed
+                default:
+                    self.logger.warning("[MSG_VM] Ignoring unknown delivery state: \(state, privacy: .public)")
+                    return
+                }
                 let wasAliased = self.pendingOutboundAliases[hashHex] != nil
                 let visibleID = Self.visibleMessageID(
                     for: hashHex,
@@ -131,11 +140,17 @@ public final class MessagingViewModel {
                         canonicalHash: hashData,
                         proofState: proofState
                     )
+                    if let deliveryMethod, !deliveryMethod.isEmpty {
+                        self.messages[index].deliveryMethod = deliveryMethod
+                    }
                     self.pendingOutboundAliases.removeValue(forKey: hashHex)
                     self.pendingDeliveryProofs.removeValue(forKey: hashHex)
                     await self.invalidatePaginationAndRefresh()
                 } else {
-                    self.messages[index].deliveryStatus = (proofState == .delivered) ? .delivered : .failed
+                    self.messages[index].deliveryStatus = Self.deliveryStatus(for: proofState)
+                    if let deliveryMethod, !deliveryMethod.isEmpty {
+                        self.messages[index].deliveryMethod = deliveryMethod
+                    }
                 }
             }
         }
@@ -450,7 +465,7 @@ public final class MessagingViewModel {
             content: message.content,
             timestamp: message.timestamp,
             isFromMe: message.isFromMe,
-            deliveryStatus: proofState == .delivered ? .delivered : .failed,
+            deliveryStatus: deliveryStatus(for: proofState),
             imageData: message.imageData,
             imageFormat: message.imageFormat,
             attachments: message.attachments,
@@ -466,6 +481,15 @@ public final class MessagingViewModel {
         canonical.snr = message.snr
         canonical.receivedInterface = nil
         return canonical
+    }
+
+    static func deliveryStatus(for state: LXMessageState) -> DeliveryStatus {
+        switch state {
+        case .sent: return .sent
+        case .delivered: return .delivered
+        case .failed: return .failed
+        default: return .sent
+        }
     }
 
     static func mergingPendingOutbound(
@@ -597,6 +621,7 @@ public final class MessagingViewModel {
         // On failure, retry-via-relay handles the final propagated fallback.
         let settingsMethod = await settingsRepository.getDefaultDeliveryMethod()
         let fallbackForLargeMessages: LXDeliveryMethod = (settingsMethod == "propagated") ? .propagated : .direct
+        let retryViaRelay = await settingsRepository.getRetryViaRelay()
 
         // Resolve icon once — passed to the typed backend send below and also
         // stashed in the local Compat.LXMessage fields for persistence/display.
@@ -703,6 +728,7 @@ public final class MessagingViewModel {
             let outcome = try await backend.lxmf.sendLxmfMessage(
                 destHashHex: conversationHash.map { String(format: "%02x", $0) }.joined(),
                 content: trimmedText, method: .opportunistic,
+                failureFallbackMethod: retryViaRelay ? .propagated : nil,
                 imageData: imageData, imageFormat: imageFormat,
                 fileAttachments: attachments?.map { RnsFileAttachment(name: $0.name, data: $0.data) },
                 iconAppearance: icon,
@@ -747,7 +773,6 @@ public final class MessagingViewModel {
         } catch {
             var failure: Error = error
             // Retry via relay if enabled
-            let retryViaRelay = await settingsRepository.getRetryViaRelay()
             if retryViaRelay {
                 logger.info("[MSG_VM] Delivery failed, retrying via relay")
 

--- a/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
@@ -19,6 +19,11 @@ import os.log
 @available(iOS 17.0, macOS 14.0, *)
 @Observable
 public final class MessagingViewModel {
+    struct PendingDeliveryProof: Equatable {
+        let state: LXMessageState
+        let method: RNSAPI.LXDeliveryMethod?
+    }
+
     // MARK: - Published Properties
 
     /// List of messages in chronological order (oldest first).
@@ -64,7 +69,7 @@ public final class MessagingViewModel {
     private var stagedRetryRecoveryHashes: [String: Data] = [:]
     private var pendingOutboundAliases: [String: String] = [:]
     private var canonicalizedOutboundAliases: [String: String] = [:]
-    private var pendingDeliveryProofs: [String: LXMessageState] = [:]
+    private var pendingDeliveryProofs: [String: PendingDeliveryProof] = [:]
 
     // MARK: - Initialization
 
@@ -126,13 +131,17 @@ public final class MessagingViewModel {
                     self.logger.warning("[MSG_VM] Ignoring unknown delivery state: \(state, privacy: .public)")
                     return
                 }
+                let proofMethod = Self.deliveryMethod(from: deliveryMethod)
                 let wasAliased = self.pendingOutboundAliases[hashHex] != nil
                 let visibleID = Self.visibleMessageID(
                     for: hashHex,
                     aliases: self.pendingOutboundAliases
                 )
                 if wasAliased && !proofPersisted {
-                    self.pendingDeliveryProofs[hashHex] = proofState
+                    self.pendingDeliveryProofs[hashHex] = PendingDeliveryProof(
+                        state: proofState,
+                        method: proofMethod
+                    )
                 }
                 guard let index = self.messages.firstIndex(where: { $0.id == visibleID }) else { return }
                 if wasAliased && proofPersisted {
@@ -246,12 +255,15 @@ public final class MessagingViewModel {
                    canonicalHash != resolvedMessages[i].storageHash {
                     pendingOutboundAliases[Self.hexString(canonicalHash)] = resolvedMessages[i].id
                 }
-                if let proof = Self.pendingProof(
+                if let proof = Self.pendingProofDetails(
                     forVisibleID: resolvedMessages[i].id,
                     aliases: pendingOutboundAliases,
                     proofs: pendingDeliveryProofs
                 ) {
-                    resolvedMessages[i].deliveryStatus = Self.deliveryStatus(for: proof)
+                    resolvedMessages[i].deliveryStatus = Self.deliveryStatus(for: proof.state)
+                    if let method = proof.method {
+                        resolvedMessages[i].deliveryMethod = method.rawValue
+                    }
                 }
             }
             await reconcileAliasedDeliveryProofs(in: resolvedMessages)
@@ -373,7 +385,7 @@ public final class MessagingViewModel {
     }
 
     @MainActor
-    private func reconcilePendingDeliveryProof(for hash: Data) async {
+    func reconcilePendingDeliveryProof(for hash: Data) async {
         let hashHex = Self.hexString(hash)
         Self.recordCanonicalAlias(
             canonicalID: hashHex,
@@ -382,7 +394,11 @@ public final class MessagingViewModel {
         )
         guard let proof = pendingDeliveryProofs[hashHex] else { return }
         do {
-            try await repository.updateMessageState(id: hash, state: proof)
+            try await repository.updateMessageState(
+                id: hash,
+                state: proof.state,
+                method: proof.method
+            )
             pendingDeliveryProofs.removeValue(forKey: hashHex)
         } catch {
             logger.error("[MSG_VM] failed to persist delivery proof: \(error.localizedDescription)")
@@ -395,7 +411,11 @@ public final class MessagingViewModel {
             guard pendingOutboundAliases[hashHex] == nil,
                   let hash = Self.hexToData(hashHex) else { continue }
             do {
-                try await repository.updateMessageState(id: hash, state: proof)
+                try await repository.updateMessageState(
+                    id: hash,
+                    state: proof.state,
+                    method: proof.method
+                )
                 if pendingDeliveryProofs[hashHex] == proof {
                     pendingDeliveryProofs.removeValue(forKey: hashHex)
                 }
@@ -412,7 +432,11 @@ public final class MessagingViewModel {
                   let storageHash = message.storageHash,
                   let proof = pendingDeliveryProofs[Self.hexString(canonicalHash)] else { continue }
             do {
-                try await repository.updateMessageState(id: storageHash, state: proof)
+                try await repository.updateMessageState(
+                    id: storageHash,
+                    state: proof.state,
+                    method: proof.method
+                )
                 if pendingDeliveryProofs[Self.hexString(canonicalHash)] == proof {
                     pendingDeliveryProofs.removeValue(forKey: Self.hexString(canonicalHash))
                 }
@@ -423,7 +447,7 @@ public final class MessagingViewModel {
     }
 
     @MainActor
-    private func pendingDeliveryProof(for hash: Data) -> LXMessageState? {
+    private func pendingDeliveryProof(for hash: Data) -> PendingDeliveryProof? {
         let hashHex = Self.hexString(hash)
         return pendingDeliveryProofs[hashHex]
     }
@@ -460,6 +484,20 @@ public final class MessagingViewModel {
         canonicalizedAliases[optimisticID] = canonicalID
     }
 
+    @MainActor
+    func registerPendingOutboundAlias(canonicalHash: Data, optimisticID: String) {
+        pendingOutboundAliases[Self.hexString(canonicalHash)] = optimisticID
+    }
+
+    private static func deliveryMethod(from value: String?) -> RNSAPI.LXDeliveryMethod? {
+        switch value {
+        case "opportunistic": return .opportunistic
+        case "direct": return .direct
+        case "propagated": return .propagated
+        default: return nil
+        }
+    }
+
     func currentMessage(for selected: Message) -> Message {
         Self.resolveCurrentMessage(
             selected,
@@ -482,6 +520,20 @@ public final class MessagingViewModel {
             ?? pendingAliases.first(where: { $0.value == selected.id })?.key
         guard let canonicalID else { return selected }
         return messages.first(where: { $0.id == canonicalID }) ?? selected
+    }
+
+    private static func pendingProofDetails(
+        forVisibleID visibleID: String,
+        aliases: [String: String],
+        proofs: [String: PendingDeliveryProof]
+    ) -> PendingDeliveryProof? {
+        if let direct = proofs[visibleID] { return direct }
+        guard let canonicalID = aliases.first(where: {
+            $0.value == visibleID && proofs[$0.key] != nil
+        })?.key else {
+            return nil
+        }
+        return proofs[canonicalID]
     }
 
     static func pendingProof(
@@ -779,7 +831,10 @@ public final class MessagingViewModel {
             let sentHash = try Self.queuedHash(from: outcome)
             lxMessage.hash = sentHash
             lxMessage.state = .sent
-            pendingOutboundAliases[Self.hexString(sentHash)] = optimisticId
+            registerPendingOutboundAlias(
+                canonicalHash: sentHash,
+                optimisticID: optimisticId
+            )
 
             // Persist so a subsequent loadMessages() doesn't wipe it.
             do {
@@ -807,7 +862,7 @@ public final class MessagingViewModel {
                 logger.error("[MSG_VM] saveMessage(outbound) failed: \(error.localizedDescription)")
                 if let index = messages.firstIndex(where: { $0.id == optimisticId }) {
                     messages[index].messageHash = sentHash
-                    messages[index].deliveryStatus = proof.map(Self.deliveryStatus(for:)) ?? .failed
+                    messages[index].deliveryStatus = proof.map { Self.deliveryStatus(for: $0.state) } ?? .failed
                 }
                 errorMessage = "Message was sent, but local confirmation could not be saved. Verify whether it arrived before retrying."
             }
@@ -849,7 +904,10 @@ public final class MessagingViewModel {
                     retryMessage.hash = retryHash
                     retryMessage.state = .sent
                     retryMessage.method = .propagated
-                    pendingOutboundAliases[Self.hexString(retryHash)] = optimisticId
+                    registerPendingOutboundAlias(
+                        canonicalHash: retryHash,
+                        optimisticID: optimisticId
+                    )
                     do {
                         try await persistMessage(retryMessage, replacing: localRetryHash)
                         await reconcilePendingDeliveryProof(for: retryHash)
@@ -875,7 +933,7 @@ public final class MessagingViewModel {
                         logger.error("[MSG_VM] saveMessage(retry-relay) failed: \(error.localizedDescription)")
                         if let index = messages.firstIndex(where: { $0.id == optimisticId }) {
                             messages[index].messageHash = retryHash
-                            messages[index].deliveryStatus = proof.map(Self.deliveryStatus(for:)) ?? .failed
+                            messages[index].deliveryStatus = proof.map { Self.deliveryStatus(for: $0.state) } ?? .failed
                         }
                         errorMessage = "Message was relayed, but local confirmation could not be saved. Verify whether it arrived before retrying."
                     }

--- a/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
@@ -428,12 +428,14 @@ public final class MessagingViewModel {
         )
         guard let proof = pendingDeliveryProofs[hashHex] else { return }
         do {
-            try await repository.updateMessageState(
+            let rowUpdated = try await repository.updateMessageState(
                 id: hash,
                 state: proof.state,
                 method: proof.method
             )
-            pendingDeliveryProofs.removeValue(forKey: hashHex)
+            if rowUpdated, pendingDeliveryProofs[hashHex] == proof {
+                pendingDeliveryProofs.removeValue(forKey: hashHex)
+            }
         } catch {
             logger.error("[MSG_VM] failed to persist delivery proof: \(error.localizedDescription)")
         }
@@ -445,12 +447,12 @@ public final class MessagingViewModel {
             guard pendingOutboundAliases[hashHex] == nil,
                   let hash = Self.hexToData(hashHex) else { continue }
             do {
-                try await repository.updateMessageState(
+                let rowUpdated = try await repository.updateMessageState(
                     id: hash,
                     state: proof.state,
                     method: proof.method
                 )
-                if pendingDeliveryProofs[hashHex] == proof {
+                if rowUpdated, pendingDeliveryProofs[hashHex] == proof {
                     pendingDeliveryProofs.removeValue(forKey: hashHex)
                 }
             } catch {
@@ -466,12 +468,13 @@ public final class MessagingViewModel {
                   let storageHash = message.storageHash,
                   let proof = pendingDeliveryProofs[Self.hexString(canonicalHash)] else { continue }
             do {
-                try await repository.updateMessageState(
+                let rowUpdated = try await repository.updateMessageState(
                     id: storageHash,
                     state: proof.state,
                     method: proof.method
                 )
-                if pendingDeliveryProofs[Self.hexString(canonicalHash)] == proof {
+                if rowUpdated,
+                   pendingDeliveryProofs[Self.hexString(canonicalHash)] == proof {
                     pendingDeliveryProofs.removeValue(forKey: Self.hexString(canonicalHash))
                 }
             } catch {

--- a/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
@@ -568,8 +568,9 @@ struct MessagingView: View {
             .presentationDragIndicator(.visible)
         }
         .sheet(item: $detailMessage) { message in
+            let currentMessage = viewModel?.messages.first(where: { $0.id == message.id }) ?? message
             MessageDetailView(
-                message: message,
+                message: currentMessage,
                 destinationHash: conversation.destinationHash,
                 pathTable: appServices.pathTable
             )

--- a/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
@@ -568,7 +568,7 @@ struct MessagingView: View {
             .presentationDragIndicator(.visible)
         }
         .sheet(item: $detailMessage) { message in
-            let currentMessage = viewModel?.messages.first(where: { $0.id == message.id }) ?? message
+            let currentMessage = viewModel?.currentMessage(for: message) ?? message
             MessageDetailView(
                 message: currentMessage,
                 destinationHash: conversation.destinationHash,

--- a/Sources/PythonBridge/PythonBridge.swift
+++ b/Sources/PythonBridge/PythonBridge.swift
@@ -71,10 +71,10 @@ public final class PythonBridge: @unchecked Sendable {
         case inbound(sourceHash: String, messageHash: String, content: String, title: String, fieldsHex: String, t: Date)
         case state(String, t: Date)
 
-        /// Delivery / failure proof for an outbound message, keyed by its LXMF
-        /// message hash hex. `state` is "delivered" or "failed". Drives the
-        /// chat UI's double-check / failed indicator.
-        case delivery(messageHash: String, state: String, t: Date)
+        /// Delivery lifecycle event for an outbound message, keyed by its LXMF
+        /// message hash hex. `method` is the effective transport used for this
+        /// attempt and is independent of `state`.
+        case delivery(messageHash: String, state: String, method: String, t: Date)
 
         // RNS.Link events — used by lxst-swift for voice calls. The
         // Swift LXST state machine consumes these to drive its own
@@ -869,7 +869,8 @@ public final class PythonBridge: @unchecked Sendable {
             case "delivery":
                 let h = pyStringFromDict(item, key: "message_hash") ?? ""
                 let state = pyStringFromDict(item, key: "state") ?? ""
-                out.append(.delivery(messageHash: h, state: state, t: t))
+                let method = pyStringFromDict(item, key: "method") ?? ""
+                out.append(.delivery(messageHash: h, state: state, method: method, t: t))
             case "link_state":
                 let linkId = pyIntFromDict(item, key: "link_id") ?? 0
                 let state = pyStringFromDict(item, key: "state") ?? ""

--- a/Sources/PythonBridge/PythonBridge.swift
+++ b/Sources/PythonBridge/PythonBridge.swift
@@ -518,8 +518,13 @@ public final class PythonBridge: @unchecked Sendable {
     /// desired-method (opportunistic / direct / propagated); the function name
     /// stays `sendOpportunistic` historically because that was the only mode
     /// when the Swift surface was first carved.
-    public func sendOpportunistic(destHashHex: String, content: String, fieldsHex: String = "",
-                                  method: String = "opportunistic") async throws -> SendOutcome {
+    public func sendOpportunistic(
+        destHashHex: String,
+        content: String,
+        fieldsHex: String = "",
+        method: String = "opportunistic",
+        failureFallbackMethod: String = ""
+    ) async throws -> SendOutcome {
         try await runOnQueue { [self] in
             try PythonRuntime.shared.withGIL { [self] in
                 guard let module = self.module else { return .notStarted }
@@ -527,18 +532,20 @@ public final class PythonBridge: @unchecked Sendable {
                     throw BridgeError.pythonException(currentPythonException())
                 }
                 defer { Py_DecRef(fn) }
-                guard let args = PyTuple_New(4) else { throw BridgeError.marshallingFailure("PyTuple_New") }
+                guard let args = PyTuple_New(5) else { throw BridgeError.marshallingFailure("PyTuple_New") }
                 defer { Py_DecRef(args) }
                 guard let soDest = PyUnicode_FromString(destHashHex),
                       let soContent = PyUnicode_FromString(content),
                       let soFields = PyUnicode_FromString(fieldsHex),
-                      let soMethod = PyUnicode_FromString(method) else {
+                      let soMethod = PyUnicode_FromString(method),
+                      let soFailureFallback = PyUnicode_FromString(failureFallbackMethod) else {
                     throw BridgeError.marshallingFailure("PyUnicode_FromString")
                 }
                 PyTuple_SetItem(args, 0, soDest)
                 PyTuple_SetItem(args, 1, soContent)
                 PyTuple_SetItem(args, 2, soFields)
                 PyTuple_SetItem(args, 3, soMethod)
+                PyTuple_SetItem(args, 4, soFailureFallback)
                 guard let result = PyObject_CallObject(fn, args) else {
                     throw BridgeError.pythonException(currentPythonException())
                 }

--- a/Sources/RNSAPI/Protocols/RnsBackend.swift
+++ b/Sources/RNSAPI/Protocols/RnsBackend.swift
@@ -65,9 +65,9 @@ public enum BackendEvent: Equatable, Sendable {
     /// attachments / reactions / replies / icon / cease through the seam.
     case inbound(sourceHash: String, messageHash: String, content: String, title: String, fieldsPacked: Data, t: Date)
     case state(String, t: Date)
-    /// Delivery / failure proof for an outbound message, keyed by its LXMF
-    /// message hash hex. `state` is "delivered" or "failed".
-    case delivery(messageHash: String, state: String, t: Date)
+    /// Delivery lifecycle event for an outbound message. `method` is the
+    /// effective transport used for this attempt and is independent of state.
+    case delivery(messageHash: String, state: String, method: LXDeliveryMethod?, t: Date)
     // RNS.Link events — consumed by lxst-swift for voice calls.
     case linkState(linkId: Int, state: String, reason: String, inbound: Bool, t: Date)
     case linkPacket(linkId: Int, data: Data, t: Date)

--- a/Sources/RNSAPI/Protocols/RnsLxmf.swift
+++ b/Sources/RNSAPI/Protocols/RnsLxmf.swift
@@ -44,6 +44,24 @@ public protocol RnsLxmf: AnyObject, Sendable {
         extraFields: [UInt8: Data]?
     ) async throws -> SendOutcome
 
+    /// Send with an optional backend-owned fallback for a later asynchronous
+    /// delivery failure. The shipping Python backend supports propagated
+    /// fallback while retaining the original message hash and complete fields.
+    @discardableResult
+    func sendLxmfMessage(
+        destHashHex: String,
+        content: String,
+        method: LXDeliveryMethod,
+        failureFallbackMethod: LXDeliveryMethod?,
+        imageData: Data?,
+        imageFormat: String?,
+        fileAttachments: [RnsFileAttachment]?,
+        iconAppearance: IconAppearance?,
+        replyToMessageHashHex: String?,
+        replyQuotedContent: String?,
+        extraFields: [UInt8: Data]?
+    ) async throws -> SendOutcome
+
     /// Send a tap-back reaction via canonical `FIELD_REACTION` (0x40) on an
     /// otherwise-empty message: `{0x00: targetHashBytes, 0x01: emojiUTF8}`.
     @discardableResult
@@ -63,6 +81,34 @@ public protocol RnsLxmf: AnyObject, Sendable {
 
 // Ergonomic overloads (protocol requirements can't carry default arguments).
 public extension RnsLxmf {
+    @discardableResult
+    func sendLxmfMessage(
+        destHashHex: String,
+        content: String,
+        method: LXDeliveryMethod,
+        failureFallbackMethod: LXDeliveryMethod?,
+        imageData: Data?,
+        imageFormat: String?,
+        fileAttachments: [RnsFileAttachment]?,
+        iconAppearance: IconAppearance?,
+        replyToMessageHashHex: String?,
+        replyQuotedContent: String?,
+        extraFields: [UInt8: Data]?
+    ) async throws -> SendOutcome {
+        try await sendLxmfMessage(
+            destHashHex: destHashHex,
+            content: content,
+            method: method,
+            imageData: imageData,
+            imageFormat: imageFormat,
+            fileAttachments: fileAttachments,
+            iconAppearance: iconAppearance,
+            replyToMessageHashHex: replyToMessageHashHex,
+            replyQuotedContent: replyQuotedContent,
+            extraFields: extraFields
+        )
+    }
+
     @discardableResult
     func sendLxmfMessage(destHashHex: String, content: String,
                          method: LXDeliveryMethod = .opportunistic) async throws -> SendOutcome {

--- a/Sources/RNSBackendPy/PythonRNSBackend.swift
+++ b/Sources/RNSBackendPy/PythonRNSBackend.swift
@@ -104,6 +104,35 @@ public final class PythonRNSBackend: RnsBackend, @unchecked Sendable {
         replyQuotedContent: String?,
         extraFields: [UInt8: Data]?
     ) async throws -> SendOutcome {
+        try await sendLxmfMessage(
+            destHashHex: destHashHex,
+            content: content,
+            method: method,
+            failureFallbackMethod: nil,
+            imageData: imageData,
+            imageFormat: imageFormat,
+            fileAttachments: fileAttachments,
+            iconAppearance: iconAppearance,
+            replyToMessageHashHex: replyToMessageHashHex,
+            replyQuotedContent: replyQuotedContent,
+            extraFields: extraFields
+        )
+    }
+
+    @discardableResult
+    public func sendLxmfMessage(
+        destHashHex: String,
+        content: String,
+        method: LXDeliveryMethod,
+        failureFallbackMethod: LXDeliveryMethod?,
+        imageData: Data?,
+        imageFormat: String?,
+        fileAttachments: [RnsFileAttachment]?,
+        iconAppearance: IconAppearance?,
+        replyToMessageHashHex: String?,
+        replyQuotedContent: String?,
+        extraFields: [UInt8: Data]?
+    ) async throws -> SendOutcome {
         // Browse/add/open remain passive. Only an actual non-propagated send
         // actively resolves the recipient path, with one request and a bounded
         // wait in Python. Propagated sends need the retained identity but do not
@@ -133,9 +162,18 @@ public final class PythonRNSBackend: RnsBackend, @unchecked Sendable {
         case .propagated: methodString = "propagated"
         default: methodString = "opportunistic"
         }
+        let failureFallbackString: String
+        switch failureFallbackMethod {
+        case .propagated?: failureFallbackString = "propagated"
+        default: failureFallbackString = ""
+        }
         return Self.map(try await bridge.sendOpportunistic(
-            destHashHex: destHashHex, content: content,
-            fieldsHex: fieldsHex, method: methodString))
+            destHashHex: destHashHex,
+            content: content,
+            fieldsHex: fieldsHex,
+            method: methodString,
+            failureFallbackMethod: failureFallbackString
+        ))
     }
 
     @discardableResult

--- a/Sources/RNSBackendPy/PythonRNSBackend.swift
+++ b/Sources/RNSBackendPy/PythonRNSBackend.swift
@@ -376,8 +376,15 @@ public final class PythonRNSBackend: RnsBackend, @unchecked Sendable {
             return .inbound(sourceHash: s, messageHash: mh, content: c, title: ti, fieldsPacked: (try? fh.hexToData()) ?? Data(), t: t)
         case let .state(s, t):
             return .state(s, t: t)
-        case let .delivery(m, s, t):
-            return .delivery(messageHash: m, state: s, t: t)
+        case let .delivery(m, s, method, t):
+            let effectiveMethod: LXDeliveryMethod?
+            switch method {
+            case "opportunistic": effectiveMethod = .opportunistic
+            case "direct": effectiveMethod = .direct
+            case "propagated": effectiveMethod = .propagated
+            default: effectiveMethod = nil
+            }
+            return .delivery(messageHash: m, state: s, method: effectiveMethod, t: t)
         case let .linkState(l, s, r, i, t):
             return .linkState(linkId: l, state: s, reason: r, inbound: i, t: t)
         case let .linkPacket(l, dat, t):

--- a/Sources/RNSBackendSwift/SwiftRNSBackend.swift
+++ b/Sources/RNSBackendSwift/SwiftRNSBackend.swift
@@ -754,17 +754,38 @@ public final class SwiftRNSBackend: RnsBackend, @unchecked Sendable {
         }
         func router(_ router: LXMFSwift.LXMRouter, didUpdateMessage message: LXMFSwift.LXMessage) {
             if message.state == .delivered {
-                continuation.yield(.delivery(messageHash: message.hash.hexHash, state: "delivered", t: Date()))
+                continuation.yield(.delivery(
+                    messageHash: message.hash.hexHash,
+                    state: "delivered",
+                    method: Self.mapDeliveryMethod(message.method),
+                    t: Date()
+                ))
             }
         }
         func router(_ router: LXMFSwift.LXMRouter, didFailMessage message: LXMFSwift.LXMessage, reason: LXMFSwift.LXMFError) {
-            continuation.yield(.delivery(messageHash: message.hash.hexHash, state: "failed", t: Date()))
+            continuation.yield(.delivery(
+                messageHash: message.hash.hexHash,
+                state: "failed",
+                method: Self.mapDeliveryMethod(message.method),
+                t: Date()
+            ))
         }
         func router(_ router: LXMFSwift.LXMRouter, didConfirmDelivery messageHash: Data) {
-            continuation.yield(.delivery(messageHash: messageHash.hexHash, state: "delivered", t: Date()))
+            continuation.yield(.delivery(messageHash: messageHash.hexHash, state: "delivered", method: nil, t: Date()))
         }
         func router(_ router: LXMFSwift.LXMRouter, didUpdateSyncState state: LXMFSwift.PropagationTransferState) {}
         func router(_ router: LXMFSwift.LXMRouter, didCompleteSyncWithNewMessages newMessages: Int) {}
+
+        private static func mapDeliveryMethod(
+            _ method: LXMFSwift.LXDeliveryMethod
+        ) -> RNSAPI.LXDeliveryMethod? {
+            switch method {
+            case .opportunistic: return .opportunistic
+            case .direct: return .direct
+            case .propagated: return .propagated
+            default: return nil
+            }
+        }
     }
 }
 

--- a/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
+++ b/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
@@ -347,11 +347,10 @@ final class MessageDetailAliasTests: XCTestCase {
         XCTAssertEqual(resolved.id, canonicalID)
         XCTAssertEqual(resolved.deliveryStatus, .delivered)
         XCTAssertEqual(resolved.deliveryMethod, "propagated")
-        let stored = try XCTUnwrap(
-            try await repository.getMessageRecord(id: canonicalHash)
-        )
+        let storedRecord = try await repository.getMessageRecord(id: canonicalHash)
+        let stored = try XCTUnwrap(storedRecord)
         XCTAssertEqual(stored.state, LXMessageState.delivered.rawValue)
-        XCTAssertEqual(stored.method, LXMFSwift.LXDeliveryMethod.propagated.rawValue)
+        XCTAssertEqual(stored.method, RNSAPI.LXDeliveryMethod.propagated.rawValue)
     }
 }
 
@@ -665,7 +664,7 @@ final class MessageRepositoryAtomicReplacementTests: XCTestCase {
         let storedDelivered = try await repository.getMessageRecord(id: canonicalHash)
         let delivered = try XCTUnwrap(storedDelivered)
         XCTAssertEqual(delivered.state, LXMessageState.delivered.rawValue)
-        XCTAssertEqual(delivered.method, LXMFSwift.LXDeliveryMethod.propagated.rawValue)
+        XCTAssertEqual(delivered.method, RNSAPI.LXDeliveryMethod.propagated.rawValue)
         XCTAssertEqual(Message(from: delivered, localHash: Data()).deliveryMethod, "propagated")
         XCTAssertNil(delivered.receivingInterface)
 
@@ -675,11 +674,10 @@ final class MessageRepositoryAtomicReplacementTests: XCTestCase {
             method: .opportunistic
         )
         XCTAssertTrue(staleSentApplied)
-        let afterStaleSent = try XCTUnwrap(
-            try await repository.getMessageRecord(id: canonicalHash)
-        )
+        let staleSentRecord = try await repository.getMessageRecord(id: canonicalHash)
+        let afterStaleSent = try XCTUnwrap(staleSentRecord)
         XCTAssertEqual(afterStaleSent.state, LXMessageState.delivered.rawValue)
-        XCTAssertEqual(afterStaleSent.method, LXMFSwift.LXDeliveryMethod.propagated.rawValue)
+        XCTAssertEqual(afterStaleSent.method, RNSAPI.LXDeliveryMethod.propagated.rawValue)
 
         let stillHasUncertainRetry = try await repository.hasUncertainRetry(for: destination)
         XCTAssertFalse(stillHasUncertainRetry)

--- a/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
+++ b/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
@@ -579,7 +579,8 @@ final class MessageRepositoryAtomicReplacementTests: XCTestCase {
 
         let applied = try await repository.applyDeliveryProof(
             canonicalHash: canonicalHash,
-            state: .delivered
+            state: .delivered,
+            method: .propagated
         )
 
         XCTAssertTrue(applied)
@@ -588,6 +589,8 @@ final class MessageRepositoryAtomicReplacementTests: XCTestCase {
         let storedDelivered = try await repository.getMessageRecord(id: canonicalHash)
         let delivered = try XCTUnwrap(storedDelivered)
         XCTAssertEqual(delivered.state, LXMessageState.delivered.rawValue)
+        XCTAssertEqual(delivered.method, LXMFSwift.LXDeliveryMethod.propagated.rawValue)
+        XCTAssertEqual(Message(from: delivered, localHash: Data()).deliveryMethod, "propagated")
         XCTAssertNil(delivered.receivingInterface)
         let stillHasUncertainRetry = try await repository.hasUncertainRetry(for: destination)
         XCTAssertFalse(stillHasUncertainRetry)

--- a/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
+++ b/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
@@ -280,41 +280,78 @@ final class AnnounceClassificationTests: XCTestCase {
 }
 
 final class MessageDetailAliasTests: XCTestCase {
+    private func temporaryDatabaseURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("columba-detail-alias-\(UUID().uuidString).sqlite")
+    }
+
+    private func removeDatabase(at url: URL) {
+        try? FileManager.default.removeItem(at: url)
+        try? FileManager.default.removeItem(atPath: url.path + "-shm")
+        try? FileManager.default.removeItem(atPath: url.path + "-wal")
+    }
+
     @MainActor
-    func testOpenDetailFollowsOptimisticMessageToCanonicalID() {
+    func testOpenDetailFollowsNormalPersistenceAndBufferedPropagatedProof() async throws {
+        let databaseURL = temporaryDatabaseURL()
+        defer { removeDatabase(at: databaseURL) }
+        let repository = try MessageRepository(grdbPath: databaseURL.path)
+        let destination = Data(repeating: 0x41, count: 16)
+        let canonicalHash = Data(repeating: 0x42, count: 32)
+        let canonicalID = canonicalHash.map { String(format: "%02x", $0) }.joined()
         let selected = Message(
             id: "optimistic",
             content: "hello",
             isFromMe: true,
             deliveryStatus: .sending
         )
-        var canonical = Message(
-            id: "canonical",
-            content: "hello",
-            isFromMe: true,
-            deliveryStatus: .delivered
+        let viewModel = MessagingViewModel(
+            conversationHash: destination,
+            repository: repository,
+            appServices: AppServices()
         )
-        canonical.deliveryMethod = "propagated"
-        var pendingAliases = ["canonical": "optimistic"]
-        var canonicalizedAliases: [String: String] = [:]
-        MessagingViewModel.recordCanonicalAlias(
-            canonicalID: "canonical",
-            pendingAliases: &pendingAliases,
-            canonicalizedAliases: &canonicalizedAliases
+        viewModel.messages = [selected]
+        viewModel.registerPendingOutboundAlias(
+            canonicalHash: canonicalHash,
+            optimisticID: selected.id
         )
 
-        let resolved = MessagingViewModel.resolveCurrentMessage(
-            selected,
-            messages: [canonical],
-            pendingAliases: pendingAliases,
-            canonicalizedAliases: canonicalizedAliases
+        NotificationCenter.default.post(
+            name: Notification.Name("ColumbaPythonDelivery"),
+            object: nil,
+            userInfo: [
+                "messageHash": canonicalHash,
+                "state": "delivered",
+                "persisted": false,
+                "deliveryMethod": "propagated",
+            ]
         )
+        for _ in 0..<10 { await Task.yield() }
 
-        XCTAssertNil(pendingAliases["canonical"])
-        XCTAssertEqual(canonicalizedAliases["optimistic"], "canonical")
-        XCTAssertEqual(resolved.id, "canonical")
+        try await repository.ensureConversation(destination, displayName: nil)
+        let canonical = RNSAPI.LXMessage(
+            destinationHash: destination,
+            sourceIdentity: nil,
+            content: Data("hello".utf8),
+            desiredMethod: .opportunistic
+        )
+        canonical.hash = canonicalHash
+        canonical.state = .sent
+        canonical.method = .opportunistic
+        try await repository.saveMessage(canonical)
+
+        await viewModel.reconcilePendingDeliveryProof(for: canonicalHash)
+        await viewModel.loadMessages()
+
+        let resolved = viewModel.currentMessage(for: selected)
+        XCTAssertEqual(resolved.id, canonicalID)
         XCTAssertEqual(resolved.deliveryStatus, .delivered)
         XCTAssertEqual(resolved.deliveryMethod, "propagated")
+        let stored = try XCTUnwrap(
+            try await repository.getMessageRecord(id: canonicalHash)
+        )
+        XCTAssertEqual(stored.state, LXMessageState.delivered.rawValue)
+        XCTAssertEqual(stored.method, LXMFSwift.LXDeliveryMethod.propagated.rawValue)
     }
 }
 

--- a/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
+++ b/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
@@ -279,6 +279,36 @@ final class AnnounceClassificationTests: XCTestCase {
     }
 }
 
+final class MessageDetailAliasTests: XCTestCase {
+    @MainActor
+    func testOpenDetailFollowsOptimisticMessageToCanonicalID() {
+        let selected = Message(
+            id: "optimistic",
+            content: "hello",
+            isFromMe: true,
+            deliveryStatus: .sending
+        )
+        var canonical = Message(
+            id: "canonical",
+            content: "hello",
+            isFromMe: true,
+            deliveryStatus: .delivered
+        )
+        canonical.deliveryMethod = "propagated"
+
+        let resolved = MessagingViewModel.resolveCurrentMessage(
+            selected,
+            messages: [canonical],
+            pendingAliases: [:],
+            canonicalizedAliases: ["optimistic": "canonical"]
+        )
+
+        XCTAssertEqual(resolved.id, "canonical")
+        XCTAssertEqual(resolved.deliveryStatus, .delivered)
+        XCTAssertEqual(resolved.deliveryMethod, "propagated")
+    }
+}
+
 final class MessageRepositoryAtomicReplacementTests: XCTestCase {
     private func temporaryDatabaseURL() -> URL {
         FileManager.default.temporaryDirectory

--- a/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
+++ b/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
@@ -292,58 +292,54 @@ final class MessageDetailAliasTests: XCTestCase {
     }
 
     @MainActor
-    func testOpenDetailFollowsNormalPersistenceAndBufferedPropagatedProof() async throws {
+    func testPublicSendBuffersProofBeforeAliasAndRefreshesOpenDetail() async throws {
         let databaseURL = temporaryDatabaseURL()
         defer { removeDatabase(at: databaseURL) }
         let repository = try MessageRepository(grdbPath: databaseURL.path)
         let destination = Data(repeating: 0x41, count: 16)
         let canonicalHash = Data(repeating: 0x42, count: 32)
         let canonicalID = canonicalHash.map { String(format: "%02x", $0) }.joined()
-        let selected = Message(
-            id: "optimistic",
-            content: "hello",
-            isFromMe: true,
-            deliveryStatus: .sending
-        )
-        let viewModel = MessagingViewModel(
+        var viewModel: MessagingViewModel!
+        var selected: Message?
+
+        viewModel = MessagingViewModel(
             conversationHash: destination,
             repository: repository,
-            appServices: AppServices()
-        )
-        viewModel.messages = [selected]
-        viewModel.registerPendingOutboundAlias(
-            canonicalHash: canonicalHash,
-            optimisticID: selected.id
+            appServices: AppServices(),
+            identity: Identity(),
+            outboundSendOperation: { _ in
+                selected = viewModel.messages.last
+                NotificationCenter.default.post(
+                    name: Notification.Name("ColumbaPythonDelivery"),
+                    object: nil,
+                    userInfo: [
+                        "messageHash": canonicalHash,
+                        "state": "delivered",
+                        "persisted": false,
+                        "deliveryMethod": "propagated",
+                    ]
+                )
+                for _ in 0..<1_000 {
+                    if viewModel.hasPendingDeliveryProof(for: canonicalHash) { break }
+                    await Task.yield()
+                }
+                guard viewModel.hasPendingDeliveryProof(for: canonicalHash) else {
+                    throw NSError(domain: "MessageDetailAliasTests", code: 1)
+                }
+                return .queued(messageHash: canonicalID)
+            }
         )
 
-        NotificationCenter.default.post(
-            name: Notification.Name("ColumbaPythonDelivery"),
-            object: nil,
-            userInfo: [
-                "messageHash": canonicalHash,
-                "state": "delivered",
-                "persisted": false,
-                "deliveryMethod": "propagated",
-            ]
+        let sent = await viewModel.sendMessage(
+            text: "hello",
+            imageData: nil,
+            imageFormat: nil,
+            attachments: nil
         )
-        for _ in 0..<10 { await Task.yield() }
 
-        try await repository.ensureConversation(destination, displayName: nil)
-        let canonical = RNSAPI.LXMessage(
-            destinationHash: destination,
-            sourceIdentity: nil,
-            content: Data("hello".utf8),
-            desiredMethod: .opportunistic
-        )
-        canonical.hash = canonicalHash
-        canonical.state = .sent
-        canonical.method = .opportunistic
-        try await repository.saveMessage(canonical)
-
-        await viewModel.reconcilePendingDeliveryProof(for: canonicalHash)
-        await viewModel.loadMessages()
-
-        let resolved = viewModel.currentMessage(for: selected)
+        XCTAssertTrue(sent)
+        let openSelection = try XCTUnwrap(selected)
+        let resolved = viewModel.currentMessage(for: openSelection)
         XCTAssertEqual(resolved.id, canonicalID)
         XCTAssertEqual(resolved.deliveryStatus, .delivered)
         XCTAssertEqual(resolved.deliveryMethod, "propagated")

--- a/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
+++ b/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
@@ -295,14 +295,23 @@ final class MessageDetailAliasTests: XCTestCase {
             deliveryStatus: .delivered
         )
         canonical.deliveryMethod = "propagated"
+        var pendingAliases = ["canonical": "optimistic"]
+        var canonicalizedAliases: [String: String] = [:]
+        MessagingViewModel.recordCanonicalAlias(
+            canonicalID: "canonical",
+            pendingAliases: &pendingAliases,
+            canonicalizedAliases: &canonicalizedAliases
+        )
 
         let resolved = MessagingViewModel.resolveCurrentMessage(
             selected,
             messages: [canonical],
-            pendingAliases: [:],
-            canonicalizedAliases: ["optimistic": "canonical"]
+            pendingAliases: pendingAliases,
+            canonicalizedAliases: canonicalizedAliases
         )
 
+        XCTAssertNil(pendingAliases["canonical"])
+        XCTAssertEqual(canonicalizedAliases["optimistic"], "canonical")
         XCTAssertEqual(resolved.id, "canonical")
         XCTAssertEqual(resolved.deliveryStatus, .delivered)
         XCTAssertEqual(resolved.deliveryMethod, "propagated")
@@ -622,6 +631,19 @@ final class MessageRepositoryAtomicReplacementTests: XCTestCase {
         XCTAssertEqual(delivered.method, LXMFSwift.LXDeliveryMethod.propagated.rawValue)
         XCTAssertEqual(Message(from: delivered, localHash: Data()).deliveryMethod, "propagated")
         XCTAssertNil(delivered.receivingInterface)
+
+        let staleSentApplied = try await repository.applyDeliveryProof(
+            canonicalHash: canonicalHash,
+            state: .sent,
+            method: .opportunistic
+        )
+        XCTAssertTrue(staleSentApplied)
+        let afterStaleSent = try XCTUnwrap(
+            try await repository.getMessageRecord(id: canonicalHash)
+        )
+        XCTAssertEqual(afterStaleSent.state, LXMessageState.delivered.rawValue)
+        XCTAssertEqual(afterStaleSent.method, LXMFSwift.LXDeliveryMethod.propagated.rawValue)
+
         let stillHasUncertainRetry = try await repository.hasUncertainRetry(for: destination)
         XCTAssertFalse(stillHasUncertainRetry)
     }

--- a/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
+++ b/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
@@ -326,6 +326,10 @@ final class MessageDetailAliasTests: XCTestCase {
                 guard viewModel.hasPendingDeliveryProof(for: canonicalHash) else {
                     throw NSError(domain: "MessageDetailAliasTests", code: 1)
                 }
+                await viewModel.loadMessages()
+                guard viewModel.hasPendingDeliveryProof(for: canonicalHash) else {
+                    throw NSError(domain: "MessageDetailAliasTests", code: 2)
+                }
                 return .queued(messageHash: canonicalID)
             }
         )

--- a/Tests/static/test_async_propagation_fallback.py
+++ b/Tests/static/test_async_propagation_fallback.py
@@ -141,6 +141,8 @@ class AsyncPropagationFallbackTests(unittest.TestCase):
             for node in tree.body
             if isinstance(node, ast.FunctionDef) and node.name == "send_opportunistic"
         )
+        bridge_lock = threading.Lock()
+        runtime_state = {"started": True, "router": router, "destination": object()}
         namespace = {
             "Any": Any,
             "LXMF": types.SimpleNamespace(LXMessage=FakeMessage),
@@ -149,15 +151,18 @@ class AsyncPropagationFallbackTests(unittest.TestCase):
                 Destination=FakeDestination,
                 Transport=types.SimpleNamespace(request_path=lambda _hash: None),
             ),
-            "_lock": threading.Lock(),
+            "_lock": bridge_lock,
             "threading": threading,
-            "_state": {"started": True, "router": router, "destination": object()},
+            "_runtime_teardown_requested": threading.Event(),
+            "_state": runtime_state,
             "_put": lambda kind, **payload: events.append((kind, payload)),
         }
         exec(
             compile(ast.Module(body=[function], type_ignores=[]), str(BRIDGE), "exec"),
             namespace,
         )
+        self.loaded_bridge_lock = bridge_lock
+        self.loaded_runtime_state = runtime_state
         return namespace["send_opportunistic"]
 
     def queue(self, router, events, *, fallback="propagated", method="opportunistic"):
@@ -296,6 +301,28 @@ class AsyncPropagationFallbackTests(unittest.TestCase):
 
         self.assertTrue(router.wait_for_handled_count(2))
         self.assertEqual([], self.delivery_events(events))
+
+    def test_runtime_replacement_prevents_requeue_on_superseded_router(self):
+        router = LockedCallbackRouter()
+        events = []
+        message = self.queue(router, events)
+
+        self.loaded_bridge_lock.acquire()
+        router.outbound_processing_lock.acquire()
+        try:
+            message.failed_callback(message)
+            self.loaded_runtime_state["router"] = FakeRouter()
+        finally:
+            self.loaded_bridge_lock.release()
+            router.outbound_processing_lock.release()
+
+        self.assertFalse(router.wait_for_handled_count(2, timeout=0.4))
+        self.assertTrue(self.wait_for_delivery_events(events, 1))
+        self.assertEqual("failed", self.delivery_events(events)[0]["state"])
+        self.assertEqual(
+            "propagated-enqueue-failed",
+            self.delivery_events(events)[0]["reason"],
+        )
 
     def test_retry_policy_crosses_the_shipping_swift_python_seam(self):
         rns_lxmf = (ROOT / "Sources/RNSAPI/Protocols/RnsLxmf.swift").read_text()

--- a/Tests/static/test_async_propagation_fallback.py
+++ b/Tests/static/test_async_propagation_fallback.py
@@ -528,6 +528,9 @@ class AsyncPropagationFallbackTests(unittest.TestCase):
         self.assertNotIn("if wasAliased && !proofPersisted", messaging_view_model)
         self.assertNotIn("(proof == .delivered) ? .delivered : .failed", messaging_view_model)
         self.assertIn("monotonicDeliveryState", message_repository)
+        self.assertIn(") async throws -> Bool", message_repository)
+        self.assertIn("let rowUpdated = try await repository.updateMessageState", messaging_view_model)
+        self.assertIn("if rowUpdated, pendingDeliveryProofs[hashHex] == proof", messaging_view_model)
         self.assertIn("Tests.static.test_async_propagation_fallback", ci_workflow)
 
     def test_retry_policy_crosses_the_shipping_swift_python_seam(self):

--- a/Tests/static/test_async_propagation_fallback.py
+++ b/Tests/static/test_async_propagation_fallback.py
@@ -1,0 +1,248 @@
+import ast
+import inspect
+import threading
+import types
+import unittest
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[2]
+BRIDGE = ROOT / "app" / "rns_bridge.py"
+
+
+class FakeHash:
+    def __init__(self, value: str = "ab" * 32):
+        self.value = value
+
+    def hex(self) -> str:
+        return self.value
+
+
+class FakeMessage:
+    GENERATING = 0
+    OUTBOUND = 1
+    SENDING = 2
+    SENT = 4
+    DELIVERED = 8
+    FAILED = 16
+    OPPORTUNISTIC = 0x01
+    DIRECT = 0x02
+    PROPAGATED = 0x03
+
+    def __init__(
+        self,
+        destination,
+        source,
+        content,
+        title="",
+        fields=None,
+        desired_method=None,
+    ):
+        self.destination = destination
+        self.source = source
+        self.content = content
+        self.title = title
+        self.fields = fields
+        self.desired_method = desired_method
+        self.method = desired_method
+        self.hash = FakeHash()
+        self.timestamp = 1_234.5
+        self.state = self.GENERATING
+        self.delivery_attempts = 4
+        self.progress = 0.75
+        self.delivery_callback = None
+        self.failed_callback = None
+
+    def register_delivery_callback(self, callback):
+        self.delivery_callback = callback
+
+    def register_failed_callback(self, callback):
+        self.failed_callback = callback
+
+
+class FakeRouter:
+    def __init__(self, *, propagation_node=True, reject_propagated=False):
+        self.outbound_propagation_node = object() if propagation_node else None
+        self.reject_propagated = reject_propagated
+        self.handled = []
+
+    def handle_outbound(self, message):
+        self.handled.append(message)
+        if message.method == FakeMessage.PROPAGATED and self.reject_propagated:
+            raise OSError("propagation enqueue rejected")
+
+
+class FakeIdentity:
+    @staticmethod
+    def recall(_hash):
+        return object()
+
+
+class FakeDestination:
+    OUT = 1
+    SINGLE = 2
+
+    def __init__(self, *args):
+        self.args = args
+
+
+class AsyncPropagationFallbackTests(unittest.TestCase):
+    def load_send(self, router, events):
+        tree = ast.parse(BRIDGE.read_text())
+        function = next(
+            node
+            for node in tree.body
+            if isinstance(node, ast.FunctionDef) and node.name == "send_opportunistic"
+        )
+        namespace = {
+            "Any": Any,
+            "LXMF": types.SimpleNamespace(LXMessage=FakeMessage),
+            "RNS": types.SimpleNamespace(
+                Identity=FakeIdentity,
+                Destination=FakeDestination,
+                Transport=types.SimpleNamespace(request_path=lambda _hash: None),
+            ),
+            "_lock": threading.Lock(),
+            "_state": {"started": True, "router": router, "destination": object()},
+            "_put": lambda kind, **payload: events.append((kind, payload)),
+        }
+        exec(
+            compile(ast.Module(body=[function], type_ignores=[]), str(BRIDGE), "exec"),
+            namespace,
+        )
+        return namespace["send_opportunistic"]
+
+    def queue(self, router, events, *, fallback="propagated", method="opportunistic"):
+        send = self.load_send(router, events)
+        kwargs = {
+            "dest_hash_hex": "01" * 16,
+            "content": "hello",
+            "fields_hex": "",
+            "method": method,
+        }
+        if "failure_fallback_method" in inspect.signature(send).parameters:
+            kwargs["failure_fallback_method"] = fallback
+        result = send(**kwargs)
+        self.assertTrue(result["ok"], result)
+        self.assertEqual(1, len(router.handled))
+        return router.handled[0]
+
+    def delivery_events(self, events):
+        return [payload for kind, payload in events if kind == "delivery"]
+
+    def test_async_failure_requeues_same_message_once_as_propagated(self):
+        router = FakeRouter()
+        events = []
+        primary = self.queue(router, events)
+        original = (
+            primary.hash.hex(),
+            primary.timestamp,
+            primary.content,
+            primary.title,
+            primary.fields,
+        )
+
+        primary.failed_callback(primary)
+
+        self.assertEqual(2, len(router.handled))
+        retry = router.handled[1]
+        self.assertIs(primary, retry)
+        self.assertEqual(
+            original,
+            (retry.hash.hex(), retry.timestamp, retry.content, retry.title, retry.fields),
+        )
+        self.assertEqual(FakeMessage.PROPAGATED, retry.desired_method)
+        self.assertEqual(FakeMessage.PROPAGATED, retry.method)
+        self.assertEqual(FakeMessage.OUTBOUND, retry.state)
+        self.assertEqual(0, retry.delivery_attempts)
+        self.assertEqual(0.0, retry.progress)
+        self.assertEqual([], self.delivery_events(events))
+
+        primary.failed_callback(primary)
+        self.assertEqual(2, len(router.handled), "duplicate failure requeued twice")
+        self.assertEqual(1, len(self.delivery_events(events)))
+        self.assertEqual("failed", self.delivery_events(events)[0]["state"])
+        self.assertEqual("propagated-failed", self.delivery_events(events)[0]["reason"])
+
+    def test_propagation_acceptance_is_sent_not_delivered(self):
+        router = FakeRouter()
+        events = []
+        message = self.queue(router, events, method="propagated", fallback="")
+        message.state = FakeMessage.SENT
+
+        message.delivery_callback(message)
+
+        self.assertEqual("sent", self.delivery_events(events)[0]["state"])
+
+    def test_recipient_proof_remains_delivered(self):
+        router = FakeRouter()
+        events = []
+        message = self.queue(router, events, fallback="")
+        message.state = FakeMessage.DELIVERED
+
+        message.delivery_callback(message)
+
+        self.assertEqual("delivered", self.delivery_events(events)[0]["state"])
+
+    def test_disabled_fallback_emits_final_failure_without_requeue(self):
+        router = FakeRouter()
+        events = []
+        message = self.queue(router, events, fallback="")
+
+        message.failed_callback(message)
+
+        self.assertEqual(1, len(router.handled))
+        self.assertEqual("failed", self.delivery_events(events)[0]["state"])
+        self.assertEqual("primary-failed", self.delivery_events(events)[0]["reason"])
+
+    def test_missing_propagation_node_emits_specific_terminal_failure(self):
+        router = FakeRouter(propagation_node=False)
+        events = []
+        message = self.queue(router, events)
+
+        message.failed_callback(message)
+
+        self.assertEqual(1, len(router.handled))
+        self.assertEqual("no-propagation-node", self.delivery_events(events)[0]["reason"])
+
+    def test_propagated_enqueue_failure_is_terminal_and_does_not_loop(self):
+        router = FakeRouter(reject_propagated=True)
+        events = []
+        message = self.queue(router, events)
+
+        message.failed_callback(message)
+
+        self.assertEqual(2, len(router.handled))
+        self.assertEqual(1, len(self.delivery_events(events)))
+        self.assertEqual("propagated-enqueue-failed", self.delivery_events(events)[0]["reason"])
+        message.failed_callback(message)
+        self.assertEqual(2, len(router.handled))
+        self.assertEqual(1, len(self.delivery_events(events)))
+
+    def test_retry_policy_crosses_the_shipping_swift_python_seam(self):
+        rns_lxmf = (ROOT / "Sources/RNSAPI/Protocols/RnsLxmf.swift").read_text()
+        backend = (ROOT / "Sources/RNSBackendPy/PythonRNSBackend.swift").read_text()
+        bridge = (ROOT / "Sources/PythonBridge/PythonBridge.swift").read_text()
+        messaging = (ROOT / "Sources/ColumbaApp/ViewModels/MessagingViewModel.swift").read_text()
+
+        self.assertIn("failureFallbackMethod", rns_lxmf)
+        self.assertIn("failureFallbackMethod", backend)
+        self.assertIn("failureFallbackMethod", bridge)
+        self.assertIn("failureFallbackMethod: retryViaRelay ? .propagated : nil", messaging)
+
+    def test_sent_delivered_failed_states_are_mapped_explicitly(self):
+        app_services = (ROOT / "Sources/ColumbaApp/Services/AppServices.swift").read_text()
+        messaging = (ROOT / "Sources/ColumbaApp/ViewModels/MessagingViewModel.swift").read_text()
+
+        for state in ('case "sent"', 'case "delivered"', 'case "failed"'):
+            self.assertIn(state, app_services)
+            self.assertIn(state, messaging)
+        self.assertNotIn(
+            '(state == "delivered") ? .delivered : .failed',
+            messaging,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tests/static/test_async_propagation_fallback.py
+++ b/Tests/static/test_async_propagation_fallback.py
@@ -248,6 +248,21 @@ class AsyncPropagationFallbackTests(unittest.TestCase):
 
         self.assertEqual("delivered", self.delivery_events(events)[0]["state"])
 
+    def test_propagation_acceptance_does_not_suppress_recipient_proof(self):
+        router = FakeRouter()
+        events = []
+        message = self.queue(router, events, method="propagated", fallback="")
+
+        message.state = FakeMessage.SENT
+        message.delivery_callback(message)
+        message.state = FakeMessage.DELIVERED
+        message.delivery_callback(message)
+
+        self.assertEqual(
+            ["sent", "delivered"],
+            [event["state"] for event in self.delivery_events(events)],
+        )
+
     def test_disabled_fallback_emits_final_failure_without_requeue(self):
         router = FakeRouter()
         events = []
@@ -314,6 +329,25 @@ class AsyncPropagationFallbackTests(unittest.TestCase):
         self.assertTrue(router.wait_for_handled_count(2))
         self.assertEqual([], self.delivery_events(events))
 
+    def test_recipient_proof_cancels_deferred_fallback_before_requeue(self):
+        router = FakeRouter()
+        events = []
+        message = self.queue(router, events)
+
+        self.loaded_bridge_lock.acquire()
+        try:
+            message.failed_callback(message)
+            message.state = FakeMessage.DELIVERED
+            message.delivery_callback(message)
+        finally:
+            self.loaded_bridge_lock.release()
+
+        self.assertFalse(router.wait_for_handled_count(2, timeout=0.4))
+        self.assertEqual(
+            ["delivered"],
+            [event["state"] for event in self.delivery_events(events)],
+        )
+
     def test_runtime_replacement_prevents_requeue_on_superseded_router(self):
         router = LockedCallbackRouter()
         events = []
@@ -357,11 +391,15 @@ class AsyncPropagationFallbackTests(unittest.TestCase):
         python_backend = (ROOT / "Sources/RNSBackendPy/PythonRNSBackend.swift").read_text()
         app_services = (ROOT / "Sources/ColumbaApp/Services/AppServices.swift").read_text()
         messaging_view = (ROOT / "Sources/ColumbaApp/Views/Messaging/MessagingView.swift").read_text()
+        messaging_view_model = (
+            ROOT / "Sources/ColumbaApp/ViewModels/MessagingViewModel.swift"
+        ).read_text()
         for source in (python_bridge, rns_backend, python_backend):
             self.assertIn("method:", source)
         self.assertIn("method: acceptedMethod", app_services)
         self.assertIn('"deliveryMethod": acceptedMethod?.rawValue ?? ""', app_services)
-        self.assertIn("viewModel?.messages.first(where:", messaging_view)
+        self.assertIn("viewModel?.currentMessage(for:", messaging_view)
+        self.assertIn("canonicalizedOutboundAliases", messaging_view_model)
 
     def test_retry_policy_crosses_the_shipping_swift_python_seam(self):
         rns_lxmf = (ROOT / "Sources/RNSAPI/Protocols/RnsLxmf.swift").read_text()

--- a/Tests/static/test_async_propagation_fallback.py
+++ b/Tests/static/test_async_propagation_fallback.py
@@ -1,4 +1,5 @@
 import ast
+import copy
 import inspect
 import threading
 import time
@@ -58,6 +59,8 @@ class FakeMessage:
         self.representation = None
         self.delivery_callback = None
         self.failed_callback = None
+        self.pack_entered = None
+        self.pack_release = None
 
     def pack(self):
         self.packed = b"packed-payload"
@@ -68,6 +71,10 @@ class FakeMessage:
             if self.desired_method == self.PROPAGATED
             else None
         )
+        if self.pack_entered is not None:
+            self.pack_entered.set()
+            if self.pack_release is not None:
+                self.pack_release.wait(timeout=1.0)
 
     def register_delivery_callback(self, callback):
         self.delivery_callback = callback
@@ -119,6 +126,33 @@ class LockedCallbackRouter(FakeRouter):
             self.outbound_processing_lock.release()
 
 
+class AdmissionBlockingRouter(FakeRouter):
+    def __init__(self):
+        super().__init__()
+        self.second_handle_entered = threading.Event()
+        self.second_handle_release = threading.Event()
+
+    def handle_outbound(self, message):
+        if self.handled:
+            self.second_handle_entered.set()
+            self.second_handle_release.wait(timeout=1.0)
+        return super().handle_outbound(message)
+
+
+class BlockingLifecycleEvents(list):
+    def __init__(self):
+        super().__init__()
+        self.sent_put_entered = threading.Event()
+        self.sent_put_release = threading.Event()
+
+    def append(self, item):
+        kind, payload = item
+        if kind == "delivery" and payload.get("state") == "sent":
+            self.sent_put_entered.set()
+            self.sent_put_release.wait(timeout=1.0)
+        super().append(item)
+
+
 class FakeIdentity:
     @staticmethod
     def recall(_hash):
@@ -152,6 +186,7 @@ class AsyncPropagationFallbackTests(unittest.TestCase):
                 Transport=types.SimpleNamespace(request_path=lambda _hash: None),
             ),
             "_lock": bridge_lock,
+            "copy": copy,
             "threading": threading,
             "_runtime_teardown_requested": threading.Event(),
             "_state": runtime_state,
@@ -263,6 +298,28 @@ class AsyncPropagationFallbackTests(unittest.TestCase):
             [event["state"] for event in self.delivery_events(events)],
         )
 
+    def test_concurrent_lifecycle_events_cannot_queue_delivered_before_sent(self):
+        router = FakeRouter()
+        events = BlockingLifecycleEvents()
+        message = self.queue(router, events, method="propagated", fallback="")
+
+        message.state = FakeMessage.SENT
+        sent_thread = threading.Thread(target=message.delivery_callback, args=(message,))
+        sent_thread.start()
+        self.assertTrue(events.sent_put_entered.wait(timeout=1.0))
+
+        message.state = FakeMessage.DELIVERED
+        delivered_thread = threading.Thread(target=message.delivery_callback, args=(message,))
+        delivered_thread.start()
+        events.sent_put_release.set()
+        sent_thread.join(timeout=1.0)
+        delivered_thread.join(timeout=1.0)
+
+        self.assertEqual(
+            ["sent", "delivered"],
+            [event["state"] for event in self.delivery_events(events)],
+        )
+
     def test_disabled_fallback_emits_final_failure_without_requeue(self):
         router = FakeRouter()
         events = []
@@ -348,6 +405,52 @@ class AsyncPropagationFallbackTests(unittest.TestCase):
             [event["state"] for event in self.delivery_events(events)],
         )
 
+    def test_proof_during_repack_does_not_mutate_primary_or_requeue(self):
+        router = FakeRouter()
+        events = []
+        message = self.queue(router, events)
+        message.pack_entered = threading.Event()
+        message.pack_release = threading.Event()
+
+        message.failed_callback(message)
+        self.assertTrue(message.pack_entered.wait(timeout=1.0))
+        message.state = FakeMessage.DELIVERED
+        message.delivery_callback(message)
+        message.pack_release.set()
+
+        self.assertFalse(router.wait_for_handled_count(2, timeout=0.4))
+        delivery = self.delivery_events(events)
+        self.assertEqual(["delivered"], [event["state"] for event in delivery])
+        self.assertEqual("opportunistic", delivery[0]["method"])
+        self.assertEqual(FakeMessage.OPPORTUNISTIC, message.desired_method)
+        self.assertEqual(FakeMessage.OPPORTUNISTIC, message.method)
+        self.assertIsNone(message.propagation_packed)
+
+    def test_final_enqueue_admission_is_atomic_against_recipient_proof(self):
+        router = AdmissionBlockingRouter()
+        events = []
+        message = self.queue(router, events)
+
+        message.failed_callback(message)
+        self.assertTrue(router.second_handle_entered.wait(timeout=1.0))
+
+        message.state = FakeMessage.DELIVERED
+        proof_done = threading.Event()
+        proof_thread = threading.Thread(
+            target=lambda: (message.delivery_callback(message), proof_done.set())
+        )
+        proof_thread.start()
+        self.assertFalse(proof_done.wait(timeout=0.1))
+
+        router.second_handle_release.set()
+        proof_thread.join(timeout=1.0)
+        self.assertTrue(proof_done.is_set())
+        self.assertTrue(router.wait_for_handled_count(2))
+        self.assertEqual(
+            ["delivered"],
+            [event["state"] for event in self.delivery_events(events)],
+        )
+
     def test_runtime_replacement_prevents_requeue_on_superseded_router(self):
         router = LockedCallbackRouter()
         events = []
@@ -394,12 +497,17 @@ class AsyncPropagationFallbackTests(unittest.TestCase):
         messaging_view_model = (
             ROOT / "Sources/ColumbaApp/ViewModels/MessagingViewModel.swift"
         ).read_text()
+        message_repository = (
+            ROOT / "Sources/ColumbaApp/Services/MessageRepository.swift"
+        ).read_text()
         for source in (python_bridge, rns_backend, python_backend):
             self.assertIn("method:", source)
         self.assertIn("method: acceptedMethod", app_services)
         self.assertIn('"deliveryMethod": acceptedMethod?.rawValue ?? ""', app_services)
         self.assertIn("viewModel?.currentMessage(for:", messaging_view)
-        self.assertIn("canonicalizedOutboundAliases", messaging_view_model)
+        self.assertIn("recordCanonicalAlias", messaging_view_model)
+        self.assertNotIn("(proof == .delivered) ? .delivered : .failed", messaging_view_model)
+        self.assertIn("monotonicDeliveryState", message_repository)
 
     def test_retry_policy_crosses_the_shipping_swift_python_seam(self):
         rns_lxmf = (ROOT / "Sources/RNSAPI/Protocols/RnsLxmf.swift").read_text()

--- a/Tests/static/test_async_propagation_fallback.py
+++ b/Tests/static/test_async_propagation_fallback.py
@@ -29,6 +29,7 @@ class FakeMessage:
     OPPORTUNISTIC = 0x01
     DIRECT = 0x02
     PROPAGATED = 0x03
+    PACKET = 0x04
 
     def __init__(
         self,
@@ -51,8 +52,21 @@ class FakeMessage:
         self.state = self.GENERATING
         self.delivery_attempts = 4
         self.progress = 0.75
+        self.packed = None
+        self.propagation_packed = None
+        self.representation = None
         self.delivery_callback = None
         self.failed_callback = None
+
+    def pack(self):
+        self.packed = b"packed-payload"
+        self.method = self.desired_method
+        self.representation = self.PACKET
+        self.propagation_packed = (
+            b"propagation-payload"
+            if self.desired_method == self.PROPAGATED
+            else None
+        )
 
     def register_delivery_callback(self, callback):
         self.delivery_callback = callback
@@ -68,6 +82,8 @@ class FakeRouter:
         self.handled = []
 
     def handle_outbound(self, message):
+        if message.packed is None:
+            message.pack()
         self.handled.append(message)
         if message.method == FakeMessage.PROPAGATED and self.reject_propagated:
             raise OSError("propagation enqueue rejected")
@@ -155,6 +171,8 @@ class AsyncPropagationFallbackTests(unittest.TestCase):
         )
         self.assertEqual(FakeMessage.PROPAGATED, retry.desired_method)
         self.assertEqual(FakeMessage.PROPAGATED, retry.method)
+        self.assertEqual(b"propagation-payload", retry.propagation_packed)
+        self.assertEqual(FakeMessage.PACKET, retry.representation)
         self.assertEqual(FakeMessage.OUTBOUND, retry.state)
         self.assertEqual(0, retry.delivery_attempts)
         self.assertEqual(0.0, retry.progress)

--- a/Tests/static/test_async_propagation_fallback.py
+++ b/Tests/static/test_async_propagation_fallback.py
@@ -324,6 +324,30 @@ class AsyncPropagationFallbackTests(unittest.TestCase):
             self.delivery_events(events)[0]["reason"],
         )
 
+    def test_delivered_fallback_carries_effective_propagated_method_across_swift_seam(self):
+        router = FakeRouter()
+        events = []
+        primary = self.queue(router, events)
+
+        primary.failed_callback(primary)
+        self.assertTrue(router.wait_for_handled_count(2))
+        retry = router.handled[1]
+        retry.state = FakeMessage.DELIVERED
+        retry.delivery_callback(retry)
+
+        delivered = self.delivery_events(events)
+        self.assertEqual(1, len(delivered))
+        self.assertEqual("delivered", delivered[0]["state"])
+        self.assertEqual("propagated", delivered[0]["method"])
+
+        python_bridge = (ROOT / "Sources/PythonBridge/PythonBridge.swift").read_text()
+        rns_backend = (ROOT / "Sources/RNSAPI/Protocols/RnsBackend.swift").read_text()
+        python_backend = (ROOT / "Sources/RNSBackendPy/PythonRNSBackend.swift").read_text()
+        app_services = (ROOT / "Sources/ColumbaApp/Services/AppServices.swift").read_text()
+        for source in (python_bridge, rns_backend, python_backend):
+            self.assertIn("method:", source)
+        self.assertIn("method: acceptedMethod", app_services)
+
     def test_retry_policy_crosses_the_shipping_swift_python_seam(self):
         rns_lxmf = (ROOT / "Sources/RNSAPI/Protocols/RnsLxmf.swift").read_text()
         backend = (ROOT / "Sources/RNSBackendPy/PythonRNSBackend.swift").read_text()

--- a/Tests/static/test_async_propagation_fallback.py
+++ b/Tests/static/test_async_propagation_fallback.py
@@ -104,6 +104,7 @@ class AsyncPropagationFallbackTests(unittest.TestCase):
                 Transport=types.SimpleNamespace(request_path=lambda _hash: None),
             ),
             "_lock": threading.Lock(),
+            "threading": threading,
             "_state": {"started": True, "router": router, "destination": object()},
             "_put": lambda kind, **payload: events.append((kind, payload)),
         }

--- a/Tests/static/test_async_propagation_fallback.py
+++ b/Tests/static/test_async_propagation_fallback.py
@@ -298,6 +298,20 @@ class AsyncPropagationFallbackTests(unittest.TestCase):
             [event["state"] for event in self.delivery_events(events)],
         )
 
+    def test_recipient_proof_upgrades_prior_failure(self):
+        router = FakeRouter()
+        events = []
+        message = self.queue(router, events, fallback="")
+
+        message.failed_callback(message)
+        message.state = FakeMessage.DELIVERED
+        message.delivery_callback(message)
+
+        self.assertEqual(
+            ["failed", "delivered"],
+            [event["state"] for event in self.delivery_events(events)],
+        )
+
     def test_concurrent_lifecycle_events_cannot_queue_delivered_before_sent(self):
         router = FakeRouter()
         events = BlockingLifecycleEvents()
@@ -506,6 +520,8 @@ class AsyncPropagationFallbackTests(unittest.TestCase):
         self.assertIn('"deliveryMethod": acceptedMethod?.rawValue ?? ""', app_services)
         self.assertIn("viewModel?.currentMessage(for:", messaging_view)
         self.assertIn("recordCanonicalAlias", messaging_view_model)
+        self.assertIn("PendingDeliveryProof", messaging_view_model)
+        self.assertIn("method: proof.method", messaging_view_model)
         self.assertNotIn("(proof == .delivered) ? .delivered : .failed", messaging_view_model)
         self.assertIn("monotonicDeliveryState", message_repository)
 

--- a/Tests/static/test_async_propagation_fallback.py
+++ b/Tests/static/test_async_propagation_fallback.py
@@ -269,6 +269,18 @@ class AsyncPropagationFallbackTests(unittest.TestCase):
         self.assertEqual(1, len(router.handled))
         self.assertEqual("no-propagation-node", self.delivery_events(events)[0]["reason"])
 
+    def test_missing_propagation_node_preserves_actual_primary_method(self):
+        router = FakeRouter(propagation_node=False)
+        events = []
+        message = self.queue(router, events, method="direct")
+
+        message.failed_callback(message)
+
+        self.assertEqual(1, len(router.handled))
+        delivery = self.delivery_events(events)
+        self.assertEqual("no-propagation-node", delivery[0]["reason"])
+        self.assertEqual("direct", delivery[0]["method"])
+
     def test_propagated_enqueue_failure_is_terminal_and_does_not_loop(self):
         router = FakeRouter(reject_propagated=True)
         events = []
@@ -344,9 +356,12 @@ class AsyncPropagationFallbackTests(unittest.TestCase):
         rns_backend = (ROOT / "Sources/RNSAPI/Protocols/RnsBackend.swift").read_text()
         python_backend = (ROOT / "Sources/RNSBackendPy/PythonRNSBackend.swift").read_text()
         app_services = (ROOT / "Sources/ColumbaApp/Services/AppServices.swift").read_text()
+        messaging_view = (ROOT / "Sources/ColumbaApp/Views/Messaging/MessagingView.swift").read_text()
         for source in (python_bridge, rns_backend, python_backend):
             self.assertIn("method:", source)
         self.assertIn("method: acceptedMethod", app_services)
+        self.assertIn('"deliveryMethod": acceptedMethod?.rawValue ?? ""', app_services)
+        self.assertIn("viewModel?.messages.first(where:", messaging_view)
 
     def test_retry_policy_crosses_the_shipping_swift_python_seam(self):
         rns_lxmf = (ROOT / "Sources/RNSAPI/Protocols/RnsLxmf.swift").read_text()

--- a/Tests/static/test_async_propagation_fallback.py
+++ b/Tests/static/test_async_propagation_fallback.py
@@ -1,6 +1,7 @@
 import ast
 import inspect
 import threading
+import time
 import types
 import unittest
 from pathlib import Path
@@ -80,13 +81,42 @@ class FakeRouter:
         self.outbound_propagation_node = object() if propagation_node else None
         self.reject_propagated = reject_propagated
         self.handled = []
+        self._handled_condition = threading.Condition()
 
     def handle_outbound(self, message):
         if message.packed is None:
             message.pack()
-        self.handled.append(message)
+        with self._handled_condition:
+            self.handled.append(message)
+            self._handled_condition.notify_all()
         if message.method == FakeMessage.PROPAGATED and self.reject_propagated:
             raise OSError("propagation enqueue rejected")
+
+    def wait_for_handled_count(self, count: int, timeout: float = 1.0) -> bool:
+        deadline = time.monotonic() + timeout
+        with self._handled_condition:
+            while len(self.handled) < count:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return False
+                self._handled_condition.wait(remaining)
+            return True
+
+
+class LockedCallbackRouter(FakeRouter):
+    def __init__(self):
+        super().__init__()
+        self.outbound_processing_lock = threading.Lock()
+
+    def handle_outbound(self, message):
+        if not self.handled:
+            return super().handle_outbound(message)
+        if not self.outbound_processing_lock.acquire(timeout=0.25):
+            raise TimeoutError("re-entered outbound router while callback lock held")
+        try:
+            return super().handle_outbound(message)
+        finally:
+            self.outbound_processing_lock.release()
 
 
 class FakeIdentity:
@@ -148,6 +178,14 @@ class AsyncPropagationFallbackTests(unittest.TestCase):
     def delivery_events(self, events):
         return [payload for kind, payload in events if kind == "delivery"]
 
+    def wait_for_delivery_events(self, events, count: int, timeout: float = 1.0) -> bool:
+        deadline = time.monotonic() + timeout
+        while len(self.delivery_events(events)) < count:
+            if time.monotonic() >= deadline:
+                return False
+            time.sleep(0.001)
+        return True
+
     def test_async_failure_requeues_same_message_once_as_propagated(self):
         router = FakeRouter()
         events = []
@@ -162,6 +200,7 @@ class AsyncPropagationFallbackTests(unittest.TestCase):
 
         primary.failed_callback(primary)
 
+        self.assertTrue(router.wait_for_handled_count(2))
         self.assertEqual(2, len(router.handled))
         retry = router.handled[1]
         self.assertIs(primary, retry)
@@ -232,12 +271,31 @@ class AsyncPropagationFallbackTests(unittest.TestCase):
 
         message.failed_callback(message)
 
+        self.assertTrue(router.wait_for_handled_count(2))
+        self.assertTrue(self.wait_for_delivery_events(events, 1))
         self.assertEqual(2, len(router.handled))
         self.assertEqual(1, len(self.delivery_events(events)))
         self.assertEqual("propagated-enqueue-failed", self.delivery_events(events)[0]["reason"])
         message.failed_callback(message)
         self.assertEqual(2, len(router.handled))
         self.assertEqual(1, len(self.delivery_events(events)))
+
+    def test_failure_callback_returns_before_locked_router_requeue(self):
+        router = LockedCallbackRouter()
+        events = []
+        message = self.queue(router, events)
+
+        router.outbound_processing_lock.acquire()
+        try:
+            started = time.monotonic()
+            message.failed_callback(message)
+            elapsed = time.monotonic() - started
+            self.assertLess(elapsed, 0.1)
+        finally:
+            router.outbound_processing_lock.release()
+
+        self.assertTrue(router.wait_for_handled_count(2))
+        self.assertEqual([], self.delivery_events(events))
 
     def test_retry_policy_crosses_the_shipping_swift_python_seam(self):
         rns_lxmf = (ROOT / "Sources/RNSAPI/Protocols/RnsLxmf.swift").read_text()

--- a/Tests/static/test_async_propagation_fallback.py
+++ b/Tests/static/test_async_propagation_fallback.py
@@ -514,6 +514,7 @@ class AsyncPropagationFallbackTests(unittest.TestCase):
         message_repository = (
             ROOT / "Sources/ColumbaApp/Services/MessageRepository.swift"
         ).read_text()
+        ci_workflow = (ROOT / ".github/workflows/tests.yml").read_text()
         for source in (python_bridge, rns_backend, python_backend):
             self.assertIn("method:", source)
         self.assertIn("method: acceptedMethod", app_services)
@@ -522,8 +523,12 @@ class AsyncPropagationFallbackTests(unittest.TestCase):
         self.assertIn("recordCanonicalAlias", messaging_view_model)
         self.assertIn("PendingDeliveryProof", messaging_view_model)
         self.assertIn("method: proof.method", messaging_view_model)
+        self.assertIn("outboundSendOperation", messaging_view_model)
+        self.assertIn("if !proofPersisted", messaging_view_model)
+        self.assertNotIn("if wasAliased && !proofPersisted", messaging_view_model)
         self.assertNotIn("(proof == .delivered) ? .delivered : .failed", messaging_view_model)
         self.assertIn("monotonicDeliveryState", message_repository)
+        self.assertIn("Tests.static.test_async_propagation_fallback", ci_workflow)
 
     def test_retry_policy_crosses_the_shipping_swift_python_seam(self):
         rns_lxmf = (ROOT / "Sources/RNSAPI/Protocols/RnsLxmf.swift").read_text()

--- a/Tests/static/test_qr_contact_send_path_contract.py
+++ b/Tests/static/test_qr_contact_send_path_contract.py
@@ -145,7 +145,7 @@ class QRContactSendPathContractTests(unittest.TestCase):
         )
         repository = self._read("Sources/ColumbaApp/Services/MessageRepository.swift")
         stage = send.index("lxMessage.state = .sending")
-        wire_send = send.index("backend.lxmf.sendLxmfMessage")
+        wire_send = send.index("sendOutbound(")
         self.assertLess(stage, wire_send)
         self.assertIn("repository.stageRetry(lxMessage, replacing: storedHash)", send)
         self.assertIn("config.observesSuspensionNotifications = true", repository)

--- a/app/rns_bridge.py
+++ b/app/rns_bridge.py
@@ -1524,28 +1524,38 @@ def send_opportunistic(dest_hash_hex: str, content: str, fields_hex: str = "",
             # LXMRouter.fail_message invokes callbacks while process_outbound
             # holds outbound_processing_lock in the shipping LXMF runtime. Run
             # requeue work after leaving that callback stack so handle_outbound
-            # cannot wait on the lock owned by its own caller.
+            # cannot wait on the lock owned by its own caller. Re-enter through
+            # the bridge lock as an ordinary send would, and fail closed if a
+            # stop/reset replaced this worker's captured router.
             original_hash = m.hash
-            m.desired_method = LXMF.LXMessage.PROPAGATED
-            m.packed = None
             try:
-                # Re-pack the same immutable payload with the propagated desired
-                # method so LXMF builds `propagation_packed` and selects packet
-                # or resource representation. Timestamp, content and fields are
-                # unchanged, so the canonical hash must remain identical.
-                m.pack()
-                if (
-                    original_hash is None
-                    or m.hash != original_hash
-                    or m.propagation_packed is None
-                ):
-                    raise ValueError("propagation repack changed canonical message")
+                with _lock:
+                    if (
+                        _runtime_teardown_requested.is_set()
+                        or not _state["started"]
+                        or _state["router"] is not router
+                    ):
+                        raise RuntimeError("LXMF runtime changed before fallback enqueue")
 
-                m.state = LXMF.LXMessage.OUTBOUND
-                m.delivery_attempts = 0
-                m.progress = 0.0
-                m.register_failed_callback(_on_propagated_failed)
-                router.handle_outbound(m)
+                    m.desired_method = LXMF.LXMessage.PROPAGATED
+                    m.packed = None
+                    # Re-pack the same immutable payload with the propagated desired
+                    # method so LXMF builds `propagation_packed` and selects packet
+                    # or resource representation. Timestamp, content and fields are
+                    # unchanged, so the canonical hash must remain identical.
+                    m.pack()
+                    if (
+                        original_hash is None
+                        or m.hash != original_hash
+                        or m.propagation_packed is None
+                    ):
+                        raise ValueError("propagation repack changed canonical message")
+
+                    m.state = LXMF.LXMessage.OUTBOUND
+                    m.delivery_attempts = 0
+                    m.progress = 0.0
+                    m.register_failed_callback(_on_propagated_failed)
+                    router.handle_outbound(m)
             except Exception:
                 _emit_terminal(m, "failed", "propagated-enqueue-failed")
 

--- a/app/rns_bridge.py
+++ b/app/rns_bridge.py
@@ -1492,7 +1492,7 @@ def send_opportunistic(dest_hash_hex: str, content: str, fields_hex: str = "",
         )
 
         callback_lock = threading.Lock()
-        callback_state = {"terminal": False, "fallback_started": False}
+        callback_state = {"outcome": None, "fallback_started": False}
 
         def _effective_method_name(m: "LXMF.LXMessage") -> str:
             method_value = getattr(m, "method", None)
@@ -1504,11 +1504,21 @@ def send_opportunistic(dest_hash_hex: str, content: str, fields_hex: str = "",
                 return "propagated"
             return ""
 
-        def _emit_terminal(m: "LXMF.LXMessage", state: str, reason: str) -> None:
+        def _emit_lifecycle(m: "LXMF.LXMessage", state: str, reason: str) -> None:
             with callback_lock:
-                if callback_state["terminal"]:
+                current = callback_state["outcome"]
+                if state == "sent":
+                    if current is not None:
+                        return
+                elif state == "delivered":
+                    if current in ("delivered", "failed"):
+                        return
+                elif state == "failed":
+                    if current in ("delivered", "failed"):
+                        return
+                else:
                     return
-                callback_state["terminal"] = True
+                callback_state["outcome"] = state
             try:
                 _put(
                     "delivery",
@@ -1524,12 +1534,12 @@ def send_opportunistic(dest_hash_hex: str, content: str, fields_hex: str = "",
             # LXMF invokes the same callback for recipient proof (DELIVERED) and
             # propagation-node acceptance (SENT). Keep those semantics distinct.
             if m.state == LXMF.LXMessage.SENT:
-                _emit_terminal(m, "sent", "propagation-accepted")
+                _emit_lifecycle(m, "sent", "propagation-accepted")
             elif m.state == LXMF.LXMessage.DELIVERED:
-                _emit_terminal(m, "delivered", "recipient-proof")
+                _emit_lifecycle(m, "delivered", "recipient-proof")
 
         def _on_propagated_failed(m: "LXMF.LXMessage") -> None:
-            _emit_terminal(m, "failed", "propagated-failed")
+            _emit_lifecycle(m, "failed", "propagated-failed")
 
         def _enqueue_propagated(m: "LXMF.LXMessage") -> None:
             # LXMRouter.fail_message invokes callbacks while process_outbound
@@ -1548,6 +1558,10 @@ def send_opportunistic(dest_hash_hex: str, content: str, fields_hex: str = "",
                     ):
                         raise RuntimeError("LXMF runtime changed before fallback enqueue")
 
+                    with callback_lock:
+                        if callback_state["outcome"] is not None:
+                            return
+
                     m.desired_method = LXMF.LXMessage.PROPAGATED
                     m.packed = None
                     # Re-pack the same immutable payload with the propagated desired
@@ -1562,40 +1576,37 @@ def send_opportunistic(dest_hash_hex: str, content: str, fields_hex: str = "",
                     ):
                         raise ValueError("propagation repack changed canonical message")
 
+                    # Recipient proof can arrive while the fallback representation
+                    # is being built. Give that authoritative outcome one last chance
+                    # to cancel before ownership returns to LXMF.
+                    with callback_lock:
+                        if callback_state["outcome"] is not None:
+                            return
+
                     m.state = LXMF.LXMessage.OUTBOUND
                     m.delivery_attempts = 0
                     m.progress = 0.0
                     m.register_failed_callback(_on_propagated_failed)
                     router.handle_outbound(m)
             except Exception:
-                _emit_terminal(m, "failed", "propagated-enqueue-failed")
+                _emit_lifecycle(m, "failed", "propagated-enqueue-failed")
 
         def _on_primary_failed(m: "LXMF.LXMessage") -> None:
             if fallback_method != LXMF.LXMessage.PROPAGATED:
-                _emit_terminal(m, "failed", "primary-failed")
+                _emit_lifecycle(m, "failed", "primary-failed")
                 return
 
             with callback_lock:
-                if callback_state["terminal"] or callback_state["fallback_started"]:
+                if callback_state["outcome"] is not None or callback_state["fallback_started"]:
                     return
                 if getattr(router, "outbound_propagation_node", None) is None:
-                    callback_state["terminal"] = True
                     missing_node = True
                 else:
                     callback_state["fallback_started"] = True
                     missing_node = False
 
             if missing_node:
-                try:
-                    _put(
-                        "delivery",
-                        message_hash=m.hash.hex(),
-                        state="failed",
-                        reason="no-propagation-node",
-                        method=_effective_method_name(m),
-                    )
-                except Exception:
-                    pass
+                _emit_lifecycle(m, "failed", "no-propagation-node")
                 return
 
             try:
@@ -1606,7 +1617,7 @@ def send_opportunistic(dest_hash_hex: str, content: str, fields_hex: str = "",
                     daemon=True,
                 ).start()
             except Exception:
-                _emit_terminal(m, "failed", "propagated-enqueue-failed")
+                _emit_lifecycle(m, "failed", "propagated-enqueue-failed")
 
         msg.register_delivery_callback(_on_delivered)
         if desired_method == LXMF.LXMessage.PROPAGATED:

--- a/app/rns_bridge.py
+++ b/app/rns_bridge.py
@@ -1548,10 +1548,22 @@ def send_opportunistic(dest_hash_hex: str, content: str, fields_hex: str = "",
                 return
 
             # LXMRouter.fail_message removed this object from pending_outbound
-            # before invoking us. Requeueing the same packed object preserves its
-            # canonical hash and all typed fields while changing only transport.
+            # before invoking us. Re-pack the same immutable payload with the
+            # propagated desired method so LXMF builds `propagation_packed` and
+            # selects packet/resource representation. Timestamp, content and
+            # fields are unchanged, so the canonical hash must remain identical.
+            original_hash = m.hash
             m.desired_method = LXMF.LXMessage.PROPAGATED
-            m.method = LXMF.LXMessage.PROPAGATED
+            m.packed = None
+            try:
+                m.pack()
+            except Exception:
+                _emit_terminal(m, "failed", "propagated-enqueue-failed")
+                return
+            if original_hash is None or m.hash != original_hash or m.propagation_packed is None:
+                _emit_terminal(m, "failed", "propagated-enqueue-failed")
+                return
+
             m.state = LXMF.LXMessage.OUTBOUND
             m.delivery_attempts = 0
             m.progress = 0.0

--- a/app/rns_bridge.py
+++ b/app/rns_bridge.py
@@ -15,6 +15,7 @@ sole signal for typing peers vs relays vs audio vs sites.
 
 from __future__ import annotations
 
+import copy
 import os
 import queue
 import threading
@@ -1491,7 +1492,7 @@ def send_opportunistic(dest_hash_hex: str, content: str, fields_hex: str = "",
             desired_method=desired_method,
         )
 
-        callback_lock = threading.Lock()
+        callback_lock = threading.RLock()
         callback_state = {"outcome": None, "fallback_started": False}
 
         def _effective_method_name(m: "LXMF.LXMessage") -> str:
@@ -1519,16 +1520,16 @@ def send_opportunistic(dest_hash_hex: str, content: str, fields_hex: str = "",
                 else:
                     return
                 callback_state["outcome"] = state
-            try:
-                _put(
-                    "delivery",
-                    message_hash=m.hash.hex(),
-                    state=state,
-                    reason=reason,
-                    method=_effective_method_name(m),
-                )
-            except Exception:
-                pass
+                try:
+                    _put(
+                        "delivery",
+                        message_hash=m.hash.hex(),
+                        state=state,
+                        reason=reason,
+                        method=_effective_method_name(m),
+                    )
+                except Exception:
+                    pass
 
         def _on_delivered(m: "LXMF.LXMessage") -> None:
             # LXMF invokes the same callback for recipient proof (DELIVERED) and
@@ -1550,6 +1551,21 @@ def send_opportunistic(dest_hash_hex: str, content: str, fields_hex: str = "",
             # stop/reset replaced this worker's captured router.
             original_hash = m.hash
             try:
+                # Build and validate propagated transport representation on a
+                # shallow copy. Recipient proof can still win while this work is
+                # in flight, and the authoritative primary message stays wholly
+                # opportunistic until final enqueue admission.
+                prepared = copy.copy(m)
+                prepared.desired_method = LXMF.LXMessage.PROPAGATED
+                prepared.packed = None
+                prepared.pack()
+                if (
+                    original_hash is None
+                    or prepared.hash != original_hash
+                    or prepared.propagation_packed is None
+                ):
+                    raise ValueError("propagation repack changed canonical message")
+
                 with _lock:
                     if (
                         _runtime_teardown_requested.is_set()
@@ -1558,36 +1574,24 @@ def send_opportunistic(dest_hash_hex: str, content: str, fields_hex: str = "",
                     ):
                         raise RuntimeError("LXMF runtime changed before fallback enqueue")
 
+                    # This RLock is the enqueue linearization boundary. Competing
+                    # recipient proof either wins before this point and cancels,
+                    # or waits until handle_outbound has accepted ownership. The
+                    # lock is reentrant because shipping LXMF can synchronously
+                    # invoke our callbacks from handle_outbound.
                     with callback_lock:
                         if callback_state["outcome"] is not None:
                             return
-
-                    m.desired_method = LXMF.LXMessage.PROPAGATED
-                    m.packed = None
-                    # Re-pack the same immutable payload with the propagated desired
-                    # method so LXMF builds `propagation_packed` and selects packet
-                    # or resource representation. Timestamp, content and fields are
-                    # unchanged, so the canonical hash must remain identical.
-                    m.pack()
-                    if (
-                        original_hash is None
-                        or m.hash != original_hash
-                        or m.propagation_packed is None
-                    ):
-                        raise ValueError("propagation repack changed canonical message")
-
-                    # Recipient proof can arrive while the fallback representation
-                    # is being built. Give that authoritative outcome one last chance
-                    # to cancel before ownership returns to LXMF.
-                    with callback_lock:
-                        if callback_state["outcome"] is not None:
-                            return
-
-                    m.state = LXMF.LXMessage.OUTBOUND
-                    m.delivery_attempts = 0
-                    m.progress = 0.0
-                    m.register_failed_callback(_on_propagated_failed)
-                    router.handle_outbound(m)
+                        m.desired_method = LXMF.LXMessage.PROPAGATED
+                        m.packed = None
+                        m.pack()
+                        if m.hash != original_hash or m.propagation_packed is None:
+                            raise ValueError("propagation repack changed canonical message")
+                        m.state = LXMF.LXMessage.OUTBOUND
+                        m.delivery_attempts = 0
+                        m.progress = 0.0
+                        m.register_failed_callback(_on_propagated_failed)
+                        router.handle_outbound(m)
             except Exception:
                 _emit_lifecycle(m, "failed", "propagated-enqueue-failed")
 

--- a/app/rns_bridge.py
+++ b/app/rns_bridge.py
@@ -1494,27 +1494,28 @@ def send_opportunistic(dest_hash_hex: str, content: str, fields_hex: str = "",
         callback_lock = threading.Lock()
         callback_state = {"terminal": False, "fallback_started": False}
 
+        def _effective_method_name(m: "LXMF.LXMessage") -> str:
+            method_value = getattr(m, "method", None)
+            if method_value == LXMF.LXMessage.OPPORTUNISTIC:
+                return "opportunistic"
+            if method_value == LXMF.LXMessage.DIRECT:
+                return "direct"
+            if method_value == LXMF.LXMessage.PROPAGATED:
+                return "propagated"
+            return ""
+
         def _emit_terminal(m: "LXMF.LXMessage", state: str, reason: str) -> None:
             with callback_lock:
                 if callback_state["terminal"]:
                     return
                 callback_state["terminal"] = True
             try:
-                method_value = getattr(m, "method", None)
-                if method_value == LXMF.LXMessage.OPPORTUNISTIC:
-                    effective_method = "opportunistic"
-                elif method_value == LXMF.LXMessage.DIRECT:
-                    effective_method = "direct"
-                elif method_value == LXMF.LXMessage.PROPAGATED:
-                    effective_method = "propagated"
-                else:
-                    effective_method = ""
                 _put(
                     "delivery",
                     message_hash=m.hash.hex(),
                     state=state,
                     reason=reason,
-                    method=effective_method,
+                    method=_effective_method_name(m),
                 )
             except Exception:
                 pass
@@ -1591,7 +1592,7 @@ def send_opportunistic(dest_hash_hex: str, content: str, fields_hex: str = "",
                         message_hash=m.hash.hex(),
                         state="failed",
                         reason="no-propagation-node",
-                        method="opportunistic",
+                        method=_effective_method_name(m),
                     )
                 except Exception:
                     pass

--- a/app/rns_bridge.py
+++ b/app/rns_bridge.py
@@ -1500,11 +1500,21 @@ def send_opportunistic(dest_hash_hex: str, content: str, fields_hex: str = "",
                     return
                 callback_state["terminal"] = True
             try:
+                method_value = getattr(m, "method", None)
+                if method_value == LXMF.LXMessage.OPPORTUNISTIC:
+                    effective_method = "opportunistic"
+                elif method_value == LXMF.LXMessage.DIRECT:
+                    effective_method = "direct"
+                elif method_value == LXMF.LXMessage.PROPAGATED:
+                    effective_method = "propagated"
+                else:
+                    effective_method = ""
                 _put(
                     "delivery",
                     message_hash=m.hash.hex(),
                     state=state,
                     reason=reason,
+                    method=effective_method,
                 )
             except Exception:
                 pass
@@ -1581,6 +1591,7 @@ def send_opportunistic(dest_hash_hex: str, content: str, fields_hex: str = "",
                         message_hash=m.hash.hex(),
                         state="failed",
                         reason="no-propagation-node",
+                        method="opportunistic",
                     )
                 except Exception:
                     pass

--- a/app/rns_bridge.py
+++ b/app/rns_bridge.py
@@ -1512,7 +1512,7 @@ def send_opportunistic(dest_hash_hex: str, content: str, fields_hex: str = "",
                     if current is not None:
                         return
                 elif state == "delivered":
-                    if current in ("delivered", "failed"):
+                    if current == "delivered":
                         return
                 elif state == "failed":
                     if current in ("delivered", "failed"):

--- a/app/rns_bridge.py
+++ b/app/rns_bridge.py
@@ -1520,6 +1520,35 @@ def send_opportunistic(dest_hash_hex: str, content: str, fields_hex: str = "",
         def _on_propagated_failed(m: "LXMF.LXMessage") -> None:
             _emit_terminal(m, "failed", "propagated-failed")
 
+        def _enqueue_propagated(m: "LXMF.LXMessage") -> None:
+            # LXMRouter.fail_message invokes callbacks while process_outbound
+            # holds outbound_processing_lock in the shipping LXMF runtime. Run
+            # requeue work after leaving that callback stack so handle_outbound
+            # cannot wait on the lock owned by its own caller.
+            original_hash = m.hash
+            m.desired_method = LXMF.LXMessage.PROPAGATED
+            m.packed = None
+            try:
+                # Re-pack the same immutable payload with the propagated desired
+                # method so LXMF builds `propagation_packed` and selects packet
+                # or resource representation. Timestamp, content and fields are
+                # unchanged, so the canonical hash must remain identical.
+                m.pack()
+                if (
+                    original_hash is None
+                    or m.hash != original_hash
+                    or m.propagation_packed is None
+                ):
+                    raise ValueError("propagation repack changed canonical message")
+
+                m.state = LXMF.LXMessage.OUTBOUND
+                m.delivery_attempts = 0
+                m.progress = 0.0
+                m.register_failed_callback(_on_propagated_failed)
+                router.handle_outbound(m)
+            except Exception:
+                _emit_terminal(m, "failed", "propagated-enqueue-failed")
+
         def _on_primary_failed(m: "LXMF.LXMessage") -> None:
             if fallback_method != LXMF.LXMessage.PROPAGATED:
                 _emit_terminal(m, "failed", "primary-failed")
@@ -1547,29 +1576,13 @@ def send_opportunistic(dest_hash_hex: str, content: str, fields_hex: str = "",
                     pass
                 return
 
-            # LXMRouter.fail_message removed this object from pending_outbound
-            # before invoking us. Re-pack the same immutable payload with the
-            # propagated desired method so LXMF builds `propagation_packed` and
-            # selects packet/resource representation. Timestamp, content and
-            # fields are unchanged, so the canonical hash must remain identical.
-            original_hash = m.hash
-            m.desired_method = LXMF.LXMessage.PROPAGATED
-            m.packed = None
             try:
-                m.pack()
-            except Exception:
-                _emit_terminal(m, "failed", "propagated-enqueue-failed")
-                return
-            if original_hash is None or m.hash != original_hash or m.propagation_packed is None:
-                _emit_terminal(m, "failed", "propagated-enqueue-failed")
-                return
-
-            m.state = LXMF.LXMessage.OUTBOUND
-            m.delivery_attempts = 0
-            m.progress = 0.0
-            m.register_failed_callback(_on_propagated_failed)
-            try:
-                router.handle_outbound(m)
+                threading.Thread(
+                    target=_enqueue_propagated,
+                    args=(m,),
+                    name="ColumbaPropagationFallback",
+                    daemon=True,
+                ).start()
             except Exception:
                 _emit_terminal(m, "failed", "propagated-enqueue-failed")
 

--- a/app/rns_bridge.py
+++ b/app/rns_bridge.py
@@ -1431,22 +1431,15 @@ def resolve_path(dest_hash_hex: str, timeout_seconds: float = 10.0) -> dict[str,
 
 
 def send_opportunistic(dest_hash_hex: str, content: str, fields_hex: str = "",
-                       method: str = "opportunistic") -> dict[str, Any]:
-    """Send an LXMF message. Returns a dict with 'ok' (bool) and 'reason'
-    (string) describing the outcome. If the destination's identity isn't
-    recallable yet (no announce / no path), kicks off a `request_path` and
-    returns ok=False reason='requesting-path'.
+                       method: str = "opportunistic",
+                       failure_fallback_method: str = "") -> dict[str, Any]:
+    """Send an LXMF message and optionally retry an async failure once.
 
-    `method` selects the LXMF desired-method on the outbound message:
-      - "opportunistic" (default): single encrypted packet, no link.
-        Upstream LXMF auto-falls-back to DIRECT when the encrypted payload
-        exceeds packet size (e.g. an image attachment).
-      - "direct": opens an RNS.Link for the transfer (link-based).
-      - "propagated": uploads to the configured propagation node; the
-        recipient downloads when it next syncs.
-
-    The function name is historical (was opportunistic-only); the bridge's
-    public Swift wrapper still uses `sendOpportunistic` for the same reason.
+    `method` selects the initial LXMF desired method. When
+    `failure_fallback_method` is ``"propagated"``, a later asynchronous failure
+    of the accepted opportunistic submission requeues the exact same LXMessage
+    once through the configured propagation node. Reusing the object preserves
+    its hash, timestamp and complete field map for Swift persistence.
     """
     with _lock:
         if not _state["started"]:
@@ -1473,8 +1466,6 @@ def send_opportunistic(dest_hash_hex: str, content: str, fields_hex: str = "",
             "lxmf",
             "delivery",
         )
-        # Decode the MessagePack-packed LXMF field map from Swift (image /
-        # attachments / icon / reply / reaction / telemetry), if any.
         fields = None
         if fields_hex:
             try:
@@ -1483,15 +1474,13 @@ def send_opportunistic(dest_hash_hex: str, content: str, fields_hex: str = "",
             except Exception:
                 fields = None
 
-        # Map the public method string onto LXMF's three desired-method codes.
-        # Anything unrecognised falls back to OPPORTUNISTIC so a typo at the
-        # Swift caller doesn't silently change wire semantics in unexpected
-        # ways (the typo + opportunistic-text combo is the lowest-risk fallback).
-        desired_method = {
+        methods = {
             "opportunistic": LXMF.LXMessage.OPPORTUNISTIC,
             "direct": LXMF.LXMessage.DIRECT,
             "propagated": LXMF.LXMessage.PROPAGATED,
-        }.get(method, LXMF.LXMessage.OPPORTUNISTIC)
+        }
+        desired_method = methods.get(method, LXMF.LXMessage.OPPORTUNISTIC)
+        fallback_method = methods.get(failure_fallback_method)
 
         msg = LXMF.LXMessage(
             peer_dest,
@@ -1502,31 +1491,84 @@ def send_opportunistic(dest_hash_hex: str, content: str, fields_hex: str = "",
             desired_method=desired_method,
         )
 
-        # Surface delivery / failure proofs to Swift so the chat UI can flip a
-        # sent message to the double-check (delivered) or failed state. The
-        # callbacks fire on RNS worker threads when a proof arrives; we drop a
-        # "delivery" event onto the queue keyed by the LXMF message hash so the
-        # Swift side can match it to the persisted message row.
-        def _on_delivered(m: "LXMF.LXMessage") -> None:
+        callback_lock = threading.Lock()
+        callback_state = {"terminal": False, "fallback_started": False}
+
+        def _emit_terminal(m: "LXMF.LXMessage", state: str, reason: str) -> None:
+            with callback_lock:
+                if callback_state["terminal"]:
+                    return
+                callback_state["terminal"] = True
             try:
-                _put("delivery", message_hash=m.hash.hex(), state="delivered")
+                _put(
+                    "delivery",
+                    message_hash=m.hash.hex(),
+                    state=state,
+                    reason=reason,
+                )
             except Exception:
                 pass
 
-        def _on_failed(m: "LXMF.LXMessage") -> None:
+        def _on_delivered(m: "LXMF.LXMessage") -> None:
+            # LXMF invokes the same callback for recipient proof (DELIVERED) and
+            # propagation-node acceptance (SENT). Keep those semantics distinct.
+            if m.state == LXMF.LXMessage.SENT:
+                _emit_terminal(m, "sent", "propagation-accepted")
+            elif m.state == LXMF.LXMessage.DELIVERED:
+                _emit_terminal(m, "delivered", "recipient-proof")
+
+        def _on_propagated_failed(m: "LXMF.LXMessage") -> None:
+            _emit_terminal(m, "failed", "propagated-failed")
+
+        def _on_primary_failed(m: "LXMF.LXMessage") -> None:
+            if fallback_method != LXMF.LXMessage.PROPAGATED:
+                _emit_terminal(m, "failed", "primary-failed")
+                return
+
+            with callback_lock:
+                if callback_state["terminal"] or callback_state["fallback_started"]:
+                    return
+                if getattr(router, "outbound_propagation_node", None) is None:
+                    callback_state["terminal"] = True
+                    missing_node = True
+                else:
+                    callback_state["fallback_started"] = True
+                    missing_node = False
+
+            if missing_node:
+                try:
+                    _put(
+                        "delivery",
+                        message_hash=m.hash.hex(),
+                        state="failed",
+                        reason="no-propagation-node",
+                    )
+                except Exception:
+                    pass
+                return
+
+            # LXMRouter.fail_message removed this object from pending_outbound
+            # before invoking us. Requeueing the same packed object preserves its
+            # canonical hash and all typed fields while changing only transport.
+            m.desired_method = LXMF.LXMessage.PROPAGATED
+            m.method = LXMF.LXMessage.PROPAGATED
+            m.state = LXMF.LXMessage.OUTBOUND
+            m.delivery_attempts = 0
+            m.progress = 0.0
+            m.register_failed_callback(_on_propagated_failed)
             try:
-                _put("delivery", message_hash=m.hash.hex(), state="failed")
+                router.handle_outbound(m)
             except Exception:
-                pass
+                _emit_terminal(m, "failed", "propagated-enqueue-failed")
 
         msg.register_delivery_callback(_on_delivered)
-        msg.register_failed_callback(_on_failed)
+        if desired_method == LXMF.LXMessage.PROPAGATED:
+            msg.register_failed_callback(_on_propagated_failed)
+        else:
+            msg.register_failed_callback(_on_primary_failed)
 
         router.handle_outbound(msg)
 
-        # `handle_outbound` packs the message, so `msg.hash` is now the real
-        # LXMF message hash. Return it so Swift persists the outbound message
-        # under the same key the delivery event will carry.
         message_hash = msg.hash.hex() if msg.hash is not None else ""
         return {"ok": True, "reason": "queued", "message_hash": message_hash}
 


### PR DESCRIPTION
## Summary

- pass the Retry via Relay policy into the shipping embedded-Python send path when an opportunistic message is queued
- handle later asynchronous opportunistic failure in the backend by repacking and requeuing the same `LXMessage` once as propagated, preserving its canonical hash and structured payload
- distinguish propagation-node acceptance (`sent`) from recipient delivery (`delivered`), persist the propagated method, and emit terminal failure when propagation is unavailable or fails
- carry effective transport independently from lifecycle state, including a direct `delivered` callback with no observed intermediate `sent`, and keep an already-open detail page synchronized

Fixes #146.

## Verification

- regression-first focused suite before production changes: 8 tests executed, 7 failed for the missing asynchronous fallback/seam behavior, 1 passed
- propagation-representation regression before its fix: 8 tests executed, 1 failed because `propagation_packed` remained absent, 7 passed
- shipping LXMF 0.9.9 lock regression before its fix: 9 tests executed, 1 failed because the failure callback synchronously waited on the router's non-reentrant outbound lock, 8 passed
- runtime-replacement regression before its fix: 10 tests executed, 1 failed because the fallback worker enqueued on a superseded router, 9 passed
- delivered-method regression before its fix: 11 tests executed, 1 failed because the event lacked effective transport metadata, 10 passed
- presentation-edge regressions before their fixes: 12 tests executed, 2 failed for no-node method preservation and notification/open-sheet seams, 10 passed
- lifecycle-arbitration regressions before their fixes: 14 tests executed, 3 failed because `sent` suppressed recipient proof, deferred fallback ignored authoritative delivery, and canonical detail aliasing was absent
- linearization regressions before their fixes: 17 tests executed, 4 failed for concurrent lifecycle event ordering, mutation during fallback preparation, atomic final enqueue admission, and missing Swift monotonic/alias defenses
- recipient-authority regressions before their fixes: 18 tests executed, 2 failed because `failed` suppressed later recipient proof and buffered proofs lost effective transport metadata
- pre-alias regressions before their fixes: the public send path emitted an unpersisted propagated delivery proof before returning the canonical hash, then forced a concurrent refresh before alias registration; production now buffers the proof and removes it only after a repository update confirms a matching row changed
- focused suite at final head: 18 passed; repeated 100/100 runs without failure
- complete static suite at final head: 243 passed, 1 skipped, 254 subtests passed
- pinned LXMF 0.9.9 copy/repack probe: shallow copy passed; the primary stayed opportunistic; hash, payload, fields, and propagated bytes were preserved
- Mac native XCTest compile/run: 19 passed at the initial Swift implementation head; the exact-head native integration test is present, but a later build-for-testing exhausted task-volume storage before reaching Swift test compilation
- exact-head `d1a30ad7` app source compiled with zero compiler errors; the low-space outer-signing failure was completed with the generated entitlements, then exact bridge equality, strict signature verification, installation, launch, and process readback passed
- CI now explicitly executes `Tests.static.test_async_propagation_fallback`; exact-head native integration test execution remains pending hosted CI because local task-volume storage prevented the device test bundle from reaching test compilation
- final app bundle at each installed candidate contained an exact byte-for-byte copy of that candidate's embedded Python bridge
- sanitized live phone diagnosis of the prior candidate observed 0 `sent` and 2 `delivered` events, reproducing the missing-method path without exposing message content or identities

## Remaining manual check

- interactive offline-recipient smoke test on the installed iPhone build should be completed before merge to confirm the configured propagation node accepts the retry in the real network environment

## Risk and rollback

The change is limited to the shipping Python LXMF send path and its Swift policy/event-persistence seam. The retry is one-shot, hash-guarded, and fails closed when no propagation node is configured, repacking fails, the hash changes, enqueue fails, or the propagated attempt later fails. Rollback is to revert this PR.
