### PR TITLE
fix: preview and export received attachments

### DIFF
--- a/Columba.xcodeproj/project.pbxproj
+++ b/Columba.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		011 /* ContactCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = F011 /* ContactCard.swift */; };
 		012 /* NetworkAnnouncesTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = F012 /* NetworkAnnouncesTab.swift */; };
 		013 /* MessagingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F013 /* MessagingView.swift */; };
+		APV002 /* MessageAttachmentPreviewItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = APV001 /* MessageAttachmentPreviewItem.swift */; };
+		APV003 /* MessageAttachmentPreviewItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = APV001 /* MessageAttachmentPreviewItem.swift */; };
 		TSP002 /* TextSizePickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = TSP001 /* TextSizePickerSheet.swift */; };
 		A41F10000000000000000001 /* MessageTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A41F10000000000000000003 /* MessageTimelineView.swift */; };
 		014 /* MessageBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = F014 /* MessageBubble.swift */; };
@@ -233,6 +235,7 @@
 		92DDF4AE0AB493CC2AA0BA20 /* LXSTSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 6000D5CED2C3C89F74999BC1 /* LXSTSwift */; };
 		9566DCEF56FEFC97BAAA47BA /* MessageFormattedTimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC4EF2D71A3D88C71D5BEDAD /* MessageFormattedTimeTests.swift */; };
 		A1B2C3D4E5F60718293A4B5E /* MessageBubbleLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718293A4B5D /* MessageBubbleLayoutTests.swift */; };
+		APVT002 /* MessageAttachmentPreviewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = APVT001 /* MessageAttachmentPreviewTests.swift */; };
 		9673457897893BF9DE512A0F /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F006 /* SettingsViewModel.swift */; };
 		973B4BBFD50C0935D1525F8E /* NomadNetBrowserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F081 /* NomadNetBrowserView.swift */; };
 		97FCC1B1FF91DD6EF2706B04 /* LoRaPresets.swift in Sources */ = {isa = PBXBuildFile; fileRef = F045 /* LoRaPresets.swift */; };
@@ -450,6 +453,7 @@
 		B68384C48BFF8F5294340EDB /* PttButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PttButton.swift; sourceTree = "<group>"; };
 		BC4EF2D71A3D88C71D5BEDAD /* MessageFormattedTimeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MessageFormattedTimeTests.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60718293A4B5D /* MessageBubbleLayoutTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MessageBubbleLayoutTests.swift; sourceTree = "<group>"; };
+		APVT001 /* MessageAttachmentPreviewTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MessageAttachmentPreviewTests.swift; sourceTree = "<group>"; };
 		BF48C97880B30682DC35613C /* CeaseTelemetry.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CeaseTelemetry.swift; sourceTree = "<group>"; };
 		BGTF /* BackgroundTransportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundTransportView.swift; sourceTree = "<group>"; };
 		BKF002 /* BackendFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendFactory.swift; sourceTree = "<group>"; };
@@ -482,6 +486,7 @@
 		TSP001 /* TextSizePickerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextSizePickerSheet.swift; sourceTree = "<group>"; };
 		A41F10000000000000000003 /* MessageTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageTimelineView.swift; sourceTree = "<group>"; };
 		F014 /* MessageBubble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBubble.swift; sourceTree = "<group>"; };
+		APV001 /* MessageAttachmentPreviewItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageAttachmentPreviewItem.swift; sourceTree = "<group>"; };
 		MDB003 /* MessageBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBody.swift; sourceTree = "<group>"; };
 		F015 /* MessageInputBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageInputBar.swift; sourceTree = "<group>"; };
 		F016 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
@@ -863,6 +868,7 @@
 				TSP001 /* TextSizePickerSheet.swift */,
 				A41F10000000000000000003 /* MessageTimelineView.swift */,
 				F014 /* MessageBubble.swift */,
+				APV001 /* MessageAttachmentPreviewItem.swift */,
 				MDB003 /* MessageBody.swift */,
 				F015 /* MessageInputBar.swift */,
 				F073 /* MessageDetailView.swift */,
@@ -1022,6 +1028,7 @@
 				30A79B9ECDB4166F8A36A670 /* CallManagerCallKitTests.swift */,
 				BC4EF2D71A3D88C71D5BEDAD /* MessageFormattedTimeTests.swift */,
 				A1B2C3D4E5F60718293A4B5D /* MessageBubbleLayoutTests.swift */,
+				APVT001 /* MessageAttachmentPreviewTests.swift */,
 				ACT01 /* AnnounceClassificationTests.swift */,
 				DRAFT001 /* DraftMessageTests.swift */,
 				EA0AA6C472B1D4EFA2896086 /* RNodeSeamTests.swift */,
@@ -1398,6 +1405,7 @@
 				BED8754AAD30B1CB58755EF8 /* MessagingView.swift in Sources */,
 				TSP003 /* TextSizePickerSheet.swift in Sources */,
 				A41F10000000000000000002 /* MessageTimelineView.swift in Sources */,
+				APV003 /* MessageAttachmentPreviewItem.swift in Sources */,
 				C204F5778ABB560C1FD4DC60 /* MessageBubble.swift in Sources */,
 				MDB002 /* MessageBody.swift in Sources */,
 				D93546FFCB0106CF3F68B2C5 /* MessageDetailView.swift in Sources */,
@@ -1580,6 +1588,7 @@
 				013 /* MessagingView.swift in Sources */,
 				TSP002 /* TextSizePickerSheet.swift in Sources */,
 				A41F10000000000000000001 /* MessageTimelineView.swift in Sources */,
+				APV002 /* MessageAttachmentPreviewItem.swift in Sources */,
 				014 /* MessageBubble.swift in Sources */,
 				MDB001 /* MessageBody.swift in Sources */,
 				073 /* MessageDetailView.swift in Sources */,
@@ -1703,6 +1712,7 @@
 				E49B977D311DA1C9ACE14CAB /* CallManagerCallKitTests.swift in Sources */,
 				9566DCEF56FEFC97BAAA47BA /* MessageFormattedTimeTests.swift in Sources */,
 				A1B2C3D4E5F60718293A4B5E /* MessageBubbleLayoutTests.swift in Sources */,
+				APVT002 /* MessageAttachmentPreviewTests.swift in Sources */,
 				ACT02 /* AnnounceClassificationTests.swift in Sources */,
 				DRAFT002 /* DraftMessageTests.swift in Sources */,
 				0FF6A5C5596A39C092AADA29 /* MigrationRoundTripTests.swift in Sources */,

--- a/Sources/ColumbaApp/Resources/Localizable.xcstrings
+++ b/Sources/ColumbaApp/Resources/Localizable.xcstrings
@@ -965,6 +965,24 @@
     },
     "%lld percent": {
       "comment": "VoiceOver value announcing the selected message text-size percentage."
+    },
+    "Image attachment": {
+      "comment": "VoiceOver label for an image attached to a chat message."
+    },
+    "File attachment: %@": {
+      "comment": "VoiceOver label for a file attached to a chat message. The placeholder is the sender-provided display name."
+    },
+    "Opens attachment preview": {
+      "comment": "VoiceOver hint for tappable image and file attachment controls."
+    },
+    "Share Attachment": {
+      "comment": "Button that opens the native export and share sheet for a previewed attachment."
+    },
+    "Unable to Open Attachment": {
+      "comment": "Error alert title when a message attachment cannot be prepared for preview."
+    },
+    "The attachment could not be prepared for preview.": {
+      "comment": "Privacy-safe error text shown when temporary attachment export fails."
     }
   },
   "version": "1.0"

--- a/Sources/ColumbaApp/Resources/Localizable.xcstrings
+++ b/Sources/ColumbaApp/Resources/Localizable.xcstrings
@@ -975,9 +975,6 @@
     "Opens attachment preview": {
       "comment": "VoiceOver hint for tappable image and file attachment controls."
     },
-    "Share Attachment": {
-      "comment": "Button that opens the native export and share sheet for a previewed attachment."
-    },
     "Unable to Open Attachment": {
       "comment": "Error alert title when a message attachment cannot be prepared for preview."
     },

--- a/Sources/ColumbaApp/Views/Messaging/MessageAttachmentPreviewItem.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageAttachmentPreviewItem.swift
@@ -1,6 +1,7 @@
 import Foundation
 import ImageIO
 import UniformTypeIdentifiers
+import Combine
 
 /// A byte-preserving temporary file prepared for native attachment preview and export.
 /// Each item owns one isolated UUID directory and removes only that directory.
@@ -116,5 +117,37 @@ final class MessageAttachmentPreviewItem: Identifiable {
         let filtered = value.lowercased().filter { $0.isASCII && ($0.isLetter || $0.isNumber) }
         guard !filtered.isEmpty, filtered.utf8.count <= 16 else { return nil }
         return filtered
+    }
+}
+
+/// Owns the current preview item and synchronously cleans up the outgoing item
+/// whenever SwiftUI replaces or dismisses the full-screen presentation.
+@MainActor
+final class MessageAttachmentPreviewStore: ObservableObject {
+    @Published var item: MessageAttachmentPreviewItem? {
+        willSet {
+            guard item?.id != newValue?.id else { return }
+            item?.cleanup()
+        }
+    }
+
+    init(item: MessageAttachmentPreviewItem? = nil) {
+        self.item = item
+    }
+
+    func present(_ item: MessageAttachmentPreviewItem) {
+        self.item = item
+    }
+
+    func dismiss() {
+        item = nil
+    }
+
+    func exitConversation() {
+        item = nil
+    }
+
+    deinit {
+        item?.cleanup()
     }
 }

--- a/Sources/ColumbaApp/Views/Messaging/MessageAttachmentPreviewItem.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageAttachmentPreviewItem.swift
@@ -146,8 +146,4 @@ final class MessageAttachmentPreviewStore: ObservableObject {
     func exitConversation() {
         item = nil
     }
-
-    deinit {
-        item?.cleanup()
-    }
 }

--- a/Sources/ColumbaApp/Views/Messaging/MessageAttachmentPreviewItem.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageAttachmentPreviewItem.swift
@@ -87,7 +87,8 @@ final class MessageAttachmentPreviewItem: Identifiable {
             if let imageData,
                let source = CGImageSourceCreateWithData(imageData as CFData, nil),
                let identifier = CGImageSourceGetType(source),
-               let detected = UTType(identifier as String).preferredFilenameExtension {
+               let detectedType = UTType(identifier as String),
+               let detected = detectedType.preferredFilenameExtension {
                 return sanitizedExtension(detected)
             }
             guard let declaredImageFormat else { return nil }

--- a/Sources/ColumbaApp/Views/Messaging/MessageAttachmentPreviewItem.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageAttachmentPreviewItem.swift
@@ -1,0 +1,119 @@
+import Foundation
+import ImageIO
+import UniformTypeIdentifiers
+
+/// A byte-preserving temporary file prepared for native attachment preview and export.
+/// Each item owns one isolated UUID directory and removes only that directory.
+final class MessageAttachmentPreviewItem: Identifiable {
+    let id = UUID()
+    let directoryURL: URL
+    let url: URL
+
+    private let fileManager: FileManager
+    private let cleanupLock = NSLock()
+    private var hasCleanedUp = false
+
+    init(
+        data: Data,
+        suggestedFilename: String,
+        declaredImageFormat: String? = nil,
+        isImage: Bool = false,
+        fileManager: FileManager = .default
+    ) throws {
+        self.fileManager = fileManager
+        let directoryURL = fileManager.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        self.directoryURL = directoryURL
+
+        do {
+            try fileManager.createDirectory(
+                at: directoryURL,
+                withIntermediateDirectories: false
+            )
+            let filename = Self.safeFilename(
+                suggestedFilename,
+                imageData: isImage ? data : nil,
+                declaredImageFormat: declaredImageFormat
+            )
+            let url = directoryURL.appendingPathComponent(filename, isDirectory: false)
+            try data.write(to: url, options: .atomic)
+            self.url = url
+        } catch {
+            try? fileManager.removeItem(at: directoryURL)
+            throw error
+        }
+    }
+
+    deinit {
+        cleanup()
+    }
+
+    func cleanup() {
+        cleanupLock.lock()
+        guard !hasCleanedUp else {
+            cleanupLock.unlock()
+            return
+        }
+        hasCleanedUp = true
+        cleanupLock.unlock()
+        try? fileManager.removeItem(at: directoryURL)
+    }
+
+    private static func safeFilename(
+        _ untrustedName: String,
+        imageData: Data?,
+        declaredImageFormat: String?
+    ) -> String {
+        let finalComponent = untrustedName
+            .split(whereSeparator: { $0 == "/" || $0 == "\\" })
+            .last
+            .map(String.init) ?? ""
+        let filtered = finalComponent.unicodeScalars.filter {
+            !CharacterSet.controlCharacters.contains($0) && $0.value != 0x7f
+        }
+        var candidate = String(String.UnicodeScalarView(filtered))
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if candidate == "." || candidate == ".." {
+            candidate = ""
+        }
+
+        let originalExtension = sanitizedExtension((candidate as NSString).pathExtension)
+        var stem = (candidate as NSString).deletingPathExtension
+        stem = stem.replacingOccurrences(of: "..", with: ".")
+            .trimmingCharacters(in: CharacterSet(charactersIn: ". "))
+        if stem.isEmpty { stem = "attachment" }
+
+        let imageExtension: String? = {
+            if let imageData,
+               let source = CGImageSourceCreateWithData(imageData as CFData, nil),
+               let identifier = CGImageSourceGetType(source),
+               let detected = UTType(identifier as String).preferredFilenameExtension {
+                return sanitizedExtension(detected)
+            }
+            guard let declaredImageFormat else { return nil }
+            let declared = declaredImageFormat
+                .trimmingCharacters(in: CharacterSet(charactersIn: ". "))
+                .lowercased()
+            let type = UTType(mimeType: declared) ?? UTType(filenameExtension: declared)
+            guard let type, type.conforms(to: .image) else {
+                return nil
+            }
+            return sanitizedExtension(type.preferredFilenameExtension ?? declared)
+        }()
+
+        let fileExtension = imageExtension ?? originalExtension
+        let suffix = fileExtension.map { ".\($0)" } ?? ""
+        let byteLimit = max(1, 120 - suffix.utf8.count)
+        while stem.utf8.count > byteLimit, !stem.isEmpty {
+            stem.removeLast()
+        }
+        if stem.isEmpty { stem = "attachment" }
+        return stem + suffix
+    }
+
+    private static func sanitizedExtension(_ value: String) -> String? {
+        let filtered = value.lowercased().filter { $0.isASCII && ($0.isLetter || $0.isNumber) }
+        guard !filtered.isEmpty, filtered.utf8.count <= 16 else { return nil }
+        return filtered
+    }
+}

--- a/Sources/ColumbaApp/Views/Messaging/MessageBubble.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageBubble.swift
@@ -143,12 +143,15 @@ struct MessageBubble: View {
                 .background(bubbleBackground)
                 .clipShape(bubbleShape)
                 .contentShape(bubbleShape)
-                .onLongPressGesture(minimumDuration: 0.4) {
-                    #if canImport(UIKit)
-                    UIImpactFeedbackGenerator(style: .medium).impactOccurred()
-                    #endif
-                    onLongPress?()
-                }
+                .simultaneousGesture(
+                    LongPressGesture(minimumDuration: 0.4)
+                        .onEnded { _ in
+                            #if canImport(UIKit)
+                            UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                            #endif
+                            onLongPress?()
+                        }
+                )
 
                 // Reaction chips (below bubble)
                 if !message.reactions.isEmpty {

--- a/Sources/ColumbaApp/Views/Messaging/MessageBubble.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageBubble.swift
@@ -126,9 +126,10 @@ struct MessageBubble: View {
                                     onOpenFileAttachment?(index)
                                 } label: {
                                     fileChip(name: attachment.name, size: attachment.data.count)
+                                        .accessibilityIdentifier("bubble_file_chip")
                                 }
                                 .buttonStyle(.plain)
-                                .accessibilityIdentifier("bubble_file_chip")
+                                .accessibilityIdentifier("bubble_file_chip_\(index)")
                                 .accessibilityLabel(
                                     String(localized: "File attachment: \(attachment.name)")
                                 )

--- a/Sources/ColumbaApp/Views/Messaging/MessageBubble.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageBubble.swift
@@ -15,6 +15,58 @@ import UIKit
 
 private let logger = Logger(subsystem: "network.columba.Columba", category: "MessageBubble")
 
+enum BubbleAction {
+    case tap
+    case longPress
+}
+
+enum BubbleActionRouter {
+    static func perform(
+        _ action: BubbleAction,
+        onTap: () -> Void,
+        onLongPress: (() -> Void)?
+    ) {
+        switch action {
+        case .tap:
+            onTap()
+        case .longPress:
+            #if canImport(UIKit)
+            UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+            #endif
+            onLongPress?()
+        }
+    }
+}
+
+private struct BubbleActionButtonStyle: PrimitiveButtonStyle {
+    let onLongPress: (() -> Void)?
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .contentShape(Rectangle())
+            .gesture(
+                LongPressGesture(minimumDuration: 0.4)
+                    .exclusively(before: TapGesture())
+                    .onEnded { outcome in
+                        switch outcome {
+                        case .first:
+                            BubbleActionRouter.perform(
+                                .longPress,
+                                onTap: configuration.trigger,
+                                onLongPress: onLongPress
+                            )
+                        case .second:
+                            BubbleActionRouter.perform(
+                                .tap,
+                                onTap: configuration.trigger,
+                                onLongPress: onLongPress
+                            )
+                        }
+                    }
+            )
+    }
+}
+
 /// Individual message bubble view.
 ///
 /// Layout:
@@ -76,7 +128,7 @@ struct MessageBubble: View {
                                 }
                                 .padding(.vertical, 4)
                         }
-                        .buttonStyle(.plain)
+                        .buttonStyle(BubbleActionButtonStyle(onLongPress: onLongPress))
                     }
 
                     // Inline image
@@ -91,7 +143,7 @@ struct MessageBubble: View {
                                 .frame(maxWidth: 250)
                                 .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
                         }
-                        .buttonStyle(.plain)
+                        .buttonStyle(BubbleActionButtonStyle(onLongPress: onLongPress))
                         // Stable handle for the Tests/interop/ harness:
                         // `assertVisible: { id: "bubble_image" }` confirms an
                         // inbound image actually rendered (vs the bubble
@@ -128,7 +180,7 @@ struct MessageBubble: View {
                                     fileChip(name: attachment.name, size: attachment.data.count)
                                         .accessibilityIdentifier("bubble_file_chip")
                                 }
-                                .buttonStyle(.plain)
+                                .buttonStyle(BubbleActionButtonStyle(onLongPress: onLongPress))
                                 .accessibilityIdentifier("bubble_file_chip_\(index)")
                                 .accessibilityLabel(
                                     String(localized: "File attachment: \(attachment.name)")
@@ -140,18 +192,22 @@ struct MessageBubble: View {
                 }
                 .padding(.horizontal, 14)
                 .padding(.vertical, 10)
-                .background(bubbleBackground)
+                .background {
+                    bubbleBackground
+                        .contentShape(bubbleShape)
+                        .gesture(
+                            LongPressGesture(minimumDuration: 0.4)
+                                .onEnded { _ in
+                                    BubbleActionRouter.perform(
+                                        .longPress,
+                                        onTap: {},
+                                        onLongPress: onLongPress
+                                    )
+                                }
+                        )
+                }
                 .clipShape(bubbleShape)
                 .contentShape(bubbleShape)
-                .simultaneousGesture(
-                    LongPressGesture(minimumDuration: 0.4)
-                        .onEnded { _ in
-                            #if canImport(UIKit)
-                            UIImpactFeedbackGenerator(style: .medium).impactOccurred()
-                            #endif
-                            onLongPress?()
-                        }
-                )
 
                 // Reaction chips (below bubble)
                 if !message.reactions.isEmpty {

--- a/Sources/ColumbaApp/Views/Messaging/MessageBubble.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageBubble.swift
@@ -37,6 +37,10 @@ struct MessageBubble: View {
     var onLongPress: (() -> Void)?
     /// Callback for validated in-app message links such as NomadNet pages.
     var onOpenLink: ((MessageLinkTarget) -> Void)?
+    /// Callback for opening the message's inline image attachment.
+    var onOpenImage: (() -> Void)?
+    /// Callback for opening a file attachment by its stable message-local index.
+    var onOpenFileAttachment: ((Int) -> Void)?
 
     // MARK: - Theme (delegates to Theme/ThemeManager)
 
@@ -78,17 +82,23 @@ struct MessageBubble: View {
                     // Inline image
                     if let imageData = message.imageData,
                        let uiImage = UIImage(data: imageData) {
-                        Image(platformImage: uiImage)
-                            .resizable()
-                            .aspectRatio(contentMode: .fit)
-                            .frame(maxWidth: 250)
-                            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-                            // Stable handle for the Tests/interop/ harness:
-                            // `assertVisible: { id: "bubble_image" }` confirms an
-                            // inbound image actually rendered (vs the bubble
-                            // existing without an image).
-                            .accessibilityIdentifier("bubble_image")
-                            .accessibilityLabel("Image attachment")
+                        Button {
+                            onOpenImage?()
+                        } label: {
+                            Image(platformImage: uiImage)
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .frame(maxWidth: 250)
+                                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                        }
+                        .buttonStyle(.plain)
+                        // Stable handle for the Tests/interop/ harness:
+                        // `assertVisible: { id: "bubble_image" }` confirms an
+                        // inbound image actually rendered (vs the bubble
+                        // existing without an image).
+                        .accessibilityIdentifier("bubble_image")
+                        .accessibilityLabel(String(localized: "Image attachment"))
+                        .accessibilityHint(String(localized: "Opens attachment preview"))
                     }
 
                     // Text content (show if non-empty)
@@ -111,8 +121,18 @@ struct MessageBubble: View {
                     // File attachment chips
                     if let attachments = message.attachments, !attachments.isEmpty {
                         VStack(alignment: .leading, spacing: 4) {
-                            ForEach(Array(attachments.enumerated()), id: \.offset) { _, attachment in
-                                fileChip(name: attachment.name, size: attachment.data.count)
+                            ForEach(Array(attachments.enumerated()), id: \.offset) { index, attachment in
+                                Button {
+                                    onOpenFileAttachment?(index)
+                                } label: {
+                                    fileChip(name: attachment.name, size: attachment.data.count)
+                                }
+                                .buttonStyle(.plain)
+                                .accessibilityIdentifier("bubble_file_chip")
+                                .accessibilityLabel(
+                                    String(localized: "File attachment: \(attachment.name)")
+                                )
+                                .accessibilityHint(String(localized: "Opens attachment preview"))
                             }
                         }
                     }
@@ -215,13 +235,7 @@ struct MessageBubble: View {
         .padding(.vertical, 6)
         .background(Color.white.opacity(0.1))
         .clipShape(Capsule())
-        // a11y for Tests/interop/ harness: pin "file attachment chip with
-        // exactly this filename rendered" — the chip's own Text(name) is
-        // also findable on its own, but tagging the whole capsule lets a
-        // future test count chips or query their size labels.
         .accessibilityElement(children: .combine)
-        .accessibilityIdentifier("bubble_file_chip")
-        .accessibilityLabel("File: \(name)")
     }
 
     private static func formatFileSize(_ bytes: Int) -> String {

--- a/Sources/ColumbaApp/Views/Messaging/MessageTimelineView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageTimelineView.swift
@@ -93,8 +93,7 @@ struct MessageTimelineView: UIViewControllerRepresentable {
         controller.onToggleReaction = onToggleReaction
         controller.onLongPress = onLongPress
         controller.onOpenLink = onOpenLink
-        controller.onOpenImage = onOpenImage
-        controller.onOpenFileAttachment = onOpenFileAttachment
+        applyAttachmentCallbacks(to: controller)
         return controller
     }
 
@@ -104,8 +103,7 @@ struct MessageTimelineView: UIViewControllerRepresentable {
         controller.onToggleReaction = onToggleReaction
         controller.onLongPress = onLongPress
         controller.onOpenLink = onOpenLink
-        controller.onOpenImage = onOpenImage
-        controller.onOpenFileAttachment = onOpenFileAttachment
+        applyAttachmentCallbacks(to: controller)
         controller.update(
             conversationID: conversationID,
             messages: messages,
@@ -113,6 +111,11 @@ struct MessageTimelineView: UIViewControllerRepresentable {
             isLoadingMore: isLoadingMore,
             allMessagesLoaded: allMessagesLoaded
         )
+    }
+
+    func applyAttachmentCallbacks(to controller: MessageTimelineViewController) {
+        controller.onOpenImage = onOpenImage
+        controller.onOpenFileAttachment = onOpenFileAttachment
     }
 }
 
@@ -488,6 +491,11 @@ final class MessageTimelineViewController: UIViewController, UICollectionViewDat
     func openFileAttachmentForTesting(messageID: String, index: Int) {
         guard let message = messages.first(where: { $0.id == messageID }) else { return }
         routeFileAttachment(message: message, index: index)
+    }
+
+    func openImageAttachmentForTesting(messageID: String) {
+        guard let message = messages.first(where: { $0.id == messageID }) else { return }
+        onOpenImage?(message)
     }
 
     private func routeFileAttachment(message: Message, index: Int) {

--- a/Sources/ColumbaApp/Views/Messaging/MessageTimelineView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageTimelineView.swift
@@ -82,6 +82,8 @@ struct MessageTimelineView: UIViewControllerRepresentable {
     let onToggleReaction: (Message, String) -> Void
     let onLongPress: (Message) -> Void
     let onOpenLink: (MessageLinkTarget) -> Void
+    let onOpenImage: (Message) -> Void
+    let onOpenFileAttachment: (Message, Int) -> Void
 
     func makeUIViewController(context: Context) -> MessageTimelineViewController {
         let controller = MessageTimelineViewController()
@@ -91,6 +93,8 @@ struct MessageTimelineView: UIViewControllerRepresentable {
         controller.onToggleReaction = onToggleReaction
         controller.onLongPress = onLongPress
         controller.onOpenLink = onOpenLink
+        controller.onOpenImage = onOpenImage
+        controller.onOpenFileAttachment = onOpenFileAttachment
         return controller
     }
 
@@ -100,6 +104,8 @@ struct MessageTimelineView: UIViewControllerRepresentable {
         controller.onToggleReaction = onToggleReaction
         controller.onLongPress = onLongPress
         controller.onOpenLink = onOpenLink
+        controller.onOpenImage = onOpenImage
+        controller.onOpenFileAttachment = onOpenFileAttachment
         controller.update(
             conversationID: conversationID,
             messages: messages,
@@ -117,6 +123,8 @@ final class MessageTimelineViewController: UIViewController, UICollectionViewDat
     var onToggleReaction: ((Message, String) -> Void)?
     var onLongPress: ((Message) -> Void)?
     var onOpenLink: ((MessageLinkTarget) -> Void)?
+    var onOpenImage: ((Message) -> Void)?
+    var onOpenFileAttachment: ((Message, Int) -> Void)?
 
     private var messages: [Message] = []
     private var conversationID: String?
@@ -314,6 +322,12 @@ final class MessageTimelineViewController: UIViewController, UICollectionViewDat
                     },
                     onOpenLink: { [weak self] target in
                         self?.onOpenLink?(target)
+                    },
+                    onOpenImage: { [weak self] in
+                        self?.onOpenImage?(message)
+                    },
+                    onOpenFileAttachment: { [weak self] index in
+                        self?.routeFileAttachment(message: message, index: index)
                     }
                 )
             }
@@ -469,6 +483,16 @@ final class MessageTimelineViewController: UIViewController, UICollectionViewDat
 
     var visibleMessageCellCount: Int {
         collectionView.indexPathsForVisibleItems.count
+    }
+
+    func openFileAttachmentForTesting(messageID: String, index: Int) {
+        guard let message = messages.first(where: { $0.id == messageID }) else { return }
+        routeFileAttachment(message: message, index: index)
+    }
+
+    private func routeFileAttachment(message: Message, index: Int) {
+        guard let attachments = message.attachments, attachments.indices.contains(index) else { return }
+        onOpenFileAttachment?(message, index)
     }
 
     struct ViewportSnapshot: Equatable {

--- a/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
@@ -172,7 +172,7 @@ struct MessagingView: View {
     @State private var showTextSizePicker = false
     @State private var messageTextScale = SettingsRepository.MessageTextScale.defaultValue
     @State private var nomadNetLinkTarget: MessageLinkTarget?
-    @State private var attachmentPreviewItem: MessageAttachmentPreviewItem?
+    @StateObject private var attachmentPreviewStore = MessageAttachmentPreviewStore()
     @State private var attachmentPreviewError: String?
     @Environment(\.dismiss) private var dismiss
     @Environment(\.scenePhase) private var scenePhase
@@ -641,9 +641,9 @@ struct MessagingView: View {
             .presentationDragIndicator(.visible)
         }
         #if os(iOS)
-        .fullScreenCover(item: $attachmentPreviewItem, onDismiss: cleanupAttachmentPreview) { item in
+        .fullScreenCover(item: $attachmentPreviewStore.item, onDismiss: attachmentPreviewStore.dismiss) { item in
             AttachmentPreviewScreen(item: item) {
-                attachmentPreviewItem = nil
+                attachmentPreviewStore.dismiss()
             }
         }
         .alert("Unable to Open Attachment", isPresented: Binding(
@@ -658,7 +658,7 @@ struct MessagingView: View {
         .onDisappear {
             flushDraft(for: .navigation)
             NotificationService.activeConversationThreadId = nil
-            cleanupAttachmentPreview()
+            attachmentPreviewStore.exitConversation()
         }
         .onChange(of: scenePhase) { oldPhase, newPhase in
             guard oldPhase == .active, newPhase != .active else { return }
@@ -911,24 +911,19 @@ struct MessagingView: View {
         declaredImageFormat: String? = nil,
         isImage: Bool = false
     ) {
-        cleanupAttachmentPreview()
         do {
-            attachmentPreviewItem = try MessageAttachmentPreviewItem(
+            let item = try MessageAttachmentPreviewItem(
                 data: data,
                 suggestedFilename: suggestedFilename,
                 declaredImageFormat: declaredImageFormat,
                 isImage: isImage
             )
+            attachmentPreviewStore.present(item)
         } catch {
             attachmentPreviewError = String(
                 localized: "The attachment could not be prepared for preview."
             )
         }
-    }
-
-    private func cleanupAttachmentPreview() {
-        attachmentPreviewItem?.cleanup()
-        attachmentPreviewItem = nil
     }
 
     @ViewBuilder

--- a/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
@@ -10,8 +10,6 @@ import SwiftUI
 import RNSAPI
 import PhotosUI
 import UniformTypeIdentifiers
-#if os(iOS)
-#endif
 import os.log
 #if canImport(UIKit)
 import UIKit
@@ -313,7 +311,11 @@ struct MessagingView: View {
                                                 reactionModeMessage = message
                                             }
                                         },
-                                        onOpenLink: openMessageLink
+                                        onOpenLink: openMessageLink,
+                                        onOpenImage: { openImageAttachment(message) },
+                                        onOpenFileAttachment: { index in
+                                            openFileAttachment(message, index: index)
+                                        }
                                     )
                                 }
                                 .id(message.id)
@@ -641,11 +643,7 @@ struct MessagingView: View {
             .presentationDragIndicator(.visible)
         }
         #if os(iOS)
-        .fullScreenCover(item: $attachmentPreviewStore.item, onDismiss: attachmentPreviewStore.dismiss) { item in
-            AttachmentPreviewScreen(item: item) {
-                attachmentPreviewStore.dismiss()
-            }
-        }
+        .quickLookPreview(attachmentPreviewURLBinding)
         .alert("Unable to Open Attachment", isPresented: Binding(
             get: { attachmentPreviewError != nil },
             set: { if !$0 { attachmentPreviewError = nil } }
@@ -865,6 +863,19 @@ struct MessagingView: View {
             }
         )
     }
+
+    #if os(iOS)
+    private var attachmentPreviewURLBinding: Binding<URL?> {
+        Binding(
+            get: { attachmentPreviewStore.item?.url },
+            set: { newURL in
+                if newURL == nil {
+                    attachmentPreviewStore.dismiss()
+                }
+            }
+        )
+    }
+    #endif
 
     private enum DraftFlushBoundary {
         case navigation
@@ -1489,73 +1500,6 @@ private struct LocationShareSheet: View {
             .padding(.horizontal)
 
             Spacer()
-        }
-    }
-}
-#endif
-
-#if os(iOS)
-@available(iOS 17.0, *)
-private struct AttachmentPreviewScreen: View {
-    let item: MessageAttachmentPreviewItem
-    let onClose: () -> Void
-
-    var body: some View {
-        NavigationStack {
-            AttachmentQuickLookPreview(url: item.url)
-                .ignoresSafeArea(edges: .bottom)
-                .navigationTitle(item.url.lastPathComponent)
-                .navigationBarTitleDisplayMode(.inline)
-                .toolbar {
-                    ToolbarItem(placement: .topBarLeading) {
-                        Button("Close", action: onClose)
-                    }
-                    ToolbarItem(placement: .topBarTrailing) {
-                        ShareLink(item: item.url) {
-                            Label("Share Attachment", systemImage: "square.and.arrow.up")
-                        }
-                        .accessibilityIdentifier("attachment_share_button")
-                    }
-                }
-        }
-        .accessibilityIdentifier("attachment_preview")
-    }
-}
-
-@available(iOS 17.0, *)
-private struct AttachmentQuickLookPreview: UIViewControllerRepresentable {
-    let url: URL
-
-    func makeCoordinator() -> Coordinator {
-        Coordinator(url: url)
-    }
-
-    func makeUIViewController(context: Context) -> QLPreviewController {
-        let controller = QLPreviewController()
-        controller.dataSource = context.coordinator
-        return controller
-    }
-
-    func updateUIViewController(_ controller: QLPreviewController, context: Context) {
-        guard context.coordinator.url != url else { return }
-        context.coordinator.url = url
-        controller.reloadData()
-    }
-
-    final class Coordinator: NSObject, QLPreviewControllerDataSource {
-        var url: URL
-
-        init(url: URL) {
-            self.url = url
-        }
-
-        func numberOfPreviewItems(in controller: QLPreviewController) -> Int { 1 }
-
-        func previewController(
-            _ controller: QLPreviewController,
-            previewItemAt index: Int
-        ) -> QLPreviewItem {
-            url as NSURL
         }
     }
 }

--- a/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
@@ -15,6 +15,7 @@ import UniformTypeIdentifiers
 import os.log
 #if canImport(UIKit)
 import UIKit
+import QuickLook
 #endif
 #if canImport(AppKit)
 import AppKit
@@ -171,6 +172,8 @@ struct MessagingView: View {
     @State private var showTextSizePicker = false
     @State private var messageTextScale = SettingsRepository.MessageTextScale.defaultValue
     @State private var nomadNetLinkTarget: MessageLinkTarget?
+    @State private var attachmentPreviewItem: MessageAttachmentPreviewItem?
+    @State private var attachmentPreviewError: String?
     @Environment(\.dismiss) private var dismiss
     @Environment(\.scenePhase) private var scenePhase
 
@@ -211,7 +214,9 @@ struct MessagingView: View {
                             reactionModeMessage = message
                         }
                     },
-                    onOpenLink: openMessageLink
+                    onOpenLink: openMessageLink,
+                    onOpenImage: openImageAttachment,
+                    onOpenFileAttachment: openFileAttachment
                 )
                 .safeAreaInset(edge: .bottom, spacing: 0) {
                     MessageInputBar(
@@ -635,9 +640,25 @@ struct MessagingView: View {
             .presentationDetents([.height(460), .large])
             .presentationDragIndicator(.visible)
         }
+        #if os(iOS)
+        .fullScreenCover(item: $attachmentPreviewItem, onDismiss: cleanupAttachmentPreview) { item in
+            AttachmentPreviewScreen(item: item) {
+                attachmentPreviewItem = nil
+            }
+        }
+        .alert("Unable to Open Attachment", isPresented: Binding(
+            get: { attachmentPreviewError != nil },
+            set: { if !$0 { attachmentPreviewError = nil } }
+        )) {
+            Button("OK", role: .cancel) { attachmentPreviewError = nil }
+        } message: {
+            Text(attachmentPreviewError ?? "")
+        }
+        #endif
         .onDisappear {
             flushDraft(for: .navigation)
             NotificationService.activeConversationThreadId = nil
+            cleanupAttachmentPreview()
         }
         .onChange(of: scenePhase) { oldPhase, newPhase in
             guard oldPhase == .active, newPhase != .active else { return }
@@ -866,6 +887,48 @@ struct MessagingView: View {
     private func openMessageLink(_ target: MessageLinkTarget) {
         guard case .nomadNet = target else { return }
         nomadNetLinkTarget = target
+    }
+
+    private func openImageAttachment(_ message: Message) {
+        guard let data = message.imageData else { return }
+        prepareAttachmentPreview(
+            data: data,
+            suggestedFilename: "image",
+            declaredImageFormat: message.imageFormat,
+            isImage: true
+        )
+    }
+
+    private func openFileAttachment(_ message: Message, index: Int) {
+        guard let attachments = message.attachments, attachments.indices.contains(index) else { return }
+        let attachment = attachments[index]
+        prepareAttachmentPreview(data: attachment.data, suggestedFilename: attachment.name)
+    }
+
+    private func prepareAttachmentPreview(
+        data: Data,
+        suggestedFilename: String,
+        declaredImageFormat: String? = nil,
+        isImage: Bool = false
+    ) {
+        cleanupAttachmentPreview()
+        do {
+            attachmentPreviewItem = try MessageAttachmentPreviewItem(
+                data: data,
+                suggestedFilename: suggestedFilename,
+                declaredImageFormat: declaredImageFormat,
+                isImage: isImage
+            )
+        } catch {
+            attachmentPreviewError = String(
+                localized: "The attachment could not be prepared for preview."
+            )
+        }
+    }
+
+    private func cleanupAttachmentPreview() {
+        attachmentPreviewItem?.cleanup()
+        attachmentPreviewItem = nil
     }
 
     @ViewBuilder
@@ -1431,6 +1494,73 @@ private struct LocationShareSheet: View {
             .padding(.horizontal)
 
             Spacer()
+        }
+    }
+}
+#endif
+
+#if os(iOS)
+@available(iOS 17.0, *)
+private struct AttachmentPreviewScreen: View {
+    let item: MessageAttachmentPreviewItem
+    let onClose: () -> Void
+
+    var body: some View {
+        NavigationStack {
+            AttachmentQuickLookPreview(url: item.url)
+                .ignoresSafeArea(edges: .bottom)
+                .navigationTitle(item.url.lastPathComponent)
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .topBarLeading) {
+                        Button("Close", action: onClose)
+                    }
+                    ToolbarItem(placement: .topBarTrailing) {
+                        ShareLink(item: item.url) {
+                            Label("Share Attachment", systemImage: "square.and.arrow.up")
+                        }
+                        .accessibilityIdentifier("attachment_share_button")
+                    }
+                }
+        }
+        .accessibilityIdentifier("attachment_preview")
+    }
+}
+
+@available(iOS 17.0, *)
+private struct AttachmentQuickLookPreview: UIViewControllerRepresentable {
+    let url: URL
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(url: url)
+    }
+
+    func makeUIViewController(context: Context) -> QLPreviewController {
+        let controller = QLPreviewController()
+        controller.dataSource = context.coordinator
+        return controller
+    }
+
+    func updateUIViewController(_ controller: QLPreviewController, context: Context) {
+        guard context.coordinator.url != url else { return }
+        context.coordinator.url = url
+        controller.reloadData()
+    }
+
+    final class Coordinator: NSObject, QLPreviewControllerDataSource {
+        var url: URL
+
+        init(url: URL) {
+            self.url = url
+        }
+
+        func numberOfPreviewItems(in controller: QLPreviewController) -> Int { 1 }
+
+        func previewController(
+            _ controller: QLPreviewController,
+            previewItemAt index: Int
+        ) -> QLPreviewItem {
+            url as NSURL
         }
     }
 }

--- a/Tests/ColumbaAppTests/MessageAttachmentPreviewTests.swift
+++ b/Tests/ColumbaAppTests/MessageAttachmentPreviewTests.swift
@@ -228,23 +228,32 @@ final class MessageAttachmentRoutingTests: XCTestCase {
     }
 
     private func dominantColorCounts(in image: UIImage) -> (red: Int, green: Int, blue: Int) {
-        guard let cgImage = image.cgImage,
-              let data = cgImage.dataProvider?.data,
-              let bytes = CFDataGetBytePtr(data) else {
+        guard let cgImage = image.cgImage else { return (0, 0, 0) }
+        let width = cgImage.width
+        let height = cgImage.height
+        let bytesPerRow = width * 4
+        var pixels = [UInt8](repeating: 0, count: height * bytesPerRow)
+        guard let context = CGContext(
+            data: &pixels,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: bytesPerRow,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else {
             return (0, 0, 0)
         }
-        let bytesPerPixel = max(1, cgImage.bitsPerPixel / 8)
+        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
+
         var counts = (red: 0, green: 0, blue: 0)
-        for y in 0..<cgImage.height {
-            for x in 0..<cgImage.width {
-                let offset = y * cgImage.bytesPerRow + x * bytesPerPixel
-                let red = Int(bytes[offset])
-                let green = Int(bytes[offset + 1])
-                let blue = Int(bytes[offset + 2])
-                if red > green * 2, red > blue * 2 { counts.red += 1 }
-                if green > red * 2, green > blue * 2 { counts.green += 1 }
-                if blue > red * 2, blue > green * 2 { counts.blue += 1 }
-            }
+        for offset in stride(from: 0, to: pixels.count, by: 4) {
+            let red = Int(pixels[offset])
+            let green = Int(pixels[offset + 1])
+            let blue = Int(pixels[offset + 2])
+            if red > green * 2, red > blue * 2 { counts.red += 1 }
+            if green > red * 2, green > blue * 2 { counts.green += 1 }
+            if blue > red * 2, blue > green * 2 { counts.blue += 1 }
         }
         return counts
     }

--- a/Tests/ColumbaAppTests/MessageAttachmentPreviewTests.swift
+++ b/Tests/ColumbaAppTests/MessageAttachmentPreviewTests.swift
@@ -1,0 +1,151 @@
+import XCTest
+import UIKit
+@testable import ColumbaApp
+
+final class MessageAttachmentPreviewItemTests: XCTestCase {
+    private let pngData = Data(base64Encoded: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4z8DwHwAFgAI/ScL1WQAAAABJRU5ErkJggg==")!
+
+    func testExportPreservesOriginalBytesAndDetectedTypeBeatsDeclaration() throws {
+        let item = try MessageAttachmentPreviewItem(
+            data: pngData,
+            suggestedFilename: "photo.jpg",
+            declaredImageFormat: "jpeg",
+            isImage: true
+        )
+        defer { item.cleanup() }
+
+        XCTAssertEqual(try Data(contentsOf: item.url), pngData)
+        XCTAssertEqual(item.url.pathExtension.lowercased(), "png")
+    }
+
+    func testImageTypeDetectionDoesNotRequireDeclaredFormat() throws {
+        let item = try MessageAttachmentPreviewItem(
+            data: pngData,
+            suggestedFilename: "image",
+            isImage: true
+        )
+        defer { item.cleanup() }
+
+        XCTAssertEqual(item.url.pathExtension.lowercased(), "png")
+        XCTAssertEqual(try Data(contentsOf: item.url), pngData)
+    }
+
+    func testMimeTypeDeclarationProvidesImageExtensionWhenBytesAreUnknown() throws {
+        let bytes = Data("not a decodable image".utf8)
+        let item = try MessageAttachmentPreviewItem(
+            data: bytes,
+            suggestedFilename: "image",
+            declaredImageFormat: "image/jpeg",
+            isImage: true
+        )
+        defer { item.cleanup() }
+
+        XCTAssertEqual(item.url.pathExtension.lowercased(), "jpg")
+        XCTAssertEqual(try Data(contentsOf: item.url), bytes)
+    }
+
+    func testAdversarialNamesStayInsideOwnedDirectory() throws {
+        let names = [
+            "../../secret.txt", "..\\..\\secret.txt", "/tmp/secret.txt",
+            "control\u{0000}name.txt", "", String(repeating: "x", count: 400) + ".txt",
+        ]
+
+        for name in names {
+            let item = try MessageAttachmentPreviewItem(data: Data("payload".utf8), suggestedFilename: name)
+            defer { item.cleanup() }
+            XCTAssertEqual(item.url.deletingLastPathComponent(), item.directoryURL)
+            XCTAssertFalse(item.url.lastPathComponent.isEmpty)
+            XCTAssertFalse(item.url.lastPathComponent.contains("/"))
+            XCTAssertFalse(item.url.lastPathComponent.contains("\\"))
+            XCTAssertLessThanOrEqual(item.url.lastPathComponent.utf8.count, 120)
+        }
+    }
+
+    func testDuplicateNamesAndCleanupAreItemScopedAndIdempotent() throws {
+        let first = try MessageAttachmentPreviewItem(data: Data("first".utf8), suggestedFilename: "same.bin")
+        let second = try MessageAttachmentPreviewItem(data: Data("second".utf8), suggestedFilename: "same.bin")
+        defer { second.cleanup() }
+
+        XCTAssertNotEqual(first.directoryURL, second.directoryURL)
+        XCTAssertEqual(try Data(contentsOf: first.url), Data("first".utf8))
+        XCTAssertEqual(try Data(contentsOf: second.url), Data("second".utf8))
+
+        first.cleanup()
+        first.cleanup()
+        XCTAssertFalse(FileManager.default.fileExists(atPath: first.directoryURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: second.url.path))
+    }
+}
+
+final class MessageAttachmentRoutingTests: XCTestCase {
+    @MainActor
+    func testFileSelectionRoutesStableIndexAndFreshCallbackWithoutReload() throws {
+        let attachments = [
+            FileAttachment(name: "first.txt", data: Data("first".utf8)),
+            FileAttachment(name: "second.txt", data: Data("second".utf8)),
+        ]
+        let message = Message(id: "with-files", content: "", isFromMe: false, attachments: attachments)
+        let controller = MessageTimelineViewController()
+        controller.loadViewIfNeeded()
+        controller.setViewportForTesting(CGSize(width: 390, height: 500))
+        controller.update(messages: [message], isLoadingMore: false, allMessagesLoaded: true)
+        let reloadCount = controller.timelineReloadCountForTesting
+
+        var staleIndex: Int?
+        controller.onOpenFileAttachment = { _, index in staleIndex = index }
+        var selected: (String, Data, Int)?
+        controller.onOpenFileAttachment = { routedMessage, index in
+            let attachment = routedMessage.attachments![index]
+            selected = (attachment.name, attachment.data, index)
+        }
+        controller.update(messages: [message], isLoadingMore: false, allMessagesLoaded: true)
+        controller.openFileAttachmentForTesting(messageID: message.id, index: 1)
+
+        XCTAssertNil(staleIndex)
+        XCTAssertEqual(selected?.0, "second.txt")
+        XCTAssertEqual(selected?.1, Data("second".utf8))
+        XCTAssertEqual(selected?.2, 1)
+        XCTAssertEqual(controller.timelineReloadCountForTesting, reloadCount)
+    }
+
+    @MainActor
+    func testAttachmentBubbleProducesVisualEvidenceAndTapCallbacks() throws {
+        let image = UIGraphicsImageRenderer(size: CGSize(width: 2, height: 2)).pngData()
+        let message = Message(
+            content: "Attachments",
+            isFromMe: false,
+            imageData: image,
+            imageFormat: "png",
+            attachments: [FileAttachment(name: "document.txt", data: Data("contents".utf8))]
+        )
+        var imageTapCount = 0
+        var fileIndex: Int?
+        let renderer = ImageRenderer(content:
+            MessageBubble(
+                message: message,
+                onOpenImage: { imageTapCount += 1 },
+                onOpenFileAttachment: { fileIndex = $0 }
+            )
+            .frame(width: 320)
+            .padding()
+            .background(Color.black)
+        )
+        renderer.scale = 3
+        let screenshot = try XCTUnwrap(renderer.uiImage)
+        XCTAssertGreaterThan(screenshot.size.height, 80)
+        let attachment = XCTAttachment(image: screenshot)
+        attachment.name = "interactive-image-and-file-attachment-controls"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+
+        let bubble = MessageBubble(
+            message: message,
+            onOpenImage: { imageTapCount += 1 },
+            onOpenFileAttachment: { fileIndex = $0 }
+        )
+        bubble.onOpenImage?()
+        bubble.onOpenFileAttachment?(0)
+        XCTAssertEqual(imageTapCount, 1)
+        XCTAssertEqual(fileIndex, 0)
+    }
+}

--- a/Tests/ColumbaAppTests/MessageAttachmentPreviewTests.swift
+++ b/Tests/ColumbaAppTests/MessageAttachmentPreviewTests.swift
@@ -78,6 +78,36 @@ final class MessageAttachmentPreviewItemTests: XCTestCase {
     }
 }
 
+final class BubbleActionRouterTests: XCTestCase {
+    func testTapInvokesOnlyTapCallback() {
+        var taps = 0
+        var longPresses = 0
+
+        BubbleActionRouter.perform(
+            .tap,
+            onTap: { taps += 1 },
+            onLongPress: { longPresses += 1 }
+        )
+
+        XCTAssertEqual(taps, 1)
+        XCTAssertEqual(longPresses, 0)
+    }
+
+    func testLongPressInvokesOnlyLongPressCallback() {
+        var taps = 0
+        var longPresses = 0
+
+        BubbleActionRouter.perform(
+            .longPress,
+            onTap: { taps += 1 },
+            onLongPress: { longPresses += 1 }
+        )
+
+        XCTAssertEqual(taps, 0)
+        XCTAssertEqual(longPresses, 1)
+    }
+}
+
 @MainActor
 final class MessageAttachmentPreviewStoreTests: XCTestCase {
     func testReplacementDismissalAndConversationExitCleanOnlyOwnedItems() throws {

--- a/Tests/ColumbaAppTests/MessageAttachmentPreviewTests.swift
+++ b/Tests/ColumbaAppTests/MessageAttachmentPreviewTests.swift
@@ -41,7 +41,7 @@ final class MessageAttachmentPreviewItemTests: XCTestCase {
         )
         defer { item.cleanup() }
 
-        XCTAssertEqual(item.url.pathExtension.lowercased(), "jpg")
+        XCTAssertEqual(item.url.pathExtension.lowercased(), "jpeg")
         XCTAssertEqual(try Data(contentsOf: item.url), bytes)
     }
 

--- a/Tests/ColumbaAppTests/MessageAttachmentPreviewTests.swift
+++ b/Tests/ColumbaAppTests/MessageAttachmentPreviewTests.swift
@@ -78,9 +78,49 @@ final class MessageAttachmentPreviewItemTests: XCTestCase {
     }
 }
 
+@MainActor
+final class MessageAttachmentPreviewStoreTests: XCTestCase {
+    func testReplacementDismissalAndConversationExitCleanOnlyOwnedItems() throws {
+        let sibling = try MessageAttachmentPreviewItem(
+            data: Data("sibling".utf8),
+            suggestedFilename: "sibling.bin"
+        )
+        defer { sibling.cleanup() }
+        let first = try MessageAttachmentPreviewItem(
+            data: Data("first".utf8),
+            suggestedFilename: "first.bin"
+        )
+        let second = try MessageAttachmentPreviewItem(
+            data: Data("second".utf8),
+            suggestedFilename: "second.bin"
+        )
+        let third = try MessageAttachmentPreviewItem(
+            data: Data("third".utf8),
+            suggestedFilename: "third.bin"
+        )
+        let store = MessageAttachmentPreviewStore(item: first)
+
+        store.present(second)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: first.directoryURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: second.url.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: sibling.url.path))
+
+        store.dismiss()
+        store.dismiss()
+        XCTAssertFalse(FileManager.default.fileExists(atPath: second.directoryURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: sibling.url.path))
+
+        store.present(third)
+        store.exitConversation()
+        store.exitConversation()
+        XCTAssertFalse(FileManager.default.fileExists(atPath: third.directoryURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: sibling.url.path))
+    }
+}
+
 final class MessageAttachmentRoutingTests: XCTestCase {
     @MainActor
-    func testFileSelectionRoutesStableIndexAndFreshCallbackWithoutReload() throws {
+    func testRepresentableRefreshesImageAndFileCallbacksWithoutReload() throws {
         let attachments = [
             FileAttachment(name: "first.txt", data: Data("first".utf8)),
             FileAttachment(name: "second.txt", data: Data("second".utf8)),
@@ -92,17 +132,31 @@ final class MessageAttachmentRoutingTests: XCTestCase {
         controller.update(messages: [message], isLoadingMore: false, allMessagesLoaded: true)
         let reloadCount = controller.timelineReloadCountForTesting
 
-        var staleIndex: Int?
-        controller.onOpenFileAttachment = { _, index in staleIndex = index }
+        var staleImageID: String?
+        var staleFileIndex: Int?
+        makeTimeline(
+            message: message,
+            onOpenImage: { staleImageID = $0.id },
+            onOpenFile: { _, index in staleFileIndex = index }
+        ).applyAttachmentCallbacks(to: controller)
+
+        var selectedImageID: String?
         var selected: (String, Data, Int)?
-        controller.onOpenFileAttachment = { routedMessage, index in
-            let attachment = routedMessage.attachments![index]
-            selected = (attachment.name, attachment.data, index)
-        }
+        makeTimeline(
+            message: message,
+            onOpenImage: { selectedImageID = $0.id },
+            onOpenFile: { routedMessage, index in
+                let attachment = routedMessage.attachments![index]
+                selected = (attachment.name, attachment.data, index)
+            }
+        ).applyAttachmentCallbacks(to: controller)
         controller.update(messages: [message], isLoadingMore: false, allMessagesLoaded: true)
+        controller.openImageAttachmentForTesting(messageID: message.id)
         controller.openFileAttachmentForTesting(messageID: message.id, index: 1)
 
-        XCTAssertNil(staleIndex)
+        XCTAssertNil(staleImageID)
+        XCTAssertNil(staleFileIndex)
+        XCTAssertEqual(selectedImageID, message.id)
         XCTAssertEqual(selected?.0, "second.txt")
         XCTAssertEqual(selected?.1, Data("second".utf8))
         XCTAssertEqual(selected?.2, 1)
@@ -110,7 +164,7 @@ final class MessageAttachmentRoutingTests: XCTestCase {
     }
 
     @MainActor
-    func testAttachmentBubbleProducesVisualEvidenceAndTapCallbacks() throws {
+    func testAttachmentBubbleProducesVisualEvidenceForInteractiveControls() throws {
         let image = UIGraphicsImageRenderer(size: CGSize(width: 2, height: 2)).pngData { context in
             UIColor.systemBlue.setFill()
             context.fill(CGRect(x: 0, y: 0, width: 2, height: 2))
@@ -122,17 +176,16 @@ final class MessageAttachmentRoutingTests: XCTestCase {
             imageFormat: "png",
             attachments: [FileAttachment(name: "document.txt", data: Data("contents".utf8))]
         )
-        var imageTapCount = 0
-        var fileIndex: Int?
         let renderer = ImageRenderer(content:
             MessageBubble(
                 message: message,
-                onOpenImage: { imageTapCount += 1 },
-                onOpenFileAttachment: { fileIndex = $0 }
+                onOpenImage: {},
+                onOpenFileAttachment: { _ in }
             )
             .frame(width: 320)
             .padding()
             .background(Color.black)
+            .preferredColorScheme(.dark)
         )
         renderer.scale = 3
         let screenshot = try XCTUnwrap(renderer.uiImage)
@@ -141,15 +194,27 @@ final class MessageAttachmentRoutingTests: XCTestCase {
         attachment.name = "interactive-image-and-file-attachment-controls"
         attachment.lifetime = .keepAlways
         add(attachment)
+    }
 
-        let bubble = MessageBubble(
-            message: message,
-            onOpenImage: { imageTapCount += 1 },
-            onOpenFileAttachment: { fileIndex = $0 }
+    @MainActor
+    private func makeTimeline(
+        message: Message,
+        onOpenImage: @escaping (Message) -> Void,
+        onOpenFile: @escaping (Message, Int) -> Void
+    ) -> MessageTimelineView {
+        MessageTimelineView(
+            conversationID: "attachment-callback-test",
+            messages: [message],
+            messageTextScale: 1,
+            isLoadingMore: false,
+            allMessagesLoaded: true,
+            onLoadOlder: { false },
+            onReply: { _ in },
+            onToggleReaction: { _, _ in },
+            onLongPress: { _ in },
+            onOpenLink: { _ in },
+            onOpenImage: onOpenImage,
+            onOpenFileAttachment: onOpenFile
         )
-        bubble.onOpenImage?()
-        bubble.onOpenFileAttachment?(0)
-        XCTAssertEqual(imageTapCount, 1)
-        XCTAssertEqual(fileIndex, 0)
     }
 }

--- a/Tests/ColumbaAppTests/MessageAttachmentPreviewTests.swift
+++ b/Tests/ColumbaAppTests/MessageAttachmentPreviewTests.swift
@@ -184,6 +184,7 @@ final class MessageAttachmentRoutingTests: XCTestCase {
             )
             .frame(width: 320)
             .padding()
+            .padding(.bottom, 32)
             .background(Color.black)
             .preferredColorScheme(.dark)
         )

--- a/Tests/ColumbaAppTests/MessageAttachmentPreviewTests.swift
+++ b/Tests/ColumbaAppTests/MessageAttachmentPreviewTests.swift
@@ -186,7 +186,7 @@ final class MessageAttachmentRoutingTests: XCTestCase {
             .padding()
             .padding(.bottom, 32)
             .background(Color.black)
-            .preferredColorScheme(.dark)
+            .environment(\.colorScheme, .dark)
         )
         renderer.scale = 3
         let screenshot = try XCTUnwrap(renderer.uiImage)

--- a/Tests/ColumbaAppTests/MessageAttachmentPreviewTests.swift
+++ b/Tests/ColumbaAppTests/MessageAttachmentPreviewTests.swift
@@ -240,7 +240,8 @@ final class MessageAttachmentRoutingTests: XCTestCase {
             bitsPerComponent: 8,
             bytesPerRow: bytesPerRow,
             space: CGColorSpaceCreateDeviceRGB(),
-            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+            bitmapInfo: CGBitmapInfo.byteOrder32Big.rawValue
+                | CGImageAlphaInfo.premultipliedLast.rawValue
         ) else {
             return (0, 0, 0)
         }

--- a/Tests/ColumbaAppTests/MessageAttachmentPreviewTests.swift
+++ b/Tests/ColumbaAppTests/MessageAttachmentPreviewTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import UIKit
+import SwiftUI
 @testable import ColumbaApp
 
 final class MessageAttachmentPreviewItemTests: XCTestCase {
@@ -110,7 +111,10 @@ final class MessageAttachmentRoutingTests: XCTestCase {
 
     @MainActor
     func testAttachmentBubbleProducesVisualEvidenceAndTapCallbacks() throws {
-        let image = UIGraphicsImageRenderer(size: CGSize(width: 2, height: 2)).pngData()
+        let image = UIGraphicsImageRenderer(size: CGSize(width: 2, height: 2)).pngData { context in
+            UIColor.systemBlue.setFill()
+            context.fill(CGRect(x: 0, y: 0, width: 2, height: 2))
+        }
         let message = Message(
             content: "Attachments",
             isFromMe: false,

--- a/Tests/ColumbaAppTests/MessageAttachmentPreviewTests.swift
+++ b/Tests/ColumbaAppTests/MessageAttachmentPreviewTests.swift
@@ -165,9 +165,13 @@ final class MessageAttachmentRoutingTests: XCTestCase {
 
     @MainActor
     func testAttachmentBubbleProducesVisualEvidenceForInteractiveControls() throws {
-        let image = UIGraphicsImageRenderer(size: CGSize(width: 2, height: 2)).pngData { context in
+        let image = UIGraphicsImageRenderer(size: CGSize(width: 96, height: 64)).pngData { context in
+            UIColor.systemRed.setFill()
+            context.fill(CGRect(x: 0, y: 0, width: 48, height: 64))
             UIColor.systemBlue.setFill()
-            context.fill(CGRect(x: 0, y: 0, width: 2, height: 2))
+            context.fill(CGRect(x: 48, y: 0, width: 48, height: 64))
+            UIColor.systemGreen.setFill()
+            context.fill(CGRect(x: 0, y: 27, width: 96, height: 10))
         }
         let message = Message(
             content: "Attachments",
@@ -176,23 +180,78 @@ final class MessageAttachmentRoutingTests: XCTestCase {
             imageFormat: "png",
             attachments: [FileAttachment(name: "document.txt", data: Data("contents".utf8))]
         )
+        let screenshot = try renderBubble(message, width: 320, dynamicTypeSize: .large)
+        let colors = dominantColorCounts(in: screenshot)
+        XCTAssertGreaterThan(colors.red, 1_000)
+        XCTAssertGreaterThan(colors.green, 1_000)
+        XCTAssertGreaterThan(colors.blue, 1_000)
+        retainScreenshot(screenshot, name: "interactive-image-and-file-attachment-controls")
+    }
+
+    @MainActor
+    func testOutgoingMultiFileBubbleAtAccessibilitySizeProducesUnclippedEvidence() throws {
+        let message = Message(
+            content: "Two independently selectable files",
+            isFromMe: true,
+            attachments: [
+                FileAttachment(name: "duplicate.txt", data: Data("first".utf8)),
+                FileAttachment(name: "duplicate.txt", data: Data("second payload".utf8)),
+            ]
+        )
+        let screenshot = try renderBubble(message, width: 280, dynamicTypeSize: .accessibility3)
+        XCTAssertGreaterThan(screenshot.size.height, 250)
+        XCTAssertEqual(screenshot.size.width, 312, accuracy: 1)
+        retainScreenshot(screenshot, name: "outgoing-multi-file-accessibility-controls")
+    }
+
+    @MainActor
+    private func renderBubble(
+        _ message: Message,
+        width: CGFloat,
+        dynamicTypeSize: DynamicTypeSize
+    ) throws -> UIImage {
         let renderer = ImageRenderer(content:
             MessageBubble(
                 message: message,
                 onOpenImage: {},
                 onOpenFileAttachment: { _ in }
             )
-            .frame(width: 320)
+            .frame(width: width)
             .padding()
             .padding(.bottom, 32)
             .background(Color.black)
             .environment(\.colorScheme, .dark)
+            .environment(\.dynamicTypeSize, dynamicTypeSize)
         )
         renderer.scale = 3
-        let screenshot = try XCTUnwrap(renderer.uiImage)
-        XCTAssertGreaterThan(screenshot.size.height, 80)
-        let attachment = XCTAttachment(image: screenshot)
-        attachment.name = "interactive-image-and-file-attachment-controls"
+        return try XCTUnwrap(renderer.uiImage)
+    }
+
+    private func dominantColorCounts(in image: UIImage) -> (red: Int, green: Int, blue: Int) {
+        guard let cgImage = image.cgImage,
+              let data = cgImage.dataProvider?.data,
+              let bytes = CFDataGetBytePtr(data) else {
+            return (0, 0, 0)
+        }
+        let bytesPerPixel = max(1, cgImage.bitsPerPixel / 8)
+        var counts = (red: 0, green: 0, blue: 0)
+        for y in 0..<cgImage.height {
+            for x in 0..<cgImage.width {
+                let offset = y * cgImage.bytesPerRow + x * bytesPerPixel
+                let red = Int(bytes[offset])
+                let green = Int(bytes[offset + 1])
+                let blue = Int(bytes[offset + 2])
+                if red > green * 2, red > blue * 2 { counts.red += 1 }
+                if green > red * 2, green > blue * 2 { counts.green += 1 }
+                if blue > red * 2, blue > green * 2 { counts.blue += 1 }
+            }
+        }
+        return counts
+    }
+
+    private func retainScreenshot(_ image: UIImage, name: String) {
+        let attachment = XCTAttachment(image: image)
+        attachment.name = name
         attachment.lifetime = .keepAlways
         add(attachment)
     }

--- a/Tests/ColumbaAppTests/MessageAttachmentPreviewTests.swift
+++ b/Tests/ColumbaAppTests/MessageAttachmentPreviewTests.swift
@@ -252,9 +252,9 @@ final class MessageAttachmentRoutingTests: XCTestCase {
             let red = Int(pixels[offset])
             let green = Int(pixels[offset + 1])
             let blue = Int(pixels[offset + 2])
-            if red > green * 2, red > blue * 2 { counts.red += 1 }
-            if green > red * 2, green > blue * 2 { counts.green += 1 }
-            if blue > red * 2, blue > green * 2 { counts.blue += 1 }
+            if red > green + 40, red > blue + 40 { counts.red += 1 }
+            if green > red + 40, green > blue + 40 { counts.green += 1 }
+            if blue > red + 40, blue > green + 40 { counts.blue += 1 }
         }
         return counts
     }

--- a/Tests/interop/conftest.py
+++ b/Tests/interop/conftest.py
@@ -544,6 +544,7 @@ class Simulator:
             # the native close, markup, and share controls without activating
             # the previewed item.
             "- tapOn: { point: \"50%,50%\" }",
+            "- waitForAnimationToEnd: { timeout: 1000 }",
             # Quick Look's native share button is the lower-right circular
             # control. iOS 26 does not expose its label through the Maestro
             # accessibility hierarchy, so target the system-owned control by

--- a/Tests/interop/conftest.py
+++ b/Tests/interop/conftest.py
@@ -539,12 +539,14 @@ class Simulator:
         lines += ["- waitForAnimationToEnd: { timeout: 2000 }"]
         if expected_preview_text is not None:
             lines += [f"- assertVisible: \"{_yaml_escape(expected_preview_text)}\""]
+        if image:
+            # Image Quick Look starts with its chrome hidden after the opening
+            # animation, so reveal the native controls before sharing.
+            lines += [
+                "- tapOn: { point: \"50%,50%\" }",
+                "- waitForAnimationToEnd: { timeout: 1000 }",
+            ]
         lines += [
-            # SwiftUI Quick Look initially hides its chrome. A center tap reveals
-            # the native close, markup, and share controls without activating
-            # the previewed item.
-            "- tapOn: { point: \"50%,50%\" }",
-            "- waitForAnimationToEnd: { timeout: 1000 }",
             # Quick Look's native share button is the lower-right circular
             # control. iOS 26 does not expose its label through the Maestro
             # accessibility hierarchy, so target the system-owned control by

--- a/Tests/interop/conftest.py
+++ b/Tests/interop/conftest.py
@@ -457,11 +457,15 @@ class Simulator:
             "- tapOn: { text: \"Allow\", optional: true }",
             "- tapOn: { text: \"Don't Allow\", optional: true }",
             "- waitForAnimationToEnd: { timeout: 1500 }",
+            "- back",
+            "- waitForAnimationToEnd: { timeout: 800 }",
+            "- back",
+            "- waitForAnimationToEnd: { timeout: 800 }",
             "- tapOn:",
             "    text: \"Chats\"",
             "    optional: true",
             "- waitForAnimationToEnd: { timeout: 2000 }",
-            f"- tapOn: \"{_yaml_escape(peer_display_name)}\"",
+            f"- tapOn: \"{_yaml_escape(content or peer_display_name)}\"",
             "- waitForAnimationToEnd: { timeout: 2500 }",
         ]
         if content is not None:
@@ -492,6 +496,52 @@ class Simulator:
                 f"content={content!r}, has_image={has_image}, "
                 f"has_file_name={has_file_name!r}). Maestro stderr:\n"
                 f"{e.stderr or e.stdout}"
+            )
+        finally:
+            flow_path.unlink(missing_ok=True)
+
+    def assert_attachment_preview_and_export(
+        self,
+        *,
+        image: bool = False,
+        file_name: Optional[str] = None,
+        timeout: float = 30.0,
+    ) -> None:
+        """Tap the rendered attachment and prove native preview plus export UI."""
+        if image == (file_name is not None):
+            raise ValueError("select exactly one attachment kind")
+        lines = ["appId: " + BUNDLE_ID, "---"]
+        if image:
+            lines += [
+                "- tapOn: { id: \"bubble_image\" }",
+                "- waitForAnimationToEnd: { timeout: 2000 }",
+                "- assertVisible: \"image.png\"",
+            ]
+            export_action = "Save Image"
+        else:
+            lines += [
+                f"- tapOn: \"{_yaml_escape(file_name or '')}\"",
+                "- waitForAnimationToEnd: { timeout: 2000 }",
+                f"- assertVisible: \"{_yaml_escape(file_name or '')}\"",
+            ]
+            export_action = "Save to Files"
+        lines += [
+            "- assertVisible: \"Share Attachment\"",
+            "- tapOn: \"Share Attachment\"",
+            "- waitForAnimationToEnd: { timeout: 2000 }",
+            f"- assertVisible: \"{export_action}\"",
+            "- tapOn: { point: \"50%,80%\" }",
+            "- waitForAnimationToEnd: { timeout: 1000 }",
+            "- tapOn: \"Close\"",
+        ]
+        flow_path = Path(os.environ.get("TMPDIR", "/tmp")) / f"_interop_preview_{os.getpid()}.yaml"
+        flow_path.write_text("\n".join(lines) + "\n")
+        try:
+            _sh(["maestro", "--device", self.udid, "test", str(flow_path)], timeout=timeout + 30)
+        except subprocess.CalledProcessError as e:
+            pytest.fail(
+                f"attachment preview/export failed (image={image}, file_name={file_name!r}). "
+                f"Maestro stderr:\n{e.stderr or e.stdout}"
             )
         finally:
             flow_path.unlink(missing_ok=True)

--- a/Tests/interop/conftest.py
+++ b/Tests/interop/conftest.py
@@ -515,6 +515,7 @@ class Simulator:
         file_name: Optional[str] = None,
         file_index: int = 0,
         expected_preview_text: Optional[str] = None,
+        expected_bytes: Optional[bytes] = None,
         timeout: float = 30.0,
     ) -> None:
         """Tap the rendered attachment and complete the native Quick Look save action."""
@@ -570,22 +571,33 @@ class Simulator:
                 "- tapOn: { text: \"Allow\", optional: true }",
                 "- waitForAnimationToEnd: { timeout: 1000 }",
             ]
-        else:
-            lines += [
-                "- assertVisible: \"Save\"",
-                "- tapOn: \"Save\"",
-                "- waitForAnimationToEnd: { timeout: 2000 }",
-            ]
-        # Native Quick Look returns with its chrome visible after the save
-        # action, so dismiss through its upper-right close control.
-        lines += [
+        elif expected_preview_text is not None:
+            # iOS 26 Simulator returns directly to Quick Look after accepting
+            # Save to Files, without exposing a second picker-level Save button.
+            lines += [f"- assertVisible: \"{_yaml_escape(expected_preview_text)}\""]
+        flow_path = Path(os.environ.get("TMPDIR", "/tmp")) / f"_interop_preview_{os.getpid()}.yaml"
+        close_path = Path(os.environ.get("TMPDIR", "/tmp")) / f"_interop_preview_close_{os.getpid()}.yaml"
+        flow_path.write_text("\n".join(lines) + "\n")
+        close_path.write_text("\n".join([
+            "appId: " + BUNDLE_ID,
+            "---",
             "- tapOn: { point: \"91%,9%\" }",
             "- waitForAnimationToEnd: { timeout: 1000 }",
-        ]
-        flow_path = Path(os.environ.get("TMPDIR", "/tmp")) / f"_interop_preview_{os.getpid()}.yaml"
-        flow_path.write_text("\n".join(lines) + "\n")
+        ]) + "\n")
+        started_at = time.time()
         try:
             _sh(["maestro", "--device", self.udid, "test", str(flow_path)], timeout=timeout + 30)
+            if expected_bytes is not None:
+                tmp_root = _app_data_container(self.udid) / "tmp"
+                matches = [
+                    item for item in tmp_root.glob("*/*")
+                    if item.is_file()
+                    and item.stat().st_mtime >= started_at - 1
+                    and item.read_bytes() == expected_bytes
+                ]
+                if not matches:
+                    pytest.fail("active Quick Look export did not match source attachment bytes")
+            _sh(["maestro", "--device", self.udid, "test", str(close_path)], timeout=timeout + 30)
         except subprocess.CalledProcessError as e:
             details = "\n".join(part for part in (e.stdout, e.stderr) if part)
             pytest.fail(
@@ -594,6 +606,7 @@ class Simulator:
             )
         finally:
             flow_path.unlink(missing_ok=True)
+            close_path.unlink(missing_ok=True)
 
     def assert_bubble_visible_via_network(
         self,

--- a/Tests/interop/conftest.py
+++ b/Tests/interop/conftest.py
@@ -521,7 +521,14 @@ class Simulator:
         lines = ["appId: " + BUNDLE_ID, "---"]
         if image:
             lines += [
-                "- tapOn: { id: \"bubble_image\" }",
+                "- tapOn:",
+                "    id: \"bubble_image\"",
+                "    index: 1",
+                "    optional: true",
+                "- tapOn:",
+                "    id: \"bubble_image\"",
+                "    index: 0",
+                "    optional: true",
                 "- waitForAnimationToEnd: { timeout: 2000 }",
                 "- assertVisible: \"image.png\"",
             ]
@@ -547,9 +554,10 @@ class Simulator:
         try:
             _sh(["maestro", "--device", self.udid, "test", str(flow_path)], timeout=timeout + 30)
         except subprocess.CalledProcessError as e:
+            details = "\n".join(part for part in (e.stdout, e.stderr) if part)
             pytest.fail(
                 f"attachment preview/export failed (image={image}, file_name={file_name!r}). "
-                f"Maestro stderr:\n{e.stderr or e.stdout}"
+                f"Maestro output:\n{details}"
             )
         finally:
             flow_path.unlink(missing_ok=True)

--- a/Tests/interop/conftest.py
+++ b/Tests/interop/conftest.py
@@ -534,7 +534,14 @@ class Simulator:
             ]
             export_action = "Save Image"
         else:
-            lines += [f"- tapOn: {{ id: \"bubble_file_chip_{file_index}\" }}"]
+            # The filename is unique to this delivered message. Index scopes
+            # duplicate names within that message without colliding with old
+            # retained bubbles that carry the same indexed control ID.
+            lines += [
+                "- tapOn:",
+                f"    text: \"{_yaml_escape(file_name or '')}\"",
+                f"    index: {file_index}",
+            ]
             export_action = "Save to Files"
         lines += ["- waitForAnimationToEnd: { timeout: 2000 }"]
         if expected_preview_text is not None:

--- a/Tests/interop/conftest.py
+++ b/Tests/interop/conftest.py
@@ -253,26 +253,34 @@ class Simulator:
     @property
     def identity_hex(self) -> str:
         """Local RNS identity hash hex (the `[RNS] started identity=…` line)."""
-        if self._cached_identity_hex is not None:
-            return self._cached_identity_hex
-        for line in self._tail_diag(LOG_TAIL_LINES * 4):
-            m = re.search(r"\[RNS\] started identity=([0-9a-f]+)\s+destination=", line)
-            if m:
-                self._cached_identity_hex = m.group(1)
-                return self._cached_identity_hex
-        pytest.fail("Couldn't find `[RNS] started identity=…` in diag.log")
+        if self._cached_identity_hex is None:
+            self._wait_for_started_destinations()
+        assert self._cached_identity_hex is not None
+        return self._cached_identity_hex
 
     @property
     def lxmf_delivery_hex(self) -> str:
         """Local LXMF delivery-destination hash hex (the `destination=…` half)."""
-        if self._cached_lxmf_delivery_hex is not None:
-            return self._cached_lxmf_delivery_hex
-        for line in self._tail_diag(LOG_TAIL_LINES * 4):
-            m = re.search(r"\[RNS\] started identity=[0-9a-f]+\s+destination=([0-9a-f]+)", line)
-            if m:
-                self._cached_lxmf_delivery_hex = m.group(1)
-                return self._cached_lxmf_delivery_hex
-        pytest.fail("Couldn't find `destination=…` in diag.log")
+        if self._cached_lxmf_delivery_hex is None:
+            self._wait_for_started_destinations()
+        assert self._cached_lxmf_delivery_hex is not None
+        return self._cached_lxmf_delivery_hex
+
+    def _wait_for_started_destinations(self, timeout: float = 30.0) -> None:
+        """Wait for async backend startup instead of racing the first config log line."""
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            for line in reversed(self._tail_diag(LOG_TAIL_LINES * 4)):
+                match = re.search(
+                    r"\[RNS\] started identity=([0-9a-f]+)\s+destination=([0-9a-f]+)",
+                    line,
+                )
+                if match:
+                    self._cached_identity_hex = match.group(1)
+                    self._cached_lxmf_delivery_hex = match.group(2)
+                    return
+            time.sleep(0.25)
+        pytest.fail("Couldn't find `[RNS] started identity=… destination=…` in diag.log")
 
     # ---- propagation-node helpers ----
 

--- a/Tests/interop/conftest.py
+++ b/Tests/interop/conftest.py
@@ -566,9 +566,12 @@ class Simulator:
                 "- tapOn: \"Save\"",
                 "- waitForAnimationToEnd: { timeout: 2000 }",
             ]
-        # Dismiss native Quick Look and return to the message thread. `back`
-        # avoids depending on Quick Look's hidden/shown chrome state.
-        lines += ["- back", "- waitForAnimationToEnd: { timeout: 1000 }"]
+        # Native Quick Look returns with its chrome visible after the save
+        # action, so dismiss through its upper-right close control.
+        lines += [
+            "- tapOn: { point: \"91%,9%\" }",
+            "- waitForAnimationToEnd: { timeout: 1000 }",
+        ]
         flow_path = Path(os.environ.get("TMPDIR", "/tmp")) / f"_interop_preview_{os.getpid()}.yaml"
         flow_path.write_text("\n".join(lines) + "\n")
         try:

--- a/Tests/interop/conftest.py
+++ b/Tests/interop/conftest.py
@@ -513,9 +513,11 @@ class Simulator:
         *,
         image: bool = False,
         file_name: Optional[str] = None,
+        file_index: int = 0,
+        expected_preview_text: Optional[str] = None,
         timeout: float = 30.0,
     ) -> None:
-        """Tap the rendered attachment and prove native preview plus export UI."""
+        """Tap the rendered attachment and complete the native Quick Look save action."""
         if image == (file_name is not None):
             raise ValueError("select exactly one attachment kind")
         lines = ["appId: " + BUNDLE_ID, "---"]
@@ -529,26 +531,44 @@ class Simulator:
                 "    id: \"bubble_image\"",
                 "    index: 0",
                 "    optional: true",
-                "- waitForAnimationToEnd: { timeout: 2000 }",
-                "- assertVisible: \"image.png\"",
             ]
             export_action = "Save Image"
         else:
-            lines += [
-                f"- tapOn: \"{_yaml_escape(file_name or '')}\"",
-                "- waitForAnimationToEnd: { timeout: 2000 }",
-                f"- assertVisible: \"{_yaml_escape(file_name or '')}\"",
-            ]
+            lines += [f"- tapOn: {{ id: \"bubble_file_chip_{file_index}\" }}"]
             export_action = "Save to Files"
+        lines += ["- waitForAnimationToEnd: { timeout: 2000 }"]
+        if expected_preview_text is not None:
+            lines += [f"- assertVisible: \"{_yaml_escape(expected_preview_text)}\""]
         lines += [
-            "- assertVisible: \"Share Attachment\"",
-            "- tapOn: \"Share Attachment\"",
+            # SwiftUI Quick Look initially hides its chrome. A center tap reveals
+            # the native close, markup, and share controls without activating
+            # the previewed item.
+            "- tapOn: { point: \"50%,50%\" }",
+            # Quick Look's native share button is the lower-right circular
+            # control. iOS 26 does not expose its label through the Maestro
+            # accessibility hierarchy, so target the system-owned control by
+            # its stable location and prove the resulting named save action.
+            "- tapOn: { point: \"88%,94%\" }",
             "- waitForAnimationToEnd: { timeout: 2000 }",
             f"- assertVisible: \"{export_action}\"",
-            "- tapOn: { point: \"50%,80%\" }",
-            "- waitForAnimationToEnd: { timeout: 1000 }",
-            "- tapOn: \"Close\"",
+            f"- tapOn: \"{export_action}\"",
+            "- waitForAnimationToEnd: { timeout: 2000 }",
         ]
+        if image:
+            lines += [
+                "- tapOn: { text: \"Allow Full Access\", optional: true }",
+                "- tapOn: { text: \"Allow\", optional: true }",
+                "- waitForAnimationToEnd: { timeout: 1000 }",
+            ]
+        else:
+            lines += [
+                "- assertVisible: \"Save\"",
+                "- tapOn: \"Save\"",
+                "- waitForAnimationToEnd: { timeout: 2000 }",
+            ]
+        # Dismiss native Quick Look and return to the message thread. `back`
+        # avoids depending on Quick Look's hidden/shown chrome state.
+        lines += ["- back", "- waitForAnimationToEnd: { timeout: 1000 }"]
         flow_path = Path(os.environ.get("TMPDIR", "/tmp")) / f"_interop_preview_{os.getpid()}.yaml"
         flow_path.write_text("\n".join(lines) + "\n")
         try:

--- a/Tests/interop/fixtures/make_test_image.py
+++ b/Tests/interop/fixtures/make_test_image.py
@@ -44,6 +44,38 @@ def png_bytes() -> bytes:
     return sig + chunk(b"IHDR", ihdr) + chunk(b"IDAT", idat) + chunk(b"IEND", b"")
 
 
+def preview_png_bytes() -> bytes:
+    """Distinctive 96x64 RGB PNG for native bubble and Quick Look evidence."""
+    sig = b"\x89PNG\r\n\x1a\n"
+
+    def chunk(tag: bytes, body: bytes) -> bytes:
+        return (
+            struct.pack(">I", len(body))
+            + tag
+            + body
+            + struct.pack(">I", zlib.crc32(tag + body))
+        )
+
+    width, height = 96, 64
+    rows = bytearray()
+    for y in range(height):
+        rows.append(0)
+        for x in range(width):
+            if 27 <= y < 37:
+                rows.extend((30, 220, 90))
+            elif x < width // 2:
+                rows.extend((235, 55, 70))
+            else:
+                rows.extend((45, 115, 245))
+    ihdr = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)
+    return (
+        sig
+        + chunk(b"IHDR", ihdr)
+        + chunk(b"IDAT", zlib.compress(bytes(rows), level=9))
+        + chunk(b"IEND", b"")
+    )
+
+
 def jpeg_bytes() -> bytes:
     """A minimal JPEG. ~125 B — small enough that hex-encoded stays under 300 chars."""
     # Hard-coded valid JPEG: SOI + APP0 (JFIF) + small DQT + minimal SOF0 + DHT (huffman tables

--- a/Tests/interop/peer_sideband.py
+++ b/Tests/interop/peer_sideband.py
@@ -332,6 +332,25 @@ class SidebandPeer:
             attachment=[filename.encode("utf-8"), data],
         )
 
+    def send_files(
+        self,
+        dest_hex: str,
+        content: str,
+        attachments: list[tuple[str, bytes]],
+    ) -> bool:
+        """Send one LXMF message containing multiple ordered file attachments."""
+        import LXMF
+
+        return self.send_with_fields(
+            dest_hex,
+            content,
+            fields={
+                LXMF.FIELD_FILE_ATTACHMENTS: [
+                    [name.encode("utf-8"), data] for name, data in attachments
+                ]
+            },
+        )
+
     def send_audio(
         self,
         dest_hex: str,

--- a/Tests/interop/test_attachments.py
+++ b/Tests/interop/test_attachments.py
@@ -290,7 +290,7 @@ def test_multiple_files_sideband_to_ios_selects_second(sim, sideband):
         content=body,
         attachments=[(name, first), (name, second)],
     )
-    sim.wait_for_log(body, timeout=20)
+    _wait_for_diag_inbound(sim, content=body)
     sim.assert_bubble_visible(content=body, has_file_name=name, timeout=30)
     sim.assert_attachment_preview_and_export(
         file_name=name,

--- a/Tests/interop/test_attachments.py
+++ b/Tests/interop/test_attachments.py
@@ -26,7 +26,7 @@ import pytest
 
 HERE = Path(__file__).parent
 sys.path.insert(0, str(HERE / "fixtures"))
-from make_test_image import png_bytes, jpeg_bytes, file_bytes  # noqa: E402
+from make_test_image import file_bytes, jpeg_bytes, png_bytes, preview_png_bytes  # noqa: E402
 
 
 # ─────────────────────────────────────────────────────────────────────────
@@ -239,7 +239,7 @@ def test_image_sideband_to_ios(sim, sideband):
     `Message.imageData`, AND the SwiftUI message bubble must render the
     image view. Pins both halves of the inbound stack — the prior
     diag.log heuristic only proved the LXMRouter callback fired."""
-    img = png_bytes()
+    img = preview_png_bytes()
     body = f"img-from-sideband-{int(time.time()*1000)}"
     assert sideband.send_image(
         dest_hex=sim.lxmf_delivery_hex,

--- a/Tests/interop/test_attachments.py
+++ b/Tests/interop/test_attachments.py
@@ -254,7 +254,7 @@ def test_image_sideband_to_ios(sim, sideband):
     _wait_for_diag_inbound(sim, content=body)
 
     sim.assert_bubble_visible(content=body, has_image=True)
-    sim.assert_attachment_preview_and_export(image=True)
+    sim.assert_attachment_preview_and_export(image=True, expected_bytes=img)
 
 
 def test_file_sideband_to_ios(sim, sideband):
@@ -277,6 +277,7 @@ def test_file_sideband_to_ios(sim, sideband):
     sim.assert_attachment_preview_and_export(
         file_name=name,
         expected_preview_text="reverse-file-interop",
+        expected_bytes=payload,
     )
 
 
@@ -298,6 +299,7 @@ def test_multiple_files_sideband_to_ios_selects_second(sim, sideband):
         file_name=name,
         file_index=1,
         expected_preview_text="second-file-payload",
+        expected_bytes=second,
     )
 
 

--- a/Tests/interop/test_attachments.py
+++ b/Tests/interop/test_attachments.py
@@ -254,6 +254,7 @@ def test_image_sideband_to_ios(sim, sideband):
     _wait_for_diag_inbound(sim, content=body)
 
     sim.assert_bubble_visible(content=body, has_image=True)
+    sim.assert_attachment_preview_and_export(image=True)
 
 
 def test_file_sideband_to_ios(sim, sideband):
@@ -272,6 +273,7 @@ def test_file_sideband_to_ios(sim, sideband):
     _wait_for_diag_inbound(sim, content=body)
 
     sim.assert_bubble_visible(content=body, has_file_name=name)
+    sim.assert_attachment_preview_and_export(file_name=name)
 
 
 def _wait_for_diag_inbound(sim, *, content: str, timeout: float = 30.0) -> None:

--- a/Tests/interop/test_attachments.py
+++ b/Tests/interop/test_attachments.py
@@ -261,8 +261,9 @@ def test_file_sideband_to_ios(sim, sideband):
     """Sideband sends a small file; iOS persists it AND the bubble renders
     a file chip whose label carries the filename."""
     payload = file_bytes(b"reverse-file-interop\n")
-    name = "from-sideband.txt"
-    body = f"file-from-sideband-{int(time.time()*1000)}"
+    stamp = int(time.time() * 1000)
+    name = f"from-sideband-{stamp}.txt"
+    body = f"file-from-sideband-{stamp}"
     assert sideband.send_file(
         dest_hex=sim.lxmf_delivery_hex,
         content=body,
@@ -281,10 +282,11 @@ def test_file_sideband_to_ios(sim, sideband):
 
 def test_multiple_files_sideband_to_ios_selects_second(sim, sideband):
     """Duplicate names remain independently selectable by attachment index."""
-    body = f"multi-file-from-sideband-{int(time.time()*1000)}"
+    stamp = int(time.time() * 1000)
+    body = f"multi-file-from-sideband-{stamp}"
     first = file_bytes(b"first-file-payload\n")
     second = file_bytes(b"second-file-payload\n")
-    name = "duplicate.txt"
+    name = f"duplicate-{stamp}.txt"
     assert sideband.send_files(
         dest_hex=sim.lxmf_delivery_hex,
         content=body,

--- a/Tests/interop/test_attachments.py
+++ b/Tests/interop/test_attachments.py
@@ -273,7 +273,30 @@ def test_file_sideband_to_ios(sim, sideband):
     _wait_for_diag_inbound(sim, content=body)
 
     sim.assert_bubble_visible(content=body, has_file_name=name)
-    sim.assert_attachment_preview_and_export(file_name=name)
+    sim.assert_attachment_preview_and_export(
+        file_name=name,
+        expected_preview_text="reverse-file-interop",
+    )
+
+
+def test_multiple_files_sideband_to_ios_selects_second(sim, sideband):
+    """Duplicate names remain independently selectable by attachment index."""
+    body = f"multi-file-from-sideband-{int(time.time()*1000)}"
+    first = file_bytes(b"first-file-payload\n")
+    second = file_bytes(b"second-file-payload\n")
+    name = "duplicate.txt"
+    assert sideband.send_files(
+        dest_hex=sim.lxmf_delivery_hex,
+        content=body,
+        attachments=[(name, first), (name, second)],
+    )
+    sim.wait_for_log(body, timeout=20)
+    sim.assert_bubble_visible(content=body, has_file_name=name, timeout=30)
+    sim.assert_attachment_preview_and_export(
+        file_name=name,
+        file_index=1,
+        expected_preview_text="second-file-payload",
+    )
 
 
 def _wait_for_diag_inbound(sim, *, content: str, timeout: float = 30.0) -> None:

--- a/Tests/static/test_attachment_preview_contract.rb
+++ b/Tests/static/test_attachment_preview_contract.rb
@@ -1,0 +1,36 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'xcodeproj'
+
+ROOT = File.expand_path('../..', __dir__)
+PROJECT = Xcodeproj::Project.open(File.join(ROOT, 'Columba.xcodeproj'))
+
+class AttachmentPreviewContractTests < Minitest::Test
+  PREVIEW_SOURCE = 'Sources/ColumbaApp/Views/Messaging/MessageAttachmentPreviewItem.swift'
+  PREVIEW_TEST = 'Tests/ColumbaAppTests/MessageAttachmentPreviewTests.swift'
+
+  def source_paths(target_name)
+    target = PROJECT.targets.find { |candidate| candidate.name == target_name }
+    refute_nil target
+    target.source_build_phase.files.map do |build_file|
+      build_file.file_ref.real_path.relative_path_from(Pathname.new(ROOT)).to_s
+    end
+  end
+
+  def test_preview_boundary_is_shared_and_regressions_are_hosted
+    assert_includes source_paths('ColumbaApp'), PREVIEW_SOURCE
+    assert_includes source_paths('ColumbaModelBApp'), PREVIEW_SOURCE
+    assert_includes source_paths('ColumbaAppTests'), PREVIEW_TEST
+  end
+
+  def test_preview_boundary_uses_private_item_directory_and_byte_type_detection
+    source = File.read(File.join(ROOT, PREVIEW_SOURCE))
+    assert_includes source, 'temporaryDirectory'
+    assert_includes source, 'UUID'
+    assert_includes source, '.atomic'
+    assert_includes source, 'CGImageSourceGetType'
+    assert_includes source, 'removeItem(at: directoryURL)'
+  end
+end

--- a/Tests/static/test_attachment_preview_contract.rb
+++ b/Tests/static/test_attachment_preview_contract.rb
@@ -56,10 +56,12 @@ class AttachmentPreviewContractTests < Minitest::Test
     assert_includes bubble, '.accessibilityIdentifier("bubble_file_chip_\(index)")'
   end
 
-  def test_parent_reaction_gesture_preserves_physical_attachment_taps
+  def test_attachment_controls_exclusively_route_tap_or_long_press
     bubble = File.read(File.join(ROOT, 'Sources/ColumbaApp/Views/Messaging/MessageBubble.swift'))
-    assert_includes bubble, '.simultaneousGesture('
-    assert_includes bubble, 'LongPressGesture(minimumDuration: 0.4)'
+    assert_includes bubble, 'PrimitiveButtonStyle'
+    assert_includes bubble, '.exclusively(before: TapGesture())'
+    assert_operator bubble.scan('.buttonStyle(BubbleActionButtonStyle').length, :>=, 3
+    assert_includes bubble, 'BubbleActionRouter.perform'
     refute_includes bubble, '.onLongPressGesture(minimumDuration: 0.4)'
   end
 end

--- a/Tests/static/test_attachment_preview_contract.rb
+++ b/Tests/static/test_attachment_preview_contract.rb
@@ -32,5 +32,19 @@ class AttachmentPreviewContractTests < Minitest::Test
     assert_includes source, '.atomic'
     assert_includes source, 'CGImageSourceGetType'
     assert_includes source, 'removeItem(at: directoryURL)'
+    assert_includes source, 'final class MessageAttachmentPreviewStore'
+    assert_includes source, 'item?.cleanup()'
+  end
+
+  def test_representable_update_and_screen_lifecycle_use_attachment_owners
+    timeline = File.read(File.join(ROOT, 'Sources/ColumbaApp/Views/Messaging/MessageTimelineView.swift'))
+    update = timeline.split('func updateUIViewController', 2).fetch(1)
+                     .split('func applyAttachmentCallbacks', 2).fetch(0)
+    assert_includes update, 'applyAttachmentCallbacks(to: controller)'
+
+    messaging = File.read(File.join(ROOT, 'Sources/ColumbaApp/Views/Messaging/MessagingView.swift'))
+    assert_includes messaging, '@StateObject private var attachmentPreviewStore'
+    assert_includes messaging, 'onDismiss: attachmentPreviewStore.dismiss'
+    assert_includes messaging, 'attachmentPreviewStore.exitConversation()'
   end
 end

--- a/Tests/static/test_attachment_preview_contract.rb
+++ b/Tests/static/test_attachment_preview_contract.rb
@@ -44,7 +44,15 @@ class AttachmentPreviewContractTests < Minitest::Test
 
     messaging = File.read(File.join(ROOT, 'Sources/ColumbaApp/Views/Messaging/MessagingView.swift'))
     assert_includes messaging, '@StateObject private var attachmentPreviewStore'
-    assert_includes messaging, 'onDismiss: attachmentPreviewStore.dismiss'
+    assert_includes messaging, '.quickLookPreview(attachmentPreviewURLBinding)'
     assert_includes messaging, 'attachmentPreviewStore.exitConversation()'
+    refute_includes messaging, 'QLPreviewController'
+    refute_includes messaging, 'ShareLink(item: item.url)'
+    assert_operator messaging.scan('onOpenImage:').length, :>=, 2
+    assert_operator messaging.scan('onOpenFileAttachment:').length, :>=, 2
+
+    bubble = File.read(File.join(ROOT, 'Sources/ColumbaApp/Views/Messaging/MessageBubble.swift'))
+    assert_includes bubble, '.accessibilityIdentifier("bubble_file_chip")'
+    assert_includes bubble, '.accessibilityIdentifier("bubble_file_chip_\(index)")'
   end
 end

--- a/Tests/static/test_attachment_preview_contract.rb
+++ b/Tests/static/test_attachment_preview_contract.rb
@@ -55,4 +55,11 @@ class AttachmentPreviewContractTests < Minitest::Test
     assert_includes bubble, '.accessibilityIdentifier("bubble_file_chip")'
     assert_includes bubble, '.accessibilityIdentifier("bubble_file_chip_\(index)")'
   end
+
+  def test_parent_reaction_gesture_preserves_physical_attachment_taps
+    bubble = File.read(File.join(ROOT, 'Sources/ColumbaApp/Views/Messaging/MessageBubble.swift'))
+    assert_includes bubble, '.simultaneousGesture('
+    assert_includes bubble, 'LongPressGesture(minimumDuration: 0.4)'
+    refute_includes bubble, '.onLongPressGesture(minimumDuration: 0.4)'
+  end
 end


### PR DESCRIPTION
## Summary

- make received image and file attachments tappable without changing their existing bubble styling or gestures
- present attachments with chat-owned SwiftUI Quick Look and preserve original bytes in isolated, safely named temporary items
- route multi-file messages by stable attachment index and refresh callbacks across timeline controller reuse
- add lifecycle, filename/type, accessibility, visual, static-contract, and Sideband-to-iOS regressions

Fixes #145

## Verification

- `xcodebuild test` on the shipping `Columba` scheme: 278 tests, 0 failures
- focused attachment XTests: 9 tests, 0 failures
- `Columba-ModelB` simulator build: succeeded
- portable static suite: 244 tests passed, 1 skipped
- attachment preview contract: 3 runs, 41 assertions, 0 failures
- controlled Sideband interop: image, file, and second duplicate-name file flows all passed
  - tapped production attachment controls
  - opened native SwiftUI Quick Look
  - selected native `Save Image` / `Save to Files`
  - verified the active Quick Look export URL was byte-identical to the received attachment
- physical iPhone: exact-head signed build, install, and launch succeeded

## Notes

On the iOS 26.4 Simulator, selecting `Save to Files` returns directly to Quick Look rather than presenting a second picker-level `Save` control. The interop lane therefore verifies selection of the named native action and byte identity at Quick Look's active export URL; it does not claim destination Files-container readback.

Two unrelated project-graph contracts remain baseline failures on the merged PR #149 baseline and are unchanged by this branch.

## Risk and rollback

The change is scoped to attachment presentation and temporary export files. It does not alter LXMF encoding, persistence, database schema, or the messaging backend. Reverting this PR restores the previous noninteractive attachment rendering.
