### PR TITLE
Fix TestFlight attachment tap handling

### DIFF
--- a/Sources/ColumbaApp/Views/Messaging/MessageAttachmentPreviewItem.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageAttachmentPreviewItem.swift
@@ -131,12 +131,27 @@ final class MessageAttachmentPreviewStore: ObservableObject {
         }
     }
 
+    private(set) var isReactionModeActive = false
+
     init(item: MessageAttachmentPreviewItem? = nil) {
         self.item = item
     }
 
     func present(_ item: MessageAttachmentPreviewItem) {
+        guard !isReactionModeActive else {
+            item.cleanup()
+            return
+        }
         self.item = item
+    }
+
+    func beginReactionMode() {
+        isReactionModeActive = true
+        item = nil
+    }
+
+    func endReactionMode() {
+        isReactionModeActive = false
     }
 
     func dismiss() {
@@ -145,5 +160,6 @@ final class MessageAttachmentPreviewStore: ObservableObject {
 
     func exitConversation() {
         item = nil
+        isReactionModeActive = false
     }
 }

--- a/Sources/ColumbaApp/Views/Messaging/MessageBody.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageBody.swift
@@ -142,6 +142,19 @@ struct PlainMessageText: View {
     }
 }
 
+struct MessageBodyLinkDispatcher {
+    let onOpenLink: ((MessageLinkTarget) -> Void)?
+
+    func open(_ url: URL) -> OpenURLAction.Result {
+        guard let target = MessageLinkParser.target(for: url),
+              let onOpenLink else {
+            return .discarded
+        }
+        onOpenLink(target)
+        return .handled
+    }
+}
+
 struct MessageBody: View {
     let content: String
     let renderer: MessageRenderer
@@ -172,17 +185,7 @@ struct MessageBody: View {
         }
         .accessibilityIdentifier("bubble_text")
         .environment(\.openURL, OpenURLAction { url in
-            guard let target = MessageLinkParser.target(for: url) else {
-                return .discarded
-            }
-            switch target {
-            case .web, .external:
-                return .systemAction(url)
-            case .nomadNet:
-                guard let onOpenLink else { return .discarded }
-                onOpenLink(target)
-                return .handled
-            }
+            MessageBodyLinkDispatcher(onOpenLink: onOpenLink).open(url)
         })
     }
 

--- a/Sources/ColumbaApp/Views/Messaging/MessageBubble.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageBubble.swift
@@ -15,15 +15,6 @@ import UIKit
 
 private let logger = Logger(subsystem: "network.columba.Columba", category: "MessageBubble")
 
-enum BubbleReplyPreviewPolicy {
-    private static let longPressSuppressionInterval: TimeInterval = 0.25
-
-    static func shouldNavigate(lastLongPressAt: Date?, now: Date = Date()) -> Bool {
-        guard let lastLongPressAt else { return true }
-        return now.timeIntervalSince(lastLongPressAt) >= longPressSuppressionInterval
-    }
-}
-
 /// Individual message bubble view.
 ///
 /// Layout:
@@ -37,7 +28,6 @@ struct MessageBubble: View {
     let message: Message
     var messageTextScale: Double = SettingsRepository.MessageTextScale.defaultValue
     @ScaledMetric(relativeTo: .body) private var bodyFontSize: CGFloat = 17
-    @State private var lastLongPressAt: Date?
 
     /// Callback for tapping a reaction chip to toggle own reaction.
     var onToggleReaction: ((String) -> Void)?
@@ -69,12 +59,7 @@ struct MessageBubble: View {
                     if let replyPreview = message.replyToPreview {
                         Button {
                             if let replyId = message.replyToId {
-                                DispatchQueue.main.async {
-                                    guard BubbleReplyPreviewPolicy.shouldNavigate(
-                                        lastLongPressAt: lastLongPressAt
-                                    ) else { return }
-                                    onTapReplyPreview?(replyId)
-                                }
+                                onTapReplyPreview?(replyId)
                             }
                         } label: {
                             Text(replyPreview)
@@ -161,7 +146,6 @@ struct MessageBubble: View {
                 .simultaneousGesture(
                     LongPressGesture(minimumDuration: 0.4)
                         .onEnded { _ in
-                            lastLongPressAt = Date()
                             #if canImport(UIKit)
                             UIImpactFeedbackGenerator(style: .medium).impactOccurred()
                             #endif

--- a/Sources/ColumbaApp/Views/Messaging/MessageBubble.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageBubble.swift
@@ -15,6 +15,15 @@ import UIKit
 
 private let logger = Logger(subsystem: "network.columba.Columba", category: "MessageBubble")
 
+enum BubbleReplyPreviewPolicy {
+    private static let longPressSuppressionInterval: TimeInterval = 0.25
+
+    static func shouldNavigate(lastLongPressAt: Date?, now: Date = Date()) -> Bool {
+        guard let lastLongPressAt else { return true }
+        return now.timeIntervalSince(lastLongPressAt) >= longPressSuppressionInterval
+    }
+}
+
 /// Individual message bubble view.
 ///
 /// Layout:
@@ -28,6 +37,7 @@ struct MessageBubble: View {
     let message: Message
     var messageTextScale: Double = SettingsRepository.MessageTextScale.defaultValue
     @ScaledMetric(relativeTo: .body) private var bodyFontSize: CGFloat = 17
+    @State private var lastLongPressAt: Date?
 
     /// Callback for tapping a reaction chip to toggle own reaction.
     var onToggleReaction: ((String) -> Void)?
@@ -59,7 +69,12 @@ struct MessageBubble: View {
                     if let replyPreview = message.replyToPreview {
                         Button {
                             if let replyId = message.replyToId {
-                                onTapReplyPreview?(replyId)
+                                DispatchQueue.main.async {
+                                    guard BubbleReplyPreviewPolicy.shouldNavigate(
+                                        lastLongPressAt: lastLongPressAt
+                                    ) else { return }
+                                    onTapReplyPreview?(replyId)
+                                }
                             }
                         } label: {
                             Text(replyPreview)
@@ -146,6 +161,7 @@ struct MessageBubble: View {
                 .simultaneousGesture(
                     LongPressGesture(minimumDuration: 0.4)
                         .onEnded { _ in
+                            lastLongPressAt = Date()
                             #if canImport(UIKit)
                             UIImpactFeedbackGenerator(style: .medium).impactOccurred()
                             #endif

--- a/Sources/ColumbaApp/Views/Messaging/MessageBubble.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageBubble.swift
@@ -15,58 +15,6 @@ import UIKit
 
 private let logger = Logger(subsystem: "network.columba.Columba", category: "MessageBubble")
 
-enum BubbleAction {
-    case tap
-    case longPress
-}
-
-enum BubbleActionRouter {
-    static func perform(
-        _ action: BubbleAction,
-        onTap: () -> Void,
-        onLongPress: (() -> Void)?
-    ) {
-        switch action {
-        case .tap:
-            onTap()
-        case .longPress:
-            #if canImport(UIKit)
-            UIImpactFeedbackGenerator(style: .medium).impactOccurred()
-            #endif
-            onLongPress?()
-        }
-    }
-}
-
-private struct BubbleActionButtonStyle: PrimitiveButtonStyle {
-    let onLongPress: (() -> Void)?
-
-    func makeBody(configuration: Configuration) -> some View {
-        configuration.label
-            .contentShape(Rectangle())
-            .gesture(
-                LongPressGesture(minimumDuration: 0.4)
-                    .exclusively(before: TapGesture())
-                    .onEnded { outcome in
-                        switch outcome {
-                        case .first:
-                            BubbleActionRouter.perform(
-                                .longPress,
-                                onTap: configuration.trigger,
-                                onLongPress: onLongPress
-                            )
-                        case .second:
-                            BubbleActionRouter.perform(
-                                .tap,
-                                onTap: configuration.trigger,
-                                onLongPress: onLongPress
-                            )
-                        }
-                    }
-            )
-    }
-}
-
 /// Individual message bubble view.
 ///
 /// Layout:
@@ -128,7 +76,7 @@ struct MessageBubble: View {
                                 }
                                 .padding(.vertical, 4)
                         }
-                        .buttonStyle(BubbleActionButtonStyle(onLongPress: onLongPress))
+                        .buttonStyle(.plain)
                     }
 
                     // Inline image
@@ -143,7 +91,7 @@ struct MessageBubble: View {
                                 .frame(maxWidth: 250)
                                 .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
                         }
-                        .buttonStyle(BubbleActionButtonStyle(onLongPress: onLongPress))
+                        .buttonStyle(.plain)
                         // Stable handle for the Tests/interop/ harness:
                         // `assertVisible: { id: "bubble_image" }` confirms an
                         // inbound image actually rendered (vs the bubble
@@ -180,7 +128,7 @@ struct MessageBubble: View {
                                     fileChip(name: attachment.name, size: attachment.data.count)
                                         .accessibilityIdentifier("bubble_file_chip")
                                 }
-                                .buttonStyle(BubbleActionButtonStyle(onLongPress: onLongPress))
+                                .buttonStyle(.plain)
                                 .accessibilityIdentifier("bubble_file_chip_\(index)")
                                 .accessibilityLabel(
                                     String(localized: "File attachment: \(attachment.name)")
@@ -192,22 +140,18 @@ struct MessageBubble: View {
                 }
                 .padding(.horizontal, 14)
                 .padding(.vertical, 10)
-                .background {
-                    bubbleBackground
-                        .contentShape(bubbleShape)
-                        .gesture(
-                            LongPressGesture(minimumDuration: 0.4)
-                                .onEnded { _ in
-                                    BubbleActionRouter.perform(
-                                        .longPress,
-                                        onTap: {},
-                                        onLongPress: onLongPress
-                                    )
-                                }
-                        )
-                }
+                .background(bubbleBackground)
                 .clipShape(bubbleShape)
                 .contentShape(bubbleShape)
+                .simultaneousGesture(
+                    LongPressGesture(minimumDuration: 0.4)
+                        .onEnded { _ in
+                            #if canImport(UIKit)
+                            UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                            #endif
+                            onLongPress?()
+                        }
+                )
 
                 // Reaction chips (below bubble)
                 if !message.reactions.isEmpty {

--- a/Sources/ColumbaApp/Views/Messaging/MessageTimelineView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageTimelineView.swift
@@ -77,6 +77,7 @@ struct MessageTimelineView: UIViewControllerRepresentable {
     let messageTextScale: Double
     let isLoadingMore: Bool
     let allMessagesLoaded: Bool
+    let reactionModeMessageID: String?
     let onLoadOlder: @MainActor () async -> Bool
     let onReply: (Message) -> Void
     let onToggleReaction: (Message, String) -> Void
@@ -93,6 +94,7 @@ struct MessageTimelineView: UIViewControllerRepresentable {
         controller.onToggleReaction = onToggleReaction
         controller.onLongPress = onLongPress
         controller.onOpenLink = onOpenLink
+        controller.setReactionMode(messageID: reactionModeMessageID)
         applyAttachmentCallbacks(to: controller)
         return controller
     }
@@ -103,6 +105,7 @@ struct MessageTimelineView: UIViewControllerRepresentable {
         controller.onToggleReaction = onToggleReaction
         controller.onLongPress = onLongPress
         controller.onOpenLink = onOpenLink
+        controller.setReactionMode(messageID: reactionModeMessageID)
         applyAttachmentCallbacks(to: controller)
         controller.update(
             conversationID: conversationID,
@@ -139,7 +142,9 @@ final class MessageTimelineViewController: UIViewController, UICollectionViewDat
     private var hasCompletedInitialPositioning = false
     private var previousViewportSize = CGSize.zero
     private var shouldFollowBottomAcrossResize = false
+    private var reactionModeMessageID: String?
     private(set) var timelineReloadCountForTesting = 0
+    private(set) var replyPreviewNavigationCountForTesting = 0
 
     private lazy var collectionView: UICollectionView = {
         let layout = UICollectionViewCompositionalLayout { _, _ in
@@ -318,9 +323,10 @@ final class MessageTimelineViewController: UIViewController, UICollectionViewDat
                         self?.onToggleReaction?(message, emoji)
                     },
                     onTapReplyPreview: { [weak self] replyID in
-                        self?.scrollToMessage(id: replyID)
+                        self?.routeReplyPreview(messageID: message.id, replyID: replyID)
                     },
                     onLongPress: { [weak self] in
+                        self?.reactionModeMessageID = message.id
                         self?.onLongPress?(message)
                     },
                     onOpenLink: { [weak self] target in
@@ -338,6 +344,22 @@ final class MessageTimelineViewController: UIViewController, UICollectionViewDat
         .margins(.all, 0)
 
         return cell
+    }
+
+    func setReactionMode(messageID: String?) {
+        reactionModeMessageID = messageID
+    }
+
+    private func routeReplyPreview(messageID: String, replyID: String) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self, self.reactionModeMessageID != messageID else { return }
+            self.replyPreviewNavigationCountForTesting += 1
+            self.scrollToMessage(id: replyID)
+        }
+    }
+
+    func routeReplyPreviewForTesting(messageID: String, replyID: String) {
+        routeReplyPreview(messageID: messageID, replyID: replyID)
     }
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {

--- a/Sources/ColumbaApp/Views/Messaging/MessageTimelineView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageTimelineView.swift
@@ -330,7 +330,7 @@ final class MessageTimelineViewController: UIViewController, UICollectionViewDat
                         self?.onLongPress?(message)
                     },
                     onOpenLink: { [weak self] target in
-                        self?.onOpenLink?(target)
+                        self?.routeMessageLink(messageID: message.id, target: target)
                     },
                     onOpenImage: { [weak self] in
                         self?.onOpenImage?(message)
@@ -360,6 +360,17 @@ final class MessageTimelineViewController: UIViewController, UICollectionViewDat
 
     func routeReplyPreviewForTesting(messageID: String, replyID: String) {
         routeReplyPreview(messageID: messageID, replyID: replyID)
+    }
+
+    private func routeMessageLink(messageID: String, target: MessageLinkTarget) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self, self.reactionModeMessageID != messageID else { return }
+            self.onOpenLink?(target)
+        }
+    }
+
+    func routeMessageLinkForTesting(messageID: String, target: MessageLinkTarget) {
+        routeMessageLink(messageID: messageID, target: target)
     }
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {

--- a/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
@@ -663,7 +663,7 @@ struct MessagingView: View {
         .onDisappear {
             flushDraft(for: .navigation)
             NotificationService.activeConversationThreadId = nil
-            attachmentPreviewStore.exitConversation()
+            exitAttachmentInteractionState()
         }
         .onChange(of: scenePhase) { oldPhase, newPhase in
             guard oldPhase == .active, newPhase != .active else { return }
@@ -905,6 +905,11 @@ struct MessagingView: View {
     private func openMessageLink(_ target: MessageLinkTarget) {
         guard case .nomadNet = target else { return }
         nomadNetLinkTarget = target
+    }
+
+    private func exitAttachmentInteractionState() {
+        reactionModeMessage = nil
+        attachmentPreviewStore.exitConversation()
     }
 
     private func openImageAttachment(_ message: Message) {

--- a/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
@@ -187,6 +187,7 @@ struct MessagingView: View {
                     messageTextScale: messageTextScale,
                     isLoadingMore: vm.isLoadingMore,
                     allMessagesLoaded: vm.allMessagesLoaded,
+                    reactionModeMessageID: reactionModeMessage?.id,
                     onLoadOlder: {
                         await vm.loadMoreMessages()
                     },
@@ -303,8 +304,11 @@ struct MessagingView: View {
                                             }
                                         },
                                         onTapReplyPreview: { replyId in
-                                            withAnimation {
-                                                proxy.scrollTo(replyId, anchor: .center)
+                                            DispatchQueue.main.async {
+                                                guard reactionModeMessage?.id != message.id else { return }
+                                                withAnimation {
+                                                    proxy.scrollTo(replyId, anchor: .center)
+                                                }
                                             }
                                         },
                                         onLongPress: {

--- a/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
@@ -317,7 +317,12 @@ struct MessagingView: View {
                                                 reactionModeMessage = message
                                             }
                                         },
-                                        onOpenLink: openMessageLink,
+                                        onOpenLink: { target in
+                                            DispatchQueue.main.async {
+                                                guard reactionModeMessage?.id != message.id else { return }
+                                                openMessageLink(target)
+                                            }
+                                        },
                                         onOpenImage: { openImageAttachment(message) },
                                         onOpenFileAttachment: { index in
                                             openFileAttachment(message, index: index)

--- a/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
@@ -208,6 +208,7 @@ struct MessagingView: View {
                         }
                     },
                     onLongPress: { message in
+                        attachmentPreviewStore.beginReactionMode()
                         withAnimation(.easeInOut(duration: 0.2)) {
                             reactionModeMessage = message
                         }
@@ -307,6 +308,7 @@ struct MessagingView: View {
                                             }
                                         },
                                         onLongPress: {
+                                            attachmentPreviewStore.beginReactionMode()
                                             withAnimation(.easeInOut(duration: 0.2)) {
                                                 reactionModeMessage = message
                                             }
@@ -495,6 +497,7 @@ struct MessagingView: View {
                         emojiPickerTargetMessage = msg
                     },
                     onDismiss: {
+                        attachmentPreviewStore.endReactionMode()
                         withAnimation(.easeInOut(duration: 0.2)) {
                             reactionModeMessage = nil
                         }

--- a/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
@@ -173,6 +173,7 @@ struct MessagingView: View {
     @StateObject private var attachmentPreviewStore = MessageAttachmentPreviewStore()
     @State private var attachmentPreviewError: String?
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.openURL) private var openURL
     @Environment(\.scenePhase) private var scenePhase
 
     // MARK: - Body
@@ -908,8 +909,12 @@ struct MessagingView: View {
     }
 
     private func openMessageLink(_ target: MessageLinkTarget) {
-        guard case .nomadNet = target else { return }
-        nomadNetLinkTarget = target
+        switch target {
+        case .nomadNet:
+            nomadNetLinkTarget = target
+        case .web(let url), .external(let url):
+            openURL(url)
+        }
     }
 
     private func exitAttachmentInteractionState() {

--- a/Tests/ColumbaAppTests/MessageAttachmentPreviewTests.swift
+++ b/Tests/ColumbaAppTests/MessageAttachmentPreviewTests.swift
@@ -212,6 +212,24 @@ final class MessageAttachmentRoutingTests: XCTestCase {
         controller.routeReplyPreviewForTesting(messageID: "replying", replyID: "original")
         await drainMainQueue()
         XCTAssertEqual(controller.replyPreviewNavigationCountForTesting, 1)
+
+        let link = MessageLinkTarget.web(URL(string: "https://example.com")!)
+        var openedLink: MessageLinkTarget?
+        controller.onOpenLink = { openedLink = $0 }
+
+        controller.routeMessageLinkForTesting(messageID: "replying", target: link)
+        controller.setReactionMode(messageID: "replying")
+        await drainMainQueue()
+        XCTAssertNil(openedLink)
+
+        controller.routeMessageLinkForTesting(messageID: "replying", target: link)
+        await drainMainQueue()
+        XCTAssertNil(openedLink)
+
+        controller.setReactionMode(messageID: nil)
+        controller.routeMessageLinkForTesting(messageID: "replying", target: link)
+        await drainMainQueue()
+        XCTAssertEqual(openedLink, link)
     }
 
     @MainActor

--- a/Tests/ColumbaAppTests/MessageAttachmentPreviewTests.swift
+++ b/Tests/ColumbaAppTests/MessageAttachmentPreviewTests.swift
@@ -78,36 +78,6 @@ final class MessageAttachmentPreviewItemTests: XCTestCase {
     }
 }
 
-final class BubbleActionRouterTests: XCTestCase {
-    func testTapInvokesOnlyTapCallback() {
-        var taps = 0
-        var longPresses = 0
-
-        BubbleActionRouter.perform(
-            .tap,
-            onTap: { taps += 1 },
-            onLongPress: { longPresses += 1 }
-        )
-
-        XCTAssertEqual(taps, 1)
-        XCTAssertEqual(longPresses, 0)
-    }
-
-    func testLongPressInvokesOnlyLongPressCallback() {
-        var taps = 0
-        var longPresses = 0
-
-        BubbleActionRouter.perform(
-            .longPress,
-            onTap: { taps += 1 },
-            onLongPress: { longPresses += 1 }
-        )
-
-        XCTAssertEqual(taps, 0)
-        XCTAssertEqual(longPresses, 1)
-    }
-}
-
 @MainActor
 final class MessageAttachmentPreviewStoreTests: XCTestCase {
     func testReplacementDismissalAndConversationExitCleanOnlyOwnedItems() throws {
@@ -145,6 +115,37 @@ final class MessageAttachmentPreviewStoreTests: XCTestCase {
         store.exitConversation()
         XCTAssertFalse(FileManager.default.fileExists(atPath: third.directoryURL.path))
         XCTAssertTrue(FileManager.default.fileExists(atPath: sibling.url.path))
+    }
+
+    func testReactionModeWinsRegardlessOfPreviewCallbackOrdering() throws {
+        let tapThenLongPress = MessageAttachmentPreviewStore()
+        let first = try MessageAttachmentPreviewItem(
+            data: Data("first".utf8),
+            suggestedFilename: "first.bin"
+        )
+        tapThenLongPress.present(first)
+        tapThenLongPress.beginReactionMode()
+        XCTAssertNil(tapThenLongPress.item)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: first.directoryURL.path))
+
+        let longPressThenTap = MessageAttachmentPreviewStore()
+        let blocked = try MessageAttachmentPreviewItem(
+            data: Data("blocked".utf8),
+            suggestedFilename: "blocked.bin"
+        )
+        longPressThenTap.beginReactionMode()
+        longPressThenTap.present(blocked)
+        XCTAssertNil(longPressThenTap.item)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: blocked.directoryURL.path))
+
+        let allowed = try MessageAttachmentPreviewItem(
+            data: Data("allowed".utf8),
+            suggestedFilename: "allowed.bin"
+        )
+        longPressThenTap.endReactionMode()
+        longPressThenTap.present(allowed)
+        XCTAssertEqual(longPressThenTap.item?.id, allowed.id)
+        longPressThenTap.dismiss()
     }
 }
 

--- a/Tests/ColumbaAppTests/MessageAttachmentPreviewTests.swift
+++ b/Tests/ColumbaAppTests/MessageAttachmentPreviewTests.swift
@@ -213,21 +213,25 @@ final class MessageAttachmentRoutingTests: XCTestCase {
         await drainMainQueue()
         XCTAssertEqual(controller.replyPreviewNavigationCountForTesting, 1)
 
-        let link = MessageLinkTarget.web(URL(string: "https://example.com")!)
+        let linkURL = URL(string: "https://example.com")!
+        let link = MessageLinkTarget.web(linkURL)
         var openedLink: MessageLinkTarget?
         controller.onOpenLink = { openedLink = $0 }
+        let dispatcher = MessageBodyLinkDispatcher { target in
+            controller.routeMessageLinkForTesting(messageID: "replying", target: target)
+        }
 
-        controller.routeMessageLinkForTesting(messageID: "replying", target: link)
+        _ = dispatcher.open(linkURL)
         controller.setReactionMode(messageID: "replying")
         await drainMainQueue()
         XCTAssertNil(openedLink)
 
-        controller.routeMessageLinkForTesting(messageID: "replying", target: link)
+        _ = dispatcher.open(linkURL)
         await drainMainQueue()
         XCTAssertNil(openedLink)
 
         controller.setReactionMode(messageID: nil)
-        controller.routeMessageLinkForTesting(messageID: "replying", target: link)
+        _ = dispatcher.open(linkURL)
         await drainMainQueue()
         XCTAssertEqual(openedLink, link)
     }

--- a/Tests/ColumbaAppTests/MessageAttachmentPreviewTests.swift
+++ b/Tests/ColumbaAppTests/MessageAttachmentPreviewTests.swift
@@ -78,6 +78,29 @@ final class MessageAttachmentPreviewItemTests: XCTestCase {
     }
 }
 
+final class BubbleReplyPreviewPolicyTests: XCTestCase {
+    func testRecentLongPressSuppressesReplyNavigation() {
+        let now = Date(timeIntervalSinceReferenceDate: 1_000)
+        XCTAssertFalse(
+            BubbleReplyPreviewPolicy.shouldNavigate(
+                lastLongPressAt: now.addingTimeInterval(-0.05),
+                now: now
+            )
+        )
+    }
+
+    func testOrdinaryTapAllowsReplyNavigation() {
+        let now = Date(timeIntervalSinceReferenceDate: 1_000)
+        XCTAssertTrue(BubbleReplyPreviewPolicy.shouldNavigate(lastLongPressAt: nil, now: now))
+        XCTAssertTrue(
+            BubbleReplyPreviewPolicy.shouldNavigate(
+                lastLongPressAt: now.addingTimeInterval(-1),
+                now: now
+            )
+        )
+    }
+}
+
 @MainActor
 final class MessageAttachmentPreviewStoreTests: XCTestCase {
     func testReplacementDismissalAndConversationExitCleanOnlyOwnedItems() throws {

--- a/Tests/ColumbaAppTests/MessageAttachmentPreviewTests.swift
+++ b/Tests/ColumbaAppTests/MessageAttachmentPreviewTests.swift
@@ -78,29 +78,6 @@ final class MessageAttachmentPreviewItemTests: XCTestCase {
     }
 }
 
-final class BubbleReplyPreviewPolicyTests: XCTestCase {
-    func testRecentLongPressSuppressesReplyNavigation() {
-        let now = Date(timeIntervalSinceReferenceDate: 1_000)
-        XCTAssertFalse(
-            BubbleReplyPreviewPolicy.shouldNavigate(
-                lastLongPressAt: now.addingTimeInterval(-0.05),
-                now: now
-            )
-        )
-    }
-
-    func testOrdinaryTapAllowsReplyNavigation() {
-        let now = Date(timeIntervalSinceReferenceDate: 1_000)
-        XCTAssertTrue(BubbleReplyPreviewPolicy.shouldNavigate(lastLongPressAt: nil, now: now))
-        XCTAssertTrue(
-            BubbleReplyPreviewPolicy.shouldNavigate(
-                lastLongPressAt: now.addingTimeInterval(-1),
-                now: now
-            )
-        )
-    }
-}
-
 @MainActor
 final class MessageAttachmentPreviewStoreTests: XCTestCase {
     func testReplacementDismissalAndConversationExitCleanOnlyOwnedItems() throws {
@@ -218,6 +195,33 @@ final class MessageAttachmentRoutingTests: XCTestCase {
     }
 
     @MainActor
+    func testReactionModeSuppressesDeferredReplyNavigationUntilDismissed() async {
+        let controller = MessageTimelineViewController()
+        controller.loadViewIfNeeded()
+
+        controller.routeReplyPreviewForTesting(messageID: "replying", replyID: "original")
+        controller.setReactionMode(messageID: "replying")
+        await drainMainQueue()
+        XCTAssertEqual(controller.replyPreviewNavigationCountForTesting, 0)
+
+        controller.routeReplyPreviewForTesting(messageID: "replying", replyID: "original")
+        await drainMainQueue()
+        XCTAssertEqual(controller.replyPreviewNavigationCountForTesting, 0)
+
+        controller.setReactionMode(messageID: nil)
+        controller.routeReplyPreviewForTesting(messageID: "replying", replyID: "original")
+        await drainMainQueue()
+        XCTAssertEqual(controller.replyPreviewNavigationCountForTesting, 1)
+    }
+
+    @MainActor
+    private func drainMainQueue() async {
+        let drained = expectation(description: "main queue drained")
+        DispatchQueue.main.async { drained.fulfill() }
+        await fulfillment(of: [drained], timeout: 1)
+    }
+
+    @MainActor
     func testAttachmentBubbleProducesVisualEvidenceForInteractiveControls() throws {
         let image = UIGraphicsImageRenderer(size: CGSize(width: 96, height: 64)).pngData { context in
             UIColor.systemRed.setFill()
@@ -332,6 +336,7 @@ final class MessageAttachmentRoutingTests: XCTestCase {
             messageTextScale: 1,
             isLoadingMore: false,
             allMessagesLoaded: true,
+            reactionModeMessageID: nil,
             onLoadOlder: { false },
             onReply: { _ in },
             onToggleReaction: { _, _ in },

--- a/Tests/static/test_attachment_preview_contract.rb
+++ b/Tests/static/test_attachment_preview_contract.rb
@@ -82,5 +82,7 @@ class AttachmentPreviewContractTests < Minitest::Test
     assert_includes timeline, 'setReactionMode(messageID: reactionModeMessageID)'
     assert_includes timeline, 'reactionModeMessageID = message.id'
     assert_includes timeline, 'self.reactionModeMessageID != messageID'
+    assert_includes timeline, 'routeMessageLink(messageID: message.id, target: target)'
+    assert_includes messaging, 'guard reactionModeMessage?.id != message.id else { return }'
   end
 end

--- a/Tests/static/test_attachment_preview_contract.rb
+++ b/Tests/static/test_attachment_preview_contract.rb
@@ -56,12 +56,21 @@ class AttachmentPreviewContractTests < Minitest::Test
     assert_includes bubble, '.accessibilityIdentifier("bubble_file_chip_\(index)")'
   end
 
-  def test_attachment_controls_exclusively_route_tap_or_long_press
+  def test_attachment_controls_use_native_buttons_and_owner_arbitrates_reactions
     bubble = File.read(File.join(ROOT, 'Sources/ColumbaApp/Views/Messaging/MessageBubble.swift'))
-    assert_includes bubble, 'PrimitiveButtonStyle'
-    assert_includes bubble, '.exclusively(before: TapGesture())'
-    assert_operator bubble.scan('.buttonStyle(BubbleActionButtonStyle').length, :>=, 3
-    assert_includes bubble, 'BubbleActionRouter.perform'
-    refute_includes bubble, '.onLongPressGesture(minimumDuration: 0.4)'
+    assert_operator bubble.scan('.buttonStyle(.plain)').length, :>=, 3
+    assert_includes bubble, '.simultaneousGesture('
+    assert_includes bubble, 'LongPressGesture(minimumDuration: 0.4)'
+    refute_includes bubble, 'PrimitiveButtonStyle'
+    refute_includes bubble, '.exclusively(before: TapGesture())'
+
+    preview = File.read(File.join(ROOT, PREVIEW_SOURCE))
+    assert_includes preview, 'beginReactionMode()'
+    assert_includes preview, 'endReactionMode()'
+    assert_includes preview, 'guard !isReactionModeActive'
+
+    messaging = File.read(File.join(ROOT, 'Sources/ColumbaApp/Views/Messaging/MessagingView.swift'))
+    assert_operator messaging.scan('attachmentPreviewStore.beginReactionMode()').length, :>=, 2
+    assert_includes messaging, 'attachmentPreviewStore.endReactionMode()'
   end
 end

--- a/Tests/static/test_attachment_preview_contract.rb
+++ b/Tests/static/test_attachment_preview_contract.rb
@@ -74,6 +74,9 @@ class AttachmentPreviewContractTests < Minitest::Test
     assert_operator messaging.scan('attachmentPreviewStore.beginReactionMode()').length, :>=, 2
     assert_includes messaging, 'attachmentPreviewStore.endReactionMode()'
     assert_includes messaging, 'reactionModeMessageID: reactionModeMessage?.id'
+    assert_includes messaging, 'private func exitAttachmentInteractionState()'
+    assert_includes messaging, "reactionModeMessage = nil\n        attachmentPreviewStore.exitConversation()"
+    assert_includes messaging, 'exitAttachmentInteractionState()'
 
     timeline = File.read(File.join(ROOT, 'Sources/ColumbaApp/Views/Messaging/MessageTimelineView.swift'))
     assert_includes timeline, 'setReactionMode(messageID: reactionModeMessageID)'

--- a/Tests/static/test_attachment_preview_contract.rb
+++ b/Tests/static/test_attachment_preview_contract.rb
@@ -61,8 +61,7 @@ class AttachmentPreviewContractTests < Minitest::Test
     assert_operator bubble.scan('.buttonStyle(.plain)').length, :>=, 3
     assert_includes bubble, '.simultaneousGesture('
     assert_includes bubble, 'LongPressGesture(minimumDuration: 0.4)'
-    assert_includes bubble, 'BubbleReplyPreviewPolicy.shouldNavigate'
-    assert_includes bubble, 'DispatchQueue.main.async'
+    refute_includes bubble, 'BubbleReplyPreviewPolicy'
     refute_includes bubble, 'PrimitiveButtonStyle'
     refute_includes bubble, '.exclusively(before: TapGesture())'
 
@@ -74,5 +73,11 @@ class AttachmentPreviewContractTests < Minitest::Test
     messaging = File.read(File.join(ROOT, 'Sources/ColumbaApp/Views/Messaging/MessagingView.swift'))
     assert_operator messaging.scan('attachmentPreviewStore.beginReactionMode()').length, :>=, 2
     assert_includes messaging, 'attachmentPreviewStore.endReactionMode()'
+    assert_includes messaging, 'reactionModeMessageID: reactionModeMessage?.id'
+
+    timeline = File.read(File.join(ROOT, 'Sources/ColumbaApp/Views/Messaging/MessageTimelineView.swift'))
+    assert_includes timeline, 'setReactionMode(messageID: reactionModeMessageID)'
+    assert_includes timeline, 'reactionModeMessageID = message.id'
+    assert_includes timeline, 'self.reactionModeMessageID != messageID'
   end
 end

--- a/Tests/static/test_attachment_preview_contract.rb
+++ b/Tests/static/test_attachment_preview_contract.rb
@@ -84,5 +84,9 @@ class AttachmentPreviewContractTests < Minitest::Test
     assert_includes timeline, 'self.reactionModeMessageID != messageID'
     assert_includes timeline, 'routeMessageLink(messageID: message.id, target: target)'
     assert_includes messaging, 'guard reactionModeMessage?.id != message.id else { return }'
+
+    message_body = File.read(File.join(ROOT, 'Sources/ColumbaApp/Views/Messaging/MessageBody.swift'))
+    assert_includes message_body, 'MessageBodyLinkDispatcher(onOpenLink: onOpenLink).open(url)'
+    refute_includes message_body, '.systemAction(url)'
   end
 end

--- a/Tests/static/test_attachment_preview_contract.rb
+++ b/Tests/static/test_attachment_preview_contract.rb
@@ -61,6 +61,8 @@ class AttachmentPreviewContractTests < Minitest::Test
     assert_operator bubble.scan('.buttonStyle(.plain)').length, :>=, 3
     assert_includes bubble, '.simultaneousGesture('
     assert_includes bubble, 'LongPressGesture(minimumDuration: 0.4)'
+    assert_includes bubble, 'BubbleReplyPreviewPolicy.shouldNavigate'
+    assert_includes bubble, 'DispatchQueue.main.async'
     refute_includes bubble, 'PrimitiveButtonStyle'
     refute_includes bubble, '.exclusively(before: TapGesture())'
 


### PR DESCRIPTION
## Summary

- restore reliable attachment activation in distribution builds by returning image and file controls to native SwiftUI `Button` behavior
- arbitrate attachment preview and reaction mode in the presentation owner so short tap, long hold, and callback ordering remain mutually safe
- bind reply-preview navigation to explicit reaction state and clear all attachment interaction state when leaving the conversation
- add regression coverage for preview cleanup, reaction ordering, production timeline callback refresh, and reply-navigation suppression

This is an additive follow-up to #150 after the merged implementation worked in a development install but failed to activate image attachments in TestFlight.

## Verification

- 280 shipping XTests passed
- 11 focused attachment, timeline-routing, and reaction-state XTests passed
- 244 portable/static tests passed, 1 skipped
- attachment contract: 4 runs, 75 assertions, 0 failures
- Sideband image to native SwiftUI Quick Look interop passed
- signed Release build installed and launched on a physical iPhone
- exact-head physical checks confirmed:
  - short tap over image opens Quick Look only
  - long hold over image opens reactions only
  - horizontal swipe beginning over image activates swipe-to-reply only
- independent exact-head specification and code-quality reviews approved with no findings

Model B was intentionally excluded from this shipping-app fix.

## Risk and rollback

The change is limited to attachment/reaction interaction ownership and related tests. It preserves native Quick Look, original-byte staging and cleanup, accessibility labels and identifiers, timeline behavior, and swipe-to-reply. Rollback is the four commits in this PR, though that would restore the TestFlight tap regression.
