### PR TITLE
Show automatically selected relay in Settings

### DIFF
--- a/Sources/ColumbaApp/Views/Settings/SettingsView.swift
+++ b/Sources/ColumbaApp/Views/Settings/SettingsView.swift
@@ -1344,9 +1344,13 @@ struct SettingsView: View {
 
                     Spacer()
 
-                    Text(vm.selectedRelayName ?? "None")
+                    Text(appServices.propagationManager?.selectedNodeName ?? "None")
                         .font(.subheadline)
-                        .foregroundStyle(vm.selectedRelayName != nil ? Theme.textPrimary : Theme.textSecondary)
+                        .foregroundStyle(
+                            appServices.propagationManager?.selectedNodeName != nil
+                                ? Theme.textPrimary
+                                : Theme.textSecondary
+                        )
                 }
 
                 Divider()

--- a/Tests/static/test_auto_selected_relay_display.py
+++ b/Tests/static/test_auto_selected_relay_display.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+import re
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SETTINGS_VIEW = ROOT / "Sources/ColumbaApp/Views/Settings/SettingsView.swift"
+
+
+def test_current_relay_reads_live_propagation_manager_selection() -> None:
+    source = SETTINGS_VIEW.read_text(encoding="utf-8")
+    card = re.search(
+        r"private func deliveryRetrievalCard\(.+?(?=\n    // MARK:|\Z)",
+        source,
+        flags=re.DOTALL,
+    )
+    assert card is not None
+    body = card.group(0)
+
+    assert "appServices.propagationManager?.selectedNodeName" in body
+    assert 'Text(vm.selectedRelayName ?? "None")' not in body


### PR DESCRIPTION
## Summary

- display the live relay selection owned by `PropagationNodeManager`
- update Settings immediately when relay auto-selection changes
- add a regression contract preventing the UI from returning to a stale copied value

## Root cause

Propagation sync could automatically select and use a relay while Settings continued rendering a snapshot copied into `SettingsViewModel`. That snapshot was not refreshed when relay discovery selected a node after the screen loaded.

## Verification

- regression observed failing before the production change and passing afterward
- `python3 -m pytest Tests/static -q`
  - 244 passed, 1 skipped, 255 subtests passed
- `git diff --check`

Native simulator verification is delegated to the repository CI lanes because the local Mac transfer gate blocked the committed bundle before Xcode execution.

## Risk

Low. The change only replaces the stale Settings snapshot read with the existing observable propagation manager state. Relay selection, persistence, and sync behavior are unchanged.