### PR TITLE
Add iOS background propagation sync

### DIFF
--- a/Columba.xcodeproj/project.pbxproj
+++ b/Columba.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		BGPSYNCBUILD001 /* BackgroundPropagationSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = BGPSYNCREF001 /* BackgroundPropagationSync.swift */; };
 		BGPSYNCTESTBUILD001 /* BackgroundPropagationSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BGPSYNCTESTREF001 /* BackgroundPropagationSyncTests.swift */; };
 		001 /* ColumbaApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F001 /* ColumbaApp.swift */; };
 		002 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = F002 /* Theme.swift */; };
@@ -408,6 +409,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		BGPSYNCREF001 /* BackgroundPropagationSync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundPropagationSync.swift; sourceTree = "<group>"; };
 		BGPSYNCTESTREF001 /* BackgroundPropagationSyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundPropagationSyncTests.swift; sourceTree = "<group>"; };
 		00A8D344945F752C18EF2D9E /* AudioManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudioManager.swift; sourceTree = "<group>"; };
 		11D4DB375C0C7BB62E8A8B23 /* ColumbaPython-Bridging-Header.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "ColumbaPython-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -983,6 +985,7 @@
 		GSVC /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				BGPSYNCREF001 /* BackgroundPropagationSync.swift */,
 				F024 /* AppServices.swift */,
 				BKF002 /* BackendFactory.swift */,
 				F025 /* MessageRepository.swift */,
@@ -1575,6 +1578,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BGPSYNCBUILD001 /* BackgroundPropagationSync.swift in Sources */,
 				001 /* ColumbaApp.swift in Sources */,
 				002 /* Theme.swift in Sources */,
 				003 /* ChatsViewModel.swift in Sources */,

--- a/Columba.xcodeproj/project.pbxproj
+++ b/Columba.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		BGPSYNCTESTBUILD001 /* BackgroundPropagationSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BGPSYNCTESTREF001 /* BackgroundPropagationSyncTests.swift */; };
 		001 /* ColumbaApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F001 /* ColumbaApp.swift */; };
 		002 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = F002 /* Theme.swift */; };
 		003 /* ChatsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F003 /* ChatsViewModel.swift */; };
@@ -407,6 +408,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		BGPSYNCTESTREF001 /* BackgroundPropagationSyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundPropagationSyncTests.swift; sourceTree = "<group>"; };
 		00A8D344945F752C18EF2D9E /* AudioManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudioManager.swift; sourceTree = "<group>"; };
 		11D4DB375C0C7BB62E8A8B23 /* ColumbaPython-Bridging-Header.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "ColumbaPython-Bridging-Header.h"; sourceTree = "<group>"; };
 		1F7375908681A4DF99F125C7 /* CallKitManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CallKitManager.swift; sourceTree = "<group>"; };
@@ -1021,6 +1023,7 @@
 		GTESTS /* ColumbaAppTests */ = {
 			isa = PBXGroup;
 			children = (
+				BGPSYNCTESTREF001 /* BackgroundPropagationSyncTests.swift */,
 				FT03 /* MicronParserTests.swift */,
 				DE307E24C72DBA41D76C9A6C /* AudioRingBufferTests.swift */,
 				FBDT /* BLESeamDriverTests.swift */,
@@ -1706,6 +1709,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BGPSYNCTESTBUILD001 /* BackgroundPropagationSyncTests.swift in Sources */,
 				T003 /* MicronParserTests.swift in Sources */,
 				2B3A3E3FB59D1E22B424E109 /* AudioRingBufferTests.swift in Sources */,
 				A0C0D9AE12F728A484F0F108 /* AudioManagerConfigChangeTests.swift in Sources */,

--- a/Sources/ColumbaApp/App/ColumbaApp.swift
+++ b/Sources/ColumbaApp/App/ColumbaApp.swift
@@ -1011,6 +1011,13 @@ struct RootView: View {
 
             self.isInitialized = true
 
+            #if os(iOS) && COLUMBA_RUNTIME_PYTHON
+            // Submit after startup as well as on scene/settings transitions. This
+            // survives the startup diagnostic-log reset and ensures the first
+            // request is based on fully restored persisted settings.
+            BackgroundPropagationRefreshScheduler.scheduleFromCurrentSettings()
+            #endif
+
             // DEBUG: Auto-trigger propagation sync on launch for testing
             if ProcessInfo.processInfo.arguments.contains("--auto-sync") {
                 let services = appServices

--- a/Sources/ColumbaApp/App/ColumbaApp.swift
+++ b/Sources/ColumbaApp/App/ColumbaApp.swift
@@ -722,16 +722,20 @@ struct RootView: View {
         handler.setUserNotificationsSuppressed(true)
         defer { handler.setUserNotificationsSuppressed(false) }
 
+        let syncOperationID = UUID()
         let workflow = BackgroundPropagationSyncWorkflow<LXMessage>(
             captureInsertionCursor: {
                 try await repository.captureMessageInsertionCursor()
             },
             sync: {
                 await withTaskCancellationHandler {
-                    await propagationManager.syncNow(timeout: 20.0)
+                    await propagationManager.syncNow(
+                        timeout: 20.0,
+                        operationID: syncOperationID
+                    )
                 } onCancel: {
                     Task { @MainActor in
-                        await propagationManager.cancelActiveSync()
+                        await propagationManager.cancelActiveSync(operationID: syncOperationID)
                     }
                 }
             },

--- a/Sources/ColumbaApp/App/ColumbaApp.swift
+++ b/Sources/ColumbaApp/App/ColumbaApp.swift
@@ -19,6 +19,22 @@ private let logger = Logger(subsystem: "network.columba.Columba", category: "Col
 
 /// Main SwiftUI App entry point.
 ///
+#if os(iOS) && COLUMBA_RUNTIME_PYTHON
+@MainActor
+private final class BackgroundPropagationCancellation {
+    private var operation: Task<Void, Never>?
+
+    func request(_ cancel: @escaping @MainActor @Sendable () async -> Void) {
+        guard operation == nil else { return }
+        operation = Task { @MainActor in await cancel() }
+    }
+
+    func wait() async {
+        await operation?.value
+    }
+}
+#endif
+
 /// Creates MainTabView as the root navigation container.
 /// Handles service initialization via AppServices.
 @main
@@ -487,6 +503,7 @@ struct RootView: View {
     #endif
     @State private var initError: String?
     @State private var isInitialized = false
+    @State private var serviceInitializationTask: Task<Bool, Never>?
     @State private var identitySwitchTrigger = UUID()
     @State private var showOnboarding: Bool
     @Environment(\.scenePhase) private var scenePhase
@@ -580,7 +597,7 @@ struct RootView: View {
         }
         .task(id: identitySwitchTrigger) {
             if !showOnboarding {
-                await initializeServices()
+                _ = await ensureServicesInitialized()
             }
         }
         .onChange(of: scenePhase) { _, newPhase in
@@ -593,7 +610,14 @@ struct RootView: View {
             BackgroundPropagationRefreshScheduler.logPendingRequests(context: context)
             #endif
             if phaseValue == .active {
-                NotificationService.shared.clearBadge()
+                if let repository = messageRepository {
+                    Task {
+                        if let unread = try? await repository.totalUnreadCount() {
+                            await NotificationService.shared
+                                .synchronizeBadgeWithDurableUnreadCount(unread)
+                        }
+                    }
+                }
                 // Sync from propagation node when app becomes active,
                 // debounced to avoid rapid re-syncs on quick app switches
                 if let propManager = appServices.propagationManager,
@@ -718,9 +742,9 @@ struct RootView: View {
             return true
         }
 
-        for _ in 0..<100 where !isInitialized {
-            guard !Task.isCancelled else { return false }
-            try? await Task.sleep(for: .milliseconds(100))
+        guard await ensureServicesInitialized() else {
+            DiagLog.log("[BG-SYNC] failed: shared service initialization unsuccessful")
+            return false
         }
 
         guard isInitialized,
@@ -739,25 +763,42 @@ struct RootView: View {
                 + "selectedNode=\(propagationManager.selectedNodeHash != nil)"
         )
 
+        guard await appServices.beginExclusivePythonHostEventProcessing() else {
+            DiagLog.log("[BG-SYNC] cancelled before acquiring host event transaction")
+            return false
+        }
         handler.setUserNotificationsSuppressed(true)
-        defer { handler.setUserNotificationsSuppressed(false) }
 
         let syncOperationID = UUID()
+        let cancellation = BackgroundPropagationCancellation()
         let workflow = BackgroundPropagationSyncWorkflow<LXMessage>(
             captureInsertionCursor: {
                 try await repository.captureMessageInsertionCursor()
             },
             sync: {
-                await withTaskCancellationHandler {
+                let result = await withTaskCancellationHandler {
                     await propagationManager.syncNow(
                         timeout: 20.0,
                         operationID: syncOperationID
                     )
                 } onCancel: {
+                    // Promptly interrupt the blocking Python operation. The
+                    // structured path below also awaits this same task before the
+                    // BG task is reported complete.
                     Task { @MainActor in
-                        await propagationManager.cancelActiveSync(operationID: syncOperationID)
+                        cancellation.request {
+                            await propagationManager.cancelActiveSync(operationID: syncOperationID)
+                        }
                     }
                 }
+                if Task.isCancelled {
+                    cancellation.request {
+                        await propagationManager.cancelActiveSync(operationID: syncOperationID)
+                    }
+                    await cancellation.wait()
+                    return false
+                }
+                return result
             },
             messagesInsertedAfter: { cursor in
                 try await repository.fetchIncomingMessagesInserted(after: cursor)
@@ -768,12 +809,34 @@ struct RootView: View {
         )
 
         let succeeded = await workflow.run()
+        handler.setUserNotificationsSuppressed(false)
+        await appServices.endExclusivePythonHostEventProcessing()
         DiagLog.log("[BG-SYNC] completed success=\(succeeded)")
         return succeeded
     }
     #endif
 
     // MARK: - Initialization
+
+    /// Share one application-lifetime initialization operation between the SwiftUI
+    /// scene and a cold-delivered background refresh. This prevents duplicate
+    /// Reticulum identities/routers and avoids treating a fixed delay as readiness.
+    @MainActor
+    private func ensureServicesInitialized() async -> Bool {
+        if isInitialized { return true }
+        if let serviceInitializationTask {
+            return await serviceInitializationTask.value
+        }
+
+        let task = Task { @MainActor in
+            await initializeServices()
+            return isInitialized
+        }
+        serviceInitializationTask = task
+        let succeeded = await task.value
+        serviceInitializationTask = nil
+        return succeeded
+    }
 
     private func initializeServices() async {
         DiagLog.log("[STARTUP] initializeServices() ENTERED")
@@ -932,6 +995,7 @@ struct RootView: View {
             if let router = appServices.router {
                 await router.setDelegate(handler)
             }
+            appServices.startPythonEventDrain()
 
             #if COLUMBA_RUNTIME_MODEL_B
             // Model B: the NE owns LXMF delivery, so the live `LXMRouter` delegate

--- a/Sources/ColumbaApp/App/ColumbaApp.swift
+++ b/Sources/ColumbaApp/App/ColumbaApp.swift
@@ -38,6 +38,13 @@ struct ColumbaApp: App {
     // MARK: - Init
 
     init() {
+        #if os(iOS) && COLUMBA_RUNTIME_PYTHON
+        // Register before starting embedded Python or any other potentially slow
+        // launch work. BGTaskScheduler requires every launch handler to be
+        // registered during application launch, including cold background launch.
+        BackgroundPropagationRefreshScheduler.register()
+        #endif
+
         #if COLUMBA_RUNTIME_PYTHON
         // Boot embedded CPython once, before anything else can touch it.
         // PythonBridge / PythonRNSBackend depend on this; without it
@@ -93,10 +100,6 @@ struct ColumbaApp: App {
             ModelBRNodeService.shared.restore()
         }
         #endif
-        #endif
-
-        #if os(iOS) && COLUMBA_RUNTIME_PYTHON
-        BackgroundPropagationRefreshScheduler.register()
         #endif
 
         // Install notification delegate early so didReceive (notification tap) works
@@ -582,6 +585,13 @@ struct RootView: View {
         }
         .onChange(of: scenePhase) { _, newPhase in
             let phaseValue = newPhase
+            #if os(iOS) && COLUMBA_RUNTIME_PYTHON
+            let context = phaseValue == .active
+                ? "scene-active"
+                : (phaseValue == .background ? "scene-background" : "scene-inactive")
+            BackgroundPropagationRefreshScheduler.logRuntime(context: context)
+            BackgroundPropagationRefreshScheduler.logPendingRequests(context: context)
+            #endif
             if phaseValue == .active {
                 NotificationService.shared.clearBadge()
                 // Sync from propagation node when app becomes active,
@@ -701,6 +711,8 @@ struct RootView: View {
     /// path rather than starting a competing identity/router initialization.
     @MainActor
     private func performBackgroundPropagationSync() async -> Bool {
+        BackgroundPropagationRefreshScheduler.logRuntime(context: "workflow-entered")
+        DiagLog.log("[BG-SYNC] workflow entered initialized=\(isInitialized)")
         guard await settingsRepository.getPeriodicSyncEnabled() else {
             DiagLog.log("[BG-SYNC] skipped: periodic sync disabled")
             return true
@@ -715,9 +727,17 @@ struct RootView: View {
               let repository = messageRepository,
               let handler = incomingMessageHandler,
               let propagationManager = appServices.propagationManager else {
-            DiagLog.log("[BG-SYNC] failed: services not ready")
+            DiagLog.log(
+                "[BG-SYNC] failed: services not ready initialized=\(isInitialized) "
+                    + "repository=\(messageRepository != nil) handler=\(incomingMessageHandler != nil) "
+                    + "propagationManager=\(appServices.propagationManager != nil)"
+            )
             return false
         }
+        DiagLog.log(
+            "[BG-SYNC] services ready backend=\(appServices.pythonBackend != nil) "
+                + "selectedNode=\(propagationManager.selectedNodeHash != nil)"
+        )
 
         handler.setUserNotificationsSuppressed(true)
         defer { handler.setUserNotificationsSuppressed(false) }
@@ -757,6 +777,10 @@ struct RootView: View {
 
     private func initializeServices() async {
         DiagLog.log("[STARTUP] initializeServices() ENTERED")
+        #if os(iOS) && COLUMBA_RUNTIME_PYTHON
+        BackgroundPropagationRefreshScheduler.logRuntime(context: "initialize-services")
+        BackgroundPropagationRefreshScheduler.logPendingRequests(context: "initialize-services")
+        #endif
 
         #if COLUMBA_RUNTIME_MODEL_B
         // Surface the Network Extension's App-Group diagnostic log into Documents

--- a/Sources/ColumbaApp/App/ColumbaApp.swift
+++ b/Sources/ColumbaApp/App/ColumbaApp.swift
@@ -9,7 +9,6 @@
 import SwiftUI
 import RNSAPI
 import UserNotifications
-import BackgroundTasks
 import SwiftBLEBridge
 import os
 #if canImport(CoreBluetooth)
@@ -96,13 +95,8 @@ struct ColumbaApp: App {
         #endif
         #endif
 
-        #if os(iOS)
-        BGTaskScheduler.shared.register(
-            forTaskWithIdentifier: "network.columba.Columba.sync",
-            using: nil
-        ) { task in
-            NotificationCenter.default.post(name: .columbaBackgroundSync, object: task)
-        }
+        #if os(iOS) && COLUMBA_RUNTIME_PYTHON
+        BackgroundPropagationRefreshScheduler.register()
         #endif
 
         // Install notification delegate early so didReceive (notification tap) works
@@ -602,7 +596,9 @@ struct RootView: View {
             }
             #if os(iOS)
             if newPhase == .background {
-                scheduleBackgroundSync()
+                #if COLUMBA_RUNTIME_PYTHON
+                BackgroundPropagationRefreshScheduler.scheduleFromCurrentSettings()
+                #endif
                 // Flush RNS's path table + known destinations to disk now —
                 // iOS won't run RNS's clean-exit persist, so without this a
                 // cold start can't recall previously-heard peers.
@@ -611,10 +607,12 @@ struct RootView: View {
             appServices.locationSharingManager?.setBackgroundState(newPhase != .active)
             #endif
         }
-        #if os(iOS)
-        .onReceive(NotificationCenter.default.publisher(for: .columbaBackgroundSync)) { note in
-            guard let task = note.object as? BGAppRefreshTask else { return }
-            handleBackgroundSync(task: task)
+        #if os(iOS) && COLUMBA_RUNTIME_PYTHON
+        .task {
+            BackgroundRefreshTaskCoordinator.shared.installHandler {
+                await performBackgroundPropagationSync()
+            }
+            BackgroundPropagationRefreshScheduler.scheduleFromCurrentSettings()
         }
         #endif
     }
@@ -694,25 +692,60 @@ struct RootView: View {
         }
     }
 
-    #if os(iOS)
-    // MARK: - Background Sync
+    #if os(iOS) && COLUMBA_RUNTIME_PYTHON
+    // MARK: - Background Propagation Sync
 
-    private func scheduleBackgroundSync() {
-        let request = BGAppRefreshTaskRequest(identifier: "network.columba.Columba.sync")
-        request.earliestBeginDate = Date(timeIntervalSinceNow: 15 * 60)
-        try? BGTaskScheduler.shared.submit(request)
-    }
+    /// Execute one system-granted refresh against the shipping embedded-Python
+    /// propagation path. A cold launch may deliver the task while normal service
+    /// initialization is still running, so wait briefly for that single startup
+    /// path rather than starting a competing identity/router initialization.
+    @MainActor
+    private func performBackgroundPropagationSync() async -> Bool {
+        guard await settingsRepository.getPeriodicSyncEnabled() else {
+            DiagLog.log("[BG-SYNC] skipped: periodic sync disabled")
+            return true
+        }
 
-    private func handleBackgroundSync(task: BGAppRefreshTask) {
-        scheduleBackgroundSync() // always reschedule first
-        let syncTask = Task {
-            await appServices.propagationManager?.syncNow()
-            task.setTaskCompleted(success: true)
+        for _ in 0..<100 where !isInitialized {
+            guard !Task.isCancelled else { return false }
+            try? await Task.sleep(for: .milliseconds(100))
         }
-        task.expirationHandler = {
-            syncTask.cancel()
-            task.setTaskCompleted(success: false)
+
+        guard isInitialized,
+              let repository = messageRepository,
+              let handler = incomingMessageHandler,
+              let propagationManager = appServices.propagationManager else {
+            DiagLog.log("[BG-SYNC] failed: services not ready")
+            return false
         }
+
+        handler.setUserNotificationsSuppressed(true)
+        defer { handler.setUserNotificationsSuppressed(false) }
+
+        let workflow = BackgroundPropagationSyncWorkflow<LXMessage>(
+            captureInsertionCursor: {
+                try await repository.captureMessageInsertionCursor()
+            },
+            sync: {
+                await withTaskCancellationHandler {
+                    await propagationManager.syncNow(timeout: 20.0)
+                } onCancel: {
+                    Task { @MainActor in
+                        await propagationManager.cancelActiveSync()
+                    }
+                }
+            },
+            messagesInsertedAfter: { cursor in
+                try await repository.fetchIncomingMessagesInserted(after: cursor)
+            },
+            notify: { message in
+                await handler.postNotificationForNewlySyncedMessage(message)
+            }
+        )
+
+        let succeeded = await workflow.run()
+        DiagLog.log("[BG-SYNC] completed success=\(succeeded)")
+        return succeeded
     }
     #endif
 
@@ -1026,12 +1059,6 @@ struct RootView: View {
             throw error
         }
     }
-}
-
-// MARK: - Notification Names
-
-extension Notification.Name {
-    static let columbaBackgroundSync = Notification.Name("network.columba.Columba.backgroundSync")
 }
 
 // MARK: - Tab Enum

--- a/Sources/ColumbaApp/App/ColumbaApp.swift
+++ b/Sources/ColumbaApp/App/ColumbaApp.swift
@@ -42,8 +42,8 @@ private final class BackgroundPropagationCancellation {
 struct ColumbaApp: App {
     // MARK: - Services
 
-    /// Settings repository for UserDefaults-backed configuration.
-    @State private var settingsRepository = SettingsRepository()
+    /// Launch-safe owner shared by BGTaskScheduler and SwiftUI.
+    @State private var applicationRuntime = ColumbaApplicationRuntime.shared
 
     /// Darwin notification observer for IPC from Network Extension.
     @State private var notificationObserver = NotificationObserver()
@@ -59,6 +59,7 @@ struct ColumbaApp: App {
         // launch work. BGTaskScheduler requires every launch handler to be
         // registered during application launch, including cold background launch.
         BackgroundPropagationRefreshScheduler.register()
+        ColumbaApplicationRuntime.shared.installBackgroundHandler()
         #endif
 
         #if COLUMBA_RUNTIME_PYTHON
@@ -132,7 +133,7 @@ struct ColumbaApp: App {
     var body: some Scene {
         WindowGroup {
             RootView(
-                settingsRepository: settingsRepository,
+                applicationRuntime: applicationRuntime,
                 notificationObserver: notificationObserver,
                 pendingDeepLink: $pendingDeepLink
             )
@@ -471,259 +472,52 @@ private struct KeyboardDismissHelper: UIViewRepresentable {
 }
 #endif
 
-// MARK: - Root View
+// MARK: - Application Runtime
 
-/// Root view that handles async service initialization.
-///
-/// Separating initialization into a View (vs App) ensures the .task modifier
-/// runs correctly in the SwiftUI lifecycle.
+/// Launch-safe owner of the minimum identity/database/RNS/LXMF service graph.
+/// BGTaskScheduler delivery must not depend on a SwiftUI scene or View.task.
+@MainActor
+@Observable
 @available(iOS 17.0, macOS 14.0, *)
-struct RootView: View {
-    // MARK: - Dependencies
+final class ColumbaApplicationRuntime {
+    static let shared = ColumbaApplicationRuntime()
 
-    let settingsRepository: SettingsRepository
-    let notificationObserver: NotificationObserver
-    @Binding var pendingDeepLink: String?
-
-    // MARK: - Services
-
-    /// Central service layer owning Identity, Router, Transport, PathTable.
-    @State private var appServices = AppServices()
-
-    /// Multi-identity manager.
-    @State private var identityManager = IdentityManager()
-
-    // MARK: - Internal State
-
-    @State private var database: LXMFDatabase?
-    @State private var messageRepository: MessageRepository?
-    @State private var incomingMessageHandler: IncomingMessageHandler?
+    let settingsRepository = SettingsRepository()
+    let appServices = AppServices()
+    let identityManager = IdentityManager()
+    var database: LXMFDatabase?
+    var messageRepository: MessageRepository?
+    var incomingMessageHandler: IncomingMessageHandler?
     #if COLUMBA_RUNTIME_MODEL_B
-    @State private var modelBInboundReplay: ModelBInboundReplay?
+    var modelBInboundReplay: ModelBInboundReplay?
     #endif
-    @State private var initError: String?
-    @State private var isInitialized = false
-    @State private var serviceInitializationTask: Task<Bool, Never>?
-    @State private var identitySwitchTrigger = UUID()
-    @State private var showOnboarding: Bool
-    @Environment(\.scenePhase) private var scenePhase
-    @Environment(\.colorScheme) private var colorScheme
+    var initError: String?
+    var isInitialized = false
+    private var serviceInitializationTask: Task<Bool, Never>?
+    private var backgroundHandlerInstalled = false
 
-    init(settingsRepository: SettingsRepository, notificationObserver: NotificationObserver, pendingDeepLink: Binding<String?>) {
-        self.settingsRepository = settingsRepository
-        self.notificationObserver = notificationObserver
-        self._pendingDeepLink = pendingDeepLink
-        // Migrate existing users so they skip onboarding
-        OnboardingViewModel.migrateExistingUsers()
-        #if DEBUG
-        let isScreenshotterLaunch = ProcessInfo.processInfo.arguments.contains("ui-screenshotter")
-        #else
-        let isScreenshotterLaunch = false
-        #endif
-        // Maestro clears app state and Keychain before every screenshot. Its
-        // explicit DEBUG-only launch argument bypasses the interactive wizard;
-        // initializeServices() creates the disposable test identity below.
-        self._showOnboarding = State(
-            initialValue: !OnboardingViewModel.hasCompletedOnboarding && !isScreenshotterLaunch
-        )
-    }
+    private init() {}
 
-    // MARK: - Body
-
-    var body: some View {
-        Group {
-            if showOnboarding {
-                #if COLUMBA_ONBOARDING_ENABLED
-                OnboardingView(
-                    identityManager: identityManager,
-                    settingsRepository: settingsRepository,
-                    appServices: appServices,
-                    onComplete: {
-                        showOnboarding = false
-                        identitySwitchTrigger = UUID()
-                    }
-                )
-                #else
-                // Onboarding flow disabled in this build — bypass straight to main UI.
-                Color.clear.onAppear { showOnboarding = false }
-                #endif
-            } else if let error = initError {
-                errorView(error)
-            } else if isInitialized,
-                      let repo = messageRepository {
-                MainTabView(
-                    appServices: appServices,
-                    messageRepository: repo,
-                    settingsRepository: settingsRepository,
-                    notificationObserver: notificationObserver,
-                    identityManager: identityManager,
-                    pendingDeepLink: $pendingDeepLink,
-                    onIdentitySwitch: {
-                        // Reset state so RootView re-initializes
-                        isInitialized = false
-                        messageRepository = nil
-                        incomingMessageHandler = nil
-                        #if COLUMBA_RUNTIME_MODEL_B
-                        modelBInboundReplay = nil
-                        #endif
-                        database = nil
-                        initError = nil
-                        identitySwitchTrigger = UUID()
-                    }
-                )
-                // Voice / CallKit removed in the Python RNS migration (Phase 0).
-                // Will return in v2 once canonical Python LXST is ported to iOS audio.
-            } else {
-                // Not yet initialized. Under Model B, init suspends before the proxy
-                // backend starts until the NE/VPN tunnel is up; on first launch that
-                // means showing the background-delivery gate instead of an indefinite
-                // "Connecting to network…" spinner on a tunnel that doesn't exist yet.
-                #if COLUMBA_RUNTIME_MODEL_B
-                if appServices.needsBackgroundDeliveryApproval {
-                    BackgroundDeliveryGateView(appServices: appServices)
-                } else {
-                    loadingView
-                }
-                #else
-                loadingView
-                #endif
-            }
-        }
-        .onChange(of: colorScheme) { _, newScheme in
-            ThemeManager.shared.systemColorScheme = newScheme
-        }
-        .onAppear {
-            ThemeManager.shared.systemColorScheme = colorScheme
-        }
-        .task(id: identitySwitchTrigger) {
-            if !showOnboarding {
-                _ = await ensureServicesInitialized()
-            }
-        }
-        .onChange(of: scenePhase) { _, newPhase in
-            let phaseValue = newPhase
-            #if os(iOS) && COLUMBA_RUNTIME_PYTHON
-            let context = phaseValue == .active
-                ? "scene-active"
-                : (phaseValue == .background ? "scene-background" : "scene-inactive")
-            BackgroundPropagationRefreshScheduler.logRuntime(context: context)
-            BackgroundPropagationRefreshScheduler.logPendingRequests(context: context)
-            #endif
-            if phaseValue == .active {
-                if let repository = messageRepository {
-                    Task {
-                        if let unread = try? await repository.totalUnreadCount() {
-                            await NotificationService.shared
-                                .synchronizeBadgeWithDurableUnreadCount(unread)
-                        }
-                    }
-                }
-                // Sync from propagation node when app becomes active,
-                // debounced to avoid rapid re-syncs on quick app switches
-                if let propManager = appServices.propagationManager,
-                   !propManager.isSyncing {
-                    let lastSync = propManager.lastSyncTime ?? .distantPast
-                    if Date().timeIntervalSince(lastSync) > 60 {
-                        Task { await propManager.syncNow() }
-                    }
-                }
-            }
-            #if os(iOS)
-            if newPhase == .background {
-                #if COLUMBA_RUNTIME_PYTHON
-                BackgroundPropagationRefreshScheduler.scheduleFromCurrentSettings()
-                #endif
-                // Flush RNS's path table + known destinations to disk now —
-                // iOS won't run RNS's clean-exit persist, so without this a
-                // cold start can't recall previously-heard peers.
-                appServices.persistRNSStateOnBackground()
-            }
-            appServices.locationSharingManager?.setBackgroundState(newPhase != .active)
-            #endif
-        }
+    func installBackgroundHandler() {
         #if os(iOS) && COLUMBA_RUNTIME_PYTHON
-        .task {
-            BackgroundRefreshTaskCoordinator.shared.installHandler {
-                await performBackgroundPropagationSync()
-            }
-            BackgroundPropagationRefreshScheduler.scheduleFromCurrentSettings()
+        guard !backgroundHandlerInstalled else { return }
+        backgroundHandlerInstalled = true
+        BackgroundRefreshTaskCoordinator.shared.installHandler { [weak self] in
+            guard let self else { return false }
+            return await self.performBackgroundPropagationSync()
         }
         #endif
     }
 
-    // MARK: - Loading View
-
-    private var loadingView: some View {
-        ZStack {
-            Theme.backgroundPrimary.ignoresSafeArea()
-
-            VStack(spacing: 20) {
-                ZStack {
-                    Circle()
-                        .fill(Theme.accentColor.opacity(0.2))
-                        .frame(width: 100, height: 100)
-
-                    Image(systemName: "bubble.left.and.bubble.right.fill")
-                        .font(.system(size: 40))
-                        .foregroundStyle(Theme.accentColor)
-                }
-
-                Text("Columba")
-                    .font(.system(size: 28, weight: .bold))
-                    .foregroundStyle(Theme.textPrimary)
-
-                ProgressView()
-                    .progressViewStyle(CircularProgressViewStyle(tint: Theme.accentColor))
-                    .scaleEffect(1.2)
-
-                Text("Connecting to network...")
-                    .font(.subheadline)
-                    .foregroundStyle(Theme.textSecondary)
-            }
-        }
-    }
-
-    // MARK: - Error View
-
-    private func errorView(_ message: String) -> some View {
-        ZStack {
-            Theme.backgroundPrimary.ignoresSafeArea()
-
-            VStack(spacing: 20) {
-                Image(systemName: "exclamationmark.triangle.fill")
-                    .font(.system(size: 50))
-                    .foregroundStyle(.orange)
-
-                Text("Connection Failed")
-                    .font(.title2.bold())
-                    .foregroundStyle(Theme.textPrimary)
-
-                Text(message)
-                    .font(.subheadline)
-                    .foregroundStyle(Theme.textSecondary)
-                    .multilineTextAlignment(.center)
-                    .padding(.horizontal, 40)
-
-                Button {
-                    Task {
-                        initError = nil
-                        await initializeServices()
-                    }
-                } label: {
-                    HStack {
-                        Image(systemName: "arrow.clockwise")
-                        Text("Retry")
-                    }
-                    .font(.headline)
-                    .foregroundStyle(.white)
-                    .padding(.horizontal, 32)
-                    .padding(.vertical, 14)
-                    .background(Theme.accentColor)
-                    .clipShape(RoundedRectangle(cornerRadius: 14))
-                }
-                .padding(.top, 10)
-            }
-        }
+    func resetAfterIdentitySwitch() {
+        isInitialized = false
+        messageRepository = nil
+        incomingMessageHandler = nil
+        #if COLUMBA_RUNTIME_MODEL_B
+        modelBInboundReplay = nil
+        #endif
+        database = nil
+        initError = nil
     }
 
     #if os(iOS) && COLUMBA_RUNTIME_PYTHON
@@ -822,7 +616,7 @@ struct RootView: View {
     /// scene and a cold-delivered background refresh. This prevents duplicate
     /// Reticulum identities/routers and avoids treating a fixed delay as readiness.
     @MainActor
-    private func ensureServicesInitialized() async -> Bool {
+    func ensureServicesInitialized() async -> Bool {
         if isInitialized { return true }
         if let serviceInitializationTask {
             return await serviceInitializationTask.value
@@ -838,7 +632,7 @@ struct RootView: View {
         return succeeded
     }
 
-    private func initializeServices() async {
+    func initializeServices() async {
         DiagLog.log("[STARTUP] initializeServices() ENTERED")
         #if os(iOS) && COLUMBA_RUNTIME_PYTHON
         BackgroundPropagationRefreshScheduler.logRuntime(context: "initialize-services")
@@ -1158,6 +952,244 @@ struct RootView: View {
             throw error
         }
     }
+}
+
+// MARK: - Root View
+
+/// Root view that handles async service initialization.
+///
+/// Separating initialization into a View (vs App) ensures the .task modifier
+/// runs correctly in the SwiftUI lifecycle.
+@available(iOS 17.0, macOS 14.0, *)
+struct RootView: View {
+    // MARK: - Dependencies
+
+    let applicationRuntime: ColumbaApplicationRuntime
+    let notificationObserver: NotificationObserver
+    @Binding var pendingDeepLink: String?
+
+    private var settingsRepository: SettingsRepository { applicationRuntime.settingsRepository }
+    private var appServices: AppServices { applicationRuntime.appServices }
+    private var identityManager: IdentityManager { applicationRuntime.identityManager }
+    private var database: LXMFDatabase? { applicationRuntime.database }
+    private var messageRepository: MessageRepository? { applicationRuntime.messageRepository }
+    private var initError: String? { applicationRuntime.initError }
+    private var isInitialized: Bool { applicationRuntime.isInitialized }
+
+    // MARK: - Internal State
+
+    @State private var identitySwitchTrigger = UUID()
+    @State private var showOnboarding: Bool
+    @Environment(\.scenePhase) private var scenePhase
+    @Environment(\.colorScheme) private var colorScheme
+
+    init(applicationRuntime: ColumbaApplicationRuntime, notificationObserver: NotificationObserver, pendingDeepLink: Binding<String?>) {
+        self.applicationRuntime = applicationRuntime
+        self.notificationObserver = notificationObserver
+        self._pendingDeepLink = pendingDeepLink
+        // Migrate existing users so they skip onboarding
+        OnboardingViewModel.migrateExistingUsers()
+        #if DEBUG
+        let isScreenshotterLaunch = ProcessInfo.processInfo.arguments.contains("ui-screenshotter")
+        #else
+        let isScreenshotterLaunch = false
+        #endif
+        // Maestro clears app state and Keychain before every screenshot. Its
+        // explicit DEBUG-only launch argument bypasses the interactive wizard;
+        // initializeServices() creates the disposable test identity below.
+        self._showOnboarding = State(
+            initialValue: !OnboardingViewModel.hasCompletedOnboarding && !isScreenshotterLaunch
+        )
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        Group {
+            if showOnboarding {
+                #if COLUMBA_ONBOARDING_ENABLED
+                OnboardingView(
+                    identityManager: identityManager,
+                    settingsRepository: settingsRepository,
+                    appServices: appServices,
+                    onComplete: {
+                        showOnboarding = false
+                        identitySwitchTrigger = UUID()
+                    }
+                )
+                #else
+                // Onboarding flow disabled in this build — bypass straight to main UI.
+                Color.clear.onAppear { showOnboarding = false }
+                #endif
+            } else if let error = initError {
+                errorView(error)
+            } else if isInitialized,
+                      let repo = messageRepository {
+                MainTabView(
+                    appServices: appServices,
+                    messageRepository: repo,
+                    settingsRepository: settingsRepository,
+                    notificationObserver: notificationObserver,
+                    identityManager: identityManager,
+                    pendingDeepLink: $pendingDeepLink,
+                    onIdentitySwitch: {
+                        applicationRuntime.resetAfterIdentitySwitch()
+                        identitySwitchTrigger = UUID()
+                    }
+                )
+                // Voice / CallKit removed in the Python RNS migration (Phase 0).
+                // Will return in v2 once canonical Python LXST is ported to iOS audio.
+            } else {
+                // Not yet initialized. Under Model B, init suspends before the proxy
+                // backend starts until the NE/VPN tunnel is up; on first launch that
+                // means showing the background-delivery gate instead of an indefinite
+                // "Connecting to network…" spinner on a tunnel that doesn't exist yet.
+                #if COLUMBA_RUNTIME_MODEL_B
+                if appServices.needsBackgroundDeliveryApproval {
+                    BackgroundDeliveryGateView(appServices: appServices)
+                } else {
+                    loadingView
+                }
+                #else
+                loadingView
+                #endif
+            }
+        }
+        .onChange(of: colorScheme) { _, newScheme in
+            ThemeManager.shared.systemColorScheme = newScheme
+        }
+        .onAppear {
+            ThemeManager.shared.systemColorScheme = colorScheme
+        }
+        .task(id: identitySwitchTrigger) {
+            if !showOnboarding {
+                _ = await applicationRuntime.ensureServicesInitialized()
+            }
+        }
+        .onChange(of: scenePhase) { _, newPhase in
+            let phaseValue = newPhase
+            #if os(iOS) && COLUMBA_RUNTIME_PYTHON
+            let context = phaseValue == .active
+                ? "scene-active"
+                : (phaseValue == .background ? "scene-background" : "scene-inactive")
+            BackgroundPropagationRefreshScheduler.logRuntime(context: context)
+            BackgroundPropagationRefreshScheduler.logPendingRequests(context: context)
+            #endif
+            if phaseValue == .active {
+                if let repository = messageRepository {
+                    Task {
+                        await NotificationService.shared
+                            .synchronizeBadgeWithDurableUnreadCount(
+                                messageRepository: repository
+                            )
+                    }
+                }
+                // Sync from propagation node when app becomes active,
+                // debounced to avoid rapid re-syncs on quick app switches
+                if let propManager = appServices.propagationManager,
+                   !propManager.isSyncing {
+                    let lastSync = propManager.lastSyncTime ?? .distantPast
+                    if Date().timeIntervalSince(lastSync) > 60 {
+                        Task { await propManager.syncNow() }
+                    }
+                }
+            }
+            #if os(iOS)
+            if newPhase == .background {
+                #if COLUMBA_RUNTIME_PYTHON
+                BackgroundPropagationRefreshScheduler.scheduleFromCurrentSettings()
+                #endif
+                // Flush RNS's path table + known destinations to disk now —
+                // iOS won't run RNS's clean-exit persist, so without this a
+                // cold start can't recall previously-heard peers.
+                appServices.persistRNSStateOnBackground()
+            }
+            appServices.locationSharingManager?.setBackgroundState(newPhase != .active)
+            #endif
+        }
+        #if os(iOS) && COLUMBA_RUNTIME_PYTHON
+        .task {
+            BackgroundPropagationRefreshScheduler.scheduleFromCurrentSettings()
+        }
+        #endif
+    }
+
+    // MARK: - Loading View
+
+    private var loadingView: some View {
+        ZStack {
+            Theme.backgroundPrimary.ignoresSafeArea()
+
+            VStack(spacing: 20) {
+                ZStack {
+                    Circle()
+                        .fill(Theme.accentColor.opacity(0.2))
+                        .frame(width: 100, height: 100)
+
+                    Image(systemName: "bubble.left.and.bubble.right.fill")
+                        .font(.system(size: 40))
+                        .foregroundStyle(Theme.accentColor)
+                }
+
+                Text("Columba")
+                    .font(.system(size: 28, weight: .bold))
+                    .foregroundStyle(Theme.textPrimary)
+
+                ProgressView()
+                    .progressViewStyle(CircularProgressViewStyle(tint: Theme.accentColor))
+                    .scaleEffect(1.2)
+
+                Text("Connecting to network...")
+                    .font(.subheadline)
+                    .foregroundStyle(Theme.textSecondary)
+            }
+        }
+    }
+
+    // MARK: - Error View
+
+    private func errorView(_ message: String) -> some View {
+        ZStack {
+            Theme.backgroundPrimary.ignoresSafeArea()
+
+            VStack(spacing: 20) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 50))
+                    .foregroundStyle(.orange)
+
+                Text("Connection Failed")
+                    .font(.title2.bold())
+                    .foregroundStyle(Theme.textPrimary)
+
+                Text(message)
+                    .font(.subheadline)
+                    .foregroundStyle(Theme.textSecondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 40)
+
+                Button {
+                    Task {
+                        applicationRuntime.initError = nil
+                        await applicationRuntime.initializeServices()
+                    }
+                } label: {
+                    HStack {
+                        Image(systemName: "arrow.clockwise")
+                        Text("Retry")
+                    }
+                    .font(.headline)
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 32)
+                    .padding(.vertical, 14)
+                    .background(Theme.accentColor)
+                    .clipShape(RoundedRectangle(cornerRadius: 14))
+                }
+                .padding(.top, 10)
+            }
+        }
+    }
+
+
 }
 
 // MARK: - Tab Enum

--- a/Sources/ColumbaApp/Resources/Info.plist
+++ b/Sources/ColumbaApp/Resources/Info.plist
@@ -50,6 +50,7 @@
 		<string>audio</string>
 		<string>bluetooth-central</string>
 		<string>bluetooth-peripheral</string>
+		<string>fetch</string>
 		<string>location</string>
 		<string>voip</string>
 	</array>

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -30,10 +30,6 @@ enum DiagLog {
         return docs.appendingPathComponent("diag.log")
     }()
 
-    static func clear() {
-        try? "".write(to: fileURL, atomically: true, encoding: .utf8)
-    }
-
     static func log(_ message: String) {
         let ts = ISO8601DateFormatter().string(from: Date())
         let line = "[\(ts)] \(message)\n"
@@ -1145,7 +1141,7 @@ public final class AppServices {
     }
 
     private func initializeUnlocked(tcpServerAddress: String) async throws {
-        DiagLog.clear()
+        DiagLog.log("[STARTUP] AppServices initialization beginning")
         let monitorLease = RuntimeActivityMonitor.shared.acquire()
         var initializationSucceeded = false
         defer {
@@ -3021,7 +3017,7 @@ public final class AppServices {
         identityHash: String,
         tcpServerAddress: String
     ) async throws {
-        DiagLog.clear()
+        DiagLog.log("[STARTUP] AppServices identity initialization beginning")
         let monitorLease = RuntimeActivityMonitor.shared.acquire()
         var initializationSucceeded = false
         defer {

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -1329,11 +1329,7 @@ public final class AppServices {
                 )
             },
             activate: {
-                propManager.startListening()
-                propManager.startPeriodicSync()
-                let announceManager = AutoAnnounceManager(appServices: self)
-                self.autoAnnounceManager = announceManager
-                announceManager.start()
+                self.activateInitializationManagers(propManager)
             }
         )
 
@@ -3263,11 +3259,7 @@ public final class AppServices {
                 )
             },
             activate: {
-                propManager.startListening()
-                propManager.startPeriodicSync()
-                let announceManager = AutoAnnounceManager(appServices: self)
-                self.autoAnnounceManager = announceManager
-                announceManager.start()
+                self.activateInitializationManagers(propManager)
             }
         )
 
@@ -3373,6 +3365,16 @@ public final class AppServices {
         )
 
         logger.info("Identity switch complete: \(identityHash)")
+    }
+
+    /// Activate initialization-owned manager tasks only after backend and
+    /// persisted propagation-node readiness have both succeeded.
+    private func activateInitializationManagers(_ propManager: PropagationNodeManager) {
+        propManager.startListening()
+        propManager.startPeriodicSync()
+        let announceManager = AutoAnnounceManager(appServices: self)
+        self.autoAnnounceManager = announceManager
+        announceManager.start()
     }
 
     // MARK: - State Observation

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -84,6 +84,39 @@ enum DiagLog {
     #endif
 }
 
+actor PythonHostEventProcessingGate {
+    private var exclusiveActive = false
+    private var normalActive = false
+
+    func beginExclusive() async -> Bool {
+        while exclusiveActive || normalActive {
+            if Task.isCancelled { return false }
+            try? await Task.sleep(for: .milliseconds(1))
+        }
+        guard !Task.isCancelled else { return false }
+        exclusiveActive = true
+        return true
+    }
+
+    func endExclusive() {
+        exclusiveActive = false
+    }
+
+    func beginNormal() async -> Bool {
+        while exclusiveActive || normalActive {
+            if Task.isCancelled { return false }
+            try? await Task.sleep(for: .milliseconds(1))
+        }
+        guard !Task.isCancelled else { return false }
+        normalActive = true
+        return true
+    }
+
+    func endNormal() {
+        normalActive = false
+    }
+}
+
 /// Low-overhead, privacy-safe runtime instrumentation for physical-device soak tests.
 ///
 /// Samples cumulative process CPU every 15 seconds, observes thermal-state changes,
@@ -567,6 +600,15 @@ public final class AppServices {
     /// Background task that drains Python events (announces, inbound
     /// messages) into Columba's existing UI plumbing.
     private var pythonEventTask: Task<Void, Never>?
+    private let pythonHostEventProcessingGate = PythonHostEventProcessingGate()
+
+    func beginExclusivePythonHostEventProcessing() async -> Bool {
+        await pythonHostEventProcessingGate.beginExclusive()
+    }
+
+    func endExclusivePythonHostEventProcessing() async {
+        await pythonHostEventProcessingGate.endExclusive()
+    }
 
     /// Tokens for the block-based NotificationCenter observers registered by
     /// `startPythonBackend()` (the lxma://test-* deep-link harness). Held so
@@ -1596,14 +1638,10 @@ public final class AppServices {
         // would require the LXMRouterDelegate protocol to drop its router param
         // (a separate, lower-value cleanup).
 
-        // Drain Python events into Columba's UI plumbing.
-        pythonEventTask?.cancel()
-        pythonEventTask = Task { [weak self, backend] in
-            for await event in backend.events {
-                guard let self else { break }
-                await self.handlePythonEvent(event)
-            }
-        }
+        // Event consumption intentionally starts only after ColumbaApp installs
+        // IncomingMessageHandler as the Compat router delegate. Backend events queue
+        // safely until startPythonEventDrain() is called; starting here would race
+        // cold-launch inbound side-channel processing against handler creation.
 
         // Seed Compat TCPInterface stubs for each enabled InterfaceEntity so
         // the InterfaceManagement UI has something to render against. Their
@@ -2181,6 +2219,24 @@ public final class AppServices {
             }
         }
         #endif // DEBUG — test-only deep-link observers
+    }
+
+    /// Begin consuming queued backend events only after the app has installed its
+    /// IncomingMessageHandler. Idempotent across repeated scene initialization.
+    func startPythonEventDrain() {
+        guard pythonEventTask == nil, let backend else {
+            DiagLog.log("[RNS] event drain start skipped active=\(pythonEventTask != nil) backend=\(backend != nil)")
+            return
+        }
+        DiagLog.log("[RNS] event drain started after incoming handler installation")
+        pythonEventTask = Task { [weak self, backend] in
+            for await event in backend.events {
+                guard let self else { break }
+                guard await self.pythonHostEventProcessingGate.beginNormal() else { break }
+                await self.handlePythonEvent(event)
+                await self.pythonHostEventProcessingGate.endNormal()
+            }
+        }
     }
 
     @MainActor

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -1627,6 +1627,9 @@ public final class AppServices {
         if propagationManager?.selectedNodeHash != nil {
             let reapplied = await propagationManager?.reapplySelectedNodeToPythonBackend() ?? false
             DiagLog.log("[RNS] reapplied persisted propagation node to Python: \(reapplied)")
+            guard reapplied else {
+                throw AppServicesError.propagationNodeRestoreFailed
+            }
         }
         #endif
 
@@ -5009,6 +5012,9 @@ public enum AppServicesError: Error, Equatable {
     /// Transport not connected
     case transportNotConnected
 
+    /// Persisted propagation node could not be restored into the embedded router
+    case propagationNodeRestoreFailed
+
 }
 
 // MARK: - CustomStringConvertible
@@ -5024,6 +5030,8 @@ extension AppServicesError: CustomStringConvertible {
             return "Router not initialized"
         case .transportNotConnected:
             return "Transport not connected"
+        case .propagationNodeRestoreFailed:
+            return "Persisted propagation node could not be restored"
         }
     }
 }

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -1585,6 +1585,13 @@ public final class AppServices {
 
         await applyIncomingMessageSizeLimitFromSettings()
 
+        #if COLUMBA_RUNTIME_PYTHON
+        if propagationManager?.selectedNodeHash != nil {
+            let reapplied = await propagationManager?.reapplySelectedNodeToPythonBackend() ?? false
+            DiagLog.log("[RNS] reapplied persisted propagation node to Python: \(reapplied)")
+        }
+        #endif
+
         // Outbound LXMF now goes directly through `backend.lxmf.sendLxmfMessage`
         // (MessagingViewModel + RnsLxmf) with TYPED fields, so the old Compat
         // router sendHook — which forwarded content only and dropped every field —
@@ -2770,6 +2777,15 @@ public final class AppServices {
         }
     }
 
+    /// Process a transaction-owned batch before a propagation sync reports
+    /// completion to its caller. The Python backend temporarily pauses its
+    /// normal drain loop while producing this batch.
+    func processPythonEventsSynchronously(_ events: [BackendEvent]) async {
+        for event in events {
+            await handlePythonEvent(event)
+        }
+    }
+
     private func handlePythonEvent(_ event: BackendEvent) async {
         switch event {
         case .announce(let destHash, let appDataHex, let aspect, let publicKeysHex, let interfaceName, let hops, let t):
@@ -2875,7 +2891,11 @@ public final class AppServices {
             // bridge plumbing lands; the Swift backend populates them now).
             if let saved = await persistInboundFromPython(sourceHash: data, messageHashHex: messageHash, content: content, title: title, fields: fields, timestamp: t),
                fields != nil, let router = self.router {
-                router.delegate?.router(router, didReceiveMessage: saved)
+                if let handler = router.delegate as? IncomingMessageHandler {
+                    _ = await handler.handleInbound(saved).value
+                } else {
+                    router.delegate?.router(router, didReceiveMessage: saved)
+                }
             }
             NotificationCenter.default.post(
                 name: Notification.Name("ColumbaPythonInbound"),

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -1308,30 +1308,33 @@ public final class AppServices {
         // Start monitoring interface state for UI updates
         startStateObserver()
 
-        // 10. Initialize propagation node manager
-        // IMPORTANT: loadPreferences() MUST run before startListening() so that
-        // the saved relay selection (selectedNodeHash, autoSelectEnabled) is restored
-        // before the listening task processes path entries and calls autoSelectBestNode().
-        // Otherwise the default autoSelectEnabled=true can overwrite the user's manual selection.
+        // 10. Restore propagation preferences before backend startup. Listener,
+        // periodic, and auto-announce tasks are activated only after the backend
+        // and persisted propagation node are ready, so a failed retry cannot leak
+        // initialization-owned tasks.
         let propManager = PropagationNodeManager(appServices: self)
         self.propagationManager = propManager
         await propManager.loadPreferences()
-        propManager.startListening()
-        propManager.startPeriodicSync()
 
-        // 11. Initialize auto-announce manager
-        let announceManager = AutoAnnounceManager(appServices: self)
-        self.autoAnnounceManager = announceManager
-        announceManager.start()
-
-        // 12. Start Python RNS backend. The Compat-layer LXMRouter / Transport
-        //     are stubs; the real network I/O happens through PythonBridge.
-        try await startPythonBackend(
-            identity: newIdentity,
-            identityHashHex: newIdentity.hexHash,
-            router: newRouter,
-            interfaces: InterfaceRepository().getEnabledInterfaces(),
-            displayName: ""
+        try await InitializationLifecycleActivation.run(
+            readiness: {
+                // The Compat-layer LXMRouter / Transport are stubs; real network
+                // I/O happens through PythonBridge.
+                try await self.startPythonBackend(
+                    identity: newIdentity,
+                    identityHashHex: newIdentity.hexHash,
+                    router: newRouter,
+                    interfaces: InterfaceRepository().getEnabledInterfaces(),
+                    displayName: ""
+                )
+            },
+            activate: {
+                propManager.startListening()
+                propManager.startPeriodicSync()
+                let announceManager = AutoAnnounceManager(appServices: self)
+                self.autoAnnounceManager = announceManager
+                announceManager.start()
+            }
         )
 
         // On-device test instrumentation: listen for the test-announce Darwin
@@ -3201,18 +3204,11 @@ public final class AppServices {
 
         startStateObserver()
 
-        // 10. Initialize propagation node manager
-        // IMPORTANT: loadPreferences() MUST run before startListening() — see first overload.
+        // 10. Restore propagation preferences now; activate listener,
+        // periodic, and auto-announce tasks only after backend readiness.
         let propManager = PropagationNodeManager(appServices: self)
         self.propagationManager = propManager
         await propManager.loadPreferences()
-        propManager.startListening()
-        propManager.startPeriodicSync()
-
-        // 11. Initialize auto-announce manager
-        let announceManager = AutoAnnounceManager(appServices: self)
-        self.autoAnnounceManager = announceManager
-        announceManager.start()
 
         // Dump all registered destinations and link callbacks for diagnostics.
         // Registered destinations now come from the active backend's neutral
@@ -3255,13 +3251,24 @@ public final class AppServices {
         await ensureTunnelManager()
         #endif
 
-        // Start Python RNS backend on the multi-identity path too.
-        try await startPythonBackend(
-            identity: identity,
-            identityHashHex: identityHash,
-            router: newRouter,
-            interfaces: InterfaceRepository().getEnabledInterfaces(),
-            displayName: ""
+        // Start the backend, then activate initialization-owned manager tasks.
+        try await InitializationLifecycleActivation.run(
+            readiness: {
+                try await self.startPythonBackend(
+                    identity: identity,
+                    identityHashHex: identityHash,
+                    router: newRouter,
+                    interfaces: InterfaceRepository().getEnabledInterfaces(),
+                    displayName: ""
+                )
+            },
+            activate: {
+                propManager.startListening()
+                propManager.startPeriodicSync()
+                let announceManager = AutoAnnounceManager(appServices: self)
+                self.autoAnnounceManager = announceManager
+                announceManager.start()
+            }
         )
 
         // On-device test instrumentation: listen for the test-announce Darwin
@@ -4997,6 +5004,19 @@ public final class AppServices {
         } catch {
             DiagLog.log("[AUTO_ANNOUNCE] failed: \(error.localizedDescription)")
         }
+    }
+}
+
+// MARK: - Initialization Lifecycle Activation
+
+@MainActor
+enum InitializationLifecycleActivation {
+    static func run(
+        readiness: @MainActor () async throws -> Void,
+        activate: @MainActor () -> Void
+    ) async throws {
+        try await readiness()
+        activate()
     }
 }
 

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -1627,9 +1627,13 @@ public final class AppServices {
         if propagationManager?.selectedNodeHash != nil {
             let reapplied = await propagationManager?.reapplySelectedNodeToPythonBackend() ?? false
             DiagLog.log("[RNS] reapplied persisted propagation node to Python: \(reapplied)")
-            guard reapplied else {
-                throw AppServicesError.propagationNodeRestoreFailed
-            }
+            try await PropagationNodeRestoreReadiness.validate(
+                reapplied: reapplied,
+                rollback: { [weak self] in
+                    await backend.stop()
+                    self?.backend = nil
+                }
+            )
         }
         #endif
 
@@ -4992,6 +4996,21 @@ public final class AppServices {
             DiagLog.log("[AUTO_ANNOUNCE] completed successfully")
         } catch {
             DiagLog.log("[AUTO_ANNOUNCE] failed: \(error.localizedDescription)")
+        }
+    }
+}
+
+// MARK: - Propagation Readiness
+
+@MainActor
+enum PropagationNodeRestoreReadiness {
+    static func validate(
+        reapplied: Bool,
+        rollback: @MainActor () async -> Void
+    ) async throws {
+        guard reapplied else {
+            await rollback()
+            throw AppServicesError.propagationNodeRestoreFailed
         }
     }
 }

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -1326,7 +1326,7 @@ public final class AppServices {
 
         // 12. Start Python RNS backend. The Compat-layer LXMRouter / Transport
         //     are stubs; the real network I/O happens through PythonBridge.
-        await startPythonBackend(
+        try await startPythonBackend(
             identity: newIdentity,
             identityHashHex: newIdentity.hexHash,
             router: newRouter,
@@ -1495,7 +1495,7 @@ public final class AppServices {
         router: LXMRouter,
         interfaces: [InterfaceEntity],
         displayName: String
-    ) async {
+    ) async throws {
         DiagLog.log("[RNS] backend start entered with \(interfaces.count) interfaces")
         if backend != nil {
             DiagLog.log("[RNS] already started")
@@ -1618,7 +1618,7 @@ public final class AppServices {
             DiagLog.log("[RNS] start FAILED: \(error)")
             logger.error("Python backend start failed: \(error.localizedDescription, privacy: .public)")
             self.backend = nil
-            return
+            throw error
         }
 
         await applyIncomingMessageSizeLimitFromSettings()
@@ -3249,7 +3249,7 @@ public final class AppServices {
         #endif
 
         // Start Python RNS backend on the multi-identity path too.
-        await startPythonBackend(
+        try await startPythonBackend(
             identity: identity,
             identityHashHex: identityHash,
             router: newRouter,

--- a/Sources/ColumbaApp/Services/BackgroundPropagationSync.swift
+++ b/Sources/ColumbaApp/Services/BackgroundPropagationSync.swift
@@ -10,6 +10,7 @@
 import BackgroundTasks
 import Foundation
 import RNSAPI
+import UIKit
 import os
 
 private let backgroundPropagationLogger = Logger(
@@ -30,6 +31,75 @@ enum BackgroundPropagationSchedulePolicy {
             ? userInterval
             : defaultInterval
         return max(minimumInterval, requested)
+    }
+}
+
+struct PendingBackgroundRefreshRequestDiagnostic: Equatable {
+    let identifier: String
+    let earliestBeginDate: Date?
+}
+
+enum BackgroundRefreshDiagnosticFormatter {
+    static func pendingRequests(
+        _ requests: [PendingBackgroundRefreshRequestDiagnostic]
+    ) -> String {
+        let formatter = ISO8601DateFormatter()
+        let entries = requests
+            .sorted { $0.identifier < $1.identifier }
+            .map { request in
+                let earliest = request.earliestBeginDate.map(formatter.string(from:)) ?? "nil"
+                return "\(request.identifier) earliest=\(earliest)"
+            }
+        return "count=\(entries.count) [\(entries.joined(separator: ", "))]"
+    }
+
+    static func runtime(
+        processID: Int32,
+        backgroundRefreshStatus: String,
+        lowPowerModeEnabled: Bool,
+        thermalState: String,
+        protectedDataAvailable: Bool,
+        sceneStates: [String]
+    ) -> String {
+        let scenes = sceneStates.sorted().joined(separator: ",")
+        return "pid=\(processID) refresh=\(backgroundRefreshStatus) "
+            + "lowPower=\(lowPowerModeEnabled) thermal=\(thermalState) "
+            + "protectedData=\(protectedDataAvailable) scenes=\(scenes.isEmpty ? "none" : scenes)"
+    }
+}
+
+private extension UIBackgroundRefreshStatus {
+    var diagnosticValue: String {
+        switch self {
+        case .available: "available"
+        case .denied: "denied"
+        case .restricted: "restricted"
+        @unknown default: "unknown"
+        }
+    }
+}
+
+private extension ProcessInfo.ThermalState {
+    var diagnosticValue: String {
+        switch self {
+        case .nominal: "nominal"
+        case .fair: "fair"
+        case .serious: "serious"
+        case .critical: "critical"
+        @unknown default: "unknown"
+        }
+    }
+}
+
+private extension UIScene.ActivationState {
+    var diagnosticValue: String {
+        switch self {
+        case .unattached: "unattached"
+        case .foregroundActive: "foregroundActive"
+        case .foregroundInactive: "foregroundInactive"
+        case .background: "background"
+        @unknown default: "unknown"
+        }
     }
 }
 
@@ -65,6 +135,7 @@ final class BackgroundRefreshTaskCoordinator {
 
     func installHandler(_ handler: @escaping Handler) {
         self.handler = handler
+        DiagLog.log("[BG-SYNC] coordinator handler installed retained=\(states.count)")
         for state in states.values where state.operation == nil && !state.completed {
             start(state)
         }
@@ -76,9 +147,11 @@ final class BackgroundRefreshTaskCoordinator {
 
         let state = TaskState(task: task)
         states[identifier] = state
+        DiagLog.log("[BG-SYNC] coordinator received handlerReady=\(handler != nil)")
         task.expirationHandler = { [weak self, weak state] in
             Task { @MainActor in
                 guard let self, let state else { return }
+                DiagLog.log("[BG-SYNC] task expiration requested")
                 state.operation?.cancel()
                 self.complete(state, success: false)
             }
@@ -91,6 +164,7 @@ final class BackgroundRefreshTaskCoordinator {
 
     private func start(_ state: TaskState) {
         guard let handler, state.operation == nil, !state.completed else { return }
+        DiagLog.log("[BG-SYNC] coordinator starting workflow")
         state.operation = Task { @MainActor [weak self, weak state] in
             guard let self, let state else { return }
             let success = await handler()
@@ -101,6 +175,7 @@ final class BackgroundRefreshTaskCoordinator {
     private func complete(_ state: TaskState, success: Bool) {
         guard !state.completed else { return }
         state.completed = true
+        DiagLog.log("[BG-SYNC] coordinator completing success=\(success)")
         state.task.expirationHandler = nil
         state.task.setTaskCompleted(success: success)
         states.removeValue(forKey: ObjectIdentifier(state.task))
@@ -141,22 +216,27 @@ struct BackgroundPropagationSyncWorkflow<Message> {
 enum BackgroundPropagationRefreshScheduler {
     static let taskIdentifier = "network.columba.Columba.sync"
 
+    @MainActor
     static func register() {
+        logRuntime(context: "registration-attempt")
         let registered = BGTaskScheduler.shared.register(
             forTaskWithIdentifier: taskIdentifier,
             using: nil
         ) { task in
             guard let refreshTask = task as? BGAppRefreshTask else {
+                DiagLog.log("[BG-SYNC] delivered unexpected task type")
                 task.setTaskCompleted(success: false)
                 return
             }
             Task { @MainActor in
                 DiagLog.log("[BG-SYNC] system task delivered")
+                logRuntime(context: "task-delivered")
                 scheduleFromCurrentSettings()
                 BackgroundRefreshTaskCoordinator.shared.receive(refreshTask)
             }
         }
         DiagLog.log("[BG-SYNC] registration success=\(registered)")
+        logPendingRequests(context: "after-registration")
     }
 
     @MainActor
@@ -175,6 +255,8 @@ enum BackgroundPropagationRefreshScheduler {
         ) else {
             backgroundPropagationLogger.info("Background propagation sync disabled")
             DiagLog.log("[BG-SYNC] scheduling disabled; pending request cancelled")
+            logRuntime(context: "scheduling-disabled")
+            logPendingRequests(context: "after-cancel-disabled")
             return
         }
 
@@ -185,12 +267,48 @@ enum BackgroundPropagationRefreshScheduler {
             backgroundPropagationLogger.info(
                 "Scheduled background propagation sync no earlier than \(Int(delay), privacy: .public)s"
             )
-            DiagLog.log("[BG-SYNC] scheduled earliest delay=\(Int(delay))s")
+            let earliest = request.earliestBeginDate.map {
+                ISO8601DateFormatter().string(from: $0)
+            } ?? "nil"
+            DiagLog.log("[BG-SYNC] scheduled earliest delay=\(Int(delay))s date=\(earliest)")
+            logRuntime(context: "after-submit")
+            logPendingRequests(context: "after-submit")
         } catch {
             backgroundPropagationLogger.error(
                 "Failed to schedule background propagation sync: \(error.localizedDescription, privacy: .public)"
             )
             DiagLog.log("[BG-SYNC] scheduling failed: \(error.localizedDescription)")
+            logRuntime(context: "submit-failed")
+            logPendingRequests(context: "after-submit-failure")
+        }
+    }
+
+    @MainActor
+    static func logRuntime(context: String) {
+        let application = UIApplication.shared
+        let processInfo = ProcessInfo.processInfo
+        let summary = BackgroundRefreshDiagnosticFormatter.runtime(
+            processID: processInfo.processIdentifier,
+            backgroundRefreshStatus: application.backgroundRefreshStatus.diagnosticValue,
+            lowPowerModeEnabled: processInfo.isLowPowerModeEnabled,
+            thermalState: processInfo.thermalState.diagnosticValue,
+            protectedDataAvailable: application.isProtectedDataAvailable,
+            sceneStates: application.connectedScenes.map { $0.activationState.diagnosticValue }
+        )
+        DiagLog.log("[BG-SYNC] runtime context=\(context) \(summary)")
+    }
+
+    @MainActor
+    static func logPendingRequests(context: String) {
+        BGTaskScheduler.shared.getPendingTaskRequests { requests in
+            let snapshots = requests.map {
+                PendingBackgroundRefreshRequestDiagnostic(
+                    identifier: $0.identifier,
+                    earliestBeginDate: $0.earliestBeginDate
+                )
+            }
+            let summary = BackgroundRefreshDiagnosticFormatter.pendingRequests(snapshots)
+            DiagLog.log("[BG-SYNC] pending context=\(context) \(summary)")
         }
     }
 }

--- a/Sources/ColumbaApp/Services/BackgroundPropagationSync.swift
+++ b/Sources/ColumbaApp/Services/BackgroundPropagationSync.swift
@@ -103,13 +103,53 @@ private extension UIScene.ActivationState {
     }
 }
 
-@MainActor
 protocol BackgroundRefreshTaskHandle: AnyObject {
     var expirationHandler: (() -> Void)? { get set }
+    var isCompleted: Bool { get }
     func setTaskCompleted(success: Bool)
 }
 
-extension BGAppRefreshTask: BackgroundRefreshTaskHandle {}
+private final class LaunchOwnedBackgroundRefreshTask: BackgroundRefreshTaskHandle, @unchecked Sendable {
+    private let task: BGAppRefreshTask
+    private let lock = NSLock()
+    private var storedExpirationHandler: (() -> Void)?
+    private var completed = false
+
+    init(task: BGAppRefreshTask) {
+        self.task = task
+        task.expirationHandler = { [weak self] in self?.expire() }
+    }
+
+    var expirationHandler: (() -> Void)? {
+        get { lock.withLock { storedExpirationHandler } }
+        set { lock.withLock { storedExpirationHandler = newValue } }
+    }
+
+    var isCompleted: Bool {
+        lock.withLock { completed }
+    }
+
+    func setTaskCompleted(success: Bool) {
+        let shouldComplete = lock.withLock {
+            guard !completed else { return false }
+            completed = true
+            storedExpirationHandler = nil
+            return true
+        }
+        if shouldComplete {
+            task.expirationHandler = nil
+            task.setTaskCompleted(success: success)
+        }
+    }
+
+    private func expire() {
+        if let handler = expirationHandler {
+            handler()
+        } else {
+            setTaskCompleted(success: false)
+        }
+    }
+}
 
 /// Retains a task delivered before SwiftUI has installed the service-backed
 /// handler. This closes the cold-launch race without relying on a lossy
@@ -142,6 +182,10 @@ final class BackgroundRefreshTaskCoordinator {
     }
 
     func receive(_ task: any BackgroundRefreshTaskHandle) {
+        guard !task.isCompleted else {
+            DiagLog.log("[BG-SYNC] coordinator ignored task already completed during launch handoff")
+            return
+        }
         let identifier = ObjectIdentifier(task)
         guard states[identifier] == nil else { return }
 
@@ -152,9 +196,18 @@ final class BackgroundRefreshTaskCoordinator {
             Task { @MainActor in
                 guard let self, let state else { return }
                 DiagLog.log("[BG-SYNC] task expiration requested")
-                state.operation?.cancel()
-                self.complete(state, success: false)
+                if let operation = state.operation {
+                    // Let the operation's structured completion path report failure
+                    // only after its Reticulum/Python cancellation cleanup returns.
+                    operation.cancel()
+                } else {
+                    self.complete(state, success: false)
+                }
             }
+        }
+        guard !task.isCompleted else {
+            states.removeValue(forKey: identifier)
+            return
         }
 
         if handler != nil {
@@ -215,6 +268,7 @@ struct BackgroundPropagationSyncWorkflow<Message> {
 
 enum BackgroundPropagationRefreshScheduler {
     static let taskIdentifier = "network.columba.Columba.sync"
+    @MainActor private static var schedulingReconciliationActive = false
 
     @MainActor
     static func register() {
@@ -228,11 +282,13 @@ enum BackgroundPropagationRefreshScheduler {
                 task.setTaskCompleted(success: false)
                 return
             }
+            let launchOwnedTask = LaunchOwnedBackgroundRefreshTask(task: refreshTask)
+            backgroundPropagationLogger.info("System background propagation task launch handler entered")
             Task { @MainActor in
                 DiagLog.log("[BG-SYNC] system task delivered")
                 logRuntime(context: "task-delivered")
                 scheduleFromCurrentSettings()
-                BackgroundRefreshTaskCoordinator.shared.receive(refreshTask)
+                BackgroundRefreshTaskCoordinator.shared.receive(launchOwnedTask)
             }
         }
         DiagLog.log("[BG-SYNC] registration success=\(registered)")
@@ -248,11 +304,11 @@ enum BackgroundPropagationRefreshScheduler {
             ? rawInterval
             : BackgroundPropagationSchedulePolicy.defaultInterval
 
-        BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: taskIdentifier)
         guard let delay = BackgroundPropagationSchedulePolicy.nextDelay(
             periodicSyncEnabled: enabled,
             userInterval: interval
         ) else {
+            BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: taskIdentifier)
             backgroundPropagationLogger.info("Background propagation sync disabled")
             DiagLog.log("[BG-SYNC] scheduling disabled; pending request cancelled")
             logRuntime(context: "scheduling-disabled")
@@ -260,6 +316,28 @@ enum BackgroundPropagationRefreshScheduler {
             return
         }
 
+        guard !schedulingReconciliationActive else {
+            DiagLog.log("[BG-SYNC] scheduling reconciliation already active")
+            return
+        }
+        schedulingReconciliationActive = true
+        BGTaskScheduler.shared.getPendingTaskRequests { requests in
+            Task { @MainActor in
+                defer { schedulingReconciliationActive = false }
+                if let existing = requests.first(where: { $0.identifier == taskIdentifier }) {
+                    let earliest = existing.earliestBeginDate.map {
+                        ISO8601DateFormatter().string(from: $0)
+                    } ?? "nil"
+                    DiagLog.log("[BG-SYNC] preserving existing pending request earliest=\(earliest)")
+                    return
+                }
+                submitNewRequest(delay: delay)
+            }
+        }
+    }
+
+    @MainActor
+    private static func submitNewRequest(delay: TimeInterval) {
         let request = BGAppRefreshTaskRequest(identifier: taskIdentifier)
         request.earliestBeginDate = Date(timeIntervalSinceNow: delay)
         do {

--- a/Sources/ColumbaApp/Services/BackgroundPropagationSync.swift
+++ b/Sources/ColumbaApp/Services/BackgroundPropagationSync.swift
@@ -247,16 +247,18 @@ struct BackgroundPropagationSyncWorkflow<Message> {
     func run() async -> Bool {
         do {
             let cursor = try await captureInsertionCursor()
-            guard !Task.isCancelled, await sync(), !Task.isCancelled else {
-                return false
-            }
-            let messages = try await messagesInsertedAfter(cursor)
             guard !Task.isCancelled else { return false }
+            let syncSucceeded = await sync()
+
+            // A failed or expired propagation attempt can still drain and persist
+            // concurrent live inbound events while ordinary notifications are
+            // suppressed. Transfer notification ownership for every durable delta
+            // before suppression is released, even though task success stays false.
+            let messages = try await messagesInsertedAfter(cursor)
             for message in messages {
-                guard !Task.isCancelled else { return false }
                 await notify(message)
             }
-            return true
+            return syncSucceeded && !Task.isCancelled
         } catch {
             backgroundPropagationLogger.error(
                 "Background propagation sync workflow failed: \(error.localizedDescription, privacy: .public)"

--- a/Sources/ColumbaApp/Services/BackgroundPropagationSync.swift
+++ b/Sources/ColumbaApp/Services/BackgroundPropagationSync.swift
@@ -1,0 +1,192 @@
+//
+//  BackgroundPropagationSync.swift
+//  ColumbaApp
+//
+//  Owns iOS BackgroundTasks scheduling and the cold-launch handoff for
+//  propagation-node synchronization in the shipping embedded-Python app.
+//
+
+#if os(iOS)
+import BackgroundTasks
+import Foundation
+import RNSAPI
+import os
+
+private let backgroundPropagationLogger = Logger(
+    subsystem: "network.columba.Columba",
+    category: "BackgroundPropagationSync"
+)
+
+enum BackgroundPropagationSchedulePolicy {
+    static let minimumInterval: TimeInterval = 15 * 60
+    static let defaultInterval: TimeInterval = 60 * 60
+
+    static func nextDelay(
+        periodicSyncEnabled: Bool,
+        userInterval: TimeInterval
+    ) -> TimeInterval? {
+        guard periodicSyncEnabled else { return nil }
+        let requested = userInterval.isFinite && userInterval > 0
+            ? userInterval
+            : defaultInterval
+        return max(minimumInterval, requested)
+    }
+}
+
+@MainActor
+protocol BackgroundRefreshTaskHandle: AnyObject {
+    var expirationHandler: (() -> Void)? { get set }
+    func setTaskCompleted(success: Bool)
+}
+
+extension BGAppRefreshTask: BackgroundRefreshTaskHandle {}
+
+/// Retains a task delivered before SwiftUI has installed the service-backed
+/// handler. This closes the cold-launch race without relying on a lossy
+/// NotificationCenter post.
+@MainActor
+final class BackgroundRefreshTaskCoordinator {
+    typealias Handler = @MainActor @Sendable () async -> Bool
+
+    private final class TaskState {
+        let task: any BackgroundRefreshTaskHandle
+        var operation: Task<Void, Never>?
+        var completed = false
+
+        init(task: any BackgroundRefreshTaskHandle) {
+            self.task = task
+        }
+    }
+
+    static let shared = BackgroundRefreshTaskCoordinator()
+
+    private var handler: Handler?
+    private var states: [ObjectIdentifier: TaskState] = [:]
+
+    func installHandler(_ handler: @escaping Handler) {
+        self.handler = handler
+        for state in states.values where state.operation == nil && !state.completed {
+            start(state)
+        }
+    }
+
+    func receive(_ task: any BackgroundRefreshTaskHandle) {
+        let identifier = ObjectIdentifier(task)
+        guard states[identifier] == nil else { return }
+
+        let state = TaskState(task: task)
+        states[identifier] = state
+        task.expirationHandler = { [weak self, weak state] in
+            Task { @MainActor in
+                guard let self, let state else { return }
+                state.operation?.cancel()
+                self.complete(state, success: false)
+            }
+        }
+
+        if handler != nil {
+            start(state)
+        }
+    }
+
+    private func start(_ state: TaskState) {
+        guard let handler, state.operation == nil, !state.completed else { return }
+        state.operation = Task { @MainActor [weak self, weak state] in
+            guard let self, let state else { return }
+            let success = await handler()
+            self.complete(state, success: success && !Task.isCancelled)
+        }
+    }
+
+    private func complete(_ state: TaskState, success: Bool) {
+        guard !state.completed else { return }
+        state.completed = true
+        state.task.expirationHandler = nil
+        state.task.setTaskCompleted(success: success)
+        states.removeValue(forKey: ObjectIdentifier(state.task))
+    }
+}
+
+/// Small closure-based workflow that can be tested without constructing the
+/// embedded Python runtime or a system BGAppRefreshTask.
+@MainActor
+struct BackgroundPropagationSyncWorkflow<Message> {
+    let captureInsertionCursor: @MainActor () async throws -> Int64
+    let sync: @MainActor () async -> Bool
+    let messagesInsertedAfter: @MainActor (Int64) async throws -> [Message]
+    let notify: @MainActor (Message) async -> Void
+
+    func run() async -> Bool {
+        do {
+            let cursor = try await captureInsertionCursor()
+            guard !Task.isCancelled, await sync(), !Task.isCancelled else {
+                return false
+            }
+            let messages = try await messagesInsertedAfter(cursor)
+            guard !Task.isCancelled else { return false }
+            for message in messages {
+                guard !Task.isCancelled else { return false }
+                await notify(message)
+            }
+            return true
+        } catch {
+            backgroundPropagationLogger.error(
+                "Background propagation sync workflow failed: \(error.localizedDescription, privacy: .public)"
+            )
+            return false
+        }
+    }
+}
+
+enum BackgroundPropagationRefreshScheduler {
+    static let taskIdentifier = "network.columba.Columba.sync"
+
+    static func register() {
+        BGTaskScheduler.shared.register(
+            forTaskWithIdentifier: taskIdentifier,
+            using: nil
+        ) { task in
+            guard let refreshTask = task as? BGAppRefreshTask else {
+                task.setTaskCompleted(success: false)
+                return
+            }
+            Task { @MainActor in
+                scheduleFromCurrentSettings()
+                BackgroundRefreshTaskCoordinator.shared.receive(refreshTask)
+            }
+        }
+    }
+
+    @MainActor
+    static func scheduleFromCurrentSettings() {
+        let defaults = UserDefaults(suiteName: appGroupIdentifier) ?? .standard
+        let enabled = defaults.bool(forKey: "periodicSyncEnabled")
+        let rawInterval = defaults.double(forKey: "syncIntervalSeconds")
+        let interval = rawInterval > 0
+            ? rawInterval
+            : BackgroundPropagationSchedulePolicy.defaultInterval
+
+        BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: taskIdentifier)
+        guard let delay = BackgroundPropagationSchedulePolicy.nextDelay(
+            periodicSyncEnabled: enabled,
+            userInterval: interval
+        ) else {
+            backgroundPropagationLogger.info("Background propagation sync disabled")
+            return
+        }
+
+        let request = BGAppRefreshTaskRequest(identifier: taskIdentifier)
+        request.earliestBeginDate = Date(timeIntervalSinceNow: delay)
+        do {
+            try BGTaskScheduler.shared.submit(request)
+            backgroundPropagationLogger.info(
+                "Scheduled background propagation sync no earlier than \(Int(delay), privacy: .public)s"
+            )
+        } catch {
+            backgroundPropagationLogger.error(
+                "Failed to schedule background propagation sync: \(error.localizedDescription, privacy: .public)"
+            )
+        }
+    }
+}
+#endif

--- a/Sources/ColumbaApp/Services/BackgroundPropagationSync.swift
+++ b/Sources/ColumbaApp/Services/BackgroundPropagationSync.swift
@@ -142,7 +142,7 @@ enum BackgroundPropagationRefreshScheduler {
     static let taskIdentifier = "network.columba.Columba.sync"
 
     static func register() {
-        BGTaskScheduler.shared.register(
+        let registered = BGTaskScheduler.shared.register(
             forTaskWithIdentifier: taskIdentifier,
             using: nil
         ) { task in
@@ -151,10 +151,12 @@ enum BackgroundPropagationRefreshScheduler {
                 return
             }
             Task { @MainActor in
+                DiagLog.log("[BG-SYNC] system task delivered")
                 scheduleFromCurrentSettings()
                 BackgroundRefreshTaskCoordinator.shared.receive(refreshTask)
             }
         }
+        DiagLog.log("[BG-SYNC] registration success=\(registered)")
     }
 
     @MainActor
@@ -172,6 +174,7 @@ enum BackgroundPropagationRefreshScheduler {
             userInterval: interval
         ) else {
             backgroundPropagationLogger.info("Background propagation sync disabled")
+            DiagLog.log("[BG-SYNC] scheduling disabled; pending request cancelled")
             return
         }
 
@@ -182,10 +185,12 @@ enum BackgroundPropagationRefreshScheduler {
             backgroundPropagationLogger.info(
                 "Scheduled background propagation sync no earlier than \(Int(delay), privacy: .public)s"
             )
+            DiagLog.log("[BG-SYNC] scheduled earliest delay=\(Int(delay))s")
         } catch {
             backgroundPropagationLogger.error(
                 "Failed to schedule background propagation sync: \(error.localizedDescription, privacy: .public)"
             )
+            DiagLog.log("[BG-SYNC] scheduling failed: \(error.localizedDescription)")
         }
     }
 }

--- a/Sources/ColumbaApp/Services/IncomingMessageHandler.swift
+++ b/Sources/ColumbaApp/Services/IncomingMessageHandler.swift
@@ -181,13 +181,12 @@ public final class IncomingMessageHandler: LXMRouterDelegate {
     public func postNotificationForNewlySyncedMessage(_ message: LXMessage) async {
         guard Self.isUserNotifiableMessage(message) else { return }
         let conversation = try? await messageRepository.fetchConversation(message.sourceHash)
-        let totalUnreadCount = try? await messageRepository.totalUnreadCount()
         await NotificationService.shared.postMessageNotification(
             message,
             senderName: conversation?.displayName,
             database: database,
             isFavorite: (conversation?.isFavorite ?? 0) != 0,
-            totalUnreadCount: totalUnreadCount
+            messageRepository: messageRepository
         )
     }
 
@@ -456,13 +455,12 @@ public final class IncomingMessageHandler: LXMRouterDelegate {
                     // over its own — now bypassed — Compat lookup).
                     let senderConversation = try? await self.messageRepository.fetchConversation(sourceHash)
                     let senderIsFavorite = (senderConversation?.isFavorite ?? 0) != 0
-                    let totalUnreadCount = try? await self.messageRepository.totalUnreadCount()
                     await NotificationService.shared.postMessageNotification(
                         message,
                         senderName: senderConversation?.displayName,
                         database: self.database,
                         isFavorite: senderIsFavorite,
-                        totalUnreadCount: totalUnreadCount
+                        messageRepository: self.messageRepository
                     )
                 }
             }

--- a/Sources/ColumbaApp/Services/IncomingMessageHandler.swift
+++ b/Sources/ColumbaApp/Services/IncomingMessageHandler.swift
@@ -166,6 +166,52 @@ public final class IncomingMessageHandler: LXMRouterDelegate {
     }
     #endif
 
+    #if os(iOS)
+    /// Suppress the router-delegate notification path while a background
+    /// propagation sync is active. The background workflow posts notifications
+    /// from the database insertion delta instead, so sender timestamps cannot
+    /// suppress a newly downloaded message or cause duplicate banners.
+    public func setUserNotificationsSuppressed(_ suppressed: Bool) {
+        suppressUserNotifications = suppressed
+    }
+
+    /// Post the same preference-aware local notification used for a live inbound
+    /// message, but only for a row proven to be newly inserted by the current
+    /// background propagation sync.
+    public func postNotificationForNewlySyncedMessage(_ message: LXMessage) async {
+        guard Self.isUserNotifiableMessage(message) else { return }
+        let conversation = try? await messageRepository.fetchConversation(message.sourceHash)
+        await NotificationService.shared.postMessageNotification(
+            message,
+            senderName: conversation?.displayName,
+            database: database,
+            isFavorite: (conversation?.isFavorite ?? 0) != 0
+        )
+    }
+
+    private static func isUserNotifiableMessage(_ message: LXMessage) -> Bool {
+        let isTelemetryOnly = message.content.isEmpty
+            && message.fields?[LXMessage.FIELD_TELEMETRY] != nil
+        guard !isTelemetryOnly else { return false }
+
+        guard let metaRaw = message.fields?[LXMessage.FIELD_COLUMBA_META] else {
+            return true
+        }
+        let metaData: Data?
+        if let data = metaRaw as? Data {
+            metaData = data
+        } else if let string = metaRaw as? String {
+            metaData = string.data(using: .utf8)
+        } else {
+            metaData = nil
+        }
+        guard let metaData else { return true }
+        let msgpackCease = ColumbaMetaCodec.unpack(metaData)?.cease == true
+        let jsonCease = String(data: metaData, encoding: .utf8)?.contains("\"cease\"") == true
+        return !msgpackCease && !jsonCease
+    }
+    #endif
+
     // MARK: - LXMRouterDelegate
 
     /// Called when a message is received and validated.

--- a/Sources/ColumbaApp/Services/IncomingMessageHandler.swift
+++ b/Sources/ColumbaApp/Services/IncomingMessageHandler.swift
@@ -181,11 +181,13 @@ public final class IncomingMessageHandler: LXMRouterDelegate {
     public func postNotificationForNewlySyncedMessage(_ message: LXMessage) async {
         guard Self.isUserNotifiableMessage(message) else { return }
         let conversation = try? await messageRepository.fetchConversation(message.sourceHash)
+        let totalUnreadCount = try? await messageRepository.totalUnreadCount()
         await NotificationService.shared.postMessageNotification(
             message,
             senderName: conversation?.displayName,
             database: database,
-            isFavorite: (conversation?.isFavorite ?? 0) != 0
+            isFavorite: (conversation?.isFavorite ?? 0) != 0,
+            totalUnreadCount: totalUnreadCount
         )
     }
 
@@ -454,11 +456,13 @@ public final class IncomingMessageHandler: LXMRouterDelegate {
                     // over its own — now bypassed — Compat lookup).
                     let senderConversation = try? await self.messageRepository.fetchConversation(sourceHash)
                     let senderIsFavorite = (senderConversation?.isFavorite ?? 0) != 0
+                    let totalUnreadCount = try? await self.messageRepository.totalUnreadCount()
                     await NotificationService.shared.postMessageNotification(
                         message,
                         senderName: senderConversation?.displayName,
                         database: self.database,
-                        isFavorite: senderIsFavorite
+                        isFavorite: senderIsFavorite,
+                        totalUnreadCount: totalUnreadCount
                     )
                 }
             }

--- a/Sources/ColumbaApp/Services/IncomingMessageHandler.swift
+++ b/Sources/ColumbaApp/Services/IncomingMessageHandler.swift
@@ -189,7 +189,7 @@ public final class IncomingMessageHandler: LXMRouterDelegate {
         )
     }
 
-    private static func isUserNotifiableMessage(_ message: LXMessage) -> Bool {
+    static func isUserNotifiableMessage(_ message: LXMessage) -> Bool {
         let isTelemetryOnly = message.content.isEmpty
             && message.fields?[LXMessage.FIELD_TELEMETRY] != nil
         guard !isTelemetryOnly else { return false }

--- a/Sources/ColumbaApp/Services/MessageRepository.swift
+++ b/Sources/ColumbaApp/Services/MessageRepository.swift
@@ -140,6 +140,28 @@ public actor MessageRepository {
                     updated_at DOUBLE NOT NULL
                 )
                 """)
+            // SQLite rowids can reuse the deleted highest value. Keep an app-owned,
+            // AUTOINCREMENT insertion ledger so a propagation transaction cannot miss
+            // a new row merely because its messages.rowid was reused. The trigger also
+            // observes writes performed directly by the embedded Python router.
+            try db.execute(sql: """
+                CREATE TABLE IF NOT EXISTS columba_message_insertions (
+                    sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+                    message_id BLOB NOT NULL UNIQUE
+                )
+                """)
+            try db.execute(sql: """
+                CREATE TRIGGER IF NOT EXISTS columba_track_message_insertion
+                AFTER INSERT ON messages
+                BEGIN
+                    INSERT OR IGNORE INTO columba_message_insertions (message_id)
+                    VALUES (NEW.message_id);
+                END
+                """)
+            try db.execute(sql: """
+                INSERT OR IGNORE INTO columba_message_insertions (message_id)
+                SELECT message_id FROM messages ORDER BY rowid ASC
+                """)
         }
     }
 
@@ -525,28 +547,32 @@ public actor MessageRepository {
             .map(Self.mapRecord)
     }
 
-    /// Capture the current insertion boundary of the canonical message table.
-    /// A later query can then identify rows that were not present before a
-    /// propagation-node synchronization, regardless of the sender's timestamp.
+    /// Capture the current monotonic insertion boundary of the canonical message
+    /// table. `messages.rowid` is unsuitable because SQLite can reuse the deleted
+    /// highest rowid; the app-owned AUTOINCREMENT ledger cannot reuse sequences.
     public func captureMessageInsertionCursor() async throws -> Int64 {
         try await replacementPool.read { db in
-            try Int64.fetchOne(db, sql: "SELECT COALESCE(MAX(rowid), 0) FROM messages") ?? 0
+            try Int64.fetchOne(
+                db,
+                sql: "SELECT COALESCE(MAX(sequence), 0) FROM columba_message_insertions"
+            ) ?? 0
         }
     }
 
-    /// Return inbound messages inserted after a previously captured boundary.
-    /// Existing rows re-delivered by a propagation node keep their original
-    /// rowid and are excluded, so notifications represent newly downloaded
-    /// device-local messages rather than historical wire timestamps.
+    /// Return inbound messages first inserted after a previously captured boundary.
+    /// Existing message IDs re-delivered by a propagation node retain their ledger
+    /// sequence and are excluded, so notifications describe new durable insertions.
     public func fetchIncomingMessagesInserted(after cursor: Int64) async throws -> [RNSAPI.LXMessage] {
         try await replacementPool.read { db in
             try LXMFSwift.MessageRecord.fetchAll(
                 db,
                 sql: """
-                    SELECT *
-                    FROM messages
-                    WHERE rowid > ? AND incoming = 1
-                    ORDER BY rowid ASC
+                    SELECT messages.*
+                    FROM columba_message_insertions
+                    JOIN messages USING (message_id)
+                    WHERE columba_message_insertions.sequence > ?
+                      AND messages.incoming = 1
+                    ORDER BY columba_message_insertions.sequence ASC
                     """,
                 arguments: [cursor]
             ).map(Self.mapToLXMessage)

--- a/Sources/ColumbaApp/Services/MessageRepository.swift
+++ b/Sources/ColumbaApp/Services/MessageRepository.swift
@@ -512,6 +512,34 @@ public actor MessageRepository {
             .map(Self.mapRecord)
     }
 
+    /// Capture the current insertion boundary of the canonical message table.
+    /// A later query can then identify rows that were not present before a
+    /// propagation-node synchronization, regardless of the sender's timestamp.
+    public func captureMessageInsertionCursor() async throws -> Int64 {
+        try await replacementPool.read { db in
+            try Int64.fetchOne(db, sql: "SELECT COALESCE(MAX(rowid), 0) FROM messages") ?? 0
+        }
+    }
+
+    /// Return inbound messages inserted after a previously captured boundary.
+    /// Existing rows re-delivered by a propagation node keep their original
+    /// rowid and are excluded, so notifications represent newly downloaded
+    /// device-local messages rather than historical wire timestamps.
+    public func fetchIncomingMessagesInserted(after cursor: Int64) async throws -> [RNSAPI.LXMessage] {
+        try await replacementPool.read { db in
+            try LXMFSwift.MessageRecord.fetchAll(
+                db,
+                sql: """
+                    SELECT *
+                    FROM messages
+                    WHERE rowid > ? AND incoming = 1
+                    ORDER BY rowid ASC
+                    """,
+                arguments: [cursor]
+            ).map(Self.mapToLXMessage)
+        }
+    }
+
     /// Save a message (outbound from the app, or Python-path inbound).
     ///
     /// Bridges the RNSAPI `LXMessage` into the GRDB store via a synthetic

--- a/Sources/ColumbaApp/Services/MessageRepository.swift
+++ b/Sources/ColumbaApp/Services/MessageRepository.swift
@@ -213,6 +213,19 @@ public actor MessageRepository {
         try await database.getConversation(hash: conversationHash).map(Self.mapConversation)
     }
 
+    /// Return the durable unread-message total used for the application icon
+    /// badge. This is independent of Notification Center history, whose delivered
+    /// requests remain present after the icon badge itself is cleared.
+    public func totalUnreadCount() async throws -> Int {
+        let count = try await replacementPool.read { db in
+            try Int.fetchOne(
+                db,
+                sql: "SELECT COALESCE(SUM(unread_count), 0) FROM conversations"
+            ) ?? 0
+        }
+        return max(0, count)
+    }
+
     private static func sortedUniqueHashes(_ hashes: [Data]) -> [Data] {
         Array(Set(hashes)).sorted { $0.lexicographicallyPrecedes($1) }
     }

--- a/Sources/ColumbaApp/Services/NotificationService.swift
+++ b/Sources/ColumbaApp/Services/NotificationService.swift
@@ -267,8 +267,14 @@ public final class NotificationService: Sendable {
 
     // MARK: - Badge Management
 
-    /// Clear the badge count (call when app becomes active).
-    public func clearBadge() {
-        UNUserNotificationCenter.current().setBadgeCount(0)
+    /// Reconcile the icon badge with canonical durable unread state. Notification
+    /// Center history is presentation state and is never used as an unread counter.
+    public func synchronizeBadgeWithDurableUnreadCount(_ totalUnreadCount: Int) async {
+        do {
+            try await UNUserNotificationCenter.current().setBadgeCount(max(0, totalUnreadCount))
+            DiagLog.log("[NOTIFICATION] badge synchronized unread=\(max(0, totalUnreadCount))")
+        } catch {
+            DiagLog.log("[NOTIFICATION] badge synchronization failed: \(error.localizedDescription)")
+        }
     }
 }

--- a/Sources/ColumbaApp/Services/NotificationService.swift
+++ b/Sources/ColumbaApp/Services/NotificationService.swift
@@ -158,6 +158,14 @@ public final class NotificationService: Sendable {
         return true
     }
 
+    /// Convert the canonical unread total into a badge value. A failed database
+    /// read yields no badge mutation rather than reviving stale Notification
+    /// Center history.
+    static func badgeValue(totalUnreadCount: Int?) -> NSNumber? {
+        guard let totalUnreadCount else { return nil }
+        return NSNumber(value: max(0, totalUnreadCount))
+    }
+
     /// Post a local notification for an incoming LXMF message.
     ///
     /// Respects user preferences for notifications, previews, and sounds.
@@ -167,17 +175,26 @@ public final class NotificationService: Sendable {
     ///   - message: The incoming LXMessage
     ///   - senderName: Display name of the sender (nil = show hash)
     ///   - database: Database for looking up conversation display name
+    ///   - totalUnreadCount: Canonical durable unread total for the icon badge
+    @discardableResult
     public func postMessageNotification(
         _ message: LXMessage,
         senderName: String?,
         database: LXMFDatabase?,
-        isFavorite: Bool = false
-    ) async {
+        isFavorite: Bool = false,
+        totalUnreadCount: Int?
+    ) async -> Bool {
         let defaults = UserDefaults.standard
-        guard Self.shouldPostMessageNotification(isFavorite: isFavorite, defaults: defaults) else { return }
+        guard Self.shouldPostMessageNotification(isFavorite: isFavorite, defaults: defaults) else {
+            DiagLog.log("[NOTIFICATION] skipped by message notification preferences")
+            return false
+        }
 
         // Check system permission
-        guard await isAuthorized() else { return }
+        guard await isAuthorized() else {
+            DiagLog.log("[NOTIFICATION] skipped: system authorization unavailable")
+            return false
+        }
 
         // Build sender display
         let senderDisplay: String
@@ -219,9 +236,9 @@ public final class NotificationService: Sendable {
         let playSound = defaults.bool(forKey: Keys.playSounds)
         content.sound = playSound ? .default : nil
 
-        // Badge: increment
-        let currentBadge = await UNUserNotificationCenter.current().deliveredNotifications().count
-        content.badge = NSNumber(value: currentBadge + 1)
+        // Badge: use canonical unread state, not retained Notification Center
+        // history. The latter survives clearBadge() and caused values such as 100.
+        content.badge = Self.badgeValue(totalUnreadCount: totalUnreadCount)
 
         // Store source hash in userInfo for navigation on tap
         content.userInfo = [
@@ -238,8 +255,13 @@ public final class NotificationService: Sendable {
 
         do {
             try await UNUserNotificationCenter.current().add(request)
+            DiagLog.log(
+                "[NOTIFICATION] submitted message request badge=\(totalUnreadCount.map(String.init) ?? "unchanged")"
+            )
+            return true
         } catch {
-            // Silently fail — notification is non-critical
+            DiagLog.log("[NOTIFICATION] submission failed: \(error.localizedDescription)")
+            return false
         }
     }
 

--- a/Sources/ColumbaApp/Services/NotificationService.swift
+++ b/Sources/ColumbaApp/Services/NotificationService.swift
@@ -50,7 +50,26 @@ final class NotificationDelegate: NSObject, UNUserNotificationCenterDelegate {
 }
 
 @available(iOS 17.0, macOS 14.0, *)
-public final class NotificationService: Sendable {
+public actor NotificationService {
+
+    private var badgeMutationActive = false
+    private var badgeMutationWaiters: [CheckedContinuation<Void, Never>] = []
+
+    private func acquireBadgeMutation() async {
+        if badgeMutationActive {
+            await withCheckedContinuation { badgeMutationWaiters.append($0) }
+        } else {
+            badgeMutationActive = true
+        }
+    }
+
+    private func releaseBadgeMutation() {
+        if badgeMutationWaiters.isEmpty {
+            badgeMutationActive = false
+        } else {
+            badgeMutationWaiters.removeFirst().resume()
+        }
+    }
 
     // MARK: - Active Conversation Tracking
 
@@ -175,14 +194,14 @@ public final class NotificationService: Sendable {
     ///   - message: The incoming LXMessage
     ///   - senderName: Display name of the sender (nil = show hash)
     ///   - database: Database for looking up conversation display name
-    ///   - totalUnreadCount: Canonical durable unread total for the icon badge
+    ///   - messageRepository: Canonical durable unread authority for the icon badge
     @discardableResult
     public func postMessageNotification(
         _ message: LXMessage,
         senderName: String?,
         database: LXMFDatabase?,
         isFavorite: Bool = false,
-        totalUnreadCount: Int?
+        messageRepository: MessageRepository
     ) async -> Bool {
         let defaults = UserDefaults.standard
         guard Self.shouldPostMessageNotification(isFavorite: isFavorite, defaults: defaults) else {
@@ -236,21 +255,25 @@ public final class NotificationService: Sendable {
         let playSound = defaults.bool(forKey: Keys.playSounds)
         content.sound = playSound ? .default : nil
 
-        // Badge: use canonical unread state, not retained Notification Center
-        // history. The latter survives clearBadge() and caused values such as 100.
-        content.badge = Self.badgeValue(totalUnreadCount: totalUnreadCount)
-
         // Store source hash in userInfo for navigation on tap
         content.userInfo = [
             "sourceHash": message.sourceHash.map { String(format: "%02x", $0) }.joined()
         ]
 
-        // Create request with unique ID (message hash)
+        // Serialize the durable unread read and Notification Center mutation. This
+        // prevents a concurrent mark-read reconciliation from completing before a
+        // stale notification badge request that was already being assembled.
+        await acquireBadgeMutation()
+        defer { releaseBadgeMutation() }
+
+        let totalUnreadCount = try? await messageRepository.totalUnreadCount()
+        content.badge = Self.badgeValue(totalUnreadCount: totalUnreadCount)
+
         let requestId = message.hash.map { String(format: "%02x", $0) }.joined()
         let request = UNNotificationRequest(
             identifier: requestId,
             content: content,
-            trigger: nil // Deliver immediately
+            trigger: nil
         )
 
         do {
@@ -267,9 +290,18 @@ public final class NotificationService: Sendable {
 
     // MARK: - Badge Management
 
-    /// Reconcile the icon badge with canonical durable unread state. Notification
-    /// Center history is presentation state and is never used as an unread counter.
-    public func synchronizeBadgeWithDurableUnreadCount(_ totalUnreadCount: Int) async {
+    /// Reconcile the icon badge with canonical durable unread state at the
+    /// serialized Notification Center side-effect boundary.
+    public func synchronizeBadgeWithDurableUnreadCount(
+        messageRepository: MessageRepository
+    ) async {
+        await acquireBadgeMutation()
+        defer { releaseBadgeMutation() }
+
+        guard let totalUnreadCount = try? await messageRepository.totalUnreadCount() else {
+            DiagLog.log("[NOTIFICATION] badge unchanged: durable unread query failed")
+            return
+        }
         do {
             try await UNUserNotificationCenter.current().setBadgeCount(max(0, totalUnreadCount))
             DiagLog.log("[NOTIFICATION] badge synchronized unread=\(max(0, totalUnreadCount))")

--- a/Sources/ColumbaApp/Services/NotificationService.swift
+++ b/Sources/ColumbaApp/Services/NotificationService.swift
@@ -146,6 +146,18 @@ public final class NotificationService: Sendable {
 
     // MARK: - Post Notification
 
+    static func shouldPostMessageNotification(
+        isFavorite: Bool,
+        defaults: UserDefaults = .standard
+    ) -> Bool {
+        guard defaults.bool(forKey: Keys.notificationsEnabled) else { return false }
+        let notifyAll = defaults.object(forKey: Keys.notifyReceivedMessage) as? Bool ?? true
+        let notifyFavoriteOnly = defaults.bool(forKey: Keys.notifyReceivedMessageFavorite)
+        if notifyFavoriteOnly && !isFavorite { return false }
+        if !notifyAll && !notifyFavoriteOnly { return false }
+        return true
+    }
+
     /// Post a local notification for an incoming LXMF message.
     ///
     /// Respects user preferences for notifications, previews, and sounds.
@@ -161,18 +173,8 @@ public final class NotificationService: Sendable {
         database: LXMFDatabase?,
         isFavorite: Bool = false
     ) async {
-        // Check user preference
         let defaults = UserDefaults.standard
-        guard defaults.bool(forKey: Keys.notificationsEnabled) else { return }
-
-        // Check per-type toggles
-        let notifyAll = defaults.object(forKey: Keys.notifyReceivedMessage) as? Bool ?? true
-        let notifyFavoriteOnly = defaults.bool(forKey: Keys.notifyReceivedMessageFavorite)
-
-        // If "favorite only" is on and this sender isn't a favorite, skip
-        if notifyFavoriteOnly && !isFavorite { return }
-        // If general message notifications are off (and not favorite-filtered), skip
-        if !notifyAll && !notifyFavoriteOnly { return }
+        guard Self.shouldPostMessageNotification(isFavorite: isFavorite, defaults: defaults) else { return }
 
         // Check system permission
         guard await isAuthorized() else { return }

--- a/Sources/ColumbaApp/Services/PropagationNodeManager.swift
+++ b/Sources/ColumbaApp/Services/PropagationNodeManager.swift
@@ -338,7 +338,11 @@ public final class PropagationNodeManager {
     ///   refresh button, pull-to-refresh, or a Sync Now action) — i.e. the cases that may
     ///   present the status sheet. Only these reset the displayed transfer state up front
     ///   (see below). Background, periodic, and on-foreground auto-syncs pass `false`.
-    public func syncNow(userInitiated: Bool = false) async {
+    @discardableResult
+    public func syncNow(
+        userInitiated: Bool = false,
+        timeout: TimeInterval = 60.0
+    ) async -> Bool {
         // For user-initiated syncs only, reset transfer state up front so a freshly-opened
         // status sheet shows THIS sync's progress from a clean "connecting" slate, not the
         // previous run's stale "Download complete / N new messages". Background / periodic
@@ -364,14 +368,14 @@ public final class PropagationNodeManager {
                 syncState.state = .noPath
                 syncState.errorDescription = "No propagation node available"
                 logger.warning("[SYNC] Model B: no propagation node, sync skipped")
-                return
+                return false
             }
             publishPropagationSeam() // ensure the NE has the latest PN + stamp cost
             syncState.state = .linking
             syncState.errorDescription = nil
             PropagationSeamConfig.postSyncNowNotification()
             logger.info("[SYNC] Model B: posted sync-now to NE")
-            return
+            return true
         }
         #elseif COLUMBA_RUNTIME_PYTHON
 
@@ -379,7 +383,7 @@ public final class PropagationNodeManager {
             logger.error("[SYNC] Python backend not available")
             syncState.state = .linkFailed
             syncState.errorDescription = "Backend not available"
-            return
+            return false
         }
 
         logger.info("[SYNC] syncNow called. knownNodes=\(self.knownNodes.count), selectedNodeHash=\(self.selectedNodeHash != nil ? "set" : "nil")")
@@ -399,7 +403,7 @@ public final class PropagationNodeManager {
             syncState.state = .noPath
             syncState.errorDescription = "No propagation node available"
             logger.warning("[SYNC] No propagation nodes discovered, sync skipped")
-            return
+            return false
         }
 
         let nodeHex = nodeHash.prefix(8).map { String(format: "%02x", $0) }.joined()
@@ -408,7 +412,7 @@ public final class PropagationNodeManager {
         syncState.errorDescription = nil
 
         do {
-            let result = try await backend.propagationSync(timeout: 60.0)
+            let result = try await backend.propagationSync(timeout: timeout)
             syncState.state = Self.mapPythonState(result.state)
             syncState.receivedMessages = result.receivedMessages
             syncState.errorDescription = result.ok ? nil : result.reason
@@ -417,11 +421,22 @@ public final class PropagationNodeManager {
                 lastSyncTime = syncState.lastSync
             }
             logger.info("[SYNC] Sync \(result.ok ? "complete" : "failed"). state=\(result.state.rawValue) newMessages=\(result.receivedMessages)")
+            return result.ok
         } catch {
             syncState.state = .transferFailed
             syncState.errorDescription = error.localizedDescription
             logger.error("[SYNC] Sync failed: \(error.localizedDescription)")
+            return false
         }
+        #endif
+    }
+
+    /// Interrupt an active shipping Python propagation sync. This is used by
+    /// BGAppRefreshTask expiration so Python does not continue polling after the
+    /// system revokes the refresh execution window.
+    public func cancelActiveSync() async {
+        #if COLUMBA_RUNTIME_PYTHON
+        await appServices?.pythonBackend?.cancelPropagationSync()
         #endif
     }
 
@@ -431,6 +446,7 @@ public final class PropagationNodeManager {
     private static func mapPythonState(_ state: PropagationSyncResult.State) -> PropagationTransferState.State {
         switch state {
         case .complete: return .complete
+        case .cancelled: return .transferFailed
         case .noPath: return .noPath
         case .transferFailed: return .transferFailed
         case .pathRequested, .linkEstablishing, .linkEstablished:

--- a/Sources/ColumbaApp/Services/PropagationNodeManager.swift
+++ b/Sources/ColumbaApp/Services/PropagationNodeManager.swift
@@ -102,6 +102,7 @@ public final class PropagationNodeManager {
     /// Main-actor single-flight guard shared by user, periodic, foreground, and
     /// BGAppRefreshTask synchronization requests.
     private var syncInFlight = false
+    private var activeSyncOperationID: UUID?
 
     /// Observer token for the NE's propagation sync-state channel (Model B). The NE
     /// owns the router/sync, so live progress arrives as App-Group snapshots bridged
@@ -345,14 +346,21 @@ public final class PropagationNodeManager {
     @discardableResult
     public func syncNow(
         userInitiated: Bool = false,
-        timeout: TimeInterval = 60.0
+        timeout: TimeInterval = 60.0,
+        operationID: UUID = UUID()
     ) async -> Bool {
         guard !syncInFlight else {
             logger.info("[SYNC] skipped overlapping propagation sync")
             return false
         }
         syncInFlight = true
-        defer { syncInFlight = false }
+        activeSyncOperationID = operationID
+        defer {
+            if activeSyncOperationID == operationID {
+                activeSyncOperationID = nil
+                syncInFlight = false
+            }
+        }
 
         // For user-initiated syncs only, reset transfer state up front so a freshly-opened
         // status sheet shows THIS sync's progress from a clean "connecting" slate, not the
@@ -447,7 +455,11 @@ public final class PropagationNodeManager {
     /// Interrupt an active shipping Python propagation sync. This is used by
     /// BGAppRefreshTask expiration so Python does not continue polling after the
     /// system revokes the refresh execution window.
-    public func cancelActiveSync() async {
+    public func cancelActiveSync(operationID: UUID) async {
+        guard activeSyncOperationID == operationID else {
+            logger.info("[SYNC] ignored cancellation for inactive propagation sync")
+            return
+        }
         #if COLUMBA_RUNTIME_PYTHON
         await appServices?.pythonBackend?.cancelPropagationSync()
         #endif

--- a/Sources/ColumbaApp/Services/PropagationNodeManager.swift
+++ b/Sources/ColumbaApp/Services/PropagationNodeManager.swift
@@ -510,7 +510,9 @@ public final class PropagationNodeManager {
         case .complete: return .complete
         case .cancelled: return .transferFailed
         case .noPath: return .noPath
-        case .transferFailed: return .transferFailed
+        case .linkFailed: return .linkFailed
+        case .transferFailed, .noIdentityReceived, .noAccess, .failed:
+            return .transferFailed
         case .pathRequested, .linkEstablishing, .linkEstablished:
             return .linking
         case .requestSent, .receiving, .responseReceived:

--- a/Sources/ColumbaApp/Services/PropagationNodeManager.swift
+++ b/Sources/ColumbaApp/Services/PropagationNodeManager.swift
@@ -99,6 +99,10 @@ public final class PropagationNodeManager {
     /// Task for periodic sync.
     private var periodicSyncTask: Task<Void, Never>?
 
+    /// Main-actor single-flight guard shared by user, periodic, foreground, and
+    /// BGAppRefreshTask synchronization requests.
+    private var syncInFlight = false
+
     /// Observer token for the NE's propagation sync-state channel (Model B). The NE
     /// owns the router/sync, so live progress arrives as App-Group snapshots bridged
     /// to `propagationSyncStateChangedInApp`; we mirror them into `syncState`.
@@ -343,6 +347,13 @@ public final class PropagationNodeManager {
         userInitiated: Bool = false,
         timeout: TimeInterval = 60.0
     ) async -> Bool {
+        guard !syncInFlight else {
+            logger.info("[SYNC] skipped overlapping propagation sync")
+            return false
+        }
+        syncInFlight = true
+        defer { syncInFlight = false }
+
         // For user-initiated syncs only, reset transfer state up front so a freshly-opened
         // status sheet shows THIS sync's progress from a clean "connecting" slate, not the
         // previous run's stale "Download complete / N new messages". Background / periodic
@@ -412,7 +423,9 @@ public final class PropagationNodeManager {
         syncState.errorDescription = nil
 
         do {
-            let result = try await backend.propagationSync(timeout: timeout)
+            let transaction = try await backend.propagationSyncAndDrain(timeout: timeout)
+            await appServices?.processPythonEventsSynchronously(transaction.events)
+            let result = transaction.result
             syncState.state = Self.mapPythonState(result.state)
             syncState.receivedMessages = result.receivedMessages
             syncState.errorDescription = result.ok ? nil : result.reason
@@ -437,6 +450,29 @@ public final class PropagationNodeManager {
     public func cancelActiveSync() async {
         #if COLUMBA_RUNTIME_PYTHON
         await appServices?.pythonBackend?.cancelPropagationSync()
+        #endif
+    }
+
+    /// Reapply the persisted relay after the embedded Python backend starts.
+    /// Preference restoration happens before backend startup on a cold launch,
+    /// so wiring only the Compat router leaves Python with no outbound node.
+    @discardableResult
+    public func reapplySelectedNodeToPythonBackend() async -> Bool {
+        #if COLUMBA_RUNTIME_PYTHON
+        guard let hash = selectedNodeHash,
+              let backend = appServices?.pythonBackend else { return false }
+        let hex = hash.map { String(format: "%02x", $0) }.joined()
+        do {
+            return try await backend.setPropagationNode(
+                destHashHex: hex,
+                stampCost: selectedNodeStampCost
+            )
+        } catch {
+            logger.error("[SYNC] Failed to reapply persisted propagation node: \(error.localizedDescription)")
+            return false
+        }
+        #else
+        return false
         #endif
     }
 

--- a/Sources/ColumbaApp/Services/PropagationNodeManager.swift
+++ b/Sources/ColumbaApp/Services/PropagationNodeManager.swift
@@ -99,6 +99,12 @@ public final class PropagationNodeManager {
     /// Task for periodic sync.
     private var periodicSyncTask: Task<Void, Never>?
 
+    /// Test seam proving that iOS does not run a second timer beside
+    /// BGAppRefreshTask. Other platforms still use the in-process timer.
+    var hasInProcessPeriodicSyncTaskForTesting: Bool {
+        periodicSyncTask != nil
+    }
+
     /// Main-actor single-flight guard shared by user, periodic, foreground, and
     /// BGAppRefreshTask synchronization requests.
     private var syncInFlight = false
@@ -351,6 +357,7 @@ public final class PropagationNodeManager {
     ) async -> Bool {
         guard !syncInFlight else {
             logger.info("[SYNC] skipped overlapping propagation sync")
+            DiagLog.log("[SYNC] rejected: propagation sync already in flight")
             return false
         }
         syncInFlight = true
@@ -400,6 +407,7 @@ public final class PropagationNodeManager {
 
         guard let backend = appServices?.pythonBackend else {
             logger.error("[SYNC] Python backend not available")
+            DiagLog.log("[SYNC] failed: Python backend unavailable")
             syncState.state = .linkFailed
             syncState.errorDescription = "Backend not available"
             return false
@@ -422,6 +430,7 @@ public final class PropagationNodeManager {
             syncState.state = .noPath
             syncState.errorDescription = "No propagation node available"
             logger.warning("[SYNC] No propagation nodes discovered, sync skipped")
+            DiagLog.log("[SYNC] failed: no propagation node selected")
             return false
         }
 
@@ -442,11 +451,16 @@ public final class PropagationNodeManager {
                 lastSyncTime = syncState.lastSync
             }
             logger.info("[SYNC] Sync \(result.ok ? "complete" : "failed"). state=\(result.state.rawValue) newMessages=\(result.receivedMessages)")
+            DiagLog.log(
+                "[SYNC] completed ok=\(result.ok) state=\(result.state.rawValue) "
+                    + "received=\(result.receivedMessages) reason=\(result.reason)"
+            )
             return result.ok
         } catch {
             syncState.state = .transferFailed
             syncState.errorDescription = error.localizedDescription
             logger.error("[SYNC] Sync failed: \(error.localizedDescription)")
+            DiagLog.log("[SYNC] failed with error: \(error.localizedDescription)")
             return false
         }
         #endif
@@ -516,6 +530,15 @@ public final class PropagationNodeManager {
         return
         #elseif COLUMBA_RUNTIME_PYTHON
 
+        #if os(iOS)
+        // BGAppRefreshTask is the only periodic scheduler on iOS. Keeping this
+        // sleeping task as well causes both operations to resume on the same
+        // system wake, and the shared single-flight guard rejects one of them.
+        periodicSyncTask?.cancel()
+        periodicSyncTask = nil
+        logger.info("[SYNC] in-process periodic timer disabled; BGAppRefreshTask owns iOS cadence")
+        return
+        #else
         guard periodicSyncEnabled else { return }
 
         periodicSyncTask?.cancel()
@@ -526,6 +549,7 @@ public final class PropagationNodeManager {
                 await syncNow()
             }
         }
+        #endif
         #endif
     }
 

--- a/Sources/ColumbaApp/Services/SettingsRepository.swift
+++ b/Sources/ColumbaApp/Services/SettingsRepository.swift
@@ -220,15 +220,16 @@ public actor SettingsRepository {
         defaults.set(enabled, forKey: Keys.periodicSyncEnabled)
     }
 
-    /// Get sync interval in seconds.
+    /// Get sync interval in seconds, clamped to the user-facing minimum.
     public func getSyncInterval() -> TimeInterval {
         let value = defaults.double(forKey: Keys.syncIntervalSeconds)
-        return value > 0 ? value : 3600 // Default 1 hour
+        let requested = value > 0 ? value : 3600
+        return max(15 * 60, requested)
     }
 
-    /// Set sync interval in seconds.
+    /// Set sync interval in seconds, clamped to the user-facing minimum.
     public func setSyncInterval(_ interval: TimeInterval) {
-        defaults.set(interval, forKey: Keys.syncIntervalSeconds)
+        defaults.set(max(15 * 60, interval), forKey: Keys.syncIntervalSeconds)
     }
 
     // MARK: - Incoming Message Size Limit

--- a/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
@@ -231,6 +231,7 @@ public final class MessagingViewModel {
             // leave a stale badge behind after the conversation was viewed.
             try await repository.ensureConversation(conversationHash, displayName: displayName)
             try await repository.markConversationRead(conversationHash)
+            await synchronizeBadgeWithDurableUnreadCount()
             await retryPendingDeliveryProofs()
 
             // Preserve the current history depth when repository notifications
@@ -320,6 +321,7 @@ public final class MessagingViewModel {
             // Reconcile messages that arrived after the initial read reset but
             // were included in the page we just displayed.
             try await repository.markConversationRead(conversationHash)
+            await synchronizeBadgeWithDurableUnreadCount()
 
             errorMessage = hasInterruptedRetry
                 ? Self.interruptedRetryWarning
@@ -330,6 +332,15 @@ public final class MessagingViewModel {
 
         isLoading = false
         await runPendingRefreshIfNeeded()
+    }
+
+    @MainActor
+    private func synchronizeBadgeWithDurableUnreadCount() async {
+        #if os(iOS)
+        if let unread = try? await repository.totalUnreadCount() {
+            await NotificationService.shared.synchronizeBadgeWithDurableUnreadCount(unread)
+        }
+        #endif
     }
 
     /// Load older messages when scrolling up.

--- a/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
@@ -337,9 +337,9 @@ public final class MessagingViewModel {
     @MainActor
     private func synchronizeBadgeWithDurableUnreadCount() async {
         #if os(iOS)
-        if let unread = try? await repository.totalUnreadCount() {
-            await NotificationService.shared.synchronizeBadgeWithDurableUnreadCount(unread)
-        }
+        await NotificationService.shared.synchronizeBadgeWithDurableUnreadCount(
+            messageRepository: repository
+        )
         #endif
     }
 

--- a/Sources/ColumbaApp/ViewModels/SettingsViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/SettingsViewModel.swift
@@ -669,6 +669,9 @@ public final class SettingsViewModel {
         await settingsRepository.setAutoSelectRelay(autoSelectRelay)
         await settingsRepository.setPeriodicSyncEnabled(autoRetrieveEnabled)
         await settingsRepository.setSyncInterval(autoRetrieveInterval)
+        #if os(iOS) && COLUMBA_RUNTIME_PYTHON
+        BackgroundPropagationRefreshScheduler.scheduleFromCurrentSettings()
+        #endif
         await appServices.applyIncomingMessageSizeLimitFromSettings()
 
         // Update propagation manager

--- a/Sources/ColumbaApp/Views/Settings/SettingsView.swift
+++ b/Sources/ColumbaApp/Views/Settings/SettingsView.swift
@@ -1384,6 +1384,8 @@ struct SettingsView: View {
                                 Task { await vm.saveDeliverySettings() }
                             }
                         )) {
+                            Text("15 minutes").tag(TimeInterval(900))
+                            Text("30 minutes").tag(TimeInterval(1800))
                             Text("1 hour").tag(TimeInterval(3600))
                             Text("3 hours").tag(TimeInterval(10800))
                             Text("6 hours").tag(TimeInterval(21600))
@@ -1392,6 +1394,11 @@ struct SettingsView: View {
                         .pickerStyle(.menu)
                         .tint(Theme.accentColor)
                     }
+
+                    Text("iOS treats this as the earliest requested refresh time. Actual background sync timing is system-controlled and may be later.")
+                        .font(.caption)
+                        .foregroundStyle(Theme.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
 
                 // Sync Now button

--- a/Sources/PythonBridge/PythonBridge.swift
+++ b/Sources/PythonBridge/PythonBridge.swift
@@ -314,7 +314,11 @@ public final class PythonBridge: @unchecked Sendable {
             case complete
             case cancelled
             case noPath = "no_path"
+            case linkFailed = "link_failed"
             case transferFailed = "transfer_failed"
+            case noIdentityReceived = "no_identity_received"
+            case noAccess = "no_access"
+            case failed
             case noRouter = "no-router"
             case notStarted = "not-started"
             case noNode = "no-node"

--- a/Sources/PythonBridge/PythonBridge.swift
+++ b/Sources/PythonBridge/PythonBridge.swift
@@ -312,6 +312,7 @@ public final class PythonBridge: @unchecked Sendable {
             case receiving
             case responseReceived = "response_received"
             case complete
+            case cancelled
             case noPath = "no_path"
             case transferFailed = "transfer_failed"
             case noRouter = "no-router"
@@ -421,6 +422,25 @@ public final class PythonBridge: @unchecked Sendable {
                 }()
                 let state = PropagationSyncResult.State(rawValue: stateStr) ?? .unknown
                 return PropagationSyncResult(ok: ok, state: state, receivedMessages: count, reason: reason)
+            }
+        }
+    }
+
+    /// Interrupt the Python propagation poll and ask LXMRouter to tear down its
+    /// active propagation request. Runs on the non-blocking bridge queue so it
+    /// can execute while `propagationSync` is sleeping on `blockingQueue`.
+    public func cancelPropagationSync() async throws {
+        try await runOnQueue { [self] in
+            try PythonRuntime.shared.withGIL { [self] in
+                guard let module = self.module else { return }
+                guard let fn = PyObject_GetAttrString(module, "cancel_propagation_sync") else {
+                    throw BridgeError.pythonException(currentPythonException())
+                }
+                defer { Py_DecRef(fn) }
+                guard let result = PyObject_CallNoArgs(fn) else {
+                    throw BridgeError.pythonException(currentPythonException())
+                }
+                Py_DecRef(result)
             }
         }
     }

--- a/Sources/RNSAPI/Protocols/RnsBackend.swift
+++ b/Sources/RNSAPI/Protocols/RnsBackend.swift
@@ -87,7 +87,11 @@ public struct PropagationSyncResult: Sendable, Equatable {
         case complete
         case cancelled
         case noPath = "no_path"
+        case linkFailed = "link_failed"
         case transferFailed = "transfer_failed"
+        case noIdentityReceived = "no_identity_received"
+        case noAccess = "no_access"
+        case failed
         case noRouter = "no-router"
         case notStarted = "not-started"
         case noNode = "no-node"

--- a/Sources/RNSAPI/Protocols/RnsBackend.swift
+++ b/Sources/RNSAPI/Protocols/RnsBackend.swift
@@ -85,6 +85,7 @@ public struct PropagationSyncResult: Sendable, Equatable {
         case receiving
         case responseReceived = "response_received"
         case complete
+        case cancelled
         case noPath = "no_path"
         case transferFailed = "transfer_failed"
         case noRouter = "no-router"

--- a/Sources/RNSBackendPy/PythonRNSBackend.swift
+++ b/Sources/RNSBackendPy/PythonRNSBackend.swift
@@ -208,6 +208,11 @@ public final class PythonRNSBackend: RnsBackend, @unchecked Sendable {
         Self.map(try await bridge.propagationSync(timeout: timeout))
     }
 
+    /// Cancel a bounded propagation sync that is currently polling in Python.
+    public func cancelPropagationSync() async {
+        try? await bridge.cancelPropagationSync()
+    }
+
     // MARK: - Telemetry (RnsTelemetry)
     //
     // The send half routes through the same `sendLxmfMessage` path as text /

--- a/Sources/RNSBackendPy/PythonRNSBackend.swift
+++ b/Sources/RNSBackendPy/PythonRNSBackend.swift
@@ -1,6 +1,32 @@
 import Foundation
 import RNSAPI
 
+private actor PythonEventDrainGate {
+    private var transactionActive = false
+    private var normalDrainActive = false
+
+    func beginTransaction() async {
+        while transactionActive || normalDrainActive {
+            try? await Task.sleep(nanoseconds: 1_000_000)
+        }
+        transactionActive = true
+    }
+
+    func endTransaction() {
+        transactionActive = false
+    }
+
+    func beginNormalDrain() -> Bool {
+        guard !transactionActive, !normalDrainActive else { return false }
+        normalDrainActive = true
+        return true
+    }
+
+    func endNormalDrain() {
+        normalDrainActive = false
+    }
+}
+
 /// Python-backed `RnsBackend` (Android `:rns-backend-py` analog). Wraps
 /// `PythonBridge` (the raw CPython embedding) and adapts its Python-flavored raw
 /// results onto the neutral RNSAPI DTOs the host (`AppServices`) consumes. The
@@ -18,6 +44,7 @@ public final class PythonRNSBackend: RnsBackend, @unchecked Sendable {
     private let bridge = PythonBridge()
     private var eventDrainTask: Task<Void, Never>?
     private var eventContinuation: AsyncStream<BackendEvent>.Continuation?
+    private let eventDrainGate = PythonEventDrainGate()
 
     public private(set) var localInfo: LocalInfo?
 
@@ -208,6 +235,24 @@ public final class PythonRNSBackend: RnsBackend, @unchecked Sendable {
         Self.map(try await bridge.propagationSync(timeout: timeout))
     }
 
+    /// Run one propagation sync while exclusively owning the Python event queue,
+    /// then return every event queued by that transfer for synchronous host-side
+    /// persistence before the caller computes its message insertion delta.
+    public func propagationSyncAndDrain(
+        timeout: TimeInterval = 60.0
+    ) async throws -> (result: PropagationSyncResult, events: [BackendEvent]) {
+        await eventDrainGate.beginTransaction()
+        do {
+            let result = Self.map(try await bridge.propagationSync(timeout: timeout))
+            let events = await bridge.drainEvents().map(Self.map)
+            await eventDrainGate.endTransaction()
+            return (result, events)
+        } catch {
+            await eventDrainGate.endTransaction()
+            throw error
+        }
+    }
+
     /// Cancel a bounded propagation sync that is currently polling in Python.
     public func cancelPropagationSync() async {
         try? await bridge.cancelPropagationSync()
@@ -362,9 +407,12 @@ public final class PythonRNSBackend: RnsBackend, @unchecked Sendable {
         eventDrainTask = Task { [weak self] in
             while !Task.isCancelled {
                 guard let self else { return }
-                let events = await self.bridge.drainEvents()
-                for event in events {
-                    self.eventContinuation?.yield(Self.map(event))
+                if await self.eventDrainGate.beginNormalDrain() {
+                    let events = await self.bridge.drainEvents()
+                    await self.eventDrainGate.endNormalDrain()
+                    for event in events {
+                        self.eventContinuation?.yield(Self.map(event))
+                    }
                 }
                 try? await Task.sleep(nanoseconds: 200_000_000) // 200ms
             }

--- a/Tests/ColumbaAppTests/BackgroundPropagationSyncTests.swift
+++ b/Tests/ColumbaAppTests/BackgroundPropagationSyncTests.swift
@@ -92,6 +92,30 @@ final class BackgroundPropagationSyncTests: XCTestCase {
         XCTAssertEqual(messages.map(\.hash), [newInbound.hash])
     }
 
+    func testRepositoryInsertionCursorSurvivesHighestRowDeletionAndRowIDReuse() async throws {
+        let databaseURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("columba-bg-rowid-reuse-\(UUID().uuidString).sqlite")
+        defer {
+            try? FileManager.default.removeItem(at: databaseURL)
+            try? FileManager.default.removeItem(atPath: databaseURL.path + "-shm")
+            try? FileManager.default.removeItem(atPath: databaseURL.path + "-wal")
+        }
+
+        let repository = try MessageRepository(grdbPath: databaseURL.path)
+        let first = makeMessage(idByte: 0x11, incoming: true)
+        let highest = makeMessage(idByte: 0x12, incoming: true)
+        try await repository.saveMessage(first)
+        try await repository.saveMessage(highest)
+        let cursor = try await repository.captureMessageInsertionCursor()
+
+        try await repository.deleteMessage(highest.hash)
+        let replacement = makeMessage(idByte: 0x13, incoming: true)
+        try await repository.saveMessage(replacement)
+
+        let messages = try await repository.fetchIncomingMessagesInserted(after: cursor)
+        XCTAssertEqual(messages.map(\.hash), [replacement.hash])
+    }
+
     func testRepositoryTotalUnreadCountIgnoresNotificationHistory() async throws {
         let databaseURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("columba-bg-badge-\(UUID().uuidString).sqlite")

--- a/Tests/ColumbaAppTests/BackgroundPropagationSyncTests.swift
+++ b/Tests/ColumbaAppTests/BackgroundPropagationSyncTests.swift
@@ -222,23 +222,30 @@ final class BackgroundPropagationSyncTests: XCTestCase {
         XCTAssertEqual(afterRelease, ["normal"])
     }
 
-    func testFailedPropagationNodeRestoreRollsBackBeforeEveryInitializationRetry() async {
+    func testFailedPropagationNodeRestoreRollsBackBeforeLifecycleActivationAndRetry() async {
         var backendRunning = false
         var starts = 0
         var rollbacks = 0
+        var lifecycleActivations = 0
 
         for _ in 0..<5 {
-            if !backendRunning {
-                backendRunning = true
-                starts += 1
-            }
-
             do {
-                try await PropagationNodeRestoreReadiness.validate(
-                    reapplied: false,
-                    rollback: {
-                        backendRunning = false
-                        rollbacks += 1
+                try await InitializationLifecycleActivation.run(
+                    readiness: {
+                        if !backendRunning {
+                            backendRunning = true
+                            starts += 1
+                        }
+                        try await PropagationNodeRestoreReadiness.validate(
+                            reapplied: false,
+                            rollback: {
+                                backendRunning = false
+                                rollbacks += 1
+                            }
+                        )
+                    },
+                    activate: {
+                        lifecycleActivations += 1
                     }
                 )
                 XCTFail("Failed propagation-node restoration must not report readiness")
@@ -246,10 +253,32 @@ final class BackgroundPropagationSyncTests: XCTestCase {
                 XCTAssertEqual(error as? AppServicesError, .propagationNodeRestoreFailed)
             }
             XCTAssertFalse(backendRunning)
+            XCTAssertEqual(lifecycleActivations, 0)
         }
 
-        XCTAssertEqual(starts, 5)
+        try? await InitializationLifecycleActivation.run(
+            readiness: {
+                if !backendRunning {
+                    backendRunning = true
+                    starts += 1
+                }
+                try await PropagationNodeRestoreReadiness.validate(
+                    reapplied: true,
+                    rollback: {
+                        backendRunning = false
+                        rollbacks += 1
+                    }
+                )
+            },
+            activate: {
+                lifecycleActivations += 1
+            }
+        )
+
+        XCTAssertTrue(backendRunning)
+        XCTAssertEqual(starts, 6)
         XCTAssertEqual(rollbacks, 5)
+        XCTAssertEqual(lifecycleActivations, 1)
     }
 
     func testWorkflowNotifiesEachMessageInsertedDuringSuccessfulSync() async {

--- a/Tests/ColumbaAppTests/BackgroundPropagationSyncTests.swift
+++ b/Tests/ColumbaAppTests/BackgroundPropagationSyncTests.swift
@@ -251,24 +251,24 @@ final class BackgroundPropagationSyncTests: XCTestCase {
         )
     }
 
-    func testWorkflowDoesNotLoadOrNotifyWhenSyncFails() async {
+    func testWorkflowTransfersDurableDeltaNotificationsWhenSyncFails() async {
         var loaded = false
-        var notified = false
+        var notified: [String] = []
         let workflow = BackgroundPropagationSyncWorkflow<String>(
             captureInsertionCursor: { 7 },
             sync: { false },
             messagesInsertedAfter: { _ in
                 loaded = true
-                return ["unexpected"]
+                return ["concurrent-live"]
             },
-            notify: { _ in notified = true }
+            notify: { notified.append($0) }
         )
 
         let succeeded = await workflow.run()
 
         XCTAssertFalse(succeeded)
-        XCTAssertFalse(loaded)
-        XCTAssertFalse(notified)
+        XCTAssertTrue(loaded)
+        XCTAssertEqual(notified, ["concurrent-live"])
     }
 
     func testTaskReceivedBeforeHandlerRunsAfterHandlerInstallation() async {

--- a/Tests/ColumbaAppTests/BackgroundPropagationSyncTests.swift
+++ b/Tests/ColumbaAppTests/BackgroundPropagationSyncTests.swift
@@ -81,6 +81,36 @@ final class BackgroundPropagationSyncTests: XCTestCase {
         XCTAssertEqual(messages.map(\.hash), [newInbound.hash])
     }
 
+    func testBackgroundNotificationClassifierRejectsTelemetryAndCeaseControls() {
+        let normal = makeMessage(idByte: 0x11, incoming: true)
+        let telemetry = makeMessage(
+            idByte: 0x12,
+            incoming: true,
+            content: Data(),
+            fields: [LXMessage.FIELD_TELEMETRY: Data([0x01])]
+        )
+        let cease = makeMessage(
+            idByte: 0x13,
+            incoming: true,
+            content: Data(),
+            fields: [LXMessage.FIELD_COLUMBA_META: Data("{\"cease\":true}".utf8)]
+        )
+
+        XCTAssertTrue(IncomingMessageHandler.isUserNotifiableMessage(normal))
+        XCTAssertFalse(IncomingMessageHandler.isUserNotifiableMessage(telemetry))
+        XCTAssertFalse(IncomingMessageHandler.isUserNotifiableMessage(cease))
+    }
+
+    func testBuiltAppDeclaresBackgroundRefreshRequirements() throws {
+        let modes = try XCTUnwrap(Bundle.main.object(forInfoDictionaryKey: "UIBackgroundModes") as? [String])
+        let identifiers = try XCTUnwrap(
+            Bundle.main.object(forInfoDictionaryKey: "BGTaskSchedulerPermittedIdentifiers") as? [String]
+        )
+
+        XCTAssertTrue(modes.contains("fetch"))
+        XCTAssertTrue(identifiers.contains(BackgroundPropagationRefreshScheduler.taskIdentifier))
+    }
+
     func testWorkflowNotifiesEachMessageInsertedDuringSuccessfulSync() async {
         var events: [String] = []
         let workflow = BackgroundPropagationSyncWorkflow<String>(
@@ -162,13 +192,18 @@ final class BackgroundPropagationSyncTests: XCTestCase {
         XCTAssertEqual(task.completions, [false])
     }
 
-    private func makeMessage(idByte: UInt8, incoming: Bool) -> LXMessage {
+    private func makeMessage(
+        idByte: UInt8,
+        incoming: Bool,
+        content: Data? = nil,
+        fields: [UInt8: Any]? = nil
+    ) -> LXMessage {
         let message = LXMessage(
             destinationHash: Data(repeating: 0xDD, count: 16),
             sourceIdentity: nil,
-            content: Data("message-\(idByte)".utf8),
+            content: content ?? Data("message-\(idByte)".utf8),
             title: Data(),
-            fields: nil,
+            fields: fields,
             desiredMethod: incoming ? .propagated : .direct
         )
         message.sourceHash = Data(repeating: 0xAA, count: 16)

--- a/Tests/ColumbaAppTests/BackgroundPropagationSyncTests.swift
+++ b/Tests/ColumbaAppTests/BackgroundPropagationSyncTests.swift
@@ -205,18 +205,21 @@ final class BackgroundPropagationSyncTests: XCTestCase {
         let gate = PythonHostEventProcessingGate()
         let events = EventRecorder()
 
-        XCTAssertTrue(await gate.beginExclusive())
+        let acquired = await gate.beginExclusive()
+        XCTAssertTrue(acquired)
         let normalDrain = Task {
             guard await gate.beginNormal() else { return }
             await events.append("normal")
             await gate.endNormal()
         }
         try? await Task.sleep(for: .milliseconds(20))
-        XCTAssertEqual(await events.values, [])
+        let beforeRelease = await events.snapshot()
+        XCTAssertEqual(beforeRelease, [])
 
         await gate.endExclusive()
         await normalDrain.value
-        XCTAssertEqual(await events.values, ["normal"])
+        let afterRelease = await events.snapshot()
+        XCTAssertEqual(afterRelease, ["normal"])
     }
 
     func testWorkflowNotifiesEachMessageInsertedDuringSuccessfulSync() async {
@@ -328,10 +331,14 @@ final class BackgroundPropagationSyncTests: XCTestCase {
 }
 
 private actor EventRecorder {
-    private(set) var values: [String] = []
+    private var values: [String] = []
 
     func append(_ value: String) {
         values.append(value)
+    }
+
+    func snapshot() -> [String] {
+        values
     }
 }
 

--- a/Tests/ColumbaAppTests/BackgroundPropagationSyncTests.swift
+++ b/Tests/ColumbaAppTests/BackgroundPropagationSyncTests.swift
@@ -115,6 +115,38 @@ final class BackgroundPropagationSyncTests: XCTestCase {
         XCTAssertEqual(NotificationService.badgeValue(totalUnreadCount: -1), NSNumber(value: 0))
     }
 
+    func testPendingRequestDiagnosticsAreDeterministicAndPrivacySafe() {
+        let summary = BackgroundRefreshDiagnosticFormatter.pendingRequests(
+            [
+                .init(
+                    identifier: BackgroundPropagationRefreshScheduler.taskIdentifier,
+                    earliestBeginDate: Date(timeIntervalSince1970: 1_722_240_900)
+                )
+            ]
+        )
+
+        XCTAssertEqual(
+            summary,
+            "count=1 [network.columba.Columba.sync earliest=2024-07-29T08:15:00Z]"
+        )
+    }
+
+    func testRuntimeDiagnosticsIncludeSchedulingConditions() {
+        let summary = BackgroundRefreshDiagnosticFormatter.runtime(
+            processID: 42,
+            backgroundRefreshStatus: "denied",
+            lowPowerModeEnabled: true,
+            thermalState: "serious",
+            protectedDataAvailable: false,
+            sceneStates: ["background"]
+        )
+
+        XCTAssertEqual(
+            summary,
+            "pid=42 refresh=denied lowPower=true thermal=serious protectedData=false scenes=background"
+        )
+    }
+
     func testBackgroundNotificationClassifierRejectsTelemetryAndCeaseControls() {
         let normal = makeMessage(idByte: 0x11, incoming: true)
         let telemetry = makeMessage(

--- a/Tests/ColumbaAppTests/BackgroundPropagationSyncTests.swift
+++ b/Tests/ColumbaAppTests/BackgroundPropagationSyncTests.swift
@@ -222,6 +222,36 @@ final class BackgroundPropagationSyncTests: XCTestCase {
         XCTAssertEqual(afterRelease, ["normal"])
     }
 
+    func testFailedPropagationNodeRestoreRollsBackBeforeEveryInitializationRetry() async {
+        var backendRunning = false
+        var starts = 0
+        var rollbacks = 0
+
+        for _ in 0..<5 {
+            if !backendRunning {
+                backendRunning = true
+                starts += 1
+            }
+
+            do {
+                try await PropagationNodeRestoreReadiness.validate(
+                    reapplied: false,
+                    rollback: {
+                        backendRunning = false
+                        rollbacks += 1
+                    }
+                )
+                XCTFail("Failed propagation-node restoration must not report readiness")
+            } catch {
+                XCTAssertEqual(error as? AppServicesError, .propagationNodeRestoreFailed)
+            }
+            XCTAssertFalse(backendRunning)
+        }
+
+        XCTAssertEqual(starts, 5)
+        XCTAssertEqual(rollbacks, 5)
+    }
+
     func testWorkflowNotifiesEachMessageInsertedDuringSuccessfulSync() async {
         var events: [String] = []
         let workflow = BackgroundPropagationSyncWorkflow<String>(

--- a/Tests/ColumbaAppTests/BackgroundPropagationSyncTests.swift
+++ b/Tests/ColumbaAppTests/BackgroundPropagationSyncTests.swift
@@ -106,7 +106,8 @@ final class BackgroundPropagationSyncTests: XCTestCase {
         try await repository.saveMessage(makeMessage(idByte: 0x22, incoming: true))
         try await repository.saveMessage(makeMessage(idByte: 0x23, incoming: false))
 
-        XCTAssertEqual(try await repository.totalUnreadCount(), 2)
+        let unreadCount = try await repository.totalUnreadCount()
+        XCTAssertEqual(unreadCount, 2)
     }
 
     func testNotificationBadgeUsesDurableUnreadCount() {

--- a/Tests/ColumbaAppTests/BackgroundPropagationSyncTests.swift
+++ b/Tests/ColumbaAppTests/BackgroundPropagationSyncTests.swift
@@ -263,7 +263,7 @@ final class BackgroundPropagationSyncTests: XCTestCase {
         XCTAssertEqual(task.completions, [true])
     }
 
-    func testExpirationCompletesTaskOnceAndSuppressesLateSuccess() async {
+    func testExpirationWaitsForOperationCleanupThenCompletesOnceAndSuppressesLateSuccess() async {
         let coordinator = BackgroundRefreshTaskCoordinator()
         let task = FakeBackgroundRefreshTask()
         let gate = AsyncGate()
@@ -275,8 +275,11 @@ final class BackgroundPropagationSyncTests: XCTestCase {
         coordinator.receive(task)
 
         task.expirationHandler?()
-        await task.waitForCompletion()
+        await Task.yield()
+        XCTAssertTrue(task.completions.isEmpty)
+
         gate.open()
+        await task.waitForCompletion()
         await Task.yield()
 
         XCTAssertEqual(task.completions, [false])

--- a/Tests/ColumbaAppTests/BackgroundPropagationSyncTests.swift
+++ b/Tests/ColumbaAppTests/BackgroundPropagationSyncTests.swift
@@ -35,6 +35,17 @@ final class BackgroundPropagationSyncTests: XCTestCase {
         )
     }
 
+    func testIOSBackgroundRefreshIsTheOnlyPeriodicSyncScheduler() {
+        let manager = PropagationNodeManager(appServices: AppServices())
+        manager.periodicSyncEnabled = true
+        manager.syncInterval = 900
+
+        manager.startPeriodicSync()
+        defer { manager.stopPeriodicSync() }
+
+        XCTAssertFalse(manager.hasInProcessPeriodicSyncTaskForTesting)
+    }
+
     func testNormalNotificationPolicyHonorsEnabledAndFavoritesOnlySettings() {
         let suiteName = "BackgroundPropagationSyncTests-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
@@ -79,6 +90,28 @@ final class BackgroundPropagationSyncTests: XCTestCase {
         let messages = try await repository.fetchIncomingMessagesInserted(after: cursor)
 
         XCTAssertEqual(messages.map(\.hash), [newInbound.hash])
+    }
+
+    func testRepositoryTotalUnreadCountIgnoresNotificationHistory() async throws {
+        let databaseURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("columba-bg-badge-\(UUID().uuidString).sqlite")
+        defer {
+            try? FileManager.default.removeItem(at: databaseURL)
+            try? FileManager.default.removeItem(atPath: databaseURL.path + "-shm")
+            try? FileManager.default.removeItem(atPath: databaseURL.path + "-wal")
+        }
+
+        let repository = try MessageRepository(grdbPath: databaseURL.path)
+        try await repository.saveMessage(makeMessage(idByte: 0x21, incoming: true))
+        try await repository.saveMessage(makeMessage(idByte: 0x22, incoming: true))
+        try await repository.saveMessage(makeMessage(idByte: 0x23, incoming: false))
+
+        XCTAssertEqual(try await repository.totalUnreadCount(), 2)
+    }
+
+    func testNotificationBadgeUsesDurableUnreadCount() {
+        XCTAssertEqual(NotificationService.badgeValue(totalUnreadCount: 3), NSNumber(value: 3))
+        XCTAssertEqual(NotificationService.badgeValue(totalUnreadCount: -1), NSNumber(value: 0))
     }
 
     func testBackgroundNotificationClassifierRejectsTelemetryAndCeaseControls() {

--- a/Tests/ColumbaAppTests/BackgroundPropagationSyncTests.swift
+++ b/Tests/ColumbaAppTests/BackgroundPropagationSyncTests.swift
@@ -201,6 +201,24 @@ final class BackgroundPropagationSyncTests: XCTestCase {
         XCTAssertTrue(identifiers.contains(BackgroundPropagationRefreshScheduler.taskIdentifier))
     }
 
+    func testHostEventGateKeepsNormalDrainOutsideBackgroundTransaction() async {
+        let gate = PythonHostEventProcessingGate()
+        let events = EventRecorder()
+
+        XCTAssertTrue(await gate.beginExclusive())
+        let normalDrain = Task {
+            guard await gate.beginNormal() else { return }
+            await events.append("normal")
+            await gate.endNormal()
+        }
+        try? await Task.sleep(for: .milliseconds(20))
+        XCTAssertEqual(await events.values, [])
+
+        await gate.endExclusive()
+        await normalDrain.value
+        XCTAssertEqual(await events.values, ["normal"])
+    }
+
     func testWorkflowNotifiesEachMessageInsertedDuringSuccessfulSync() async {
         var events: [String] = []
         let workflow = BackgroundPropagationSyncWorkflow<String>(
@@ -309,11 +327,19 @@ final class BackgroundPropagationSyncTests: XCTestCase {
     }
 }
 
-@MainActor
+private actor EventRecorder {
+    private(set) var values: [String] = []
+
+    func append(_ value: String) {
+        values.append(value)
+    }
+}
+
 private final class FakeBackgroundRefreshTask: BackgroundRefreshTaskHandle {
     var expirationHandler: (() -> Void)?
     private(set) var completions: [Bool] = []
     private var continuation: CheckedContinuation<Void, Never>?
+    var isCompleted: Bool { !completions.isEmpty }
 
     func setTaskCompleted(success: Bool) {
         completions.append(success)

--- a/Tests/ColumbaAppTests/BackgroundPropagationSyncTests.swift
+++ b/Tests/ColumbaAppTests/BackgroundPropagationSyncTests.swift
@@ -4,6 +4,7 @@
 //
 
 import XCTest
+import RNSAPI
 @testable import ColumbaApp
 
 @MainActor
@@ -32,6 +33,52 @@ final class BackgroundPropagationSyncTests: XCTestCase {
             ),
             30 * 60
         )
+    }
+
+    func testNormalNotificationPolicyHonorsEnabledAndFavoritesOnlySettings() {
+        let suiteName = "BackgroundPropagationSyncTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(false, forKey: "notifications_enabled")
+        XCTAssertFalse(NotificationService.shouldPostMessageNotification(isFavorite: true, defaults: defaults))
+
+        defaults.set(true, forKey: "notifications_enabled")
+        defaults.set(true, forKey: "notify_received_message")
+        defaults.set(true, forKey: "notify_received_message_favorite")
+        XCTAssertFalse(NotificationService.shouldPostMessageNotification(isFavorite: false, defaults: defaults))
+        XCTAssertTrue(NotificationService.shouldPostMessageNotification(isFavorite: true, defaults: defaults))
+
+        defaults.set(false, forKey: "notify_received_message_favorite")
+        XCTAssertTrue(NotificationService.shouldPostMessageNotification(isFavorite: false, defaults: defaults))
+
+        defaults.set(false, forKey: "notify_received_message")
+        XCTAssertFalse(NotificationService.shouldPostMessageNotification(isFavorite: true, defaults: defaults))
+    }
+
+    func testRepositoryInsertionCursorReturnsOnlyNewInboundMessages() async throws {
+        let databaseURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("columba-bg-sync-\(UUID().uuidString).sqlite")
+        defer {
+            try? FileManager.default.removeItem(at: databaseURL)
+            try? FileManager.default.removeItem(atPath: databaseURL.path + "-shm")
+            try? FileManager.default.removeItem(atPath: databaseURL.path + "-wal")
+        }
+
+        let repository = try MessageRepository(grdbPath: databaseURL.path)
+        let oldMessage = makeMessage(idByte: 0x01, incoming: true)
+        try await repository.saveMessage(oldMessage)
+        let cursor = try await repository.captureMessageInsertionCursor()
+
+        try await repository.saveMessage(oldMessage)
+        let newInbound = makeMessage(idByte: 0x02, incoming: true)
+        let newOutbound = makeMessage(idByte: 0x03, incoming: false)
+        try await repository.saveMessage(newInbound)
+        try await repository.saveMessage(newOutbound)
+
+        let messages = try await repository.fetchIncomingMessagesInserted(after: cursor)
+
+        XCTAssertEqual(messages.map(\.hash), [newInbound.hash])
     }
 
     func testWorkflowNotifiesEachMessageInsertedDuringSuccessfulSync() async {
@@ -113,6 +160,24 @@ final class BackgroundPropagationSyncTests: XCTestCase {
         await Task.yield()
 
         XCTAssertEqual(task.completions, [false])
+    }
+
+    private func makeMessage(idByte: UInt8, incoming: Bool) -> LXMessage {
+        let message = LXMessage(
+            destinationHash: Data(repeating: 0xDD, count: 16),
+            sourceIdentity: nil,
+            content: Data("message-\(idByte)".utf8),
+            title: Data(),
+            fields: nil,
+            desiredMethod: incoming ? .propagated : .direct
+        )
+        message.sourceHash = Data(repeating: 0xAA, count: 16)
+        message.hash = Data(repeating: idByte, count: 16)
+        message.timestamp = Date().timeIntervalSince1970
+        message.incoming = incoming
+        message.state = incoming ? .received : .sent
+        message.method = incoming ? .propagated : .direct
+        return message
     }
 }
 

--- a/Tests/ColumbaAppTests/BackgroundPropagationSyncTests.swift
+++ b/Tests/ColumbaAppTests/BackgroundPropagationSyncTests.swift
@@ -1,0 +1,153 @@
+//
+//  BackgroundPropagationSyncTests.swift
+//  ColumbaAppTests
+//
+
+import XCTest
+@testable import ColumbaApp
+
+@MainActor
+final class BackgroundPropagationSyncTests: XCTestCase {
+    func testSchedulePolicyDisablesRefreshWhenPeriodicSyncIsOff() {
+        XCTAssertNil(
+            BackgroundPropagationSchedulePolicy.nextDelay(
+                periodicSyncEnabled: false,
+                userInterval: 3_600
+            )
+        )
+    }
+
+    func testSchedulePolicyFloorsUserIntervalAtFifteenMinutes() {
+        XCTAssertEqual(
+            BackgroundPropagationSchedulePolicy.nextDelay(
+                periodicSyncEnabled: true,
+                userInterval: 60
+            ),
+            15 * 60
+        )
+        XCTAssertEqual(
+            BackgroundPropagationSchedulePolicy.nextDelay(
+                periodicSyncEnabled: true,
+                userInterval: 30 * 60
+            ),
+            30 * 60
+        )
+    }
+
+    func testWorkflowNotifiesEachMessageInsertedDuringSuccessfulSync() async {
+        var events: [String] = []
+        let workflow = BackgroundPropagationSyncWorkflow<String>(
+            captureInsertionCursor: {
+                events.append("capture")
+                return 42
+            },
+            sync: {
+                events.append("sync")
+                return true
+            },
+            messagesInsertedAfter: { cursor in
+                events.append("load:\(cursor)")
+                return ["first", "second"]
+            },
+            notify: { message in
+                events.append("notify:\(message)")
+            }
+        )
+
+        let succeeded = await workflow.run()
+
+        XCTAssertTrue(succeeded)
+        XCTAssertEqual(
+            events,
+            ["capture", "sync", "load:42", "notify:first", "notify:second"]
+        )
+    }
+
+    func testWorkflowDoesNotLoadOrNotifyWhenSyncFails() async {
+        var loaded = false
+        var notified = false
+        let workflow = BackgroundPropagationSyncWorkflow<String>(
+            captureInsertionCursor: { 7 },
+            sync: { false },
+            messagesInsertedAfter: { _ in
+                loaded = true
+                return ["unexpected"]
+            },
+            notify: { _ in notified = true }
+        )
+
+        let succeeded = await workflow.run()
+
+        XCTAssertFalse(succeeded)
+        XCTAssertFalse(loaded)
+        XCTAssertFalse(notified)
+    }
+
+    func testTaskReceivedBeforeHandlerRunsAfterHandlerInstallation() async {
+        let coordinator = BackgroundRefreshTaskCoordinator()
+        let task = FakeBackgroundRefreshTask()
+
+        coordinator.receive(task)
+        XCTAssertTrue(task.completions.isEmpty)
+
+        coordinator.installHandler { true }
+        await task.waitForCompletion()
+
+        XCTAssertEqual(task.completions, [true])
+    }
+
+    func testExpirationCompletesTaskOnceAndSuppressesLateSuccess() async {
+        let coordinator = BackgroundRefreshTaskCoordinator()
+        let task = FakeBackgroundRefreshTask()
+        let gate = AsyncGate()
+
+        coordinator.installHandler {
+            await gate.wait()
+            return true
+        }
+        coordinator.receive(task)
+
+        task.expirationHandler?()
+        await task.waitForCompletion()
+        gate.open()
+        await Task.yield()
+
+        XCTAssertEqual(task.completions, [false])
+    }
+}
+
+@MainActor
+private final class FakeBackgroundRefreshTask: BackgroundRefreshTaskHandle {
+    var expirationHandler: (() -> Void)?
+    private(set) var completions: [Bool] = []
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func setTaskCompleted(success: Bool) {
+        completions.append(success)
+        continuation?.resume()
+        continuation = nil
+    }
+
+    func waitForCompletion() async {
+        if !completions.isEmpty { return }
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+}
+
+@MainActor
+private final class AsyncGate {
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func wait() async {
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func open() {
+        continuation?.resume()
+        continuation = nil
+    }
+}

--- a/Tests/static/test_background_refresh_wiring.py
+++ b/Tests/static/test_background_refresh_wiring.py
@@ -6,6 +6,20 @@ ROOT = Path(__file__).resolve().parents[2]
 APP = ROOT / "Sources" / "ColumbaApp"
 
 
+def closure_body(source: str, marker: str, start: int = 0):
+    marker_index = source.index(marker, start)
+    open_brace = source.index("{", marker_index)
+    depth = 0
+    for index in range(open_brace, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[open_brace + 1:index], open_brace, index
+    raise AssertionError(f"Unterminated Swift closure after {marker}")
+
+
 class BackgroundRefreshWiringContractTests(unittest.TestCase):
     def test_registration_precedes_embedded_python_start(self):
         source = (APP / "App" / "ColumbaApp.swift").read_text()
@@ -28,11 +42,49 @@ class BackgroundRefreshWiringContractTests(unittest.TestCase):
         self.assertIn("await backend.stop()", start)
         self.assertIn("self?.backend = nil", start)
         self.assertIn("PropagationNodeRestoreReadiness.validate", start)
-        self.assertEqual(services.count("InitializationLifecycleActivation.run("), 2)
-        for segment in services.split("InitializationLifecycleActivation.run(")[1:]:
+        initialization = services[
+            services.index("private func initializeUnlocked(tcpServerAddress"):
+            services.index("// MARK: - State Observation")
+        ]
+        self.assertEqual(initialization.count("InitializationLifecycleActivation.run("), 2)
+
+        activation_ranges = []
+        search_from = 0
+        for _ in range(2):
+            run = initialization.index("InitializationLifecycleActivation.run(", search_from)
+            body, body_start, body_end = closure_body(initialization, "activate:", run)
+            readiness = initialization[run:initialization.index("activate:", run)]
             self.assertLess(
-                segment.index("startPythonBackend("),
-                segment.index("propManager.startListening()"),
+                readiness.index("startPythonBackend("),
+                initialization[run:body_start].index("activate:"),
+            )
+            for required in (
+                "propManager.startListening()",
+                "propManager.startPeriodicSync()",
+                "announceManager.start()",
+            ):
+                self.assertIn(required, body)
+            activation_ranges.append((body_start, body_end))
+            search_from = body_end
+
+        for activation in (
+            "propManager.startListening()",
+            "propManager.startPeriodicSync()",
+            "announceManager.start()",
+        ):
+            self.assertEqual(initialization.count(activation), 2)
+            positions = []
+            offset = 0
+            while True:
+                position = initialization.find(activation, offset)
+                if position < 0:
+                    break
+                positions.append(position)
+                offset = position + 1
+            self.assertTrue(
+                all(any(begin < position < end for begin, end in activation_ranges)
+                    for position in positions),
+                f"{activation} must occur only inside readiness-gated activation closures",
             )
 
     def test_service_initialization_cannot_erase_cold_launch_evidence(self):

--- a/Tests/static/test_background_refresh_wiring.py
+++ b/Tests/static/test_background_refresh_wiring.py
@@ -17,6 +17,46 @@ class BackgroundRefreshWiringContractTests(unittest.TestCase):
         source = (APP / "Services" / "AppServices.swift").read_text()
         self.assertNotIn("DiagLog.clear()", source)
 
+    def test_background_workflow_awaits_shared_initialization_instead_of_polling(self):
+        app = (APP / "App" / "ColumbaApp.swift").read_text()
+        background = app[
+            app.index("private func performBackgroundPropagationSync"):
+            app.index("// MARK: - Initialization")
+        ]
+        self.assertIn("await ensureServicesInitialized()", background)
+        self.assertNotIn("for _ in 0..<100", background)
+
+    def test_python_event_drain_starts_only_after_incoming_handler_installation(self):
+        app = (APP / "App" / "ColumbaApp.swift").read_text()
+        services = (APP / "Services" / "AppServices.swift").read_text()
+        delegate_install = app.index("await router.setDelegate(handler)")
+        drain_start = app.index("appServices.startPythonEventDrain()")
+        self.assertLess(delegate_install, drain_start)
+
+        backend_start = services.index("private func startPythonBackend(")
+        drain_method = services.index("func startPythonEventDrain()")
+        self.assertNotIn("pythonEventTask = Task", services[backend_start:drain_method])
+
+    def test_scheduling_preserves_an_accepted_pending_request(self):
+        source = (APP / "Services" / "BackgroundPropagationSync.swift").read_text()
+        schedule = source[
+            source.index("static func scheduleFromCurrentSettings") :
+            source.index("static func logRuntime")
+        ]
+        self.assertIn("getPendingTaskRequests", schedule)
+        self.assertIn("preserving existing pending request", schedule)
+        self.assertNotIn(
+            "cancel(taskRequestWithIdentifier: taskIdentifier)\n        guard let delay",
+            schedule,
+        )
+
+    def test_badge_is_not_cleared_while_durable_unread_rows_remain(self):
+        app = (APP / "App" / "ColumbaApp.swift").read_text()
+        messaging = (APP / "ViewModels" / "MessagingViewModel.swift").read_text()
+        self.assertNotIn("NotificationService.shared.clearBadge()", app)
+        self.assertIn("synchronizeBadgeWithDurableUnreadCount", app)
+        self.assertIn("synchronizeBadgeWithDurableUnreadCount", messaging)
+
     def test_built_source_declares_refresh_identifier_and_fetch_mode(self):
         plist = (APP / "Resources" / "Info.plist").read_text()
         self.assertIn("BGTaskSchedulerPermittedIdentifiers", plist)

--- a/Tests/static/test_background_refresh_wiring.py
+++ b/Tests/static/test_background_refresh_wiring.py
@@ -28,6 +28,12 @@ class BackgroundRefreshWiringContractTests(unittest.TestCase):
         self.assertIn("await backend.stop()", start)
         self.assertIn("self?.backend = nil", start)
         self.assertIn("PropagationNodeRestoreReadiness.validate", start)
+        self.assertEqual(services.count("InitializationLifecycleActivation.run("), 2)
+        for segment in services.split("InitializationLifecycleActivation.run(")[1:]:
+            self.assertLess(
+                segment.index("startPythonBackend("),
+                segment.index("propManager.startListening()"),
+            )
 
     def test_service_initialization_cannot_erase_cold_launch_evidence(self):
         source = (APP / "Services" / "AppServices.swift").read_text()

--- a/Tests/static/test_background_refresh_wiring.py
+++ b/Tests/static/test_background_refresh_wiring.py
@@ -13,6 +13,19 @@ class BackgroundRefreshWiringContractTests(unittest.TestCase):
         python_start = source.index("PythonRuntime.shared.start()")
         self.assertLess(registration, python_start)
 
+    def test_launch_safe_runtime_installs_workflow_outside_root_view_task(self):
+        source = (APP / "App" / "ColumbaApp.swift").read_text()
+        app_init = source[source.index("struct ColumbaApp: App"):source.index("// MARK: - App Body")]
+        root_view = source[source.index("struct RootView: View"):]
+        self.assertIn("ColumbaApplicationRuntime.shared.installBackgroundHandler()", app_init)
+        self.assertNotIn("BackgroundRefreshTaskCoordinator.shared.installHandler", root_view)
+
+    def test_embedded_backend_start_failure_propagates_to_readiness(self):
+        services = (APP / "Services" / "AppServices.swift").read_text()
+        start = services[services.index("private func startPythonBackend("):]
+        self.assertIn(") async throws {", start[:500])
+        self.assertIn("self.backend = nil\n            throw error", start)
+
     def test_service_initialization_cannot_erase_cold_launch_evidence(self):
         source = (APP / "Services" / "AppServices.swift").read_text()
         self.assertNotIn("DiagLog.clear()", source)
@@ -66,8 +79,10 @@ class BackgroundRefreshWiringContractTests(unittest.TestCase):
     def test_background_sync_uses_immediate_local_notification_and_badge(self):
         notifications = (APP / "Services" / "NotificationService.swift").read_text()
         incoming = (APP / "Services" / "IncomingMessageHandler.swift").read_text()
-        self.assertIn("trigger: nil // Deliver immediately", notifications)
+        self.assertIn("trigger: nil", notifications)
         self.assertIn("content.badge = Self.badgeValue(totalUnreadCount:", notifications)
+        self.assertIn("await acquireBadgeMutation()", notifications)
+        self.assertIn("messageRepository.totalUnreadCount()", notifications)
         self.assertIn("postNotificationForNewlySyncedMessage", incoming)
         self.assertNotIn("deliveredNotifications().count", notifications)
 

--- a/Tests/static/test_background_refresh_wiring.py
+++ b/Tests/static/test_background_refresh_wiring.py
@@ -6,6 +6,103 @@ ROOT = Path(__file__).resolve().parents[2]
 APP = ROOT / "Sources" / "ColumbaApp"
 
 
+def strip_swift_noncode(source: str) -> str:
+    """Blank Swift comments and string literals while preserving positions/newlines."""
+    output = list(source)
+
+    def blank(index: int):
+        if output[index] != "\n":
+            output[index] = " "
+
+    index = 0
+    state = "code"
+    block_depth = 0
+    string_hashes = 0
+    multiline = False
+    while index < len(source):
+        if state == "line_comment":
+            if source[index] == "\n":
+                state = "code"
+            else:
+                blank(index)
+            index += 1
+            continue
+
+        if state == "block_comment":
+            if source.startswith("/*", index):
+                blank(index)
+                blank(index + 1)
+                block_depth += 1
+                index += 2
+            elif source.startswith("*/", index):
+                blank(index)
+                blank(index + 1)
+                block_depth -= 1
+                index += 2
+                if block_depth == 0:
+                    state = "code"
+            else:
+                blank(index)
+                index += 1
+            continue
+
+        if state == "string":
+            delimiter = ('"""' if multiline else '"') + ("#" * string_hashes)
+            if source.startswith(delimiter, index):
+                for position in range(index, index + len(delimiter)):
+                    blank(position)
+                index += len(delimiter)
+                state = "code"
+            elif not multiline and string_hashes == 0 and source[index] == "\\":
+                blank(index)
+                index += 1
+                if index < len(source):
+                    blank(index)
+                    index += 1
+            else:
+                blank(index)
+                index += 1
+            continue
+
+        if source.startswith("//", index):
+            blank(index)
+            blank(index + 1)
+            state = "line_comment"
+            index += 2
+        elif source.startswith("/*", index):
+            blank(index)
+            blank(index + 1)
+            state = "block_comment"
+            block_depth = 1
+            index += 2
+        elif source[index] == '"':
+            multiline = source.startswith('"""', index)
+            length = 3 if multiline else 1
+            for position in range(index, index + length):
+                blank(position)
+            string_hashes = 0
+            state = "string"
+            index += length
+        elif source[index] == "#":
+            end = index
+            while end < len(source) and source[end] == "#":
+                end += 1
+            if end < len(source) and source[end] == '"':
+                string_hashes = end - index
+                multiline = source.startswith('"""', end)
+                length = string_hashes + (3 if multiline else 1)
+                for position in range(index, index + length):
+                    blank(position)
+                state = "string"
+                index += length
+            else:
+                index += 1
+        else:
+            index += 1
+
+    return "".join(output)
+
+
 class BackgroundRefreshWiringContractTests(unittest.TestCase):
     def test_registration_precedes_embedded_python_start(self):
         source = (APP / "App" / "ColumbaApp.swift").read_text()
@@ -21,7 +118,9 @@ class BackgroundRefreshWiringContractTests(unittest.TestCase):
         self.assertNotIn("BackgroundRefreshTaskCoordinator.shared.installHandler", root_view)
 
     def test_embedded_backend_start_failure_propagates_to_readiness(self):
-        services = (APP / "Services" / "AppServices.swift").read_text()
+        services = strip_swift_noncode(
+            (APP / "Services" / "AppServices.swift").read_text()
+        )
         start = services[services.index("private func startPythonBackend("):]
         self.assertIn(") async throws {", start[:500])
         self.assertIn("self.backend = nil\n            throw error", start)
@@ -49,13 +148,25 @@ class BackgroundRefreshWiringContractTests(unittest.TestCase):
             self.assertNotIn("announceManager.start()", path)
 
         self.assertEqual(services.count("activateInitializationManagers(propManager)"), 2)
-        helper = services[helper_start:services.index("// MARK: - State Observation")]
+        helper_end = services.index("private func startStateObserver()")
+        helper = services[helper_start:helper_end]
         for activation in (
             "propManager.startListening()",
             "propManager.startPeriodicSync()",
             "announceManager.start()",
         ):
             self.assertEqual(helper.count(activation), 1)
+
+    def test_swift_noncode_stripping_rejects_fake_wiring(self):
+        fake = '''
+        /* activate: { self.activateInitializationManagers(propManager) } */
+        // self.activateInitializationManagers(propManager)
+        "self.activateInitializationManagers(propManager)"
+        #"self.activateInitializationManagers(propManager)"#
+        activate: { self.activateInitializationManagers(propManager) }
+        '''
+        stripped = strip_swift_noncode(fake)
+        self.assertEqual(stripped.count("activateInitializationManagers"), 1)
 
     def test_service_initialization_cannot_erase_cold_launch_evidence(self):
         source = (APP / "Services" / "AppServices.swift").read_text()

--- a/Tests/static/test_background_refresh_wiring.py
+++ b/Tests/static/test_background_refresh_wiring.py
@@ -6,20 +6,6 @@ ROOT = Path(__file__).resolve().parents[2]
 APP = ROOT / "Sources" / "ColumbaApp"
 
 
-def closure_body(source: str, marker: str, start: int = 0):
-    marker_index = source.index(marker, start)
-    open_brace = source.index("{", marker_index)
-    depth = 0
-    for index in range(open_brace, len(source)):
-        if source[index] == "{":
-            depth += 1
-        elif source[index] == "}":
-            depth -= 1
-            if depth == 0:
-                return source[open_brace + 1:index], open_brace, index
-    raise AssertionError(f"Unterminated Swift closure after {marker}")
-
-
 class BackgroundRefreshWiringContractTests(unittest.TestCase):
     def test_registration_precedes_embedded_python_start(self):
         source = (APP / "App" / "ColumbaApp.swift").read_text()
@@ -42,50 +28,34 @@ class BackgroundRefreshWiringContractTests(unittest.TestCase):
         self.assertIn("await backend.stop()", start)
         self.assertIn("self?.backend = nil", start)
         self.assertIn("PropagationNodeRestoreReadiness.validate", start)
-        initialization = services[
-            services.index("private func initializeUnlocked(tcpServerAddress"):
-            services.index("// MARK: - State Observation")
-        ]
-        self.assertEqual(initialization.count("InitializationLifecycleActivation.run("), 2)
+        first_start = services.index("private func initializeUnlocked(tcpServerAddress")
+        second_start = services.index("private func initializeUnlocked(\n        identity:")
+        helper_start = services.index("private func activateInitializationManagers(")
+        initialization_paths = (
+            services[first_start:second_start],
+            services[second_start:helper_start],
+        )
+        gated_call = (
+            "activate: {\n"
+            "                self.activateInitializationManagers(propManager)\n"
+            "            }"
+        )
+        for path in initialization_paths:
+            self.assertEqual(path.count("InitializationLifecycleActivation.run("), 1)
+            self.assertEqual(path.count(gated_call), 1)
+            self.assertLess(path.index("startPythonBackend("), path.index(gated_call))
+            self.assertNotIn("propManager.startListening()", path)
+            self.assertNotIn("propManager.startPeriodicSync()", path)
+            self.assertNotIn("announceManager.start()", path)
 
-        activation_ranges = []
-        search_from = 0
-        for _ in range(2):
-            run = initialization.index("InitializationLifecycleActivation.run(", search_from)
-            body, body_start, body_end = closure_body(initialization, "activate:", run)
-            readiness = initialization[run:initialization.index("activate:", run)]
-            self.assertLess(
-                readiness.index("startPythonBackend("),
-                initialization[run:body_start].index("activate:"),
-            )
-            for required in (
-                "propManager.startListening()",
-                "propManager.startPeriodicSync()",
-                "announceManager.start()",
-            ):
-                self.assertIn(required, body)
-            activation_ranges.append((body_start, body_end))
-            search_from = body_end
-
+        self.assertEqual(services.count("activateInitializationManagers(propManager)"), 2)
+        helper = services[helper_start:services.index("// MARK: - State Observation")]
         for activation in (
             "propManager.startListening()",
             "propManager.startPeriodicSync()",
             "announceManager.start()",
         ):
-            self.assertEqual(initialization.count(activation), 2)
-            positions = []
-            offset = 0
-            while True:
-                position = initialization.find(activation, offset)
-                if position < 0:
-                    break
-                positions.append(position)
-                offset = position + 1
-            self.assertTrue(
-                all(any(begin < position < end for begin, end in activation_ranges)
-                    for position in positions),
-                f"{activation} must occur only inside readiness-gated activation closures",
-            )
+            self.assertEqual(helper.count(activation), 1)
 
     def test_service_initialization_cannot_erase_cold_launch_evidence(self):
         source = (APP / "Services" / "AppServices.swift").read_text()

--- a/Tests/static/test_background_refresh_wiring.py
+++ b/Tests/static/test_background_refresh_wiring.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+APP = ROOT / "Sources" / "ColumbaApp"
+
+
+class BackgroundRefreshWiringContractTests(unittest.TestCase):
+    def test_registration_precedes_embedded_python_start(self):
+        source = (APP / "App" / "ColumbaApp.swift").read_text()
+        registration = source.index("BackgroundPropagationRefreshScheduler.register()")
+        python_start = source.index("PythonRuntime.shared.start()")
+        self.assertLess(registration, python_start)
+
+    def test_service_initialization_cannot_erase_cold_launch_evidence(self):
+        source = (APP / "Services" / "AppServices.swift").read_text()
+        self.assertNotIn("DiagLog.clear()", source)
+
+    def test_built_source_declares_refresh_identifier_and_fetch_mode(self):
+        plist = (APP / "Resources" / "Info.plist").read_text()
+        self.assertIn("BGTaskSchedulerPermittedIdentifiers", plist)
+        self.assertIn("network.columba.Columba.sync", plist)
+        self.assertIn("<string>fetch</string>", plist)
+
+    def test_background_sync_uses_immediate_local_notification_and_badge(self):
+        notifications = (APP / "Services" / "NotificationService.swift").read_text()
+        incoming = (APP / "Services" / "IncomingMessageHandler.swift").read_text()
+        self.assertIn("trigger: nil // Deliver immediately", notifications)
+        self.assertIn("content.badge = Self.badgeValue(totalUnreadCount:", notifications)
+        self.assertIn("postNotificationForNewlySyncedMessage", incoming)
+        self.assertNotIn("deliveredNotifications().count", notifications)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tests/static/test_background_refresh_wiring.py
+++ b/Tests/static/test_background_refresh_wiring.py
@@ -25,6 +25,9 @@ class BackgroundRefreshWiringContractTests(unittest.TestCase):
         start = services[services.index("private func startPythonBackend("):]
         self.assertIn(") async throws {", start[:500])
         self.assertIn("self.backend = nil\n            throw error", start)
+        self.assertIn("await backend.stop()", start)
+        self.assertIn("self?.backend = nil", start)
+        self.assertIn("PropagationNodeRestoreReadiness.validate", start)
 
     def test_service_initialization_cannot_erase_cold_launch_evidence(self):
         source = (APP / "Services" / "AppServices.swift").read_text()

--- a/Tests/static/test_background_refresh_wiring.py
+++ b/Tests/static/test_background_refresh_wiring.py
@@ -19,6 +19,15 @@ def strip_swift_noncode(source: str) -> str:
     block_depth = 0
     string_hashes = 0
     multiline = False
+
+    def is_escaped(position: int) -> bool:
+        backslashes = 0
+        position -= 1
+        while position >= 0 and source[position] == "\\":
+            backslashes += 1
+            position -= 1
+        return backslashes % 2 == 1
+
     while index < len(source):
         if state == "line_comment":
             if source[index] == "\n":
@@ -48,7 +57,9 @@ def strip_swift_noncode(source: str) -> str:
 
         if state == "string":
             delimiter = ('"""' if multiline else '"') + ("#" * string_hashes)
-            if source.startswith(delimiter, index):
+            if source.startswith(delimiter, index) and not (
+                multiline and string_hashes == 0 and is_escaped(index)
+            ):
                 for position in range(index, index + len(delimiter)):
                     blank(position)
                 index += len(delimiter)
@@ -163,6 +174,10 @@ class BackgroundRefreshWiringContractTests(unittest.TestCase):
         // self.activateInitializationManagers(propManager)
         "self.activateInitializationManagers(propManager)"
         #"self.activateInitializationManagers(propManager)"#
+        """
+        escaped delimiter: \"""
+        self.activateInitializationManagers(propManager)
+        """
         activate: { self.activateInitializationManagers(propManager) }
         '''
         stripped = strip_swift_noncode(fake)

--- a/Tests/static/test_propagation_sync_cancellation.py
+++ b/Tests/static/test_propagation_sync_cancellation.py
@@ -1,0 +1,118 @@
+import ast
+import threading
+import time
+import types
+import unittest
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[2]
+BRIDGE = ROOT / "app" / "rns_bridge.py"
+
+
+class FakeRouter:
+    def __init__(self, state: int):
+        self.outbound_propagation_node = object()
+        self.propagation_transfer_state = state
+        self.propagation_transfer_last_result = 0
+        self.requests = 0
+        self.cancelled = 0
+        self.requested = threading.Event()
+
+    def request_messages_from_propagation_node(self, _identity):
+        self.requests += 1
+        self.requested.set()
+
+    def cancel_propagation_node_requests(self):
+        self.cancelled += 1
+
+
+class PropagationSyncCancellationTests(unittest.TestCase):
+    def load_functions(self, router: FakeRouter):
+        tree = ast.parse(BRIDGE.read_text(encoding="utf-8"))
+        functions: list[ast.stmt] = [
+            node
+            for node in tree.body
+            if isinstance(node, ast.FunctionDef)
+            and node.name in {
+                "propagation_sync",
+                "cancel_propagation_sync",
+                "_propagation_state_name",
+            }
+        ]
+        router_type = types.SimpleNamespace(
+            PR_COMPLETE=5,
+            PR_NO_PATH=6,
+            PR_TRANSFER_FAILED=7,
+            PR_PATH_REQUESTED=1,
+            PR_LINK_ESTABLISHING=2,
+            PR_LINK_ESTABLISHED=3,
+            PR_REQUEST_SENT=4,
+            PR_RECEIVING=8,
+            PR_RESPONSE_RECEIVED=9,
+        )
+        namespace = {
+            "Any": Any,
+            "LXMF": types.SimpleNamespace(LXMRouter=router_type),
+            "threading": threading,
+            "time": time,
+            "_lock": threading.Lock(),
+            "_propagation_sync_cancellation_lock": threading.Lock(),
+            "_active_propagation_sync_cancellation": None,
+            "_state": {"started": True, "router": router, "identity": object()},
+        }
+        exec(compile(ast.Module(body=functions, type_ignores=[]), str(BRIDGE), "exec"), namespace)
+        return namespace
+
+    def test_late_cancellation_after_completion_does_not_poison_next_sync(self):
+        router = FakeRouter(state=5)
+        bridge = self.load_functions(router)
+
+        self.assertTrue(bridge["propagation_sync"]()["ok"])
+        self.assertEqual(
+            bridge["cancel_propagation_sync"](),
+            {"ok": True, "active": False, "router_cancelled": False},
+        )
+        self.assertTrue(bridge["propagation_sync"]()["ok"])
+        self.assertEqual(router.requests, 2)
+        self.assertEqual(router.cancelled, 0)
+
+    def test_active_cancellation_only_interrupts_current_sync(self):
+        router = FakeRouter(state=0)
+        bridge = self.load_functions(router)
+        result = {}
+        worker = threading.Thread(
+            target=lambda: result.update(bridge["propagation_sync"](timeout=2.0))
+        )
+        worker.start()
+        self.assertTrue(router.requested.wait(timeout=1.0))
+
+        self.assertEqual(
+            bridge["cancel_propagation_sync"](),
+            {"ok": True, "active": True, "router_cancelled": True},
+        )
+        worker.join(timeout=1.5)
+
+        self.assertFalse(worker.is_alive())
+        self.assertEqual(result["state"], "cancelled")
+        self.assertEqual(router.cancelled, 1)
+
+        router.propagation_transfer_state = 5
+        self.assertTrue(bridge["propagation_sync"]()["ok"])
+
+    def test_swift_cancellation_is_scoped_to_the_originating_operation(self):
+        manager = (
+            ROOT / "Sources" / "ColumbaApp" / "Services" / "PropagationNodeManager.swift"
+        ).read_text(encoding="utf-8")
+        app = (
+            ROOT / "Sources" / "ColumbaApp" / "App" / "ColumbaApp.swift"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("activeSyncOperationID == operationID", manager)
+        self.assertIn("cancelActiveSync(operationID: UUID)", manager)
+        self.assertIn("cancelActiveSync(operationID: syncOperationID)", app)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tests/static/test_propagation_sync_cancellation.py
+++ b/Tests/static/test_propagation_sync_cancellation.py
@@ -19,6 +19,8 @@ class FakeRouter:
         self.requests = 0
         self.cancelled = 0
         self.requested = threading.Event()
+        self.cancel_entered = threading.Event()
+        self.cancel_release: threading.Event | None = None
 
     def request_messages_from_propagation_node(self, _identity):
         self.requests += 1
@@ -26,6 +28,9 @@ class FakeRouter:
 
     def cancel_propagation_node_requests(self):
         self.cancelled += 1
+        self.cancel_entered.set()
+        if self.cancel_release is not None:
+            self.cancel_release.wait(timeout=1.0)
 
 
 class PropagationSyncCancellationTests(unittest.TestCase):
@@ -58,7 +63,7 @@ class PropagationSyncCancellationTests(unittest.TestCase):
             "threading": threading,
             "time": time,
             "_lock": threading.Lock(),
-            "_propagation_sync_cancellation_lock": threading.Lock(),
+            "_propagation_sync_cancellation_lock": threading.Condition(),
             "_active_propagation_sync_cancellation": None,
             "_state": {"started": True, "router": router, "identity": object()},
         }
@@ -100,6 +105,42 @@ class PropagationSyncCancellationTests(unittest.TestCase):
 
         router.propagation_transfer_state = 5
         self.assertTrue(bridge["propagation_sync"]()["ok"])
+
+    def test_next_sync_waits_for_router_cancellation_to_finish(self):
+        router = FakeRouter(state=0)
+        router.cancel_release = threading.Event()
+        bridge = self.load_functions(router)
+        first_result = {}
+        first = threading.Thread(
+            target=lambda: first_result.update(bridge["propagation_sync"](timeout=2.0))
+        )
+        first.start()
+        self.assertTrue(router.requested.wait(timeout=1.0))
+
+        cancellation = threading.Thread(target=bridge["cancel_propagation_sync"])
+        cancellation.start()
+        self.assertTrue(router.cancel_entered.wait(timeout=1.0))
+
+        next_result = {}
+        successor = threading.Thread(
+            target=lambda: next_result.update(bridge["propagation_sync"](timeout=2.0))
+        )
+        successor.start()
+        time.sleep(0.1)
+        self.assertEqual(router.requests, 1)
+
+        router.propagation_transfer_state = 5
+        router.cancel_release.set()
+        cancellation.join(timeout=1.0)
+        first.join(timeout=1.0)
+        successor.join(timeout=1.0)
+
+        self.assertFalse(cancellation.is_alive())
+        self.assertFalse(first.is_alive())
+        self.assertFalse(successor.is_alive())
+        self.assertEqual(first_result["state"], "cancelled")
+        self.assertTrue(next_result["ok"])
+        self.assertEqual(router.requests, 2)
 
     def test_swift_cancellation_is_scoped_to_the_originating_operation(self):
         manager = (

--- a/Tests/static/test_propagation_sync_cancellation.py
+++ b/Tests/static/test_propagation_sync_cancellation.py
@@ -43,6 +43,7 @@ class PropagationSyncCancellationTests(unittest.TestCase):
             and node.name in {
                 "propagation_sync",
                 "cancel_propagation_sync",
+                "_cancel_router_propagation_request",
                 "_propagation_state_name",
             }
         ]
@@ -50,6 +51,10 @@ class PropagationSyncCancellationTests(unittest.TestCase):
             PR_COMPLETE=5,
             PR_NO_PATH=6,
             PR_TRANSFER_FAILED=7,
+            PR_LINK_FAILED=10,
+            PR_NO_IDENTITY_RCVD=11,
+            PR_NO_ACCESS=12,
+            PR_FAILED=13,
             PR_PATH_REQUESTED=1,
             PR_LINK_ESTABLISHING=2,
             PR_LINK_ESTABLISHED=3,
@@ -141,6 +146,36 @@ class PropagationSyncCancellationTests(unittest.TestCase):
         self.assertEqual(first_result["state"], "cancelled")
         self.assertTrue(next_result["ok"])
         self.assertEqual(router.requests, 2)
+
+    def test_timeout_cancels_router_before_releasing_operation_slot(self):
+        router = FakeRouter(state=0)
+        bridge = self.load_functions(router)
+
+        result = bridge["propagation_sync"](timeout=0.01)
+
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["reason"], "timeout")
+        self.assertEqual(router.cancelled, 1)
+        self.assertIsNone(bridge["_active_propagation_sync_cancellation"])
+
+    def test_all_pinned_failure_states_are_terminal(self):
+        states = {
+            6: "no_path",
+            7: "transfer_failed",
+            10: "link_failed",
+            11: "no_identity_received",
+            12: "no_access",
+            13: "failed",
+        }
+        for state, expected_name in states.items():
+            with self.subTest(state=state):
+                router = FakeRouter(state=state)
+                bridge = self.load_functions(router)
+                started = time.monotonic()
+                result = bridge["propagation_sync"](timeout=1.0)
+                self.assertLess(time.monotonic() - started, 0.5)
+                self.assertFalse(result["ok"])
+                self.assertEqual(result["state"], expected_name)
 
     def test_swift_cancellation_is_scoped_to_the_originating_operation(self):
         manager = (

--- a/app/rns_bridge.py
+++ b/app/rns_bridge.py
@@ -277,6 +277,7 @@ def _install_native_stamp_generator_unless_stopping() -> bool:
 
 
 _lock = threading.Lock()
+_propagation_sync_cancelled = threading.Event()
 # Teardown publishes intent without waiting for `_lock`, allowing a start that
 # already owns it to reject or undo process-global callback registration.
 _runtime_teardown_requested = threading.Event()
@@ -686,6 +687,10 @@ def propagation_sync(timeout: float = 60.0) -> dict[str, Any]:
 
     Requires set_propagation_node() to have been called with a valid
     `lxmf.propagation` destination first."""
+    if _propagation_sync_cancelled.is_set():
+        _propagation_sync_cancelled.clear()
+        return {"ok": False, "state": "cancelled", "received_messages": 0, "reason": "cancelled"}
+
     with _lock:
         if not _state["started"]:
             return {"ok": False, "state": "not-started", "received_messages": 0, "reason": "not-started"}
@@ -707,6 +712,9 @@ def propagation_sync(timeout: float = 60.0) -> dict[str, Any]:
     deadline = time.monotonic() + timeout
     last_seen_state: Any = None
     while time.monotonic() < deadline:
+        if _propagation_sync_cancelled.is_set():
+            _propagation_sync_cancelled.clear()
+            return {"ok": False, "state": "cancelled", "received_messages": 0, "reason": "cancelled"}
         try:
             state_val = getattr(router, "propagation_transfer_state", None)
             last_seen_state = state_val
@@ -737,6 +745,23 @@ def propagation_sync(timeout: float = 60.0) -> dict[str, Any]:
         "received_messages": received,
         "reason": "ok" if ok else state_name,
     }
+
+
+def cancel_propagation_sync() -> dict[str, Any]:
+    """Cancel an active bounded propagation-node request and its polling loop."""
+    _propagation_sync_cancelled.set()
+    with _lock:
+        router = _state.get("router")
+    cancelled_router = False
+    if router is not None:
+        cancel = getattr(router, "cancel_propagation_node_requests", None)
+        if callable(cancel):
+            try:
+                cancel()
+                cancelled_router = True
+            except Exception:
+                pass
+    return {"ok": True, "router_cancelled": cancelled_router}
 
 
 def _propagation_state_name(val: Any) -> str:

--- a/app/rns_bridge.py
+++ b/app/rns_bridge.py
@@ -676,6 +676,20 @@ def set_incoming_message_size_limit_kb(limit_kb: int) -> dict[str, Any]:
         return {"ok": True, "reason": "ok", "limit_kb": bounded}
 
 
+def _cancel_router_propagation_request(router: Any) -> bool:
+    """Synchronously tear down one router-owned propagation request."""
+    if router is None:
+        return False
+    cancel = getattr(router, "cancel_propagation_node_requests", None)
+    if not callable(cancel):
+        return False
+    try:
+        cancel()
+        return True
+    except Exception:
+        return False
+
+
 def propagation_sync(timeout: float = 60.0) -> dict[str, Any]:
     """Block until the current LXMF propagation-node sync finishes (or
     times out). Returns `{ok, state, received_messages, reason}`.
@@ -721,24 +735,38 @@ def propagation_sync(timeout: float = 60.0) -> dict[str, Any]:
         # propagation_transfer_state from its own thread.
         deadline = time.monotonic() + timeout
         last_seen_state: Any = None
+        terminal_reached = False
+        terminal_states = {
+            getattr(LXMF.LXMRouter, "PR_COMPLETE", 0x07),
+            getattr(LXMF.LXMRouter, "PR_NO_PATH", 0xF0),
+            getattr(LXMF.LXMRouter, "PR_LINK_FAILED", 0xF1),
+            getattr(LXMF.LXMRouter, "PR_TRANSFER_FAILED", 0xF2),
+            getattr(LXMF.LXMRouter, "PR_NO_IDENTITY_RCVD", 0xF3),
+            getattr(LXMF.LXMRouter, "PR_NO_ACCESS", 0xF4),
+            getattr(LXMF.LXMRouter, "PR_FAILED", 0xFE),
+        }
         while time.monotonic() < deadline:
             if cancellation.is_set():
                 return {"ok": False, "state": "cancelled", "received_messages": 0, "reason": "cancelled"}
             try:
                 state_val = getattr(router, "propagation_transfer_state", None)
                 last_seen_state = state_val
-                # Only PR_COMPLETE / PR_NO_PATH / PR_TRANSFER_FAILED are
-                # truly terminal — link-established is intermediate.
-                real_terminal = {
-                    getattr(LXMF.LXMRouter, "PR_COMPLETE", 5),
-                    getattr(LXMF.LXMRouter, "PR_NO_PATH", 6),
-                    getattr(LXMF.LXMRouter, "PR_TRANSFER_FAILED", 7),
-                }
-                if state_val in real_terminal:
+                if state_val in terminal_states:
+                    terminal_reached = True
                     break
             except Exception:
                 pass
             time.sleep(0.5)
+
+        if not terminal_reached:
+            cancellation.set()
+            _cancel_router_propagation_request(router)
+            return {
+                "ok": False,
+                "state": "transfer_failed",
+                "received_messages": 0,
+                "reason": "timeout",
+            }
 
         received = 0
         try:
@@ -773,15 +801,7 @@ def cancel_propagation_sync() -> dict[str, Any]:
         # request while this call is still about to tear down router propagation.
         with _lock:
             router = _state.get("router")
-        cancelled_router = False
-        if router is not None:
-            cancel = getattr(router, "cancel_propagation_node_requests", None)
-            if callable(cancel):
-                try:
-                    cancel()
-                    cancelled_router = True
-                except Exception:
-                    pass
+        cancelled_router = _cancel_router_propagation_request(router)
         return {"ok": True, "active": True, "router_cancelled": cancelled_router}
 
 
@@ -800,7 +820,11 @@ def _propagation_state_name(val: Any) -> str:
         getattr(LXMF.LXMRouter, "PR_RESPONSE_RECEIVED", -7): "response_received",
         getattr(LXMF.LXMRouter, "PR_COMPLETE", -8): "complete",
         getattr(LXMF.LXMRouter, "PR_NO_PATH", -9): "no_path",
-        getattr(LXMF.LXMRouter, "PR_TRANSFER_FAILED", -10): "transfer_failed",
+        getattr(LXMF.LXMRouter, "PR_LINK_FAILED", -10): "link_failed",
+        getattr(LXMF.LXMRouter, "PR_TRANSFER_FAILED", -11): "transfer_failed",
+        getattr(LXMF.LXMRouter, "PR_NO_IDENTITY_RCVD", -12): "no_identity_received",
+        getattr(LXMF.LXMRouter, "PR_NO_ACCESS", -13): "no_access",
+        getattr(LXMF.LXMRouter, "PR_FAILED", -14): "failed",
     }
     return mapping.get(val, f"state_{val}")
 

--- a/app/rns_bridge.py
+++ b/app/rns_bridge.py
@@ -277,7 +277,7 @@ def _install_native_stamp_generator_unless_stopping() -> bool:
 
 
 _lock = threading.Lock()
-_propagation_sync_cancellation_lock = threading.Lock()
+_propagation_sync_cancellation_lock = threading.Condition()
 _active_propagation_sync_cancellation: threading.Event | None = None
 # Teardown publishes intent without waiting for `_lock`, allowing a start that
 # already owns it to reject or undo process-global callback registration.
@@ -691,6 +691,11 @@ def propagation_sync(timeout: float = 60.0) -> dict[str, Any]:
     cancellation = threading.Event()
     global _active_propagation_sync_cancellation
     with _propagation_sync_cancellation_lock:
+        while (
+            _active_propagation_sync_cancellation is not None
+            and _active_propagation_sync_cancellation.is_set()
+        ):
+            _propagation_sync_cancellation_lock.wait()
         if _active_propagation_sync_cancellation is not None:
             return {"ok": False, "state": "transfer-failed", "received_messages": 0, "reason": "sync-in-progress"}
         _active_propagation_sync_cancellation = cancellation
@@ -753,6 +758,7 @@ def propagation_sync(timeout: float = 60.0) -> dict[str, Any]:
         with _propagation_sync_cancellation_lock:
             if _active_propagation_sync_cancellation is cancellation:
                 _active_propagation_sync_cancellation = None
+                _propagation_sync_cancellation_lock.notify_all()
 
 
 def cancel_propagation_sync() -> dict[str, Any]:
@@ -762,18 +768,21 @@ def cancel_propagation_sync() -> dict[str, Any]:
         if cancellation is None:
             return {"ok": True, "active": False, "router_cancelled": False}
         cancellation.set()
-    with _lock:
-        router = _state.get("router")
-    cancelled_router = False
-    if router is not None:
-        cancel = getattr(router, "cancel_propagation_node_requests", None)
-        if callable(cancel):
-            try:
-                cancel()
-                cancelled_router = True
-            except Exception:
-                pass
-    return {"ok": True, "active": True, "router_cancelled": cancelled_router}
+        # Keep the operation slot occupied until the router-wide cancellation has
+        # finished. Otherwise a successor can publish its fresh event and start a
+        # request while this call is still about to tear down router propagation.
+        with _lock:
+            router = _state.get("router")
+        cancelled_router = False
+        if router is not None:
+            cancel = getattr(router, "cancel_propagation_node_requests", None)
+            if callable(cancel):
+                try:
+                    cancel()
+                    cancelled_router = True
+                except Exception:
+                    pass
+        return {"ok": True, "active": True, "router_cancelled": cancelled_router}
 
 
 def _propagation_state_name(val: Any) -> str:

--- a/app/rns_bridge.py
+++ b/app/rns_bridge.py
@@ -277,7 +277,8 @@ def _install_native_stamp_generator_unless_stopping() -> bool:
 
 
 _lock = threading.Lock()
-_propagation_sync_cancelled = threading.Event()
+_propagation_sync_cancellation_lock = threading.Lock()
+_active_propagation_sync_cancellation: threading.Event | None = None
 # Teardown publishes intent without waiting for `_lock`, allowing a start that
 # already owns it to reject or undo process-global callback registration.
 _runtime_teardown_requested = threading.Event()
@@ -687,69 +688,80 @@ def propagation_sync(timeout: float = 60.0) -> dict[str, Any]:
 
     Requires set_propagation_node() to have been called with a valid
     `lxmf.propagation` destination first."""
-    if _propagation_sync_cancelled.is_set():
-        _propagation_sync_cancelled.clear()
-        return {"ok": False, "state": "cancelled", "received_messages": 0, "reason": "cancelled"}
+    cancellation = threading.Event()
+    global _active_propagation_sync_cancellation
+    with _propagation_sync_cancellation_lock:
+        if _active_propagation_sync_cancellation is not None:
+            return {"ok": False, "state": "transfer-failed", "received_messages": 0, "reason": "sync-in-progress"}
+        _active_propagation_sync_cancellation = cancellation
 
-    with _lock:
-        if not _state["started"]:
-            return {"ok": False, "state": "not-started", "received_messages": 0, "reason": "not-started"}
-        router = _state["router"]
-        identity = _state["identity"]
-        if router is None or identity is None:
-            return {"ok": False, "state": "no-router", "received_messages": 0, "reason": "no-router"}
-        outbound = getattr(router, "outbound_propagation_node", None)
-        if outbound is None:
-            return {"ok": False, "state": "no-node", "received_messages": 0, "reason": "no-node-selected"}
+    try:
+        with _lock:
+            if not _state["started"]:
+                return {"ok": False, "state": "not-started", "received_messages": 0, "reason": "not-started"}
+            router = _state["router"]
+            identity = _state["identity"]
+            if router is None or identity is None:
+                return {"ok": False, "state": "no-router", "received_messages": 0, "reason": "no-router"}
+            outbound = getattr(router, "outbound_propagation_node", None)
+            if outbound is None:
+                return {"ok": False, "state": "no-node", "received_messages": 0, "reason": "no-node-selected"}
 
+            try:
+                router.request_messages_from_propagation_node(identity)
+            except Exception as e:
+                return {"ok": False, "state": "transfer-failed", "received_messages": 0, "reason": f"start-failed: {e}"}
+
+        # Poll the router state outside the lock so the router can update
+        # propagation_transfer_state from its own thread.
+        deadline = time.monotonic() + timeout
+        last_seen_state: Any = None
+        while time.monotonic() < deadline:
+            if cancellation.is_set():
+                return {"ok": False, "state": "cancelled", "received_messages": 0, "reason": "cancelled"}
+            try:
+                state_val = getattr(router, "propagation_transfer_state", None)
+                last_seen_state = state_val
+                # Only PR_COMPLETE / PR_NO_PATH / PR_TRANSFER_FAILED are
+                # truly terminal — link-established is intermediate.
+                real_terminal = {
+                    getattr(LXMF.LXMRouter, "PR_COMPLETE", 5),
+                    getattr(LXMF.LXMRouter, "PR_NO_PATH", 6),
+                    getattr(LXMF.LXMRouter, "PR_TRANSFER_FAILED", 7),
+                }
+                if state_val in real_terminal:
+                    break
+            except Exception:
+                pass
+            time.sleep(0.5)
+
+        received = 0
         try:
-            router.request_messages_from_propagation_node(identity)
-        except Exception as e:
-            return {"ok": False, "state": "transfer-failed", "received_messages": 0, "reason": f"start-failed: {e}"}
-
-    # Poll the router state outside the lock so the router can update
-    # propagation_transfer_state from its own thread.
-    deadline = time.monotonic() + timeout
-    last_seen_state: Any = None
-    while time.monotonic() < deadline:
-        if _propagation_sync_cancelled.is_set():
-            _propagation_sync_cancelled.clear()
-            return {"ok": False, "state": "cancelled", "received_messages": 0, "reason": "cancelled"}
-        try:
-            state_val = getattr(router, "propagation_transfer_state", None)
-            last_seen_state = state_val
-            # Only PR_COMPLETE / PR_NO_PATH / PR_TRANSFER_FAILED are
-            # truly terminal — link-established is intermediate.
-            real_terminal = {
-                getattr(LXMF.LXMRouter, "PR_COMPLETE", 5),
-                getattr(LXMF.LXMRouter, "PR_NO_PATH", 6),
-                getattr(LXMF.LXMRouter, "PR_TRANSFER_FAILED", 7),
-            }
-            if state_val in real_terminal:
-                break
+            received = int(getattr(router, "propagation_transfer_last_result", 0) or 0)
         except Exception:
             pass
-        time.sleep(0.5)
 
-    received = 0
-    try:
-        received = int(getattr(router, "propagation_transfer_last_result", 0) or 0)
-    except Exception:
-        pass
-
-    state_name = _propagation_state_name(last_seen_state)
-    ok = state_name == "complete"
-    return {
-        "ok": ok,
-        "state": state_name,
-        "received_messages": received,
-        "reason": "ok" if ok else state_name,
-    }
+        state_name = _propagation_state_name(last_seen_state)
+        ok = state_name == "complete"
+        return {
+            "ok": ok,
+            "state": state_name,
+            "received_messages": received,
+            "reason": "ok" if ok else state_name,
+        }
+    finally:
+        with _propagation_sync_cancellation_lock:
+            if _active_propagation_sync_cancellation is cancellation:
+                _active_propagation_sync_cancellation = None
 
 
 def cancel_propagation_sync() -> dict[str, Any]:
     """Cancel an active bounded propagation-node request and its polling loop."""
-    _propagation_sync_cancelled.set()
+    with _propagation_sync_cancellation_lock:
+        cancellation = _active_propagation_sync_cancellation
+        if cancellation is None:
+            return {"ok": True, "active": False, "router_cancelled": False}
+        cancellation.set()
     with _lock:
         router = _state.get("router")
     cancelled_router = False
@@ -761,7 +773,7 @@ def cancel_propagation_sync() -> dict[str, Any]:
                 cancelled_router = True
             except Exception:
                 pass
-    return {"ok": True, "router_cancelled": cancelled_router}
+    return {"ok": True, "active": True, "router_cancelled": cancelled_router}
 
 
 def _propagation_state_name(val: Any) -> str:


### PR DESCRIPTION
## Summary
- add application-owned `BGAppRefreshTask` registration, retention, scheduling reconciliation, and exactly-once completion for iOS propagation synchronization
- initialize the embedded Python/Reticulum service graph independently of SwiftUI view lifecycle and require a live backend plus persisted propagation-node restoration before reporting readiness
- serialize ordinary and background event processing around one bounded propagation transaction, including callback drain and durable message classification after unsuccessful transfers
- submit eligible local notifications for newly inserted synchronized messages and derive badges from canonical durable unread state
- use an app-owned monotonic insertion ledger so classification remains correct after SQLite row deletion and row-ID reuse
- remove the competing iOS periodic timer while retaining timer behavior for other runtime flavors
- add actionable scheduler, startup, propagation, persistence, notification, and completion diagnostics

## Verification
- exact feature head: `2a68ef5a980c310e1a710ac92debd9e8f32d6db6`
- static/Python suite: 261 tests, 260 passed, 1 skipped
- focused background wiring contracts: 11/11 passed
- full iOS simulator suite: 298/298 passed
- Python `py_compile`: passed
- `git diff --check`: passed
- independent immutable exact-head review: approved
- signed physical iPhone build, signature verification, install without data deletion, and launch: passed
- effective Info.plist contains `fetch` and `network.columba.Columba.sync`
- genuine cold background delivery on the physically validated production tree completed the full initialization and propagation path successfully with `initialized=false` at entry
- genuine background retrieval also produced a successful local notification request with a canonical durable badge

## Scheduling and presentation limitations
- `earliestBeginDate` is a not-before date, not a deadline or guaranteed cadence; iOS retains control over whether and when the task runs
- `BGAppRefreshTask` exposes no public priority, urgency, QoS, or deadline control
- local notification submission does not guarantee visible presentation; authorization, Focus, foreground policy, and system presentation rules still apply
- this remains a Reticulum propagation workflow and does not introduce an APNs dependency

## Risk / rollback
- primary risk is lifecycle behavior under discretionary iOS scheduling and bounded embedded-runtime teardown
- diagnostics distinguish scheduler withholding from registration, startup, propagation, persistence, notification submission, and presentation failures
- rollback is a normal revert of this branch; no remote schema or service migration is required