### PR TITLE
Fix inbound propagated delivery method details

### DIFF
--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -2090,6 +2090,7 @@ public final class AppServices {
                     content: content,
                     title: "",
                     fields: nil,
+                    method: .opportunistic,
                     timestamp: Date()
                 )
             }

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -2738,7 +2738,7 @@ public final class AppServices {
     /// run side-channel handling (reactions/replies/telemetry/icon/cease) through
     /// IncomingMessageHandler. Returns nil if blocked or persistence failed.
     @discardableResult
-    private func persistInboundFromPython(sourceHash: Data, messageHashHex: String, content: String, title: String, fields: [UInt8: Any]?, timestamp: Date) async -> LXMessage? {
+    private func persistInboundFromPython(sourceHash: Data, messageHashHex: String, content: String, title: String, fields: [UInt8: Any]?, method: LXDeliveryMethod?, timestamp: Date) async -> LXMessage? {
         // Route Python-path inbound persistence through the GRDB canonical
         // store (the same one the UI reads and the Swift/NE path writes), via
         // the shared MessageRepository's RNSAPI-typed methods — NOT the
@@ -2804,7 +2804,7 @@ public final class AppServices {
                 content: content.data(using: .utf8) ?? Data(),
                 title: title.data(using: .utf8) ?? Data(),
                 fields: fields,
-                desiredMethod: .opportunistic
+                desiredMethod: method ?? .unknown
             )
             message.sourceHash = sourceHash
             message.hash = messageHash
@@ -2938,7 +2938,7 @@ public final class AppServices {
                     DiagLog.log("[RNS] stamped display name onto convo \(data.map { String(format: "%02x", $0) }.joined().prefix(8))")
                 }
             }
-        case .inbound(let sourceHash, let messageHash, let content, let title, let fieldsPacked, let t):
+        case .inbound(let sourceHash, let messageHash, let content, let title, let fieldsPacked, let method, let t):
             DiagLog.log("[RNS] inbound source=\(sourceHash) content=\"\(content)\" fields=\(fieldsPacked.count)B")
             guard let data = Data(hexString: sourceHash) else { return }
             let fields = fieldsPacked.isEmpty ? nil : LxmfFieldCodec.unpack(fieldsPacked)
@@ -2947,7 +2947,7 @@ public final class AppServices {
             // IncomingMessageHandler — the router.delegate, wired in ColumbaApp.
             // Same path for both backends (Python sends empty fields until its
             // bridge plumbing lands; the Swift backend populates them now).
-            if let saved = await persistInboundFromPython(sourceHash: data, messageHashHex: messageHash, content: content, title: title, fields: fields, timestamp: t),
+            if let saved = await persistInboundFromPython(sourceHash: data, messageHashHex: messageHash, content: content, title: title, fields: fields, method: method, timestamp: t),
                fields != nil, let router = self.router {
                 if let handler = router.delegate as? IncomingMessageHandler {
                     _ = await handler.handleInbound(saved).value

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -2809,6 +2809,7 @@ public final class AppServices {
             )
             message.sourceHash = sourceHash
             message.hash = messageHash
+            message.method = method ?? .unknown
             message.incoming = true
             message.timestamp = timestamp.timeIntervalSince1970
             message.state = .received

--- a/Sources/ColumbaApp/Services/MessageRepository.swift
+++ b/Sources/ColumbaApp/Services/MessageRepository.swift
@@ -589,6 +589,19 @@ public actor MessageRepository {
     /// map so the chat UI's `LxmfFieldCodec.unpack` can recover attachments.
     public func saveMessage(_ message: RNSAPI.LXMessage) async throws {
         try await database.saveMessage(Self.mapToGRDBMessage(message))
+        // LXMFSwift's enum has no unknown case, so the adapter must use a valid
+        // method while constructing its message. Replace that temporary value
+        // with an out-of-domain raw sentinel before this actor returns. Reads map
+        // the sentinel back to RNSAPI `.unknown`, allowing the details UI to hide
+        // unavailable metadata instead of falsely claiming Opportunistic.
+        if message.method == .unknown {
+            try await replacementPool.write { db in
+                try db.execute(
+                    sql: "UPDATE messages SET method = ? WHERE message_id = ?",
+                    arguments: [UInt8(0), message.hash]
+                )
+            }
+        }
         if !message.incoming {
             NotificationCenter.default.post(
                 name: Self.conversationActivityNotification,
@@ -1204,8 +1217,9 @@ extension MessageRepository {
 
     /// RNSAPI `LXDeliveryMethod` → GRDB `LXDeliveryMethod`.
     ///
-    /// RNSAPI `.unknown` has no GRDB peer; default to `.opportunistic` (the
-    /// canonical LXMF default delivery method).
+    /// RNSAPI `.unknown` has no GRDB enum peer. The mapped message temporarily
+    /// uses `.opportunistic`; `saveMessage` replaces it with raw sentinel zero
+    /// before returning so reads map it back to `.unknown`.
     static func mapMethodToGRDB(_ m: RNSAPI.LXDeliveryMethod) -> LXMFSwift.LXDeliveryMethod {
         switch m {
         case .opportunistic: return .opportunistic

--- a/Sources/ColumbaApp/Services/MessageRepository.swift
+++ b/Sources/ColumbaApp/Services/MessageRepository.swift
@@ -588,19 +588,22 @@ public actor MessageRepository {
     /// which `mapRecord` passes back through as the RNSAPI `packedLxmf` field
     /// map so the chat UI's `LxmfFieldCodec.unpack` can recover attachments.
     public func saveMessage(_ message: RNSAPI.LXMessage) async throws {
-        try await database.saveMessage(Self.mapToGRDBMessage(message))
-        // LXMFSwift's enum has no unknown case, so the adapter must use a valid
-        // method while constructing its message. Replace that temporary value
-        // with an out-of-domain raw sentinel before this actor returns. Reads map
-        // the sentinel back to RNSAPI `.unknown`, allowing the details UI to hide
-        // unavailable metadata instead of falsely claiming Opportunistic.
+        let mapped = Self.mapToGRDBMessage(message)
         if message.method == .unknown {
+            // LXMFSwift's enum cannot represent unknown, but its persisted record
+            // stores a raw byte. Build the record from the mapped message, replace
+            // only that byte with an out-of-domain sentinel, and save the
+            // conversation + message in one immediate transaction. This prevents
+            // readers or competing writers from observing a temporary
+            // Opportunistic value.
+            var record = try LXMFSwift.MessageRecord(from: mapped)
+            record.method = 0
             try await replacementPool.write { db in
-                try db.execute(
-                    sql: "UPDATE messages SET method = ? WHERE message_id = ?",
-                    arguments: [UInt8(0), message.hash]
-                )
+                try Self.updateConversation(for: mapped, in: db)
+                try record.save(db)
             }
+        } else {
+            try await database.saveMessage(mapped)
         }
         if !message.incoming {
             NotificationCenter.default.post(
@@ -608,6 +611,45 @@ public actor MessageRepository {
                 object: nil,
                 userInfo: [Self.conversationHashUserInfoKey: message.destinationHash]
             )
+        }
+    }
+
+    /// Mirror LXMFSwift's conversation update inside the app-owned transaction
+    /// used for raw method values that its enum cannot represent.
+    private static func updateConversation(
+        for message: LXMFSwift.LXMessage,
+        in db: Database
+    ) throws {
+        let conversationHash = message.incoming ? message.sourceHash : message.destinationHash
+        if var conversation = try LXMFSwift.ConversationRecord
+            .filter(Column("destination_hash") == conversationHash)
+            .fetchOne(db) {
+            if message.timestamp >= conversation.lastMessageTimestamp {
+                conversation.lastMessageTimestamp = message.timestamp
+                conversation.updatedAt = Date().timeIntervalSince1970
+                if !message.content.isEmpty,
+                   let content = String(data: message.content, encoding: .utf8),
+                   !content.isEmpty {
+                    conversation.lastMessagePreview = String(content.prefix(100))
+                }
+            }
+            if message.incoming {
+                conversation.unreadCount += 1
+                conversation.isUnread = 1
+            }
+            try conversation.update(db)
+        } else {
+            let preview = String(data: message.content, encoding: .utf8).map {
+                String($0.prefix(100))
+            }
+            let conversation = LXMFSwift.ConversationRecord(
+                destinationHash: conversationHash,
+                displayName: nil,
+                lastMessageTimestamp: message.timestamp,
+                lastMessagePreview: preview,
+                unreadCount: message.incoming ? 1 : 0
+            )
+            try conversation.insert(db)
         }
     }
 
@@ -1217,9 +1259,9 @@ extension MessageRepository {
 
     /// RNSAPI `LXDeliveryMethod` → GRDB `LXDeliveryMethod`.
     ///
-    /// RNSAPI `.unknown` has no GRDB enum peer. The mapped message temporarily
-    /// uses `.opportunistic`; `saveMessage` replaces it with raw sentinel zero
-    /// before returning so reads map it back to `.unknown`.
+    /// RNSAPI `.unknown` has no GRDB enum peer. `saveMessage` replaces the
+    /// mapped record's temporary value with raw sentinel zero before inserting
+    /// it in the same transaction, so reads map it back to `.unknown`.
     static func mapMethodToGRDB(_ m: RNSAPI.LXDeliveryMethod) -> LXMFSwift.LXDeliveryMethod {
         switch m {
         case .opportunistic: return .opportunistic

--- a/Sources/ColumbaApp/Views/Messaging/MessageBubble.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageBubble.swift
@@ -495,6 +495,8 @@ public struct Message: Identifiable, Equatable {
             self.deliveryMethod = "direct"
         case LXDeliveryMethod.propagated.rawValue:
             self.deliveryMethod = "propagated"
+        case LXDeliveryMethod.paper.rawValue:
+            self.deliveryMethod = "paper"
         default:
             self.deliveryMethod = nil
         }

--- a/Sources/ColumbaApp/Views/Messaging/MessageDetailView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageDetailView.swift
@@ -282,6 +282,9 @@ struct MessageDetailView: View {
             case "propagated":
                 return ("point.3.connected.trianglepath.dotted", "Propagated",
                         "Delivered via relay/propagation node")
+            case "paper":
+                return ("doc.text", "Paper",
+                        "Transferred as a paper LXMF message")
             default:
                 return ("questionmark.circle", method.capitalized, "")
             }

--- a/Sources/PythonBridge/PythonBridge.swift
+++ b/Sources/PythonBridge/PythonBridge.swift
@@ -68,7 +68,7 @@ public final class PythonBridge: @unchecked Sendable {
 
     public enum Event: Equatable, Sendable {
         case announce(destHash: String, appDataHex: String, aspect: String, publicKeysHex: String, interfaceName: String, hops: Int, t: Date)
-        case inbound(sourceHash: String, messageHash: String, content: String, title: String, fieldsHex: String, t: Date)
+        case inbound(sourceHash: String, messageHash: String, content: String, title: String, fieldsHex: String, method: String, t: Date)
         case state(String, t: Date)
 
         /// Delivery lifecycle event for an outbound message, keyed by its LXMF
@@ -886,7 +886,8 @@ public final class PythonBridge: @unchecked Sendable {
                 let c = pyStringFromDict(item, key: "content") ?? ""
                 let title = pyStringFromDict(item, key: "title") ?? ""
                 let fieldsHex = pyStringFromDict(item, key: "fields_hex") ?? ""
-                out.append(.inbound(sourceHash: h, messageHash: messageHash, content: c, title: title, fieldsHex: fieldsHex, t: t))
+                let method = pyStringFromDict(item, key: "method") ?? ""
+                out.append(.inbound(sourceHash: h, messageHash: messageHash, content: c, title: title, fieldsHex: fieldsHex, method: method, t: t))
             case "state":
                 let v = pyStringFromDict(item, key: "value") ?? "?"
                 out.append(.state(v, t: t))

--- a/Sources/RNSAPI/Protocols/RnsBackend.swift
+++ b/Sources/RNSAPI/Protocols/RnsBackend.swift
@@ -63,7 +63,7 @@ public enum BackendEvent: Equatable, Sendable {
     /// `fieldsPacked` is the inbound LXMF field map as MessagePack bytes (empty
     /// = no fields) — decode with `LxmfFieldCodec.unpack`. Carries telemetry /
     /// attachments / reactions / replies / icon / cease through the seam.
-    case inbound(sourceHash: String, messageHash: String, content: String, title: String, fieldsPacked: Data, t: Date)
+    case inbound(sourceHash: String, messageHash: String, content: String, title: String, fieldsPacked: Data, method: LXDeliveryMethod?, t: Date)
     case state(String, t: Date)
     /// Delivery lifecycle event for an outbound message. `method` is the
     /// effective transport used for this attempt and is independent of state.

--- a/Sources/RNSBackendPy/PythonRNSBackend.swift
+++ b/Sources/RNSBackendPy/PythonRNSBackend.swift
@@ -423,10 +423,18 @@ public final class PythonRNSBackend: RnsBackend, @unchecked Sendable {
         switch e {
         case let .announce(d, a, asp, pk, ifn, h, t):
             return .announce(destHash: d, appDataHex: a, aspect: asp, publicKeysHex: pk, interfaceName: ifn, hops: h, t: t)
-        case let .inbound(s, mh, c, ti, fh, t):
+        case let .inbound(s, mh, c, ti, fh, method, t):
             // fieldsHex = MessagePack-packed LXMF field map (hex), extracted by
             // rns_bridge.py's delivery callback; decode to the neutral fieldsPacked.
-            return .inbound(sourceHash: s, messageHash: mh, content: c, title: ti, fieldsPacked: (try? fh.hexToData()) ?? Data(), t: t)
+            let deliveryMethod: LXDeliveryMethod?
+            switch method {
+            case "opportunistic": deliveryMethod = .opportunistic
+            case "direct": deliveryMethod = .direct
+            case "propagated": deliveryMethod = .propagated
+            case "paper": deliveryMethod = .paper
+            default: deliveryMethod = nil
+            }
+            return .inbound(sourceHash: s, messageHash: mh, content: c, title: ti, fieldsPacked: (try? fh.hexToData()) ?? Data(), method: deliveryMethod, t: t)
         case let .state(s, t):
             return .state(s, t: t)
         case let .delivery(m, s, method, t):

--- a/Sources/RNSBackendSwift/SwiftRNSBackend.swift
+++ b/Sources/RNSBackendSwift/SwiftRNSBackend.swift
@@ -783,6 +783,7 @@ public final class SwiftRNSBackend: RnsBackend, @unchecked Sendable {
             case .opportunistic: return .opportunistic
             case .direct: return .direct
             case .propagated: return .propagated
+            case .paper: return .paper
             default: return nil
             }
         }

--- a/Sources/RNSBackendSwift/SwiftRNSBackend.swift
+++ b/Sources/RNSBackendSwift/SwiftRNSBackend.swift
@@ -750,7 +750,7 @@ public final class SwiftRNSBackend: RnsBackend, @unchecked Sendable {
             let content = String(data: message.content, encoding: .utf8) ?? ""
             let title = String(data: message.title, encoding: .utf8) ?? ""
             let fieldsPacked = (message.fields?.isEmpty == false) ? LxmfFieldCodec.pack(message.fields!) : Data()
-            continuation.yield(.inbound(sourceHash: message.sourceHash.hexHash, messageHash: message.hash.hexHash, content: content, title: title, fieldsPacked: fieldsPacked, t: Date()))
+            continuation.yield(.inbound(sourceHash: message.sourceHash.hexHash, messageHash: message.hash.hexHash, content: content, title: title, fieldsPacked: fieldsPacked, method: Self.mapDeliveryMethod(message.method), t: Date()))
         }
         func router(_ router: LXMFSwift.LXMRouter, didUpdateMessage message: LXMFSwift.LXMessage) {
             if message.state == .delivered {

--- a/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
+++ b/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
@@ -467,7 +467,7 @@ final class MessageRepositoryAtomicReplacementTests: XCTestCase {
         defer { removeDatabase(at: databaseURL) }
         let repository = try MessageRepository(grdbPath: databaseURL.path)
         let inspectionQueue = try DatabaseQueue(path: databaseURL.path)
-        try inspectionQueue.write { db in
+        try await inspectionQueue.write { db in
             try db.execute(sql: """
                 CREATE TRIGGER reject_unknown_method_correction
                 BEFORE UPDATE OF method ON messages
@@ -505,7 +505,7 @@ final class MessageRepositoryAtomicReplacementTests: XCTestCase {
         defer { removeDatabase(at: databaseURL) }
         let repository = try MessageRepository(grdbPath: databaseURL.path)
         let inspectionQueue = try DatabaseQueue(path: databaseURL.path)
-        try inspectionQueue.write { db in
+        try await inspectionQueue.write { db in
             try db.execute(sql: """
                 CREATE TRIGGER reject_unknown_method_insert
                 BEFORE INSERT ON messages

--- a/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
+++ b/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
@@ -462,6 +462,86 @@ final class MessageRepositoryAtomicReplacementTests: XCTestCase {
         XCTAssertNil(Message(from: stored, localHash: Data()).deliveryMethod)
     }
 
+    func testUnknownInboundMethodDoesNotUseCorrectiveUpdate() async throws {
+        let databaseURL = temporaryDatabaseURL()
+        defer { removeDatabase(at: databaseURL) }
+        let repository = try MessageRepository(grdbPath: databaseURL.path)
+        let inspectionQueue = try DatabaseQueue(path: databaseURL.path)
+        try inspectionQueue.write { db in
+            try db.execute(sql: """
+                CREATE TRIGGER reject_unknown_method_correction
+                BEFORE UPDATE OF method ON messages
+                WHEN NEW.method = 0
+                BEGIN
+                    SELECT RAISE(ABORT, 'unknown method must be inserted atomically');
+                END
+                """)
+        }
+        let source = Data(repeating: 0x37, count: 16)
+        let messageHash = Data(repeating: 0x38, count: 32)
+        let message = RNSAPI.LXMessage(
+            destinationHash: source,
+            sourceIdentity: nil,
+            content: Data("atomic unknown".utf8),
+            desiredMethod: .unknown
+        )
+        message.sourceHash = source
+        message.hash = messageHash
+        message.method = .unknown
+        message.incoming = true
+        message.state = .received
+
+        try await repository.saveMessage(message)
+
+        let storedRecord = try await repository.getMessageRecord(id: messageHash)
+        XCTAssertEqual(
+            try XCTUnwrap(storedRecord).method,
+            RNSAPI.LXDeliveryMethod.unknown.rawValue
+        )
+    }
+
+    func testUnknownInboundInsertFailureRollsBackConversation() async throws {
+        let databaseURL = temporaryDatabaseURL()
+        defer { removeDatabase(at: databaseURL) }
+        let repository = try MessageRepository(grdbPath: databaseURL.path)
+        let inspectionQueue = try DatabaseQueue(path: databaseURL.path)
+        try inspectionQueue.write { db in
+            try db.execute(sql: """
+                CREATE TRIGGER reject_unknown_method_insert
+                BEFORE INSERT ON messages
+                WHEN NEW.method = 0
+                BEGIN
+                    SELECT RAISE(ABORT, 'forced unknown insert failure');
+                END
+                """)
+        }
+        let source = Data(repeating: 0x39, count: 16)
+        let messageHash = Data(repeating: 0x3a, count: 32)
+        let message = RNSAPI.LXMessage(
+            destinationHash: source,
+            sourceIdentity: nil,
+            content: Data("rollback unknown".utf8),
+            desiredMethod: .unknown
+        )
+        message.sourceHash = source
+        message.hash = messageHash
+        message.method = .unknown
+        message.incoming = true
+        message.state = .received
+
+        do {
+            try await repository.saveMessage(message)
+            XCTFail("Expected forced insert failure")
+        } catch {
+            // Expected: the trigger aborts the transaction.
+        }
+
+        let storedRecord = try await repository.getMessageRecord(id: messageHash)
+        let conversation = try await repository.fetchConversation(source)
+        XCTAssertNil(storedRecord)
+        XCTAssertNil(conversation)
+    }
+
     func testPaperInboundMethodPersistsForMessageDetails() async throws {
         let databaseURL = temporaryDatabaseURL()
         defer { removeDatabase(at: databaseURL) }

--- a/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
+++ b/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
@@ -410,6 +410,31 @@ final class MessageRepositoryAtomicReplacementTests: XCTestCase {
         }
     }
 
+    func testInboundPropagatedMethodPersistsForMessageDetails() async throws {
+        let databaseURL = temporaryDatabaseURL()
+        defer { removeDatabase(at: databaseURL) }
+        let repository = try MessageRepository(grdbPath: databaseURL.path)
+        let source = Data(repeating: 0x31, count: 16)
+        let messageHash = Data(repeating: 0x32, count: 32)
+        let message = RNSAPI.LXMessage(
+            destinationHash: source,
+            sourceIdentity: nil,
+            content: Data("relay message".utf8),
+            desiredMethod: .propagated
+        )
+        message.sourceHash = source
+        message.hash = messageHash
+        message.incoming = true
+        message.state = .received
+
+        try await repository.saveMessage(message)
+
+        let storedRecord = try await repository.getMessageRecord(id: messageHash)
+        let stored = try XCTUnwrap(storedRecord)
+        XCTAssertEqual(stored.method, RNSAPI.LXDeliveryMethod.propagated.rawValue)
+        XCTAssertEqual(Message(from: stored, localHash: Data()).deliveryMethod, "propagated")
+    }
+
     func testAnnouncedNameAtomicallyReplacesGeneratedFallback() async throws {
         let databaseURL = temporaryDatabaseURL()
         defer { removeDatabase(at: databaseURL) }

--- a/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
+++ b/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
@@ -436,6 +436,58 @@ final class MessageRepositoryAtomicReplacementTests: XCTestCase {
         XCTAssertEqual(Message(from: stored, localHash: Data()).deliveryMethod, "propagated")
     }
 
+    func testUnknownInboundMethodDoesNotRenderAsOpportunistic() async throws {
+        let databaseURL = temporaryDatabaseURL()
+        defer { removeDatabase(at: databaseURL) }
+        let repository = try MessageRepository(grdbPath: databaseURL.path)
+        let source = Data(repeating: 0x33, count: 16)
+        let messageHash = Data(repeating: 0x34, count: 32)
+        let message = RNSAPI.LXMessage(
+            destinationHash: source,
+            sourceIdentity: nil,
+            content: Data("unknown method".utf8),
+            desiredMethod: .unknown
+        )
+        message.sourceHash = source
+        message.hash = messageHash
+        message.method = .unknown
+        message.incoming = true
+        message.state = .received
+
+        try await repository.saveMessage(message)
+
+        let storedRecord = try await repository.getMessageRecord(id: messageHash)
+        let stored = try XCTUnwrap(storedRecord)
+        XCTAssertEqual(stored.method, RNSAPI.LXDeliveryMethod.unknown.rawValue)
+        XCTAssertNil(Message(from: stored, localHash: Data()).deliveryMethod)
+    }
+
+    func testPaperInboundMethodPersistsForMessageDetails() async throws {
+        let databaseURL = temporaryDatabaseURL()
+        defer { removeDatabase(at: databaseURL) }
+        let repository = try MessageRepository(grdbPath: databaseURL.path)
+        let source = Data(repeating: 0x35, count: 16)
+        let messageHash = Data(repeating: 0x36, count: 32)
+        let message = RNSAPI.LXMessage(
+            destinationHash: source,
+            sourceIdentity: nil,
+            content: Data("paper message".utf8),
+            desiredMethod: .paper
+        )
+        message.sourceHash = source
+        message.hash = messageHash
+        message.method = .paper
+        message.incoming = true
+        message.state = .received
+
+        try await repository.saveMessage(message)
+
+        let storedRecord = try await repository.getMessageRecord(id: messageHash)
+        let stored = try XCTUnwrap(storedRecord)
+        XCTAssertEqual(stored.method, RNSAPI.LXDeliveryMethod.paper.rawValue)
+        XCTAssertEqual(Message(from: stored, localHash: Data()).deliveryMethod, "paper")
+    }
+
     func testAnnouncedNameAtomicallyReplacesGeneratedFallback() async throws {
         let databaseURL = temporaryDatabaseURL()
         defer { removeDatabase(at: databaseURL) }

--- a/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
+++ b/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
@@ -424,6 +424,7 @@ final class MessageRepositoryAtomicReplacementTests: XCTestCase {
         )
         message.sourceHash = source
         message.hash = messageHash
+        message.method = .propagated
         message.incoming = true
         message.state = .received
 

--- a/Tests/static/test_inbound_delivery_method.py
+++ b/Tests/static/test_inbound_delivery_method.py
@@ -1,0 +1,99 @@
+import ast
+import types
+import unittest
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[2]
+BRIDGE = ROOT / "app" / "rns_bridge.py"
+
+
+class FakeMessage:
+    OPPORTUNISTIC = 0x01
+    DIRECT = 0x02
+    PROPAGATED = 0x03
+    PAPER = 0x04
+
+    def __init__(self, method: int):
+        self.method = method
+        self.fields = None
+        self.source_hash = bytes.fromhex("11" * 16)
+        self.hash = bytes.fromhex("22" * 32)
+        self.message_id = self.hash
+        self.packed = None
+
+    def content_as_string(self) -> str:
+        return "received through relay"
+
+    def title_as_string(self) -> str:
+        return ""
+
+
+class InboundDeliveryMethodTests(unittest.TestCase):
+    def load_callback(self, events):
+        tree = ast.parse(BRIDGE.read_text(encoding="utf-8"))
+        functions = {
+            node.name: node
+            for node in tree.body
+            if isinstance(node, ast.FunctionDef)
+            and node.name in {
+                "_canonical_inbound_hash",
+                "_inbound_delivery_method_name",
+                "_delivery_callback",
+            }
+        }
+        self.assertEqual(
+            {
+                "_canonical_inbound_hash",
+                "_inbound_delivery_method_name",
+                "_delivery_callback",
+            },
+            set(functions),
+        )
+        namespace = {
+            "Any": Any,
+            "LXMF": types.SimpleNamespace(LXMessage=FakeMessage),
+            "RNS": types.SimpleNamespace(LOG_ERROR=1, log=lambda *_args: None),
+            "_put": lambda kind, **payload: events.append((kind, payload)),
+        }
+        module = ast.Module(
+            body=[
+                functions["_canonical_inbound_hash"],
+                functions["_inbound_delivery_method_name"],
+                functions["_delivery_callback"],
+            ],
+            type_ignores=[],
+        )
+        exec(compile(module, str(BRIDGE), "exec"), namespace)
+        return namespace["_delivery_callback"]
+
+    def test_propagated_inbound_callback_preserves_delivery_method(self):
+        events = []
+        callback = self.load_callback(events)
+
+        callback(FakeMessage(FakeMessage.PROPAGATED))
+
+        self.assertEqual(1, len(events))
+        kind, payload = events[0]
+        self.assertEqual("inbound", kind)
+        self.assertEqual("propagated", payload.get("method"))
+        self.assertEqual("22" * 32, payload["message_hash"])
+
+    def test_inbound_callback_maps_all_supported_delivery_methods(self):
+        for value, expected in (
+            (FakeMessage.OPPORTUNISTIC, "opportunistic"),
+            (FakeMessage.DIRECT, "direct"),
+            (FakeMessage.PROPAGATED, "propagated"),
+            (FakeMessage.PAPER, "paper"),
+            (0x7F, ""),
+        ):
+            with self.subTest(method=value):
+                events = []
+                callback = self.load_callback(events)
+                callback(FakeMessage(value))
+                self.assertEqual(expected, events[0][1].get("method"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tests/static/test_reported_runtime_bugs.py
+++ b/Tests/static/test_reported_runtime_bugs.py
@@ -106,7 +106,8 @@ class ReportedRuntimeBugContracts(unittest.TestCase):
             r"case inbound\(sourceHash: String, messageHash: String, content:",
         )
         self.assertIsNotNone(re.search(
-            r'case "inbound":.*?key: "message_hash".*?\.inbound\(sourceHash: h, messageHash:',
+            r'case "inbound":.*?key: "message_hash".*?key: "method".*?'
+            r'\.inbound\(sourceHash: h, messageHash:.*?method: method',
             py_bridge,
             re.DOTALL,
         ))
@@ -114,13 +115,15 @@ class ReportedRuntimeBugContracts(unittest.TestCase):
         backend_event = RNS_BACKEND.read_text()
         self.assertRegex(
             backend_event,
-            r"case inbound\(sourceHash: String, messageHash: String, content:",
+            r"case inbound\(sourceHash: String, messageHash: String, content:.*?"
+            r"method: LXDeliveryMethod\?",
         )
 
         py_backend = PY_BACKEND.read_text()
         self.assertIsNotNone(re.search(
-            r"case let \.inbound\(s, mh, c, ti, fh, t\):.*?"
-            r"\.inbound\(sourceHash: s, messageHash: mh, content: c",
+            r"case let \.inbound\(s, mh, c, ti, fh, method, t\):.*?"
+            r"\.inbound\(sourceHash: s, messageHash: mh, content: c.*?"
+            r"method: deliveryMethod",
             py_backend,
             re.DOTALL,
         ))
@@ -129,7 +132,8 @@ class ReportedRuntimeBugContracts(unittest.TestCase):
         self.assertRegex(
             swift_backend,
             r"\.inbound\(sourceHash: message\.sourceHash\.hexHash, "
-            r"messageHash: message\.hash\.hexHash, content:",
+            r"messageHash: message\.hash\.hexHash, content:.*?"
+            r"method: Self\.mapDeliveryMethod\(message\.method\)",
         )
 
         app_services = APP_SERVICES.read_text()
@@ -142,13 +146,17 @@ class ReportedRuntimeBugContracts(unittest.TestCase):
         assert persist is not None
         persist_source = persist.group(0)
         self.assertIn("messageHashHex: String", persist_source)
+        self.assertIn("method: LXDeliveryMethod?", persist_source)
         self.assertIn("Data(hexString: messageHashHex)", persist_source)
         self.assertIn("parsedHash.count == 32", persist_source)
         self.assertIn("Data([0x00]) + Data(SHA256.hash(data: seed))", persist_source)
         self.assertIn("persistInbound using local non-wire message id", persist_source)
+        self.assertIn("desiredMethod: method ?? .unknown", persist_source)
         self.assertIsNotNone(re.search(
             r"case \.inbound\(let sourceHash, let messageHash, let content,"
-            r".*?persistInboundFromPython\(sourceHash: data, messageHashHex: messageHash,",
+            r".*?let method, let t\):.*?"
+            r"persistInboundFromPython\(sourceHash: data, messageHashHex: messageHash,"
+            r".*?method: method, timestamp: t\)",
             app_services,
             re.DOTALL,
         ))

--- a/Tests/static/test_reported_runtime_bugs.py
+++ b/Tests/static/test_reported_runtime_bugs.py
@@ -158,7 +158,10 @@ class ReportedRuntimeBugContracts(unittest.TestCase):
             ROOT / "Sources/ColumbaApp/Services/MessageRepository.swift"
         ).read_text()
         self.assertIn("if message.method == .unknown", repository)
-        self.assertIn("arguments: [UInt8(0), message.hash]", repository)
+        self.assertIn("record.method = 0", repository)
+        self.assertIn("try await replacementPool.write", repository)
+        self.assertIn("try Self.updateConversation(for: mapped, in: db)", repository)
+        self.assertIn("try record.save(db)", repository)
         bubble = MESSAGE_BUBBLE.read_text()
         self.assertIn("case LXDeliveryMethod.paper.rawValue:", bubble)
         self.assertIn('self.deliveryMethod = "paper"', bubble)

--- a/Tests/static/test_reported_runtime_bugs.py
+++ b/Tests/static/test_reported_runtime_bugs.py
@@ -152,6 +152,7 @@ class ReportedRuntimeBugContracts(unittest.TestCase):
         self.assertIn("Data([0x00]) + Data(SHA256.hash(data: seed))", persist_source)
         self.assertIn("persistInbound using local non-wire message id", persist_source)
         self.assertIn("desiredMethod: method ?? .unknown", persist_source)
+        self.assertIn("message.method = method ?? .unknown", persist_source)
         self.assertIsNotNone(re.search(
             r"case \.inbound\(let sourceHash, let messageHash, let content,"
             r".*?let method, let t\):.*?"

--- a/Tests/static/test_reported_runtime_bugs.py
+++ b/Tests/static/test_reported_runtime_bugs.py
@@ -135,6 +135,7 @@ class ReportedRuntimeBugContracts(unittest.TestCase):
             r"messageHash: message\.hash\.hexHash, content:.*?"
             r"method: Self\.mapDeliveryMethod\(message\.method\)",
         )
+        self.assertIn("case .paper: return .paper", swift_backend)
 
         app_services = APP_SERVICES.read_text()
         persist = re.search(
@@ -153,6 +154,14 @@ class ReportedRuntimeBugContracts(unittest.TestCase):
         self.assertIn("persistInbound using local non-wire message id", persist_source)
         self.assertIn("desiredMethod: method ?? .unknown", persist_source)
         self.assertIn("message.method = method ?? .unknown", persist_source)
+        repository = (
+            ROOT / "Sources/ColumbaApp/Services/MessageRepository.swift"
+        ).read_text()
+        self.assertIn("if message.method == .unknown", repository)
+        self.assertIn("arguments: [UInt8(0), message.hash]", repository)
+        bubble = MESSAGE_BUBBLE.read_text()
+        self.assertIn("case LXDeliveryMethod.paper.rawValue:", bubble)
+        self.assertIn('self.deliveryMethod = "paper"', bubble)
         self.assertIsNotNone(re.search(
             r"case \.inbound\(let sourceHash, let messageHash, let content,"
             r".*?let method, let t\):.*?"

--- a/app/rns_bridge.py
+++ b/app/rns_bridge.py
@@ -432,6 +432,20 @@ def _canonical_inbound_hash(message: Any) -> bytes | None:
     return None
 
 
+def _inbound_delivery_method_name(message: Any) -> str:
+    """Map the received LXMF method to the shared persistence vocabulary."""
+    method = getattr(message, "method", None)
+    for attribute, name in (
+        ("OPPORTUNISTIC", "opportunistic"),
+        ("DIRECT", "direct"),
+        ("PROPAGATED", "propagated"),
+        ("PAPER", "paper"),
+    ):
+        if method == getattr(LXMF.LXMessage, attribute, None):
+            return name
+    return ""
+
+
 def _delivery_callback(message: "LXMF.LXMessage") -> None:
     """Fires for every inbound LXMF message routed to our delivery destination."""
     try:
@@ -472,6 +486,7 @@ def _delivery_callback(message: "LXMF.LXMessage") -> None:
         content=content,
         title=title,
         fields_hex=fields_hex,
+        method=_inbound_delivery_method_name(message),
     )
 
 


### PR DESCRIPTION
## Summary

- preserve the effective inbound LXMF delivery method from the embedded runtime through the Swift event boundary and persistence
- render propagated and paper delivery methods accurately in Message Details
- preserve unknown methods without falsely classifying them as opportunistic
- persist unknown inbound methods atomically with their conversation updates
- add callback, bridge, persistence, rendering, unknown-method, and rollback regressions

Fixes #157

## Verification

- `python3 -B -m unittest discover -s Tests/static -p 'test_*.py'` - 264 passed, 1 skipped
- Python syntax compilation passed
- Shipping XCTest - 307 passed on the exact candidate
- Model B compatibility build passed on the exact candidate
- Signed physical iPhone build, data-preserving install, and launch passed
- Fresh propagation-node synchronization physically verified that a newly received propagated message shows **Propagated** under Delivery Method
- Temporary privacy-safe boundary instrumentation confirmed `propagated` at both embedded Python and Swift boundaries and was removed before publication

## Risk and rollback

The change extends typed inbound event metadata and persistence behavior. Unknown methods remain intentionally unclassified rather than being guessed. Rollback is a normal revert of this PR; no schema migration is introduced.
