### PR TITLE
Clarify network announce feedback

### DIFF
--- a/Sources/ColumbaApp/Resources/Localizable.xcstrings
+++ b/Sources/ColumbaApp/Resources/Localizable.xcstrings
@@ -980,6 +980,46 @@
     },
     "The attachment could not be prepared for preview.": {
       "comment": "Privacy-safe error text shown when temporary attachment export fails."
+    },
+    "Announce to Network": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Announce to Network"
+          }
+        }
+      }
+    },
+    "Announced": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Announced"
+          }
+        }
+      }
+    },
+    "Broadcasts your identity so nearby peers can discover you": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Broadcasts your identity so nearby peers can discover you"
+          }
+        }
+      }
+    },
+    "Send Announce": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Send Announce"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Sources/ColumbaApp/ViewModels/ContactsViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/ContactsViewModel.swift
@@ -10,6 +10,53 @@ import Foundation
 import RNSAPI
 import Observation
 
+// MARK: - Announce Feedback
+
+/// Owns the transient success state for network announces.
+///
+/// Each new success supersedes the previous timeout. The generation check is a
+/// second fence behind task cancellation so an obsolete reset can never hide a
+/// newer success banner.
+@MainActor
+@Observable
+public final class AnnounceFeedbackState {
+    public private(set) var isVisible = false
+
+    @ObservationIgnored private var resetTask: Task<Void, Never>?
+    @ObservationIgnored private var generation: UInt64 = 0
+
+    public nonisolated init() {}
+
+    deinit {
+        resetTask?.cancel()
+    }
+
+    @discardableResult
+    public func show(for duration: Duration = .seconds(3)) -> UInt64 {
+        resetTask?.cancel()
+        generation &+= 1
+        let currentGeneration = generation
+        isVisible = true
+
+        resetTask = Task { [weak self] in
+            do {
+                try await Task.sleep(for: duration)
+            } catch {
+                return
+            }
+            self?.dismiss(ifCurrent: currentGeneration)
+        }
+        return currentGeneration
+    }
+
+    /// Internal seam for deterministic stale-timeout regression tests.
+    func dismiss(ifCurrent candidateGeneration: UInt64) {
+        guard candidateGeneration == generation else { return }
+        isVisible = false
+        resetTask = nil
+    }
+}
+
 // MARK: - Contact Type
 
 /// Type of contact badge.
@@ -340,8 +387,8 @@ public final class ContactsViewModel {
     /// True while sending an announce.
     public var isAnnouncing = false
 
-    /// Brief feedback after announce succeeds.
-    public var announceSuccess = false
+    /// Transient feedback shown after a successful network announce.
+    public let announceFeedback = AnnounceFeedbackState()
 
     /// Error message if load failed.
     public var errorMessage: String?
@@ -893,16 +940,11 @@ public final class ContactsViewModel {
     @MainActor
     public func sendAnnounce() async {
         isAnnouncing = true
-        announceSuccess = false
 
         do {
             let displayName = await SettingsRepository().getDisplayName()
             try await appServices.sendAllAnnounces(displayName: displayName)
-            announceSuccess = true
-            Task {
-                try? await Task.sleep(for: .seconds(3))
-                await MainActor.run { self.announceSuccess = false }
-            }
+            announceFeedback.show()
         } catch {
             errorMessage = "Announce failed: \(error.localizedDescription)"
         }

--- a/Sources/ColumbaApp/ViewModels/ContactsViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/ContactsViewModel.swift
@@ -49,11 +49,22 @@ public final class AnnounceFeedbackState {
         return currentGeneration
     }
 
+    /// Hide any current success before admitting another announce attempt.
+    /// This also invalidates the previous timeout so a failed retry cannot leave
+    /// stale success feedback visible.
+    public func hide() {
+        resetTask?.cancel()
+        resetTask = nil
+        generation &+= 1
+        isVisible = false
+    }
+
     /// Internal seam for deterministic stale-timeout regression tests.
     func dismiss(ifCurrent candidateGeneration: UInt64) {
         guard candidateGeneration == generation else { return }
-        isVisible = false
+        resetTask?.cancel()
         resetTask = nil
+        isVisible = false
     }
 }
 
@@ -939,6 +950,7 @@ public final class ContactsViewModel {
     /// Send an LXMF delivery announce so peers can discover and message this device.
     @MainActor
     public func sendAnnounce() async {
+        announceFeedback.hide()
         isAnnouncing = true
 
         do {

--- a/Sources/ColumbaApp/Views/Contacts/ContactsView.swift
+++ b/Sources/ColumbaApp/Views/Contacts/ContactsView.swift
@@ -8,6 +8,9 @@
 
 import SwiftUI
 import RNSAPI
+#if os(iOS)
+import UIKit
+#endif
 
 // MARK: - Navigation Target
 
@@ -140,7 +143,7 @@ public struct ContactsView: View {
                     toolbarContent(vm)
                 }
                 .safeAreaInset(edge: .top) {
-                    if vm.announceSuccess {
+                    if vm.announceFeedback.isVisible {
                         Label("Announced", systemImage: "checkmark.circle.fill")
                             .font(.subheadline.weight(.semibold))
                             .foregroundStyle(.green)
@@ -157,7 +160,17 @@ public struct ContactsView: View {
                             .padding(.top, 8)
                     }
                 }
-                .animation(.easeInOut, value: vm.announceSuccess)
+                .animation(.easeInOut, value: vm.announceFeedback.isVisible)
+                #if os(iOS)
+                .onChange(of: vm.announceFeedback.isVisible) { _, isVisible in
+                    if isVisible {
+                        UIAccessibility.post(
+                            notification: .announcement,
+                            argument: String(localized: "Announced")
+                        )
+                    }
+                }
+                #endif
                 .navigationDestination(for: ContactsNavTarget.self) { target in
                     switch target {
                     case .nodeDetails(let contact):
@@ -601,11 +614,11 @@ public struct ContactsView: View {
                     ProgressView()
                         .scaleEffect(0.8)
                 } else {
-                    Image(systemName: viewModel?.announceSuccess == true
+                    Image(systemName: viewModel?.announceFeedback.isVisible == true
                           ? "checkmark.circle.fill"
                           : "antenna.radiowaves.left.and.right")
                         .font(.title3)
-                        .foregroundStyle(viewModel?.announceSuccess == true ? .green : Theme.accentColor)
+                        .foregroundStyle(viewModel?.announceFeedback.isVisible == true ? .green : Theme.accentColor)
                 }
             }
             .disabled(viewModel?.isAnnouncing == true)

--- a/Sources/ColumbaApp/Views/Contacts/ContactsView.swift
+++ b/Sources/ColumbaApp/Views/Contacts/ContactsView.swift
@@ -139,6 +139,25 @@ public struct ContactsView: View {
                 .toolbar {
                     toolbarContent(vm)
                 }
+                .safeAreaInset(edge: .top) {
+                    if vm.announceSuccess {
+                        Label("Announced", systemImage: "checkmark.circle.fill")
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(.green)
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 10)
+                            .background(.regularMaterial, in: Capsule())
+                            .overlay {
+                                Capsule()
+                                    .stroke(.green.opacity(0.35), lineWidth: 1)
+                            }
+                            .shadow(color: .black.opacity(0.15), radius: 6, y: 2)
+                            .accessibilityIdentifier("announce_success_banner")
+                            .transition(.move(edge: .top).combined(with: .opacity))
+                            .padding(.top, 8)
+                    }
+                }
+                .animation(.easeInOut, value: vm.announceSuccess)
                 .navigationDestination(for: ContactsNavTarget.self) { target in
                     switch target {
                     case .nodeDetails(let contact):
@@ -590,6 +609,8 @@ public struct ContactsView: View {
                 }
             }
             .disabled(viewModel?.isAnnouncing == true)
+            .accessibilityLabel("Announce to Network")
+            .accessibilityHint("Broadcasts your identity so nearby peers can discover you")
             .help("Send Announce")
 
             #if os(iOS)

--- a/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
+++ b/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
@@ -25,6 +25,32 @@ import GRDB
 /// what the device decodes off the wire. Lives in Tests/ColumbaAppTests (runs
 /// via the Columba.xcodeproj scheme) because `Contact` lives in the ColumbaApp
 /// module.
+@MainActor
+final class AnnounceFeedbackStateTests: XCTestCase {
+    func testNewestSuccessOwnsVisibilityUntilItsOwnTimeout() async throws {
+        let feedback = AnnounceFeedbackState()
+
+        let firstGeneration = feedback.show(for: .seconds(60))
+        let secondGeneration = feedback.show(for: .seconds(60))
+
+        feedback.dismiss(ifCurrent: firstGeneration)
+        XCTAssertTrue(feedback.isVisible, "A stale timeout must not hide newer feedback")
+
+        feedback.dismiss(ifCurrent: secondGeneration)
+        XCTAssertFalse(feedback.isVisible)
+    }
+
+    func testSuccessAutomaticallyDismissesAfterRequestedDuration() async throws {
+        let feedback = AnnounceFeedbackState()
+
+        feedback.show(for: .milliseconds(20))
+        XCTAssertTrue(feedback.isVisible)
+
+        try await Task.sleep(for: .milliseconds(100))
+        XCTAssertFalse(feedback.isVisible)
+    }
+}
+
 final class AnnounceClassificationTests: XCTestCase {
 
     private let pnMetaName: UInt64 = 0x01

--- a/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
+++ b/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
@@ -40,6 +40,22 @@ final class AnnounceFeedbackStateTests: XCTestCase {
         XCTAssertFalse(feedback.isVisible)
     }
 
+    func testStartingAnotherAttemptClearsPriorSuccessAndInvalidatesItsTimeout() {
+        let feedback = AnnounceFeedbackState()
+
+        let priorGeneration = feedback.show(for: .seconds(60))
+        feedback.hide()
+
+        XCTAssertFalse(feedback.isVisible, "A retry must clear stale success immediately")
+
+        let retryGeneration = feedback.show(for: .seconds(60))
+        feedback.dismiss(ifCurrent: priorGeneration)
+        XCTAssertTrue(feedback.isVisible, "The prior timeout must not hide retry success")
+
+        feedback.dismiss(ifCurrent: retryGeneration)
+        XCTAssertFalse(feedback.isVisible)
+    }
+
     func testSuccessAutomaticallyDismissesAfterRequestedDuration() async throws {
         let feedback = AnnounceFeedbackState()
 

--- a/Tests/static/test_contacts_network_performance.py
+++ b/Tests/static/test_contacts_network_performance.py
@@ -63,9 +63,14 @@ class ContactsNetworkPerformanceContractTests(unittest.TestCase):
             self.view,
         )
         self.assertIn(".safeAreaInset(edge: .top)", self.view)
-        self.assertIn("if vm.announceSuccess", self.view)
+        self.assertIn("if vm.announceFeedback.isVisible", self.view)
         self.assertIn('Label("Announced", systemImage: "checkmark.circle.fill")', self.view)
         self.assertIn('.accessibilityIdentifier("announce_success_banner")', self.view)
+        self.assertIn("UIAccessibility.post(", self.view)
+        self.assertIn("notification: .announcement", self.view)
+        self.assertIn("public let announceFeedback = AnnounceFeedbackState()", self.vm)
+        self.assertIn("resetTask?.cancel()", self.vm)
+        self.assertIn("dismiss(ifCurrent: currentGeneration)", self.vm)
 
     def test_reappearance_refreshes_saved_state_without_rebuilding_paths(self):
         self.assertIn("private var hasLoadedContacts = false", self.vm)

--- a/Tests/static/test_contacts_network_performance.py
+++ b/Tests/static/test_contacts_network_performance.py
@@ -10,6 +10,7 @@ IDENTICON = ROOT / "Sources/ColumbaApp/Views/Components/Identicon.swift"
 GENERATOR = ROOT / "Sources/ColumbaApp/Views/Components/IdenticonGenerator.swift"
 CONTACTS_VIEW = ROOT / "Sources/ColumbaApp/Views/Contacts/ContactsView.swift"
 MESSAGE_REPOSITORY = ROOT / "Sources/ColumbaApp/Services/MessageRepository.swift"
+LOCALIZATIONS = ROOT / "Sources/ColumbaApp/Resources/Localizable.xcstrings"
 
 
 class ContactsNetworkPerformanceContractTests(unittest.TestCase):
@@ -21,6 +22,7 @@ class ContactsNetworkPerformanceContractTests(unittest.TestCase):
         cls.generator = GENERATOR.read_text()
         cls.view = CONTACTS_VIEW.read_text()
         cls.repository = MESSAGE_REPOSITORY.read_text()
+        cls.localizations = LOCALIZATIONS.read_text()
 
     def test_contact_diagnostics_are_aggregate_only(self):
         self.assertNotIn("relayContacts.map", self.vm)
@@ -69,8 +71,16 @@ class ContactsNetworkPerformanceContractTests(unittest.TestCase):
         self.assertIn("UIAccessibility.post(", self.view)
         self.assertIn("notification: .announcement", self.view)
         self.assertIn("public let announceFeedback = AnnounceFeedbackState()", self.vm)
+        self.assertIn("announceFeedback.hide()", self.vm)
         self.assertIn("resetTask?.cancel()", self.vm)
         self.assertIn("dismiss(ifCurrent: currentGeneration)", self.vm)
+        for text in (
+            "Announce to Network",
+            "Announced",
+            "Broadcasts your identity so nearby peers can discover you",
+            "Send Announce",
+        ):
+            self.assertIn(f'"{text}"', self.localizations)
 
     def test_reappearance_refreshes_saved_state_without_rebuilding_paths(self):
         self.assertIn("private var hasLoadedContacts = false", self.vm)

--- a/Tests/static/test_contacts_network_performance.py
+++ b/Tests/static/test_contacts_network_performance.py
@@ -56,6 +56,17 @@ class ContactsNetworkPerformanceContractTests(unittest.TestCase):
         self.assertIn("patternCache.countLimit = 4096", self.generator)
         self.assertIn("public static func cachedPattern", self.generator)
 
+    def test_announce_action_explains_itself_and_shows_success_feedback(self):
+        self.assertIn('.accessibilityLabel("Announce to Network")', self.view)
+        self.assertIn(
+            '.accessibilityHint("Broadcasts your identity so nearby peers can discover you")',
+            self.view,
+        )
+        self.assertIn(".safeAreaInset(edge: .top)", self.view)
+        self.assertIn("if vm.announceSuccess", self.view)
+        self.assertIn('Label("Announced", systemImage: "checkmark.circle.fill")', self.view)
+        self.assertIn('.accessibilityIdentifier("announce_success_banner")', self.view)
+
     def test_reappearance_refreshes_saved_state_without_rebuilding_paths(self):
         self.assertIn("private var hasLoadedContacts = false", self.vm)
         self.assertIn("public func loadContacts(force: Bool = false)", self.vm)


### PR DESCRIPTION
## Summary

- show a localized Announced banner after successful network announces
- explain the announce action with accessible labeling and VoiceOver feedback
- generation-fence and cancel feedback timeouts across retries

## Verification

- 265 static tests passed, 1 skipped
- AnnounceFeedbackStateTests: 3 tests passed on the native iOS test target
- shipping and Model B simulator builds passed
- signed physical-device build, install, launch, and manual announce feedback passed
- independent exact-head standards and issue-conformance reviews approved

Fixes #151
