### PR TITLE
Fix privacy settings toggle semantics

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,6 +75,7 @@ jobs:
             Tests.static.test_migration_export_flow \
             Tests.static.test_ios_stamp_runtime_hardening \
             Tests.static.test_async_propagation_fallback \
+            Tests.static.test_privacy_settings_contract \
             Tests.static.test_ui_screenshotter_readiness \
             Tests.static.test_collect_maestro_screenshots
 

--- a/Sources/ColumbaApp/Resources/Localizable.xcstrings
+++ b/Sources/ColumbaApp/Resources/Localizable.xcstrings
@@ -981,6 +981,39 @@
     "The attachment could not be prepared for preview.": {
       "comment": "Privacy-safe error text shown when temporary attachment export fails."
     },
+    "Messages from contacts only": {
+      "comment": "Label for the privacy control that rejects messages from unknown senders.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Messages from contacts only"
+          }
+        }
+      }
+    },
+    "Only contacts can message you. Messages from unknown senders are silently discarded.": {
+      "comment": "Privacy explanation shown when messages from unknown senders are blocked.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Only contacts can message you. Messages from unknown senders are silently discarded."
+          }
+        }
+      }
+    },
+    "Anyone can send you messages, including unknown senders.": {
+      "comment": "Privacy explanation shown when messages from unknown senders are allowed.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anyone can send you messages, including unknown senders."
+          }
+        }
+      }
+    },
     "Announce to Network": {
       "localizations": {
         "en": {

--- a/Sources/ColumbaApp/Views/Settings/SettingsView.swift
+++ b/Sources/ColumbaApp/Views/Settings/SettingsView.swift
@@ -664,16 +664,23 @@ struct SettingsView: View {
         ExpandableSettingsCard(
             icon: "shield.fill",
             title: "Privacy",
-            isExpanded: Binding(get: { vm.isPrivacyExpanded }, set: { vm.isPrivacyExpanded = $0 }),
-            toggle: Binding(get: { vm.blockUnknownSenders }, set: { newValue in
-                vm.blockUnknownSenders = newValue
-                vm.saveSettings()
-            })
+            isExpanded: Binding(get: { vm.isPrivacyExpanded }, set: { vm.isPrivacyExpanded = $0 })
         ) {
             VStack(alignment: .leading, spacing: 12) {
+                Toggle(String(localized: "Messages from contacts only"), isOn: Binding(
+                    get: { vm.blockUnknownSenders },
+                    set: { newValue in
+                        vm.blockUnknownSenders = newValue
+                        vm.saveSettings()
+                    }
+                ))
+                .font(.subheadline)
+                .foregroundStyle(Theme.textSecondary)
+                .toggleStyle(AccentToggleStyle())
+
                 Text(vm.blockUnknownSenders
-                    ? "Only contacts can message you. Messages from unknown senders are silently discarded."
-                    : "Anyone can send you messages, including unknown senders.")
+                    ? String(localized: "Only contacts can message you. Messages from unknown senders are silently discarded.")
+                    : String(localized: "Anyone can send you messages, including unknown senders."))
                     .font(.caption)
                     .foregroundStyle(Theme.textSecondary)
             }

--- a/Tests/static/test_privacy_settings_contract.py
+++ b/Tests/static/test_privacy_settings_contract.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Regression contract for GitHub issue 160 privacy-card semantics."""
+
+import json
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SETTINGS_VIEW = ROOT / "Sources/ColumbaApp/Views/Settings/SettingsView.swift"
+LOCALIZATIONS = ROOT / "Sources/ColumbaApp/Resources/Localizable.xcstrings"
+
+
+class PrivacySettingsContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        source = SETTINGS_VIEW.read_text(encoding="utf-8")
+        match = re.search(
+            r"private func privacyCard\(_ vm: SettingsViewModel\) -> some View \{"
+            r"(?P<body>.*?)\n    \}\n\n    // MARK: - Notifications Card",
+            source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(match)
+        assert match is not None
+        self.privacy_card = match.group("body")
+        self.catalog = json.loads(LOCALIZATIONS.read_text(encoding="utf-8"))["strings"]
+
+    def test_header_has_no_ambiguous_privacy_toggle(self) -> None:
+        header = self.privacy_card.split(") {", 1)[0]
+        self.assertNotIn("toggle:", header)
+
+    def test_expanded_content_names_and_explains_the_message_filter(self) -> None:
+        self.assertIn(
+            'Toggle(String(localized: "Messages from contacts only")',
+            self.privacy_card,
+        )
+        self.assertIn("vm.blockUnknownSenders = newValue", self.privacy_card)
+        self.assertIn("vm.saveSettings()", self.privacy_card)
+
+        expected_strings = (
+            "Messages from contacts only",
+            "Only contacts can message you. Messages from unknown senders are silently discarded.",
+            "Anyone can send you messages, including unknown senders.",
+        )
+        for text in expected_strings:
+            self.assertIn(f'String(localized: "{text}")', self.privacy_card)
+            self.assertIn(text, self.catalog)
+            localization = self.catalog[text]["localizations"]["en"]["stringUnit"]
+            self.assertEqual(localization["state"], "translated")
+            self.assertEqual(localization["value"], text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- remove the ambiguous message-filter switch from the collapsed Privacy card header
- expose the control inside the expanded card as **Messages from contacts only**
- match Android's enabled and disabled explanations and localize all new copy
- add a CI-enforced regression contract for the header, binding, persistence, and catalog entries

Fixes #160

## Verification

- `python3 -B -m unittest Tests.static.test_privacy_settings_contract` - 2 passed
- canonical static CI command - 112 passed locally
- full static test discovery - 267 passed, 1 skipped during independent exact-commit review
- shipping iOS Simulator build succeeded with Xcode 26.4.1
- Maestro verified the collapsed header, expanded disabled state, switch interaction, and enabled explanation
- exact commit built, signed, installed, launched, and process-verified on a physical iPhone without clearing app data
- independent review approved commit `6ec51c01` with no blocking findings

## Risk and rollback

Risk is limited to the Privacy card's presentation and localization. The existing `blockUnknownSenders` setting and persistence path are unchanged. Reverting this commit restores the previous header switch.
