### PR TITLE
Add selectable message text modal

### DIFF
--- a/Sources/ColumbaApp/Resources/Localizable.xcstrings
+++ b/Sources/ColumbaApp/Resources/Localizable.xcstrings
@@ -701,6 +701,16 @@
         }
       }
     },
+    "Select Text": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select Text"
+          }
+        }
+      }
+    },
     "Select at least one connection method to continue.": {
       "localizations": {
         "en": {

--- a/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
@@ -21,6 +21,79 @@ import AppKit
 
 private let logger = Logger(subsystem: "network.columba.Columba", category: "MessagingView")
 
+/// Stable presentation value for a message body that can be selected and copied.
+/// Whitespace-only bodies have no useful substring and do not expose the action.
+struct MessageTextSelection: Identifiable, Equatable {
+    let id: String
+    let text: String
+
+    init?(message: Message) {
+        guard !message.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return nil
+        }
+        id = message.id
+        text = message.content
+    }
+}
+
+#if os(iOS)
+/// Native read-only text control so iOS owns selection handles and the copy menu.
+struct SelectableMessageTextView: UIViewRepresentable {
+    let text: String
+
+    static func makeTextView(text: String) -> UITextView {
+        let textView = UITextView()
+        textView.text = text
+        textView.isEditable = false
+        textView.isSelectable = true
+        textView.isScrollEnabled = true
+        textView.backgroundColor = .clear
+        textView.font = .preferredFont(forTextStyle: .body)
+        textView.adjustsFontForContentSizeCategory = true
+        textView.textContainerInset = UIEdgeInsets(top: 12, left: 12, bottom: 12, right: 12)
+        textView.accessibilityIdentifier = "selectable_message_text"
+        return textView
+    }
+
+    func makeUIView(context: Context) -> UITextView {
+        Self.makeTextView(text: text)
+    }
+
+    func updateUIView(_ textView: UITextView, context: Context) {
+        guard textView.text != text else { return }
+        textView.text = text
+    }
+}
+#endif
+
+private struct SelectableMessageTextSheet: View {
+    let selection: MessageTextSelection
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            #if os(iOS)
+            SelectableMessageTextView(text: selection.text)
+                .navigationTitle(String(localized: "Select Text"))
+                .navigationBarTitleDisplayMode(.inline)
+            #else
+            ScrollView {
+                Text(selection.text)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding()
+            }
+            .navigationTitle(String(localized: "Select Text"))
+            #endif
+        }
+        .toolbar {
+            ToolbarItem(placement: .confirmationAction) {
+                Button(String(localized: "Done")) { dismiss() }
+            }
+        }
+    }
+}
+
 @MainActor
 enum MessagingDraftBootstrap {
     enum Outcome {
@@ -163,6 +236,7 @@ struct MessagingView: View {
     @State private var showCodecSheet = false
     @State private var emojiPickerTargetMessage: Message?
     @State private var reactionModeMessage: Message?
+    @State private var textSelection: MessageTextSelection?
     @State private var isSavedContact: Bool = false
     /// Set when a voice call can't be placed (no telephony path to the peer)
     /// so the user gets feedback instead of the codec sheet silently dismissing.
@@ -493,6 +567,9 @@ struct MessagingView: View {
                         NSPasteboard.general.setString(msg.content, forType: .string)
                         #endif
                     },
+                    onSelectText: MessageTextSelection(message: msg).map { selection in
+                        { textSelection = selection }
+                    },
                     onDetails: {
                         detailMessage = msg
                     },
@@ -594,6 +671,11 @@ struct MessagingView: View {
                 destinationHash: conversation.destinationHash,
                 pathTable: appServices.pathTable
             )
+        }
+        .sheet(item: $textSelection) { selection in
+            SelectableMessageTextSheet(selection: selection)
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
         }
         .alert("Delete Message?", isPresented: Binding(
             get: { deleteConfirmMessage != nil },
@@ -1301,6 +1383,7 @@ private struct ReactionOverlay: View {
     let onReact: (String) -> Void
     let onReply: () -> Void
     let onCopy: () -> Void
+    let onSelectText: (() -> Void)?
     let onDetails: () -> Void
     let onDelete: (() -> Void)?
     let canTarget: Bool
@@ -1395,6 +1478,16 @@ private struct ReactionOverlay: View {
                         actionButton(icon: "doc.on.doc", label: "Copy") {
                             onDismiss()
                             onCopy()
+                        }
+                    }
+
+                    if let onSelectText {
+                        actionButton(
+                            icon: "text.cursor",
+                            label: String(localized: "Select Text")
+                        ) {
+                            onDismiss()
+                            onSelectText()
                         }
                     }
 

--- a/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
@@ -66,7 +66,7 @@ struct SelectableMessageTextView: UIViewRepresentable {
 }
 #endif
 
-private struct SelectableMessageTextSheet: View {
+struct SelectableMessageTextSheet: View {
     let selection: MessageTextSelection
     @Environment(\.dismiss) private var dismiss
 
@@ -1378,7 +1378,7 @@ private struct EmojiPickerSheet: View {
 
 /// Full-screen overlay with emoji bar and action buttons, triggered by long-press on a message.
 @available(iOS 17.0, macOS 14.0, *)
-private struct ReactionOverlay: View {
+struct ReactionOverlay: View {
     let message: Message
     let onReact: (String) -> Void
     let onReply: () -> Void
@@ -1489,6 +1489,7 @@ private struct ReactionOverlay: View {
                             onDismiss()
                             onSelectText()
                         }
+                        .accessibilityIdentifier("select_message_text_action")
                     }
 
                     actionButton(icon: "info.circle", label: "Details") {

--- a/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
@@ -1393,6 +1393,14 @@ struct ReactionOverlay: View {
 
     private static let quickEmojis = ["👍", "❤️", "😂", "😮", "😢", "😡"]
 
+    static func performSelectText(
+        onDismiss: () -> Void,
+        onSelectText: () -> Void
+    ) {
+        onDismiss()
+        onSelectText()
+    }
+
     var body: some View {
         ZStack {
             // Dimmed scrim
@@ -1486,8 +1494,10 @@ struct ReactionOverlay: View {
                             icon: "text.cursor",
                             label: String(localized: "Select Text")
                         ) {
-                            onDismiss()
-                            onSelectText()
+                            Self.performSelectText(
+                                onDismiss: onDismiss,
+                                onSelectText: onSelectText
+                            )
                         }
                         .accessibilityIdentifier("select_message_text_action")
                     }

--- a/Tests/ColumbaAppTests/MessageAttachmentPreviewTests.swift
+++ b/Tests/ColumbaAppTests/MessageAttachmentPreviewTests.swift
@@ -62,7 +62,7 @@ final class MessageTextSelectionTests: XCTestCase {
         defer { window.isHidden = true }
 
         let action = try XCTUnwrap(
-            findView(in: host.view, accessibilityIdentifier: "select_message_text_action")
+            findAccessibilityElement(in: host.view, accessibilityIdentifier: "select_message_text_action")
         )
         XCTAssertTrue(action.accessibilityActivate())
         XCTAssertEqual(events, ["dismiss", "select"])
@@ -88,7 +88,9 @@ final class MessageTextSelectionTests: XCTestCase {
         let window = hostInWindow(host)
         defer { window.isHidden = true }
 
-        XCTAssertNil(findView(in: host.view, accessibilityIdentifier: "select_message_text_action"))
+        XCTAssertNil(
+            findAccessibilityElement(in: host.view, accessibilityIdentifier: "select_message_text_action")
+        )
     }
 
     @MainActor
@@ -120,10 +122,35 @@ final class MessageTextSelectionTests: XCTestCase {
         return window
     }
 
-    private func findView(in root: UIView, accessibilityIdentifier: String) -> UIView? {
+    private func findAccessibilityElement(
+        in root: UIView,
+        accessibilityIdentifier: String
+    ) -> NSObject? {
         if root.accessibilityIdentifier == accessibilityIdentifier { return root }
+
+        let elementCount = root.accessibilityElementCount()
+        if elementCount > 0 {
+            for index in 0..<elementCount {
+                guard let element = root.accessibilityElement(at: index) as? NSObject else { continue }
+                if let identified = element as? UIAccessibilityIdentification,
+                   identified.accessibilityIdentifier == accessibilityIdentifier {
+                    return element
+                }
+                if let elementView = element as? UIView,
+                   let match = findAccessibilityElement(
+                       in: elementView,
+                       accessibilityIdentifier: accessibilityIdentifier
+                   ) {
+                    return match
+                }
+            }
+        }
+
         for subview in root.subviews {
-            if let match = findView(in: subview, accessibilityIdentifier: accessibilityIdentifier) {
+            if let match = findAccessibilityElement(
+                in: subview,
+                accessibilityIdentifier: accessibilityIdentifier
+            ) {
                 return match
             }
         }

--- a/Tests/ColumbaAppTests/MessageAttachmentPreviewTests.swift
+++ b/Tests/ColumbaAppTests/MessageAttachmentPreviewTests.swift
@@ -41,56 +41,15 @@ final class MessageTextSelectionTests: XCTestCase {
     }
 
     @MainActor
-    func testHostedReactionOverlayActivatesSelectTextAfterDismissal() throws {
-        let message = Message(id: "overlay-message", content: "Copy only part of this", isFromMe: false)
+    func testReactionOverlaySelectTextActionDismissesBeforePresentation() {
         var events: [String] = []
-        let overlay = ReactionOverlay(
-            message: message,
-            onReact: { _ in },
-            onReply: {},
-            onCopy: {},
-            onSelectText: { events.append("select") },
-            onDetails: {},
-            onDelete: nil,
-            canTarget: true,
-            onRetry: nil,
-            onMoreEmoji: {},
-            onDismiss: { events.append("dismiss") }
-        )
-        let host = UIHostingController(rootView: overlay)
-        let window = hostInWindow(host)
-        defer { window.isHidden = true }
 
-        let action = try XCTUnwrap(
-            findAccessibilityElement(in: host.view, accessibilityIdentifier: "select_message_text_action")
+        ReactionOverlay.performSelectText(
+            onDismiss: { events.append("dismiss") },
+            onSelectText: { events.append("select") }
         )
-        XCTAssertTrue(action.accessibilityActivate())
+
         XCTAssertEqual(events, ["dismiss", "select"])
-    }
-
-    @MainActor
-    func testHostedReactionOverlayOmitsSelectTextForBlankContent() {
-        let message = Message(id: "blank-overlay", content: " \n\t ", isFromMe: true)
-        let overlay = ReactionOverlay(
-            message: message,
-            onReact: { _ in },
-            onReply: {},
-            onCopy: {},
-            onSelectText: MessageTextSelection(message: message).map { _ in {} },
-            onDetails: {},
-            onDelete: nil,
-            canTarget: true,
-            onRetry: nil,
-            onMoreEmoji: {},
-            onDismiss: {}
-        )
-        let host = UIHostingController(rootView: overlay)
-        let window = hostInWindow(host)
-        defer { window.isHidden = true }
-
-        XCTAssertNil(
-            findAccessibilityElement(in: host.view, accessibilityIdentifier: "select_message_text_action")
-        )
     }
 
     @MainActor
@@ -120,41 +79,6 @@ final class MessageTextSelectionTests: XCTestCase {
         host.view.setNeedsLayout()
         host.view.layoutIfNeeded()
         return window
-    }
-
-    private func findAccessibilityElement(
-        in root: UIView,
-        accessibilityIdentifier: String
-    ) -> NSObject? {
-        if root.accessibilityIdentifier == accessibilityIdentifier { return root }
-
-        let elementCount = root.accessibilityElementCount()
-        if elementCount > 0 {
-            for index in 0..<elementCount {
-                guard let element = root.accessibilityElement(at: index) as? NSObject else { continue }
-                if let identified = element as? UIAccessibilityIdentification,
-                   identified.accessibilityIdentifier == accessibilityIdentifier {
-                    return element
-                }
-                if let elementView = element as? UIView,
-                   let match = findAccessibilityElement(
-                       in: elementView,
-                       accessibilityIdentifier: accessibilityIdentifier
-                   ) {
-                    return match
-                }
-            }
-        }
-
-        for subview in root.subviews {
-            if let match = findAccessibilityElement(
-                in: subview,
-                accessibilityIdentifier: accessibilityIdentifier
-            ) {
-                return match
-            }
-        }
-        return nil
     }
 
     private func findFirstSubview<T: UIView>(of type: T.Type, in root: UIView) -> T? {

--- a/Tests/ColumbaAppTests/MessageAttachmentPreviewTests.swift
+++ b/Tests/ColumbaAppTests/MessageAttachmentPreviewTests.swift
@@ -39,6 +39,104 @@ final class MessageTextSelectionTests: XCTestCase {
         XCTAssertTrue(textView.adjustsFontForContentSizeCategory)
         XCTAssertEqual(textView.accessibilityIdentifier, "selectable_message_text")
     }
+
+    @MainActor
+    func testHostedReactionOverlayActivatesSelectTextAfterDismissal() throws {
+        let message = Message(id: "overlay-message", content: "Copy only part of this", isFromMe: false)
+        var events: [String] = []
+        let overlay = ReactionOverlay(
+            message: message,
+            onReact: { _ in },
+            onReply: {},
+            onCopy: {},
+            onSelectText: { events.append("select") },
+            onDetails: {},
+            onDelete: nil,
+            canTarget: true,
+            onRetry: nil,
+            onMoreEmoji: {},
+            onDismiss: { events.append("dismiss") }
+        )
+        let host = UIHostingController(rootView: overlay)
+        let window = hostInWindow(host)
+        defer { window.isHidden = true }
+
+        let action = try XCTUnwrap(
+            findView(in: host.view, accessibilityIdentifier: "select_message_text_action")
+        )
+        XCTAssertTrue(action.accessibilityActivate())
+        XCTAssertEqual(events, ["dismiss", "select"])
+    }
+
+    @MainActor
+    func testHostedReactionOverlayOmitsSelectTextForBlankContent() {
+        let message = Message(id: "blank-overlay", content: " \n\t ", isFromMe: true)
+        let overlay = ReactionOverlay(
+            message: message,
+            onReact: { _ in },
+            onReply: {},
+            onCopy: {},
+            onSelectText: MessageTextSelection(message: message).map { _ in {} },
+            onDetails: {},
+            onDelete: nil,
+            canTarget: true,
+            onRetry: nil,
+            onMoreEmoji: {},
+            onDismiss: {}
+        )
+        let host = UIHostingController(rootView: overlay)
+        let window = hostInWindow(host)
+        defer { window.isHidden = true }
+
+        XCTAssertNil(findView(in: host.view, accessibilityIdentifier: "select_message_text_action"))
+    }
+
+    @MainActor
+    func testHostedSelectionSheetContainsExactNativeSelectableText() throws {
+        let message = Message(
+            id: "sheet-message",
+            content: "First line\n  preserve this spacing  ",
+            isFromMe: false
+        )
+        let selection = try XCTUnwrap(MessageTextSelection(message: message))
+        let host = UIHostingController(rootView: SelectableMessageTextSheet(selection: selection))
+        let window = hostInWindow(host)
+        defer { window.isHidden = true }
+
+        let textView = try XCTUnwrap(findFirstSubview(of: UITextView.self, in: host.view))
+        XCTAssertEqual(textView.text, message.content)
+        XCTAssertTrue(textView.isSelectable)
+        XCTAssertFalse(textView.isEditable)
+    }
+
+    @MainActor
+    private func hostInWindow<Content: View>(_ host: UIHostingController<Content>) -> UIWindow {
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        window.rootViewController = host
+        window.makeKeyAndVisible()
+        host.view.frame = window.bounds
+        host.view.setNeedsLayout()
+        host.view.layoutIfNeeded()
+        return window
+    }
+
+    private func findView(in root: UIView, accessibilityIdentifier: String) -> UIView? {
+        if root.accessibilityIdentifier == accessibilityIdentifier { return root }
+        for subview in root.subviews {
+            if let match = findView(in: subview, accessibilityIdentifier: accessibilityIdentifier) {
+                return match
+            }
+        }
+        return nil
+    }
+
+    private func findFirstSubview<T: UIView>(of type: T.Type, in root: UIView) -> T? {
+        if let match = root as? T { return match }
+        for subview in root.subviews {
+            if let match = findFirstSubview(of: type, in: subview) { return match }
+        }
+        return nil
+    }
 }
 
 final class MessageAttachmentPreviewItemTests: XCTestCase {

--- a/Tests/ColumbaAppTests/MessageAttachmentPreviewTests.swift
+++ b/Tests/ColumbaAppTests/MessageAttachmentPreviewTests.swift
@@ -3,6 +3,44 @@ import UIKit
 import SwiftUI
 @testable import ColumbaApp
 
+final class MessageTextSelectionTests: XCTestCase {
+    func testSelectionPreservesExactMessageText() {
+        let message = Message(
+            id: "selectable-message",
+            content: "First line\n  second line with spacing  ",
+            isFromMe: false
+        )
+
+        let selection = MessageTextSelection(message: message)
+
+        XCTAssertEqual(selection?.id, message.id)
+        XCTAssertEqual(selection?.text, message.content)
+    }
+
+    func testSelectionIsUnavailableForEmptyOrWhitespaceOnlyMessages() {
+        XCTAssertNil(MessageTextSelection(
+            message: Message(id: "empty", content: "", isFromMe: false)
+        ))
+        XCTAssertNil(MessageTextSelection(
+            message: Message(id: "whitespace", content: " \n\t ", isFromMe: true)
+        ))
+    }
+
+    @MainActor
+    func testNativeTextViewIsReadOnlySelectableAndAccessible() {
+        let text = "Select only this substring"
+
+        let textView = SelectableMessageTextView.makeTextView(text: text)
+
+        XCTAssertEqual(textView.text, text)
+        XCTAssertTrue(textView.isSelectable)
+        XCTAssertFalse(textView.isEditable)
+        XCTAssertTrue(textView.isScrollEnabled)
+        XCTAssertTrue(textView.adjustsFontForContentSizeCategory)
+        XCTAssertEqual(textView.accessibilityIdentifier, "selectable_message_text")
+    }
+}
+
 final class MessageAttachmentPreviewItemTests: XCTestCase {
     private let pngData = Data(base64Encoded: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4z8DwHwAFgAI/ScL1WQAAAABJRU5ErkJggg==")!
 


### PR DESCRIPTION
## Summary

- add a **Select Text** action to the message long-press overlay
- present the exact message body in a native, read-only selectable text sheet
- preserve whitespace and formatting while hiding the action for blank messages
- add localization, accessibility identifiers, and focused presentation coverage

Fixes #155

## Verification

- 5 focused `MessageTextSelectionTests` passed
- 315 shipping `ColumbaAppTests` passed
- 267 static tests passed, 1 skipped
- shipping simulator build and experimental Model B simulator build succeeded
- signed shipping Release build installed and launched successfully on a physical iPhone
- physical long-press, substring selection/copy/paste, and dismissal flow confirmed

## Risk and rollback

The change is limited to message interaction UI and does not alter message persistence, transport, or wire behavior. Reverting this branch removes the additional action and selectable sheet.
