### PR TITLE
Fix LXMA contact links in message bubbles

### DIFF
--- a/Sources/ColumbaApp/ViewModels/ContactsViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/ContactsViewModel.swift
@@ -999,9 +999,13 @@ public final class ContactsViewModel {
     /// Returns nil on any validation failure.
     public static func parseLXMA(_ urlString: String) -> (destinationHash: Data, publicKey: Data)? {
         var s = urlString
-        // Strip scheme prefix
+        // Strip the canonical URI prefix or the equivalent opaque action URL
+        // used by message links. Foundation rejects the canonical hierarchical
+        // form because it interprets the 128-character public key as a port.
         if s.hasPrefix("lxma://") {
             s = String(s.dropFirst("lxma://".count))
+        } else if s.hasPrefix("lxma:") {
+            s = String(s.dropFirst("lxma:".count))
         } else {
             return nil
         }

--- a/Sources/ColumbaApp/Views/Contacts/ContactsView.swift
+++ b/Sources/ColumbaApp/Views/Contacts/ContactsView.swift
@@ -364,18 +364,27 @@ public struct ContactsView: View {
         } message: {
             Text("Enter a custom name for this contact. Clear to use the announce name.")
         }
-        .onChange(of: pendingDeepLink?.wrappedValue) { _, newValue in
-            if let urlString = newValue, let parsed = ContactsViewModel.parseLXMA(urlString) {
-                pendingDeepLink?.wrappedValue = nil
-                scannedContact = ScannedContact(
-                    destinationHash: parsed.destinationHash,
-                    publicKey: parsed.publicKey
-                )
-            }
+        .onAppear {
+            consumePendingDeepLink()
+        }
+        .onChange(of: pendingDeepLink?.wrappedValue) { _, _ in
+            consumePendingDeepLink()
         }
     }
 
     // MARK: - Tab Picker
+
+    /// Consume both cold-start and already-mounted LXMA URLs exactly once.
+    /// `onChange` does not fire when the binding is already populated at mount.
+    private func consumePendingDeepLink() {
+        guard let urlString = pendingDeepLink?.wrappedValue,
+              let parsed = ContactsViewModel.parseLXMA(urlString) else { return }
+        pendingDeepLink?.wrappedValue = nil
+        scannedContact = ScannedContact(
+            destinationHash: parsed.destinationHash,
+            publicKey: parsed.publicKey
+        )
+    }
 
     private func tabPicker(_ vm: ContactsViewModel) -> some View {
         Picker("Tab", selection: Binding(

--- a/Sources/ColumbaApp/Views/MainTabView.swift
+++ b/Sources/ColumbaApp/Views/MainTabView.swift
@@ -106,6 +106,7 @@ struct MainTabView: View {
         .tint(Theme.accentColor)
         .onAppear {
             consumePendingRNodeSetup()
+            routePendingDeepLink()
         }
         .onChange(of: pendingRNodeSetup) { _, requested in
             // MainTabView can already be mounted behind onboarding, in which case
@@ -114,10 +115,8 @@ struct MainTabView: View {
                 consumePendingRNodeSetup()
             }
         }
-        .onChange(of: pendingDeepLink) { _, newValue in
-            if newValue != nil {
-                selectedTab = .contacts
-            }
+        .onChange(of: pendingDeepLink) { _, _ in
+            routePendingDeepLink()
         }
         #if os(iOS)
         .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in
@@ -207,5 +206,13 @@ struct MainTabView: View {
         selectedTab = .settings
         shouldOpenRNodeWizard = true
         pendingRNodeSetup = false
+    }
+
+    /// Route both cold-start and already-mounted LXMA URLs to Contacts.
+    /// `onChange` alone misses a value that exists before this view mounts.
+    private func routePendingDeepLink() {
+        if pendingDeepLink != nil {
+            selectedTab = .contacts
+        }
     }
 }

--- a/Sources/ColumbaApp/Views/Messaging/MessageBody.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageBody.swift
@@ -37,6 +37,10 @@ enum MessageLinkParser {
         pattern: #"^(?:nomadnetwork://)?([0-9a-fA-F]{32}):(/[^\s,;!?)\]]+)$"#,
         options: [.caseInsensitive]
     )
+    private static let anchoredLXMA = try! NSRegularExpression(
+        pattern: #"^lxma:(?://)?([0-9a-fA-F]{32}):([0-9a-fA-F]{128})$"#,
+        options: [.caseInsensitive]
+    )
     private static let detectors = [
         try! NSRegularExpression(pattern: bareNomadNetPattern),
         try! NSRegularExpression(pattern: explicitPattern, options: [.caseInsensitive]),
@@ -90,6 +94,18 @@ enum MessageLinkParser {
            let pathRange = Range(match.range(at: 2), in: cleaned),
            let hash = Data(hexString: String(cleaned[hashRange])) {
             return .nomadNet(nodeHash: hash, path: String(cleaned[pathRange]))
+        }
+
+        if let match = anchoredLXMA.firstMatch(in: cleaned, range: range),
+           let hashRange = Range(match.range(at: 1), in: cleaned),
+           let publicKeyRange = Range(match.range(at: 2), in: cleaned),
+           let actionURL = URL(
+            string: "lxma:\(cleaned[hashRange]):\(cleaned[publicKeyRange])"
+           ) {
+            // A canonical lxma:// URI is not a valid hierarchical Foundation URL:
+            // the 128-character public key is interpreted as an invalid port.
+            // Use the equivalent opaque form for the attributed link and app route.
+            return .external(actionURL)
         }
 
         guard let url = URL(string: cleaned),

--- a/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
+++ b/Tests/ColumbaAppTests/AnnounceClassificationTests.swift
@@ -204,9 +204,12 @@ final class AnnounceClassificationTests: XCTestCase {
         let uri = "lxma://\(destinationHex):\(publicKeyHex)"
 
         let parsed = ContactsViewModel.parseLXMA(uri)
+        let routed = ContactsViewModel.parseLXMA("lxma:\(destinationHex):\(publicKeyHex)")
 
         XCTAssertEqual(parsed?.destinationHash, destinationHash)
         XCTAssertEqual(parsed?.publicKey, identity.publicKeys)
+        XCTAssertEqual(routed?.destinationHash, destinationHash)
+        XCTAssertEqual(routed?.publicKey, identity.publicKeys)
     }
 
     func testLXMAContactRejectsPublicIdentityThatDoesNotOwnDestination() throws {

--- a/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
+++ b/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
@@ -21,6 +21,20 @@ final class MessageLinkParserTests: XCTestCase {
         ])
     }
 
+    func testPlaintextDetectsCanonicalLXMAContactLink() throws {
+        let destinationHash = String(repeating: "01", count: 16)
+        let publicKey = String(repeating: "ab", count: 64)
+        let lxma = "lxma://\(destinationHash):\(publicKey)"
+
+        let match = try XCTUnwrap(MessageLinkParser.matches(in: "Add \(lxma) now").first)
+
+        let actionURL = try XCTUnwrap(URL(string: "lxma:\(destinationHash):\(publicKey)"))
+        XCTAssertEqual(match.text, lxma)
+        XCTAssertEqual(match.target, .external(actionURL))
+        XCTAssertEqual(match.target.url, actionURL)
+        XCTAssertEqual(MessageLinkParser.target(for: actionURL), .external(actionURL))
+    }
+
     func testMarkdownLinkTargetsAllowOnlySupportedSchemes() {
         XCTAssertEqual(
             MessageLinkParser.target(for: URL(string: "https://example.com")!),

--- a/Tests/static/test_lxma_deep_link_lifecycle.py
+++ b/Tests/static/test_lxma_deep_link_lifecycle.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Regression contract for cold-start and already-mounted LXMA deep links."""
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MAIN_TAB = ROOT / "Sources/ColumbaApp/Views/MainTabView.swift"
+CONTACTS = ROOT / "Sources/ColumbaApp/Views/Contacts/ContactsView.swift"
+
+
+class LXMADeepLinkLifecycleTests(unittest.TestCase):
+    def test_main_tab_routes_initial_and_late_deep_links_to_contacts(self) -> None:
+        source = MAIN_TAB.read_text(encoding="utf-8")
+
+        self.assertIn("routePendingDeepLink()", source)
+        self.assertIn("private func routePendingDeepLink()", source)
+        self.assertIn("if pendingDeepLink != nil", source)
+        self.assertIn("selectedTab = .contacts", source)
+
+        on_appear = source.split(".onAppear {", 1)[1].split("}", 1)[0]
+        self.assertIn("routePendingDeepLink()", on_appear)
+
+        on_change = source.split(".onChange(of: pendingDeepLink)", 1)[1].split("}", 2)[0]
+        self.assertIn("routePendingDeepLink()", on_change)
+
+    def test_contacts_consumes_initial_and_late_deep_links_idempotently(self) -> None:
+        source = CONTACTS.read_text(encoding="utf-8")
+
+        self.assertIn("private func consumePendingDeepLink()", source)
+        self.assertIn("pendingDeepLink?.wrappedValue = nil", source)
+        self.assertIn("scannedContact = ScannedContact(", source)
+
+        self.assertIn(".onAppear {\n            consumePendingDeepLink()\n        }", source)
+        on_change = source.split(".onChange(of: pendingDeepLink?.wrappedValue)", 1)[1].split("}", 2)[0]
+        self.assertIn("consumePendingDeepLink()", on_change)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- detect canonical `lxma://<destination>:<public-key>` contact URIs in plaintext message bubbles
- attach a Foundation-safe opaque `lxma:<destination>:<public-key>` action URL while preserving canonical display text
- accept both canonical and routed forms while retaining identity-to-destination cryptographic validation
- route and consume deep links on both cold start and already-mounted views so the Add Contact flow appears reliably

Fixes #156.

## Verification

- focused LXMA parser and routing XCTest coverage: 7 passed
- full shipping XCTest suite before the lifecycle follow-up: 316 passed
- Model B compatibility suite before the lifecycle follow-up: 21 passed
- exact-head static suite: 269 passed, 1 skipped, 267 subtests passed
- exact-head signed physical iPhone build succeeded and passed strict `codesign` verification
- installed exact head on the physical iPhone without clearing app data
- physical payload launch confirmed the Add Contact flow appears

## Risk

Low. The change is limited to LXMA contact-link detection, parsing, and idempotent SwiftUI lifecycle routing. Malformed or cryptographically mismatched LXMA identities remain rejected.
