### PR TITLE
Remove vestigial MonospaceLine minWidth plumbing

### DIFF
--- a/Sources/ColumbaApp/Views/NomadNet/MonospaceLineView.swift
+++ b/Sources/ColumbaApp/Views/NomadNet/MonospaceLineView.swift
@@ -22,10 +22,6 @@ struct MonospaceLineView: View {
     let bold: Bool
     var defaultForegroundColor: Color? = nil
     var linkForegroundColor: Color? = nil
-    /// Force the UIKit label to be at least this wide so center/right alignment
-    /// resolves against the visible viewport, not just the text's intrinsic width.
-    /// Pass 0 to opt out (label sizes to its own intrinsic only).
-    var minWidth: CGFloat = 0
     var onLinkTapped: ((MicronLink) -> Void)?
 
     var body: some View {
@@ -34,7 +30,6 @@ struct MonospaceLineView: View {
             attributedString: buildAttributedString(),
             cellHeight: cellHeight,
             alignment: alignment,
-            minWidth: minWidth,
             onTap: handleTap
         )
         .frame(height: cellHeight)
@@ -151,7 +146,6 @@ private struct UIMonospaceLine: UIViewRepresentable {
     let attributedString: NSAttributedString
     let cellHeight: CGFloat
     let alignment: MicronAlignment
-    let minWidth: CGFloat
     var onTap: ((Int) -> Void)?
 
     /// Return only the label's intrinsic content width. SwiftUI `.frame`


### PR DESCRIPTION
## Summary

- remove the unused `MonospaceLineView.minWidth` property
- stop forwarding the dead value into `UIMonospaceLine`
- retain minimum-width and alignment ownership in `MicronDocumentView` through SwiftUI `.frame(minWidth:alignment:)`

Fixes #68.

## Why this is behavior-preserving

No call site supplied `MonospaceLineView.minWidth`, so it always remained at its default value of zero. `UIMonospaceLine.sizeThatFits()` never read the forwarded property and always returned the label's intrinsic width. The existing SwiftUI frame remains the sole minimum-width implementation.

## Verification

- full static suite: 269 passed, 1 skipped, 267 subtests passed
- exact-head signed shipping iPhone build succeeded with `COLUMBA_NOMADNET_ENABLED`
- strict code-signature verification passed
- repository-wide search confirms the removed property has no remaining references
