### PR TITLE
Configure composer Return key behavior

### DIFF
--- a/Sources/ColumbaApp/Resources/Localizable.xcstrings
+++ b/Sources/ColumbaApp/Resources/Localizable.xcstrings
@@ -991,6 +991,17 @@
     "The attachment could not be prepared for preview.": {
       "comment": "Privacy-safe error text shown when temporary attachment export fails."
     },
+    "Type a message...": {
+      "comment": "Placeholder and VoiceOver label for the message composer.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Type a message..."
+          }
+        }
+      }
+    },
     "Enter Key Sends Message": {
       "comment": "Settings toggle controlling whether the on-screen keyboard Enter key sends the current message.",
       "localizations": {

--- a/Sources/ColumbaApp/Resources/Localizable.xcstrings
+++ b/Sources/ColumbaApp/Resources/Localizable.xcstrings
@@ -991,6 +991,50 @@
     "The attachment could not be prepared for preview.": {
       "comment": "Privacy-safe error text shown when temporary attachment export fails."
     },
+    "Enter Key Sends Message": {
+      "comment": "Settings toggle controlling whether the on-screen keyboard Enter key sends the current message.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter Key Sends Message"
+          }
+        }
+      }
+    },
+    "Messaging": {
+      "comment": "Title of the settings card containing message composition preferences.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Messaging"
+          }
+        }
+      }
+    },
+    "Press Enter to send. Turn this off when you want Enter to insert new lines.": {
+      "comment": "Explanation shown when the message composer Enter key sends messages.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Press Enter to send. Turn this off when you want Enter to insert new lines."
+          }
+        }
+      }
+    },
+    "Press Enter to insert a new line. Use the send button to send the message.": {
+      "comment": "Explanation shown when the message composer Enter key inserts a line break.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Press Enter to insert a new line. Use the send button to send the message."
+          }
+        }
+      }
+    },
     "Messages from contacts only": {
       "comment": "Label for the privacy control that rejects messages from unknown senders.",
       "localizations": {

--- a/Sources/ColumbaApp/Views/Messaging/MessageInputBar.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageInputBar.swift
@@ -12,6 +12,15 @@ import RNSAPI
 import UIKit
 #endif
 
+enum ComposerKeyboardPreference {
+    static let key = "send_message_on_return"
+    static let defaultValue = true
+
+    static func sendsOnReturn(in defaults: UserDefaults = .standard) -> Bool {
+        defaults.object(forKey: key) as? Bool ?? defaultValue
+    }
+}
+
 /// Message input bar with text field and action buttons.
 ///
 /// Features:
@@ -33,6 +42,8 @@ struct MessageInputBar: View {
     var onAttachment: () -> Void
 
     @FocusState private var isFocused: Bool
+    @AppStorage(ComposerKeyboardPreference.key)
+    private var sendsOnReturn = ComposerKeyboardPreference.defaultValue
 
     // MARK: - Theme (delegates to Theme/ThemeManager)
 
@@ -122,14 +133,7 @@ struct MessageInputBar: View {
                 // Text field container
                 HStack(alignment: .bottom, spacing: 8) {
                     // Text field
-                    TextField("Type a message...", text: $text, axis: .vertical)
-                        .font(.body)
-                        .foregroundStyle(Theme.textPrimary)
-                        .lineLimit(1...6)
-                        .accessibilityIdentifier("message_composer")
-                        .focused($isFocused)
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 10)
+                    messageTextField
                 }
                 .background(Theme.backgroundTertiary)
                 .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
@@ -181,6 +185,33 @@ struct MessageInputBar: View {
             .padding(.vertical, 10)
             .background(.ultraThinMaterial)
         }
+    }
+
+    @ViewBuilder
+    private var messageTextField: some View {
+        if sendsOnReturn {
+            baseMessageTextField
+                .submitLabel(.send)
+                .onSubmit {
+                    if canSend {
+                        onSend()
+                    }
+                }
+        } else {
+            baseMessageTextField
+                .submitLabel(.return)
+        }
+    }
+
+    private var baseMessageTextField: some View {
+        TextField("Type a message...", text: $text, axis: .vertical)
+            .font(.body)
+            .foregroundStyle(Theme.textPrimary)
+            .lineLimit(1...6)
+            .accessibilityIdentifier("message_composer")
+            .focused($isFocused)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
     }
 
     // MARK: - File Chip View

--- a/Sources/ColumbaApp/Views/Messaging/MessageInputBar.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageInputBar.swift
@@ -43,6 +43,7 @@ private struct ComposerTextView: UIViewRepresentable {
         textView.textContainer.lineFragmentPadding = 0
         textView.isScrollEnabled = false
         textView.accessibilityIdentifier = "message_composer"
+        textView.accessibilityLabel = String(localized: "Type a message...")
         return textView
     }
 
@@ -98,7 +99,9 @@ private struct ComposerTextView: UIViewRepresentable {
             shouldChangeTextIn range: NSRange,
             replacementText replacement: String
         ) -> Bool {
-            guard replacement == "\n", sendsOnReturn else { return true }
+            guard replacement == "\n",
+                  sendsOnReturn,
+                  textView.markedTextRange == nil else { return true }
             onSubmit()
             return false
         }
@@ -280,6 +283,7 @@ struct MessageInputBar: View {
                     .padding(.horizontal, 12)
                     .padding(.vertical, 10)
                     .allowsHitTesting(false)
+                    .accessibilityHidden(true)
             }
 
             #if os(iOS)

--- a/Sources/ColumbaApp/Views/Messaging/MessageInputBar.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageInputBar.swift
@@ -44,7 +44,21 @@ private final class ComposerUITextView: UITextView {
         pasteGeneration += 1
         let generation = pasteGeneration
         isPerformingPaste = true
+
+        // UIKit 26.6 can discard a newline-only paste before mutating a
+        // UITextView. Route that exact payload through UIKeyInput so it still
+        // follows the native delegate path and replaces the current selection.
+        if UIPasteboard.general.string == "\n" {
+            insertText("\n")
+            finishPasteIfNeeded(generation: generation)
+            return
+        }
+
         super.paste(sender)
+        finishPasteIfNeeded(generation: generation)
+    }
+
+    private func finishPasteIfNeeded(generation: Int) {
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
             guard let self, self.pasteGeneration == generation else { return }
             self.isPerformingPaste = false

--- a/Sources/ColumbaApp/Views/Messaging/MessageInputBar.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageInputBar.swift
@@ -45,10 +45,14 @@ private final class ComposerUITextView: UITextView {
         let generation = pasteGeneration
         isPerformingPaste = true
         super.paste(sender)
-        DispatchQueue.main.async { [weak self] in
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
             guard let self, self.pasteGeneration == generation else { return }
             self.isPerformingPaste = false
         }
+    }
+
+    func finishPaste() {
+        isPerformingPaste = false
     }
 }
 
@@ -120,6 +124,7 @@ private struct ComposerTextView: UIViewRepresentable {
         }
 
         func textViewDidChange(_ textView: UITextView) {
+            defer { (textView as? ComposerUITextView)?.finishPaste() }
             text.wrappedValue = textView.text
             textView.invalidateIntrinsicContentSize()
         }

--- a/Sources/ColumbaApp/Views/Messaging/MessageInputBar.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageInputBar.swift
@@ -21,6 +21,91 @@ enum ComposerKeyboardPreference {
     }
 }
 
+#if os(iOS)
+private struct ComposerTextView: UIViewRepresentable {
+    @Binding var text: String
+    let sendsOnReturn: Bool
+    let onSubmit: () -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(text: $text, sendsOnReturn: sendsOnReturn, onSubmit: onSubmit)
+    }
+
+    func makeUIView(context: Context) -> UITextView {
+        let textView = UITextView()
+        textView.delegate = context.coordinator
+        textView.backgroundColor = .clear
+        textView.font = .preferredFont(forTextStyle: .body)
+        textView.adjustsFontForContentSizeCategory = true
+        textView.textColor = UIColor(Theme.textPrimary)
+        textView.tintColor = UIColor(Theme.accentColor)
+        textView.textContainerInset = UIEdgeInsets(top: 10, left: 12, bottom: 10, right: 12)
+        textView.textContainer.lineFragmentPadding = 0
+        textView.isScrollEnabled = false
+        textView.accessibilityIdentifier = "message_composer"
+        return textView
+    }
+
+    func updateUIView(_ textView: UITextView, context: Context) {
+        context.coordinator.text = $text
+        context.coordinator.sendsOnReturn = sendsOnReturn
+        context.coordinator.onSubmit = onSubmit
+        textView.returnKeyType = sendsOnReturn ? .send : .default
+        textView.textColor = UIColor(Theme.textPrimary)
+        textView.tintColor = UIColor(Theme.accentColor)
+        if textView.text != text {
+            textView.text = text
+            textView.invalidateIntrinsicContentSize()
+        }
+    }
+
+    func sizeThatFits(
+        _ proposal: ProposedViewSize,
+        uiView: UITextView,
+        context: Context
+    ) -> CGSize? {
+        guard let width = proposal.width else { return nil }
+        let fittingSize = uiView.sizeThatFits(
+            CGSize(width: width, height: CGFloat.greatestFiniteMagnitude)
+        )
+        let lineHeight = uiView.font?.lineHeight ?? UIFont.preferredFont(forTextStyle: .body).lineHeight
+        let verticalInsets = uiView.textContainerInset.top + uiView.textContainerInset.bottom
+        let minimumHeight = lineHeight + verticalInsets
+        let maximumHeight = lineHeight * 6 + verticalInsets
+        let height = min(max(fittingSize.height, minimumHeight), maximumHeight)
+        uiView.isScrollEnabled = fittingSize.height > maximumHeight
+        return CGSize(width: width, height: height)
+    }
+
+    final class Coordinator: NSObject, UITextViewDelegate {
+        var text: Binding<String>
+        var sendsOnReturn: Bool
+        var onSubmit: () -> Void
+
+        init(text: Binding<String>, sendsOnReturn: Bool, onSubmit: @escaping () -> Void) {
+            self.text = text
+            self.sendsOnReturn = sendsOnReturn
+            self.onSubmit = onSubmit
+        }
+
+        func textViewDidChange(_ textView: UITextView) {
+            text.wrappedValue = textView.text
+            textView.invalidateIntrinsicContentSize()
+        }
+
+        func textView(
+            _ textView: UITextView,
+            shouldChangeTextIn range: NSRange,
+            replacementText replacement: String
+        ) -> Bool {
+            guard replacement == "\n", sendsOnReturn else { return true }
+            onSubmit()
+            return false
+        }
+    }
+}
+#endif
+
 /// Message input bar with text field and action buttons.
 ///
 /// Features:
@@ -41,7 +126,6 @@ struct MessageInputBar: View {
     var onImagePicker: () -> Void
     var onAttachment: () -> Void
 
-    @FocusState private var isFocused: Bool
     @AppStorage(ComposerKeyboardPreference.key)
     private var sendsOnReturn = ComposerKeyboardPreference.defaultValue
 
@@ -187,31 +271,38 @@ struct MessageInputBar: View {
         }
     }
 
-    @ViewBuilder
     private var messageTextField: some View {
-        if sendsOnReturn {
-            baseMessageTextField
-                .submitLabel(.send)
-                .onSubmit {
+        ZStack(alignment: .topLeading) {
+            if text.isEmpty {
+                Text("Type a message...")
+                    .font(.body)
+                    .foregroundStyle(Theme.textSecondary)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 10)
+                    .allowsHitTesting(false)
+            }
+
+            #if os(iOS)
+            ComposerTextView(
+                text: $text,
+                sendsOnReturn: sendsOnReturn,
+                onSubmit: {
                     if canSend {
                         onSend()
                     }
                 }
-        } else {
-            baseMessageTextField
-                .submitLabel(.return)
-        }
-    }
-
-    private var baseMessageTextField: some View {
-        TextField("Type a message...", text: $text, axis: .vertical)
-            .font(.body)
+            )
             .foregroundStyle(Theme.textPrimary)
-            .lineLimit(1...6)
-            .accessibilityIdentifier("message_composer")
-            .focused($isFocused)
-            .padding(.horizontal, 12)
-            .padding(.vertical, 10)
+            #else
+            TextField("Type a message...", text: $text, axis: .vertical)
+                .font(.body)
+                .foregroundStyle(Theme.textPrimary)
+                .lineLimit(1...6)
+                .accessibilityIdentifier("message_composer")
+                .padding(.horizontal, 12)
+                .padding(.vertical, 10)
+            #endif
+        }
     }
 
     // MARK: - File Chip View

--- a/Sources/ColumbaApp/Views/Messaging/MessageInputBar.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageInputBar.swift
@@ -21,7 +21,31 @@ enum ComposerKeyboardPreference {
     }
 }
 
+enum ComposerReturnDecision {
+    static func shouldSubmit(
+        replacementText: String,
+        sendsOnReturn: Bool,
+        hasMarkedText: Bool,
+        isPerformingPaste: Bool
+    ) -> Bool {
+        replacementText == "\n"
+            && sendsOnReturn
+            && !hasMarkedText
+            && !isPerformingPaste
+    }
+}
+
 #if os(iOS)
+private final class ComposerUITextView: UITextView {
+    private(set) var isPerformingPaste = false
+
+    override func paste(_ sender: Any?) {
+        isPerformingPaste = true
+        defer { isPerformingPaste = false }
+        super.paste(sender)
+    }
+}
+
 private struct ComposerTextView: UIViewRepresentable {
     @Binding var text: String
     let sendsOnReturn: Bool
@@ -32,7 +56,7 @@ private struct ComposerTextView: UIViewRepresentable {
     }
 
     func makeUIView(context: Context) -> UITextView {
-        let textView = UITextView()
+        let textView = ComposerUITextView()
         textView.delegate = context.coordinator
         textView.backgroundColor = .clear
         textView.font = .preferredFont(forTextStyle: .body)
@@ -99,9 +123,13 @@ private struct ComposerTextView: UIViewRepresentable {
             shouldChangeTextIn range: NSRange,
             replacementText replacement: String
         ) -> Bool {
-            guard replacement == "\n",
-                  sendsOnReturn,
-                  textView.markedTextRange == nil else { return true }
+            let shouldSubmit = ComposerReturnDecision.shouldSubmit(
+                replacementText: replacement,
+                sendsOnReturn: sendsOnReturn,
+                hasMarkedText: textView.markedTextRange != nil,
+                isPerformingPaste: (textView as? ComposerUITextView)?.isPerformingPaste == true
+            )
+            guard shouldSubmit else { return true }
             onSubmit()
             return false
         }

--- a/Sources/ColumbaApp/Views/Messaging/MessageInputBar.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageInputBar.swift
@@ -38,11 +38,17 @@ enum ComposerReturnDecision {
 #if os(iOS)
 private final class ComposerUITextView: UITextView {
     private(set) var isPerformingPaste = false
+    private var pasteGeneration = 0
 
     override func paste(_ sender: Any?) {
+        pasteGeneration += 1
+        let generation = pasteGeneration
         isPerformingPaste = true
-        defer { isPerformingPaste = false }
         super.paste(sender)
+        DispatchQueue.main.async { [weak self] in
+            guard let self, self.pasteGeneration == generation else { return }
+            self.isPerformingPaste = false
+        }
     }
 }
 

--- a/Sources/ColumbaApp/Views/Settings/SettingsView.swift
+++ b/Sources/ColumbaApp/Views/Settings/SettingsView.swift
@@ -50,6 +50,9 @@ struct SettingsView: View {
     @State private var showDataMigration = false
     @State private var onboardingReviewIdentity: LocalIdentity?
     @State private var onboardingReviewError: String?
+    @State private var isMessagingExpanded = false
+    @AppStorage(ComposerKeyboardPreference.key)
+    private var sendsOnReturn = ComposerKeyboardPreference.defaultValue
     #if COLUMBA_RUNTIME_MODEL_B
     /// Presents the background-transport explainer / enable sheet.
     @State private var showBackgroundTransport = false
@@ -87,6 +90,9 @@ struct SettingsView: View {
                         AppearanceCard(
                             isExpanded: Binding(get: { vm.isAppearanceExpanded }, set: { vm.isAppearanceExpanded = $0 })
                         )
+
+                        // Messaging
+                        messagingCard
 
                         // Identity
                         identityCard(vm)
@@ -250,6 +256,28 @@ struct SettingsView: View {
             while !Task.isCancelled {
                 try? await Task.sleep(for: .seconds(2))
                 await viewModel?.refreshConnectionState()
+            }
+        }
+    }
+
+    private var messagingCard: some View {
+        ExpandableSettingsCard(
+            icon: "message.fill",
+            title: String(localized: "Messaging"),
+            isExpanded: $isMessagingExpanded
+        ) {
+            VStack(alignment: .leading, spacing: 12) {
+                Toggle(String(localized: "Enter Key Sends Message"), isOn: $sendsOnReturn)
+                    .font(.subheadline)
+                    .foregroundStyle(Theme.textSecondary)
+                    .toggleStyle(AccentToggleStyle())
+                    .accessibilityIdentifier("setting_send_message_on_return")
+
+                Text(sendsOnReturn
+                    ? String(localized: "Press Enter to send. Turn this off when you want Enter to insert new lines.")
+                    : String(localized: "Press Enter to insert a new line. Use the send button to send the message."))
+                    .font(.caption)
+                    .foregroundStyle(Theme.textSecondary)
             }
         }
     }

--- a/Tests/ColumbaAppTests/IncomingMessageSizeLimitTests.swift
+++ b/Tests/ColumbaAppTests/IncomingMessageSizeLimitTests.swift
@@ -53,6 +53,27 @@ final class IncomingMessageSizeLimitTests: XCTestCase {
     }
 }
 
+final class ComposerKeyboardPreferenceTests: XCTestCase {
+    private let key = "send_message_on_return"
+
+    func testReturnKeyDefaultsToSendingMessages() {
+        let suiteName = "ComposerKeyboardPreferenceTests-default-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        XCTAssertTrue(ComposerKeyboardPreference.sendsOnReturn(in: defaults))
+    }
+
+    func testReturnKeyCanBeConfiguredToInsertNewlines() {
+        let suiteName = "ComposerKeyboardPreferenceTests-newline-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(false, forKey: key)
+
+        XCTAssertFalse(ComposerKeyboardPreference.sendsOnReturn(in: defaults))
+    }
+}
+
 final class MessageTextScaleTests: XCTestCase {
     private let key = "message_text_scale"
 

--- a/Tests/ColumbaAppTests/IncomingMessageSizeLimitTests.swift
+++ b/Tests/ColumbaAppTests/IncomingMessageSizeLimitTests.swift
@@ -72,6 +72,39 @@ final class ComposerKeyboardPreferenceTests: XCTestCase {
 
         XCTAssertFalse(ComposerKeyboardPreference.sendsOnReturn(in: defaults))
     }
+
+    func testOnlyUnmarkedKeyboardReturnSubmits() {
+        XCTAssertTrue(ComposerReturnDecision.shouldSubmit(
+            replacementText: "\n",
+            sendsOnReturn: true,
+            hasMarkedText: false,
+            isPerformingPaste: false
+        ))
+        XCTAssertFalse(ComposerReturnDecision.shouldSubmit(
+            replacementText: "\n",
+            sendsOnReturn: true,
+            hasMarkedText: false,
+            isPerformingPaste: true
+        ))
+        XCTAssertFalse(ComposerReturnDecision.shouldSubmit(
+            replacementText: "\n",
+            sendsOnReturn: true,
+            hasMarkedText: true,
+            isPerformingPaste: false
+        ))
+        XCTAssertFalse(ComposerReturnDecision.shouldSubmit(
+            replacementText: "\n",
+            sendsOnReturn: false,
+            hasMarkedText: false,
+            isPerformingPaste: false
+        ))
+        XCTAssertFalse(ComposerReturnDecision.shouldSubmit(
+            replacementText: "pasted text",
+            sendsOnReturn: true,
+            hasMarkedText: false,
+            isPerformingPaste: false
+        ))
+    }
 }
 
 final class MessageTextScaleTests: XCTestCase {

--- a/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
+++ b/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
@@ -136,7 +136,7 @@ final class ComposerReturnKeyPresentationTests: XCTestCase {
         }
     }
 
-    private func hostedComposer(sendsOnReturn: Bool) throws -> (UIHostingController<MessageInputBar>, UITextField, SendCounter) {
+    private func hostedComposer(sendsOnReturn: Bool) throws -> (UIHostingController<MessageInputBar>, UITextView, SendCounter) {
         UserDefaults.standard.set(sendsOnReturn, forKey: ComposerKeyboardPreference.key)
         let counter = SendCounter()
         let host = UIHostingController(rootView: MessageInputBar(
@@ -150,7 +150,7 @@ final class ComposerReturnKeyPresentationTests: XCTestCase {
         host.view.frame = CGRect(x: 0, y: 0, width: 390, height: 220)
         host.view.setNeedsLayout()
         host.view.layoutIfNeeded()
-        let field = try XCTUnwrap(descendants(of: UITextField.self, in: host.view).first)
+        let field = try XCTUnwrap(descendants(of: UITextView.self, in: host.view).first)
         return (host, field, counter)
     }
 
@@ -163,7 +163,12 @@ final class ComposerReturnKeyPresentationTests: XCTestCase {
         let (host, field, counter) = try hostedComposer(sendsOnReturn: true)
         withExtendedLifetime(host) {
             XCTAssertEqual(field.returnKeyType, .send)
-            XCTAssertEqual(field.delegate?.textFieldShouldReturn?(field), true)
+            let shouldInsertNewline = field.delegate?.textView?(
+                field,
+                shouldChangeTextIn: NSRange(location: field.text.count, length: 0),
+                replacementText: "\n"
+            )
+            XCTAssertEqual(shouldInsertNewline, false)
             XCTAssertEqual(counter.value, 1)
         }
     }
@@ -172,7 +177,12 @@ final class ComposerReturnKeyPresentationTests: XCTestCase {
         let (host, field, counter) = try hostedComposer(sendsOnReturn: false)
         withExtendedLifetime(host) {
             XCTAssertEqual(field.returnKeyType, .default)
-            XCTAssertNil(field.delegate?.textFieldShouldReturn?(field))
+            let shouldInsertNewline = field.delegate?.textView?(
+                field,
+                shouldChangeTextIn: NSRange(location: field.text.count, length: 0),
+                replacementText: "\n"
+            )
+            XCTAssertEqual(shouldInsertNewline, true)
             XCTAssertEqual(counter.value, 0)
         }
     }

--- a/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
+++ b/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
@@ -229,6 +229,7 @@ final class ComposerReturnKeyPresentationTests: XCTestCase {
         RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.01))
 
         XCTAssertEqual(counter.value, 0)
+        XCTAssertEqual(field.text, "Hello\n")
         XCTAssertEqual(state.text, "Hello\n")
     }
 

--- a/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
+++ b/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
@@ -158,7 +158,10 @@ final class ComposerReturnKeyPresentationTests: XCTestCase {
         host.view.setNeedsLayout()
         host.view.layoutIfNeeded()
         RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.01))
-        let field = try XCTUnwrap(descendants(of: UITextView.self, in: host.view).first)
+        let field = try XCTUnwrap(
+            descendants(of: UITextView.self, in: host.view)
+                .first(where: { $0.accessibilityIdentifier == "message_composer" })
+        )
         return (window, field, state, counter)
     }
 
@@ -171,9 +174,12 @@ final class ComposerReturnKeyPresentationTests: XCTestCase {
         let (window, field, state, counter) = try hostedComposer(sendsOnReturn: true)
         withExtendedLifetime(window) {
             XCTAssertEqual(field.returnKeyType, .send)
-            field.selectedRange = NSRange(location: field.text.count, length: 0)
-            field.insertText("\n")
-            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.01))
+            let shouldInsertNewline = field.delegate?.textView?(
+                field,
+                shouldChangeTextIn: NSRange(location: field.text.count, length: 0),
+                replacementText: "\n"
+            )
+            XCTAssertEqual(shouldInsertNewline, false)
             XCTAssertEqual(counter.value, 1)
             XCTAssertEqual(state.text, "Hello")
         }
@@ -183,11 +189,14 @@ final class ComposerReturnKeyPresentationTests: XCTestCase {
         let (window, field, state, counter) = try hostedComposer(sendsOnReturn: false)
         withExtendedLifetime(window) {
             XCTAssertEqual(field.returnKeyType, .default)
-            field.selectedRange = NSRange(location: field.text.count, length: 0)
-            field.insertText("\n")
-            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.01))
+            let shouldInsertNewline = field.delegate?.textView?(
+                field,
+                shouldChangeTextIn: NSRange(location: field.text.count, length: 0),
+                replacementText: "\n"
+            )
+            XCTAssertEqual(shouldInsertNewline, true)
             XCTAssertEqual(counter.value, 0)
-            XCTAssertEqual(state.text, "Hello\n")
+            XCTAssertEqual(state.text, "Hello")
         }
     }
 }

--- a/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
+++ b/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
@@ -222,6 +222,8 @@ final class ComposerReturnKeyPresentationTests: XCTestCase {
         }
 
         pasteboard.string = "\n"
+        XCTAssertTrue(field.becomeFirstResponder())
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.01))
         field.selectedRange = NSRange(location: field.text.count, length: 0)
         field.paste(nil)
         RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.01))

--- a/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
+++ b/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
@@ -174,6 +174,7 @@ final class ComposerReturnKeyPresentationTests: XCTestCase {
         let (window, field, state, counter) = try hostedComposer(sendsOnReturn: true)
         withExtendedLifetime(window) {
             XCTAssertEqual(field.returnKeyType, .send)
+            XCTAssertEqual(field.accessibilityLabel, "Type a message...")
             let shouldInsertNewline = field.delegate?.textView?(
                 field,
                 shouldChangeTextIn: NSRange(location: field.text.count, length: 0),
@@ -182,6 +183,23 @@ final class ComposerReturnKeyPresentationTests: XCTestCase {
             XCTAssertEqual(shouldInsertNewline, false)
             XCTAssertEqual(counter.value, 1)
             XCTAssertEqual(state.text, "Hello")
+        }
+    }
+
+    func testMarkedTextIsCommittedInsteadOfSending() throws {
+        let (window, field, _, counter) = try hostedComposer(sendsOnReturn: true)
+        withExtendedLifetime(window) {
+            field.setMarkedText("候", selectedRange: NSRange(location: 1, length: 0))
+            XCTAssertNotNil(field.markedTextRange)
+
+            let shouldCommitMarkedText = field.delegate?.textView?(
+                field,
+                shouldChangeTextIn: NSRange(location: field.text.count, length: 0),
+                replacementText: "\n"
+            )
+
+            XCTAssertEqual(shouldCommitMarkedText, true)
+            XCTAssertEqual(counter.value, 0)
         }
     }
 

--- a/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
+++ b/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
@@ -130,17 +130,22 @@ final class ComposerReturnKeyPresentationTests: XCTestCase {
         var value = 0
     }
 
+    private final class ComposerState {
+        var text = "Hello"
+    }
+
     private func descendants<T: UIView>(of type: T.Type, in root: UIView) -> [T] {
         root.subviews.flatMap { subview in
             (subview as? T).map { [$0] } ?? [] + descendants(of: type, in: subview)
         }
     }
 
-    private func hostedComposer(sendsOnReturn: Bool) throws -> (UIWindow, UITextView, SendCounter) {
+    private func hostedComposer(sendsOnReturn: Bool) throws -> (UIWindow, UITextView, ComposerState, SendCounter) {
         UserDefaults.standard.set(sendsOnReturn, forKey: ComposerKeyboardPreference.key)
+        let state = ComposerState()
         let counter = SendCounter()
         let host = UIHostingController(rootView: MessageInputBar(
-            text: .constant("Hello"),
+            text: Binding(get: { state.text }, set: { state.text = $0 }),
             attachedImage: .constant(nil),
             attachedFiles: .constant([]),
             onSend: { counter.value += 1 },
@@ -154,7 +159,7 @@ final class ComposerReturnKeyPresentationTests: XCTestCase {
         host.view.layoutIfNeeded()
         RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.01))
         let field = try XCTUnwrap(descendants(of: UITextView.self, in: host.view).first)
-        return (window, field, counter)
+        return (window, field, state, counter)
     }
 
     override func tearDown() {
@@ -163,30 +168,26 @@ final class ComposerReturnKeyPresentationTests: XCTestCase {
     }
 
     func testDefaultReturnKeyPresentsSendAndSubmitsMessage() throws {
-        let (window, field, counter) = try hostedComposer(sendsOnReturn: true)
+        let (window, field, state, counter) = try hostedComposer(sendsOnReturn: true)
         withExtendedLifetime(window) {
             XCTAssertEqual(field.returnKeyType, .send)
-            let shouldInsertNewline = field.delegate?.textView?(
-                field,
-                shouldChangeTextIn: NSRange(location: field.text.count, length: 0),
-                replacementText: "\n"
-            )
-            XCTAssertEqual(shouldInsertNewline, false)
+            field.selectedRange = NSRange(location: field.text.count, length: 0)
+            field.insertText("\n")
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.01))
             XCTAssertEqual(counter.value, 1)
+            XCTAssertEqual(state.text, "Hello")
         }
     }
 
     func testNewlinePreferencePresentsReturnWithoutSubmitting() throws {
-        let (window, field, counter) = try hostedComposer(sendsOnReturn: false)
+        let (window, field, state, counter) = try hostedComposer(sendsOnReturn: false)
         withExtendedLifetime(window) {
             XCTAssertEqual(field.returnKeyType, .default)
-            let shouldInsertNewline = field.delegate?.textView?(
-                field,
-                shouldChangeTextIn: NSRange(location: field.text.count, length: 0),
-                replacementText: "\n"
-            )
-            XCTAssertEqual(shouldInsertNewline, true)
+            field.selectedRange = NSRange(location: field.text.count, length: 0)
+            field.insertText("\n")
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.01))
             XCTAssertEqual(counter.value, 0)
+            XCTAssertEqual(state.text, "Hello\n")
         }
     }
 }

--- a/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
+++ b/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
@@ -124,6 +124,60 @@ final class MessageRendererMappingTests: XCTestCase {
     }
 }
 
+@MainActor
+final class ComposerReturnKeyPresentationTests: XCTestCase {
+    private final class SendCounter {
+        var value = 0
+    }
+
+    private func descendants<T: UIView>(of type: T.Type, in root: UIView) -> [T] {
+        root.subviews.flatMap { subview in
+            (subview as? T).map { [$0] } ?? [] + descendants(of: type, in: subview)
+        }
+    }
+
+    private func hostedComposer(sendsOnReturn: Bool) throws -> (UIHostingController<MessageInputBar>, UITextField, SendCounter) {
+        UserDefaults.standard.set(sendsOnReturn, forKey: ComposerKeyboardPreference.key)
+        let counter = SendCounter()
+        let host = UIHostingController(rootView: MessageInputBar(
+            text: .constant("Hello"),
+            attachedImage: .constant(nil),
+            attachedFiles: .constant([]),
+            onSend: { counter.value += 1 },
+            onImagePicker: {},
+            onAttachment: {}
+        ))
+        host.view.frame = CGRect(x: 0, y: 0, width: 390, height: 220)
+        host.view.setNeedsLayout()
+        host.view.layoutIfNeeded()
+        let field = try XCTUnwrap(descendants(of: UITextField.self, in: host.view).first)
+        return (host, field, counter)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: ComposerKeyboardPreference.key)
+        super.tearDown()
+    }
+
+    func testDefaultReturnKeyPresentsSendAndSubmitsMessage() throws {
+        let (host, field, counter) = try hostedComposer(sendsOnReturn: true)
+        withExtendedLifetime(host) {
+            XCTAssertEqual(field.returnKeyType, .send)
+            XCTAssertEqual(field.delegate?.textFieldShouldReturn?(field), true)
+            XCTAssertEqual(counter.value, 1)
+        }
+    }
+
+    func testNewlinePreferencePresentsReturnWithoutSubmitting() throws {
+        let (host, field, counter) = try hostedComposer(sendsOnReturn: false)
+        withExtendedLifetime(host) {
+            XCTAssertEqual(field.returnKeyType, .default)
+            XCTAssertNil(field.delegate?.textFieldShouldReturn?(field))
+            XCTAssertEqual(counter.value, 0)
+        }
+    }
+}
+
 final class MessageBubbleLayoutTests: XCTestCase {
 
     private func descendants<T: UIView>(of type: T.Type, in root: UIView) -> [T] {

--- a/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
+++ b/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
@@ -172,6 +172,10 @@ final class ComposerReturnKeyPresentationTests: XCTestCase {
 
     func testDefaultReturnKeyPresentsSendAndSubmitsMessage() throws {
         let (window, field, state, counter) = try hostedComposer(sendsOnReturn: true)
+        defer {
+            window.isHidden = true
+            window.rootViewController = nil
+        }
         withExtendedLifetime(window) {
             XCTAssertEqual(field.returnKeyType, .send)
             XCTAssertEqual(field.accessibilityLabel, "Type a message...")
@@ -188,6 +192,10 @@ final class ComposerReturnKeyPresentationTests: XCTestCase {
 
     func testMarkedTextIsCommittedInsteadOfSending() throws {
         let (window, field, _, counter) = try hostedComposer(sendsOnReturn: true)
+        defer {
+            window.isHidden = true
+            window.rootViewController = nil
+        }
         withExtendedLifetime(window) {
             field.setMarkedText("候", selectedRange: NSRange(location: 1, length: 0))
             XCTAssertNotNil(field.markedTextRange)
@@ -205,6 +213,10 @@ final class ComposerReturnKeyPresentationTests: XCTestCase {
 
     func testNewlinePreferencePresentsReturnWithoutSubmitting() throws {
         let (window, field, state, counter) = try hostedComposer(sendsOnReturn: false)
+        defer {
+            window.isHidden = true
+            window.rootViewController = nil
+        }
         withExtendedLifetime(window) {
             XCTAssertEqual(field.returnKeyType, .default)
             let shouldInsertNewline = field.delegate?.textView?(

--- a/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
+++ b/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
@@ -174,7 +174,7 @@ final class ComposerReturnKeyPresentationTests: XCTestCase {
         let (window, field, state, counter) = try hostedComposer(sendsOnReturn: true)
         defer {
             window.isHidden = true
-            window.rootViewController = nil
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.01))
         }
         withExtendedLifetime(window) {
             XCTAssertEqual(field.returnKeyType, .send)
@@ -194,7 +194,7 @@ final class ComposerReturnKeyPresentationTests: XCTestCase {
         let (window, field, _, counter) = try hostedComposer(sendsOnReturn: true)
         defer {
             window.isHidden = true
-            window.rootViewController = nil
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.01))
         }
         withExtendedLifetime(window) {
             field.setMarkedText("候", selectedRange: NSRange(location: 1, length: 0))
@@ -215,7 +215,7 @@ final class ComposerReturnKeyPresentationTests: XCTestCase {
         let (window, field, state, counter) = try hostedComposer(sendsOnReturn: false)
         defer {
             window.isHidden = true
-            window.rootViewController = nil
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.01))
         }
         withExtendedLifetime(window) {
             XCTAssertEqual(field.returnKeyType, .default)

--- a/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
+++ b/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
@@ -211,6 +211,25 @@ final class ComposerReturnKeyPresentationTests: XCTestCase {
         }
     }
 
+    func testPastedSingleNewlineIsInsertedWithoutSending() throws {
+        let pasteboard = UIPasteboard.general
+        let previousItems = pasteboard.items
+        let (window, field, state, counter) = try hostedComposer(sendsOnReturn: true)
+        defer {
+            pasteboard.items = previousItems
+            window.isHidden = true
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.01))
+        }
+
+        pasteboard.string = "\n"
+        field.selectedRange = NSRange(location: field.text.count, length: 0)
+        field.paste(nil)
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.01))
+
+        XCTAssertEqual(counter.value, 0)
+        XCTAssertEqual(state.text, "Hello\n")
+    }
+
     func testNewlinePreferencePresentsReturnWithoutSubmitting() throws {
         let (window, field, state, counter) = try hostedComposer(sendsOnReturn: false)
         defer {

--- a/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
+++ b/Tests/ColumbaAppTests/MessageBubbleLayoutTests.swift
@@ -136,7 +136,7 @@ final class ComposerReturnKeyPresentationTests: XCTestCase {
         }
     }
 
-    private func hostedComposer(sendsOnReturn: Bool) throws -> (UIHostingController<MessageInputBar>, UITextView, SendCounter) {
+    private func hostedComposer(sendsOnReturn: Bool) throws -> (UIWindow, UITextView, SendCounter) {
         UserDefaults.standard.set(sendsOnReturn, forKey: ComposerKeyboardPreference.key)
         let counter = SendCounter()
         let host = UIHostingController(rootView: MessageInputBar(
@@ -147,11 +147,14 @@ final class ComposerReturnKeyPresentationTests: XCTestCase {
             onImagePicker: {},
             onAttachment: {}
         ))
-        host.view.frame = CGRect(x: 0, y: 0, width: 390, height: 220)
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 220))
+        window.rootViewController = host
+        window.makeKeyAndVisible()
         host.view.setNeedsLayout()
         host.view.layoutIfNeeded()
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.01))
         let field = try XCTUnwrap(descendants(of: UITextView.self, in: host.view).first)
-        return (host, field, counter)
+        return (window, field, counter)
     }
 
     override func tearDown() {
@@ -160,8 +163,8 @@ final class ComposerReturnKeyPresentationTests: XCTestCase {
     }
 
     func testDefaultReturnKeyPresentsSendAndSubmitsMessage() throws {
-        let (host, field, counter) = try hostedComposer(sendsOnReturn: true)
-        withExtendedLifetime(host) {
+        let (window, field, counter) = try hostedComposer(sendsOnReturn: true)
+        withExtendedLifetime(window) {
             XCTAssertEqual(field.returnKeyType, .send)
             let shouldInsertNewline = field.delegate?.textView?(
                 field,
@@ -174,8 +177,8 @@ final class ComposerReturnKeyPresentationTests: XCTestCase {
     }
 
     func testNewlinePreferencePresentsReturnWithoutSubmitting() throws {
-        let (host, field, counter) = try hostedComposer(sendsOnReturn: false)
-        withExtendedLifetime(host) {
+        let (window, field, counter) = try hostedComposer(sendsOnReturn: false)
+        withExtendedLifetime(window) {
             XCTAssertEqual(field.returnKeyType, .default)
             let shouldInsertNewline = field.delegate?.textView?(
                 field,


### PR DESCRIPTION
## Summary

- make the message composer send on Return by default
- add a persisted Settings toggle that changes Return to newline insertion
- use native multiline text-input handling while preserving IME composition and pasted newlines
- add localized, accessible settings and composer presentation
- cover preference persistence and the production-connected UIKit interaction path

Fixes #171

## Verification

- focused composer and preference tests: 7 passed, 0 failed
- complete shipping `ColumbaAppTests`: 323 passed, 0 failed
- physical iPhone Debug build and strict signature verification passed
- in-place physical installation, launch, and process readback passed
- independent review of exact head `63d4ca57cfc03ef29d96eb911d3c9fc022f51570`: approved with zero findings
- hosted Xcode 26.6 `python`, `modelb`, and `ui` checks passed on the exact head
- `git diff --check` passed

## Risk and rollback

The primary risk is the SwiftUI-to-`UITextView` bridge used for native Return-key interception. Regression coverage exercises ordinary Return, newline mode, marked text, accessibility, and the real paste path. Rollback is a normal revert of this PR.
