### PR TITLE
Show disconnected interface recovery banner

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -358,7 +358,7 @@ jobs:
           export PATH="$HOME/.maestro/bin:$PATH"
           mkdir -p ui-screenshots
           screenshot_status=0
-          for flow in contacts-list.yml chats-list.yml settings.yml map.yml; do
+          for flow in contacts-list.yml chats-list.yml settings.yml map.yml interface-connectivity-banner.yml; do
             if ! (
               cd ui-screenshots
               maestro --device "$DEVICE_ID" test "$GITHUB_WORKSPACE/flows/$flow"

--- a/Sources/ColumbaApp/Resources/Localizable.xcstrings
+++ b/Sources/ColumbaApp/Resources/Localizable.xcstrings
@@ -1,12 +1,12 @@
 {
   "sourceLanguage": "en",
   "strings": {
-    "Add or configure a network interface to establish connectivity.": {
+    "Manage": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Add or configure a network interface to establish connectivity."
+            "value": "Manage"
           }
         }
       }

--- a/Sources/ColumbaApp/Resources/Localizable.xcstrings
+++ b/Sources/ColumbaApp/Resources/Localizable.xcstrings
@@ -1,6 +1,46 @@
 {
   "sourceLanguage": "en",
   "strings": {
+    "Add or configure a network interface to establish connectivity.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add or configure a network interface to establish connectivity."
+          }
+        }
+      }
+    },
+    "Manage Interfaces": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manage Interfaces"
+          }
+        }
+      }
+    },
+    "No Interfaces Connected": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Interfaces Connected"
+          }
+        }
+      }
+    },
+    "Opens network interface settings": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opens network interface settings"
+          }
+        }
+      }
+    },
     "A relay helps your device reach Reticulum peers over the internet. It transports encrypted Reticulum traffic — it does not create an account or hold your identity. We've selected a recommended default.": {
       "localizations": {
         "en": {

--- a/Sources/ColumbaApp/Views/MainTabView.swift
+++ b/Sources/ColumbaApp/Views/MainTabView.swift
@@ -11,15 +11,13 @@ import RNSAPI
 
 struct InterfaceConnectivityBannerContent: Equatable {
     let title: String
-    let message: String
     let actionTitle: String
 
     static func forConnectionState(isConnected: Bool) -> Self? {
         guard !isConnected else { return nil }
         return Self(
             title: String(localized: "No Interfaces Connected"),
-            message: String(localized: "Add or configure a network interface to establish connectivity."),
-            actionTitle: String(localized: "Manage Interfaces")
+            actionTitle: String(localized: "Manage")
         )
     }
 }
@@ -29,32 +27,37 @@ private struct InterfaceConnectivityBanner: View {
     let onManageInterfaces: () -> Void
 
     var body: some View {
-        HStack(alignment: .top, spacing: 12) {
-            Image(systemName: "exclamationmark.triangle.fill")
-                .foregroundStyle(Theme.warning)
-                .accessibilityHidden(true)
+        VStack(spacing: 0) {
+            Button(action: onManageInterfaces) {
+                HStack(spacing: 10) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(Theme.warning)
+                        .accessibilityHidden(true)
 
-            VStack(alignment: .leading, spacing: 4) {
-                Text(content.title)
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(Theme.textPrimary)
-                Text(content.message)
-                    .font(.caption)
-                    .foregroundStyle(Theme.textSecondary)
-                    .fixedSize(horizontal: false, vertical: true)
+                    Text(content.title)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(Theme.textPrimary)
 
-                Button(content.actionTitle, action: onManageInterfaces)
-                    .font(.caption.weight(.semibold))
-                    .buttonStyle(.borderedProminent)
-                    .controlSize(.small)
-                    .tint(Theme.accentColor)
-                    .padding(.top, 2)
-                    .accessibilityHint("Opens network interface settings")
-                    .accessibilityIdentifier("connectivity_banner_manage_interfaces")
+                    Spacer(minLength: 8)
+
+                    Text(content.actionTitle)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(Theme.accentColor)
+
+                    Image(systemName: "chevron.right")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(Theme.accentColor)
+                        .accessibilityHidden(true)
+                }
+                .frame(minHeight: 32)
+                .contentShape(Rectangle())
             }
+            .buttonStyle(.plain)
+            .accessibilityHint("Opens network interface settings")
+            .accessibilityIdentifier("connectivity_banner_manage_interfaces")
         }
         .padding(.horizontal, 16)
-        .padding(.vertical, 10)
+        .padding(.vertical, 6)
         .background(Theme.warning.opacity(0.14))
         .overlay(alignment: .bottom) {
             Divider()

--- a/Sources/ColumbaApp/Views/MainTabView.swift
+++ b/Sources/ColumbaApp/Views/MainTabView.swift
@@ -42,16 +42,16 @@ private struct InterfaceConnectivityBanner: View {
                     .font(.caption)
                     .foregroundStyle(Theme.textSecondary)
                     .fixedSize(horizontal: false, vertical: true)
+
+                Button(content.actionTitle, action: onManageInterfaces)
+                    .font(.caption.weight(.semibold))
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+                    .tint(Theme.accentColor)
+                    .padding(.top, 2)
+                    .accessibilityHint("Opens network interface settings")
+                    .accessibilityIdentifier("connectivity_banner_manage_interfaces")
             }
-
-            Spacer(minLength: 4)
-
-            Button(content.actionTitle, action: onManageInterfaces)
-                .font(.caption.weight(.semibold))
-                .buttonStyle(.borderedProminent)
-                .tint(Theme.accentColor)
-                .accessibilityHint("Opens network interface settings")
-                .accessibilityIdentifier("connectivity_banner_manage_interfaces")
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 10)
@@ -108,7 +108,17 @@ struct MainTabView: View {
     // MARK: - Body
 
     var body: some View {
-        TabView(selection: $selectedTab) {
+        VStack(spacing: 0) {
+            if let content = InterfaceConnectivityBannerContent.forConnectionState(
+                isConnected: appServices.isConnected
+            ) {
+                InterfaceConnectivityBanner(content: content) {
+                    selectedTab = .settings
+                    shouldOpenInterfaceManagement = true
+                }
+            }
+
+            TabView(selection: $selectedTab) {
             // Chats Tab
             ChatsView(
                 appServices: appServices,
@@ -160,18 +170,9 @@ struct MainTabView: View {
                     .accessibilityIdentifier("tab_settings")
             }
             .tag(Tab.settings)
-        }
-        .tint(Theme.accentColor)
-        .safeAreaInset(edge: .top, spacing: 0) {
-            if let content = InterfaceConnectivityBannerContent.forConnectionState(
-                isConnected: appServices.isConnected
-            ) {
-                InterfaceConnectivityBanner(content: content) {
-                    selectedTab = .settings
-                    shouldOpenInterfaceManagement = true
-                }
             }
         }
+        .tint(Theme.accentColor)
         .onAppear {
             consumePendingRNodeSetup()
             routePendingDeepLink()

--- a/Sources/ColumbaApp/Views/MainTabView.swift
+++ b/Sources/ColumbaApp/Views/MainTabView.swift
@@ -49,7 +49,7 @@ private struct InterfaceConnectivityBanner: View {
                         .foregroundStyle(Theme.accentColor)
                         .accessibilityHidden(true)
                 }
-                .frame(minHeight: 32)
+                .frame(minHeight: 44)
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
@@ -57,7 +57,7 @@ private struct InterfaceConnectivityBanner: View {
             .accessibilityIdentifier("connectivity_banner_manage_interfaces")
         }
         .padding(.horizontal, 16)
-        .padding(.vertical, 6)
+        .padding(.vertical, 0)
         .background(Theme.warning.opacity(0.14))
         .overlay(alignment: .bottom) {
             Divider()

--- a/Sources/ColumbaApp/Views/MainTabView.swift
+++ b/Sources/ColumbaApp/Views/MainTabView.swift
@@ -109,6 +109,10 @@ struct MainTabView: View {
 
     var body: some View {
         VStack(spacing: 0) {
+            // The shipping runtime owns the aggregate TCP/Auto/RNode/BLE state.
+            // Model B's relay lives in the Network Extension and is not represented
+            // by AppServices.isConnected, so do not present a false offline banner there.
+            #if COLUMBA_RUNTIME_PYTHON
             if let content = InterfaceConnectivityBannerContent.forConnectionState(
                 isConnected: appServices.isConnected
             ) {
@@ -117,6 +121,7 @@ struct MainTabView: View {
                     shouldOpenInterfaceManagement = true
                 }
             }
+            #endif
 
             TabView(selection: $selectedTab) {
             // Chats Tab

--- a/Sources/ColumbaApp/Views/MainTabView.swift
+++ b/Sources/ColumbaApp/Views/MainTabView.swift
@@ -54,7 +54,7 @@ private struct InterfaceConnectivityBanner: View {
             }
             .buttonStyle(.plain)
             .accessibilityHint("Opens network interface settings")
-            .accessibilityIdentifier("connectivity_banner_manage_interfaces")
+            .accessibilityIdentifier("interface_connectivity_banner")
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 0)
@@ -62,7 +62,6 @@ private struct InterfaceConnectivityBanner: View {
         .overlay(alignment: .bottom) {
             Divider()
         }
-        .accessibilityIdentifier("interface_connectivity_banner")
     }
 }
 

--- a/Sources/ColumbaApp/Views/MainTabView.swift
+++ b/Sources/ColumbaApp/Views/MainTabView.swift
@@ -9,6 +9,60 @@
 import SwiftUI
 import RNSAPI
 
+struct InterfaceConnectivityBannerContent: Equatable {
+    let title: String
+    let message: String
+    let actionTitle: String
+
+    static func forConnectionState(isConnected: Bool) -> Self? {
+        guard !isConnected else { return nil }
+        return Self(
+            title: String(localized: "No Interfaces Connected"),
+            message: String(localized: "Add or configure a network interface to establish connectivity."),
+            actionTitle: String(localized: "Manage Interfaces")
+        )
+    }
+}
+
+private struct InterfaceConnectivityBanner: View {
+    let content: InterfaceConnectivityBannerContent
+    let onManageInterfaces: () -> Void
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(Theme.warning)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(content.title)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Theme.textPrimary)
+                Text(content.message)
+                    .font(.caption)
+                    .foregroundStyle(Theme.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 4)
+
+            Button(content.actionTitle, action: onManageInterfaces)
+                .font(.caption.weight(.semibold))
+                .buttonStyle(.borderedProminent)
+                .tint(Theme.accentColor)
+                .accessibilityHint("Opens network interface settings")
+                .accessibilityIdentifier("connectivity_banner_manage_interfaces")
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(Theme.warning.opacity(0.14))
+        .overlay(alignment: .bottom) {
+            Divider()
+        }
+        .accessibilityIdentifier("interface_connectivity_banner")
+    }
+}
+
 /// Main tab-based navigation container.
 ///
 /// Provides navigation between:
@@ -37,6 +91,9 @@ struct MainTabView: View {
     /// trigger the wizard. The request may exist before MainTabView appears or
     /// arrive later when onboarding completes over an already-mounted tab view.
     @State private var shouldOpenRNodeWizard: Bool = false
+    /// Session-scoped route request raised by the disconnected-interface banner.
+    /// Settings consumes it after its navigation stack and interface model exist.
+    @State private var shouldOpenInterfaceManagement: Bool = false
     /// Which app-root voice-call cover (if any) is showing, driven off
     /// callManager.callState so a call's UI shows from any tab and survives
     /// navigating away from the chat. A single optional makes the two covers
@@ -95,7 +152,8 @@ struct MainTabView: View {
                 settingsRepository: settingsRepository,
                 identityManager: identityManager,
                 onIdentitySwitch: onIdentitySwitch,
-                shouldOpenRNodeWizard: $shouldOpenRNodeWizard
+                shouldOpenRNodeWizard: $shouldOpenRNodeWizard,
+                shouldOpenInterfaceManagement: $shouldOpenInterfaceManagement
             )
             .tabItem {
                 Label(Tab.settings.title, systemImage: Tab.settings.icon)
@@ -104,6 +162,16 @@ struct MainTabView: View {
             .tag(Tab.settings)
         }
         .tint(Theme.accentColor)
+        .safeAreaInset(edge: .top, spacing: 0) {
+            if let content = InterfaceConnectivityBannerContent.forConnectionState(
+                isConnected: appServices.isConnected
+            ) {
+                InterfaceConnectivityBanner(content: content) {
+                    selectedTab = .settings
+                    shouldOpenInterfaceManagement = true
+                }
+            }
+        }
         .onAppear {
             consumePendingRNodeSetup()
             routePendingDeepLink()

--- a/Sources/ColumbaApp/Views/Settings/SettingsView.swift
+++ b/Sources/ColumbaApp/Views/Settings/SettingsView.swift
@@ -38,6 +38,8 @@ struct SettingsView: View {
     /// Session-scoped flag from MainTabView requesting the RNode wizard.
     /// Cleared by SettingsView only after the wizard has actually been triggered.
     @Binding var shouldOpenRNodeWizard: Bool
+    /// Session-scoped request from the app shell to push Network Interfaces.
+    @Binding var shouldOpenInterfaceManagement: Bool
 
     // MARK: - State
 
@@ -240,6 +242,11 @@ struct SettingsView: View {
                 openRequestedRNodeWizard()
             }
         }
+        .onChange(of: shouldOpenInterfaceManagement) { _, requested in
+            if requested {
+                openRequestedInterfaceManagement()
+            }
+        }
         .task {
             if viewModel == nil {
                 viewModel = SettingsViewModel(
@@ -251,6 +258,7 @@ struct SettingsView: View {
             await viewModel?.loadSettings()
 
             openRequestedRNodeWizard()
+            openRequestedInterfaceManagement()
 
             // Poll connection state every 2s so the card stays live
             while !Task.isCancelled {
@@ -302,6 +310,26 @@ struct SettingsView: View {
             shouldOpenRNodeWizard = false
         }
         #endif
+    }
+
+    /// Consume a root-level route request after Settings has mounted. The same
+    /// helper owns direct taps inside Settings so both paths build identical state.
+    private func openRequestedInterfaceManagement() {
+        guard shouldOpenInterfaceManagement else { return }
+        openInterfaceManagement()
+        shouldOpenInterfaceManagement = false
+    }
+
+    private func openInterfaceManagement() {
+        if interfaceRepository == nil {
+            let repo = InterfaceRepository()
+            interfaceRepository = repo
+            interfaceViewModel = InterfaceManagementViewModel(
+                repository: repo,
+                appServices: appServices
+            )
+        }
+        showInterfaceManagement = true
     }
 
     // MARK: - Network Card
@@ -365,15 +393,7 @@ struct SettingsView: View {
 
                 // Manage Interfaces Button
                 Button(action: {
-                    if interfaceRepository == nil {
-                        let repo = InterfaceRepository()
-                        interfaceRepository = repo
-                        interfaceViewModel = InterfaceManagementViewModel(
-                            repository: repo,
-                            appServices: appServices
-                        )
-                    }
-                    showInterfaceManagement = true
+                    openInterfaceManagement()
                 }) {
                     HStack(spacing: 8) {
                         Image(systemName: "gearshape")

--- a/Tests/ColumbaAppTests/RuntimeFlavorTests.swift
+++ b/Tests/ColumbaAppTests/RuntimeFlavorTests.swift
@@ -14,6 +14,23 @@ import XCTest
 #endif
 
 final class RuntimeFlavorTests: XCTestCase {
+    func testDisconnectedInterfaceBannerOffersDirectRecovery() {
+        XCTAssertEqual(
+            InterfaceConnectivityBannerContent.forConnectionState(isConnected: false),
+            InterfaceConnectivityBannerContent(
+                title: "No Interfaces Connected",
+                message: "Add or configure a network interface to establish connectivity.",
+                actionTitle: "Manage Interfaces"
+            )
+        )
+    }
+
+    func testConnectedInterfaceHidesConnectivityBanner() {
+        XCTAssertNil(
+            InterfaceConnectivityBannerContent.forConnectionState(isConnected: true)
+        )
+    }
+
     func testActiveFlavorMatchesHostConfiguration() {
         #if COLUMBA_RUNTIME_MODEL_B
         XCTAssertEqual(BackendPreference.runtimeFlavor, .modelB)

--- a/Tests/ColumbaAppTests/RuntimeFlavorTests.swift
+++ b/Tests/ColumbaAppTests/RuntimeFlavorTests.swift
@@ -19,8 +19,7 @@ final class RuntimeFlavorTests: XCTestCase {
             InterfaceConnectivityBannerContent.forConnectionState(isConnected: false),
             InterfaceConnectivityBannerContent(
                 title: "No Interfaces Connected",
-                message: "Add or configure a network interface to establish connectivity.",
-                actionTitle: "Manage Interfaces"
+                actionTitle: "Manage"
             )
         )
     }

--- a/Tests/static/test_interface_connectivity_banner.py
+++ b/Tests/static/test_interface_connectivity_banner.py
@@ -1,0 +1,52 @@
+import json
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MAIN_TAB = ROOT / "Sources/ColumbaApp/Views/MainTabView.swift"
+SETTINGS = ROOT / "Sources/ColumbaApp/Views/Settings/SettingsView.swift"
+LOCALIZATIONS = ROOT / "Sources/ColumbaApp/Resources/Localizable.xcstrings"
+
+
+class InterfaceConnectivityBannerContractTests(unittest.TestCase):
+    def test_shipping_banner_uses_live_aggregate_connection_state(self) -> None:
+        source = MAIN_TAB.read_text(encoding="utf-8")
+
+        self.assertIn("#if COLUMBA_RUNTIME_PYTHON", source)
+        self.assertIn("isConnected: appServices.isConnected", source)
+        self.assertIn('accessibilityIdentifier("interface_connectivity_banner")', source)
+        self.assertIn(
+            'accessibilityIdentifier("connectivity_banner_manage_interfaces")',
+            source,
+        )
+
+    def test_banner_action_routes_directly_to_interface_management(self) -> None:
+        main_tab = MAIN_TAB.read_text(encoding="utf-8")
+        settings = SETTINGS.read_text(encoding="utf-8")
+
+        self.assertIn("selectedTab = .settings", main_tab)
+        self.assertIn("shouldOpenInterfaceManagement = true", main_tab)
+        self.assertIn(
+            "shouldOpenInterfaceManagement: $shouldOpenInterfaceManagement",
+            main_tab,
+        )
+        self.assertIn(".onChange(of: shouldOpenInterfaceManagement)", settings)
+        self.assertIn("openRequestedInterfaceManagement()", settings)
+        self.assertIn("showInterfaceManagement = true", settings)
+        self.assertIn("shouldOpenInterfaceManagement = false", settings)
+
+    def test_banner_copy_is_translation_ready(self) -> None:
+        catalog = json.loads(LOCALIZATIONS.read_text(encoding="utf-8"))
+        required = {
+            "No Interfaces Connected",
+            "Add or configure a network interface to establish connectivity.",
+            "Manage Interfaces",
+            "Opens network interface settings",
+        }
+
+        self.assertTrue(required.issubset(catalog["strings"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tests/static/test_interface_connectivity_banner.py
+++ b/Tests/static/test_interface_connectivity_banner.py
@@ -67,6 +67,8 @@ class InterfaceConnectivityBannerContractTests(unittest.TestCase):
             5,
         )
         self.assertGreaterEqual(flow.count('text: "Network Interfaces"'), 3)
+        self.assertEqual(flow.count('id: "BackButton"'), 2)
+        self.assertNotIn("\n- back\n", flow)
         self.assertIn('id: "screen_settings"', flow)
         self.assertGreaterEqual(flow.count('id: "tab_chats|message.fill"'), 3)
 

--- a/Tests/static/test_interface_connectivity_banner.py
+++ b/Tests/static/test_interface_connectivity_banner.py
@@ -42,7 +42,7 @@ class InterfaceConnectivityBannerContractTests(unittest.TestCase):
         source = MAIN_TAB.read_text(encoding="utf-8")
 
         self.assertIn("HStack(spacing: 10)", source)
-        self.assertIn(".frame(minHeight: 32)", source)
+        self.assertIn(".frame(minHeight: 44)", source)
         self.assertIn('String(localized: "Manage")', source)
         self.assertNotIn("Text(content.message)", source)
         self.assertNotIn("Add or configure a network interface", source)

--- a/Tests/static/test_interface_connectivity_banner.py
+++ b/Tests/static/test_interface_connectivity_banner.py
@@ -7,6 +7,8 @@ ROOT = Path(__file__).resolve().parents[2]
 MAIN_TAB = ROOT / "Sources/ColumbaApp/Views/MainTabView.swift"
 SETTINGS = ROOT / "Sources/ColumbaApp/Views/Settings/SettingsView.swift"
 LOCALIZATIONS = ROOT / "Sources/ColumbaApp/Resources/Localizable.xcstrings"
+UI_FLOW = ROOT / "flows/interface-connectivity-banner.yml"
+CI_WORKFLOW = ROOT / ".github/workflows/tests.yml"
 
 
 class InterfaceConnectivityBannerContractTests(unittest.TestCase):
@@ -46,6 +48,20 @@ class InterfaceConnectivityBannerContractTests(unittest.TestCase):
         }
 
         self.assertTrue(required.issubset(catalog["strings"]))
+
+    def test_ui_flow_covers_cold_mounted_and_repeated_routes(self) -> None:
+        flow = UI_FLOW.read_text(encoding="utf-8")
+        workflow = CI_WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn("interface-connectivity-banner.yml", workflow)
+        self.assertIn('id: "interface_connectivity_banner"', flow)
+        self.assertEqual(
+            flow.count('id: "connectivity_banner_manage_interfaces"'),
+            3,
+        )
+        self.assertGreaterEqual(flow.count('text: "Network Interfaces"'), 3)
+        self.assertIn('id: "screen_settings"', flow)
+        self.assertGreaterEqual(flow.count('id: "tab_chats|message.fill"'), 3)
 
 
 if __name__ == "__main__":

--- a/Tests/static/test_interface_connectivity_banner.py
+++ b/Tests/static/test_interface_connectivity_banner.py
@@ -38,11 +38,20 @@ class InterfaceConnectivityBannerContractTests(unittest.TestCase):
         self.assertIn("showInterfaceManagement = true", settings)
         self.assertIn("shouldOpenInterfaceManagement = false", settings)
 
+    def test_persistent_banner_uses_compact_single_row(self) -> None:
+        source = MAIN_TAB.read_text(encoding="utf-8")
+
+        self.assertIn("HStack(spacing: 10)", source)
+        self.assertIn(".frame(minHeight: 32)", source)
+        self.assertIn('String(localized: "Manage")', source)
+        self.assertNotIn("Text(content.message)", source)
+        self.assertNotIn("Add or configure a network interface", source)
+
     def test_banner_copy_is_translation_ready(self) -> None:
         catalog = json.loads(LOCALIZATIONS.read_text(encoding="utf-8"))
         required = {
             "No Interfaces Connected",
-            "Add or configure a network interface to establish connectivity.",
+            "Manage",
             "Manage Interfaces",
             "Opens network interface settings",
         }

--- a/Tests/static/test_interface_connectivity_banner.py
+++ b/Tests/static/test_interface_connectivity_banner.py
@@ -17,10 +17,9 @@ class InterfaceConnectivityBannerContractTests(unittest.TestCase):
 
         self.assertIn("#if COLUMBA_RUNTIME_PYTHON", source)
         self.assertIn("isConnected: appServices.isConnected", source)
-        self.assertIn('accessibilityIdentifier("interface_connectivity_banner")', source)
-        self.assertIn(
-            'accessibilityIdentifier("connectivity_banner_manage_interfaces")',
-            source,
+        self.assertEqual(
+            source.count('accessibilityIdentifier("interface_connectivity_banner")'),
+            1,
         )
 
     def test_banner_action_routes_directly_to_interface_management(self) -> None:
@@ -63,10 +62,9 @@ class InterfaceConnectivityBannerContractTests(unittest.TestCase):
         workflow = CI_WORKFLOW.read_text(encoding="utf-8")
 
         self.assertIn("interface-connectivity-banner.yml", workflow)
-        self.assertIn('id: "interface_connectivity_banner"', flow)
         self.assertEqual(
-            flow.count('id: "connectivity_banner_manage_interfaces"'),
-            3,
+            flow.count('id: "interface_connectivity_banner"'),
+            5,
         )
         self.assertGreaterEqual(flow.count('text: "Network Interfaces"'), 3)
         self.assertIn('id: "screen_settings"', flow)

--- a/Tests/static/test_reported_runtime_bugs.py
+++ b/Tests/static/test_reported_runtime_bugs.py
@@ -252,7 +252,13 @@ class ReportedRuntimeBugContracts(unittest.TestCase):
             settings,
             re.DOTALL,
         ))
-        self.assertIn("openRequestedRNodeWizard()\n\n            // Poll connection state", settings)
+        self.assertIsNotNone(re.search(
+            r"await viewModel\?\.loadSettings\(\).*?"
+            r"openRequestedRNodeWizard\(\).*?"
+            r"// Poll connection state",
+            settings,
+            re.DOTALL,
+        ))
         self.assertIn("private func openRequestedRNodeWizard()", settings)
 
         consumer = re.search(

--- a/flows/interface-connectivity-banner.yml
+++ b/flows/interface-connectivity-banner.yml
@@ -13,7 +13,7 @@ name: interface-connectivity-banner
 - assertVisible:
     text: "No Interfaces Connected"
 - assertVisible:
-    text: "Add or configure a network interface to establish connectivity."
+    text: "Manage"
 
 # Cold route: Settings has not been selected or initialized by the user yet.
 - tapOn:

--- a/flows/interface-connectivity-banner.yml
+++ b/flows/interface-connectivity-banner.yml
@@ -24,7 +24,8 @@ name: interface-connectivity-banner
     timeout: 10000
 - assertVisible:
     text: "Network Interfaces"
-- back
+- tapOn:
+    id: "BackButton"
 - extendedWaitUntil:
     visible:
       id: "screen_settings"
@@ -47,7 +48,8 @@ name: interface-connectivity-banner
     visible:
       text: "Network Interfaces"
     timeout: 10000
-- back
+- tapOn:
+    id: "BackButton"
 
 # A third request proves the consumed Boolean route can be raised repeatedly.
 - tapOn:

--- a/flows/interface-connectivity-banner.yml
+++ b/flows/interface-connectivity-banner.yml
@@ -17,7 +17,7 @@ name: interface-connectivity-banner
 
 # Cold route: Settings has not been selected or initialized by the user yet.
 - tapOn:
-    id: "connectivity_banner_manage_interfaces"
+    id: "interface_connectivity_banner"
 - extendedWaitUntil:
     visible:
       text: "Network Interfaces"
@@ -42,7 +42,7 @@ name: interface-connectivity-banner
 - tapOn:
     id: "tab_chats|message.fill"
 - tapOn:
-    id: "connectivity_banner_manage_interfaces"
+    id: "interface_connectivity_banner"
 - extendedWaitUntil:
     visible:
       text: "Network Interfaces"
@@ -53,7 +53,7 @@ name: interface-connectivity-banner
 - tapOn:
     id: "tab_chats|message.fill"
 - tapOn:
-    id: "connectivity_banner_manage_interfaces"
+    id: "interface_connectivity_banner"
 - extendedWaitUntil:
     visible:
       text: "Network Interfaces"

--- a/flows/interface-connectivity-banner.yml
+++ b/flows/interface-connectivity-banner.yml
@@ -1,0 +1,61 @@
+appId: network.columba.Columba
+name: interface-connectivity-banner
+---
+- launchApp:
+    clearState: true
+    clearKeychain: true
+    arguments:
+      ui-screenshotter: true
+- extendedWaitUntil:
+    visible:
+      id: "interface_connectivity_banner"
+    timeout: 30000
+- assertVisible:
+    text: "No Interfaces Connected"
+- assertVisible:
+    text: "Add or configure a network interface to establish connectivity."
+
+# Cold route: Settings has not been selected or initialized by the user yet.
+- tapOn:
+    id: "connectivity_banner_manage_interfaces"
+- extendedWaitUntil:
+    visible:
+      text: "Network Interfaces"
+    timeout: 10000
+- assertVisible:
+    text: "Network Interfaces"
+- back
+- extendedWaitUntil:
+    visible:
+      id: "screen_settings"
+    timeout: 10000
+
+# Mount Settings normally, leave it, then route through the banner again.
+- tapOn:
+    id: "tab_chats|message.fill"
+- assertVisible:
+    id: "interface_connectivity_banner"
+- tapOn:
+    id: "tab_settings|gearshape.fill"
+- assertVisible:
+    id: "screen_settings"
+- tapOn:
+    id: "tab_chats|message.fill"
+- tapOn:
+    id: "connectivity_banner_manage_interfaces"
+- extendedWaitUntil:
+    visible:
+      text: "Network Interfaces"
+    timeout: 10000
+- back
+
+# A third request proves the consumed Boolean route can be raised repeatedly.
+- tapOn:
+    id: "tab_chats|message.fill"
+- tapOn:
+    id: "connectivity_banner_manage_interfaces"
+- extendedWaitUntil:
+    visible:
+      text: "Network Interfaces"
+    timeout: 10000
+- takeScreenshot: "interface-connectivity-banner-route"


### PR DESCRIPTION
## Summary

- show a persistent top-level warning when the shipping Reticulum runtime has no connected interfaces
- keep the banner synchronized with aggregate TCP, AutoInterface, RNode, and BLE connectivity
- route the compact, fully tappable `Manage` row directly to Network Interfaces
- cover cold, mounted, back-stack, and repeated routing through a CI-registered Maestro flow

## UX

The unresolved state is intentionally not dismissible. It uses a compact 44-point row with a warning icon, status title, and trailing Manage action, and disappears automatically when connectivity returns.

## Verification

- red regression proved before implementation
- focused `RuntimeFlavorTests`: 8 passed
- full shipping XCTest suite: 325 passed
- static suite: 274 passed, 1 skipped
- Model B simulator build: passed
- compact simulator layout inspected for clipping and navigation overlap
- signed physical iPhone build, in-place install, launch, and process readback: passed
- final exact-head standards and UX reviews: approved

## Risk and rollback

Risk is limited to the shipping app shell and Settings navigation request handling. Reverting this PR restores the prior UI without a data migration.

Closes #170
