### PR TITLE
Fix Network card interface listing

### DIFF
--- a/Sources/ColumbaApp/Resources/Localizable.xcstrings
+++ b/Sources/ColumbaApp/Resources/Localizable.xcstrings
@@ -1,6 +1,46 @@
 {
   "sourceLanguage": "en",
   "strings": {
+    "No active interface": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No active interface"
+          }
+        }
+      }
+    },
+    "Interfaces:": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Interfaces:"
+          }
+        }
+      }
+    },
+    "TCP": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "TCP"
+          }
+        }
+      }
+    },
+    "TCP Server": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "TCP Server"
+          }
+        }
+      }
+    },
     "Manage": {
       "localizations": {
         "en": {

--- a/Sources/ColumbaApp/ViewModels/SettingsViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/SettingsViewModel.swift
@@ -69,6 +69,26 @@ public struct IdentityInfo: Equatable {
 
 // MARK: - SettingsViewModel
 
+enum NetworkInterfacePresentation {
+    static func connectedTCPDescriptions(
+        configuredInterfaces: [InterfaceEntity],
+        connectedEntityIds: Set<String>
+    ) -> [String] {
+        configuredInterfaces.compactMap { entity in
+            guard entity.enabled, connectedEntityIds.contains(entity.id) else { return nil }
+
+            switch entity.config {
+            case .tcpClient(let config):
+                return "TCP (\(config.targetHost):\(String(config.targetPort)))"
+            case .tcpServer(let config):
+                return "TCP Server (\(config.listenIp):\(String(config.listenPort)))"
+            default:
+                return nil
+            }
+        }
+    }
+}
+
 /// ViewModel for settings screen.
 ///
 /// Uses iOS 17+ @Observable macro for automatic SwiftUI observation.
@@ -500,26 +520,36 @@ public final class SettingsViewModel {
         // Build connected interface string from all active interfaces.
         var activeInterfaces: [String] = []
 
+        let configuredInterfaces = InterfaceRepository().getEnabledInterfaces()
+
         if modelB {
             // Model B: the NE owns MULTIPLE relays (one `ne-tcp-relay-<entityId>` per
-            // enabled tcpClient). Label the card with the relays that are ACTUALLY online,
-            // matched by entity id via the per-relay snapshot — NOT the first-configured
-            // one. The old code labeled with `.first(tcpClient)` whenever ANY relay was up
-            // (a coarse any-online bool), so a down first relay (e.g. a dead community hub)
-            // was shown as the connected interface while a different relay carried traffic.
+            // enabled tcpClient). Label the card with every relay that is actually online.
             let onlineIds = Set(await appServices.neTcpRelayStatuses().filter { $0.online }.map { $0.entityId })
-            let interfaceRepo = InterfaceRepository()
-            for entity in interfaceRepo.getEnabledInterfaces() where entity.type == .tcpClient {
-                guard onlineIds.contains(entity.id), case .tcpClient(let config) = entity.config else { continue }
-                activeInterfaces.append("TCP (\(config.targetHost):\(String(config.targetPort)))")
+            activeInterfaces.append(contentsOf: NetworkInterfacePresentation.connectedTCPDescriptions(
+                configuredInterfaces: configuredInterfaces,
+                connectedEntityIds: onlineIds
+            ))
+        } else {
+            // Shipping Python: every configured TCP interface has its own runtime entry.
+            // Build the card from all connected entity IDs instead of the legacy
+            // `tcpInterface` convenience accessor, whose dictionary-first value can be
+            // a disconnected interface while another connection is carrying traffic.
+            var connectedTCPIds: Set<String> = []
+            for (entityId, tcpInterface) in appServices.tcpInterfaces
+                where await tcpInterface.state == .connected {
+                connectedTCPIds.insert(entityId)
             }
-        } else if let tcp = appServices.tcpInterface, await tcp.state == .connected {
-            // Model A: the app owns a single local TCP interface.
-            let interfaceRepo = InterfaceRepository()
-            if let tcpEntity = interfaceRepo.getEnabledInterfaces().first(where: { $0.type == .tcpClient }),
-               case .tcpClient(let config) = tcpEntity.config {
-                activeInterfaces.append("TCP (\(config.targetHost):\(String(config.targetPort)))")
-            } else {
+
+            let tcpDescriptions = NetworkInterfacePresentation.connectedTCPDescriptions(
+                configuredInterfaces: configuredInterfaces,
+                connectedEntityIds: connectedTCPIds
+            )
+            activeInterfaces.append(contentsOf: tcpDescriptions)
+
+            // Preserve a truthful fallback for legacy runtime-created TCP entries
+            // that are not backed by a persisted InterfaceEntity.
+            if !connectedTCPIds.isEmpty, tcpDescriptions.isEmpty {
                 activeInterfaces.append("TCP")
             }
         }

--- a/Sources/ColumbaApp/ViewModels/SettingsViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/SettingsViewModel.swift
@@ -70,6 +70,10 @@ public struct IdentityInfo: Equatable {
 // MARK: - SettingsViewModel
 
 enum NetworkInterfacePresentation {
+    static func listText(_ descriptions: [String]) -> String {
+        descriptions.isEmpty ? "No active interface" : descriptions.joined(separator: "\n")
+    }
+
     static func connectedTCPDescriptions(
         configuredInterfaces: [InterfaceEntity],
         connectedEntityIds: Set<String>
@@ -575,7 +579,7 @@ public final class SettingsViewModel {
                 activeInterfaces.append("Bluetooth LE")
             }
         }
-        connectedInterface = activeInterfaces.isEmpty ? "No active interface" : activeInterfaces.joined(separator: ", ")
+        connectedInterface = NetworkInterfacePresentation.listText(activeInterfaces)
 
         // Overall state: in Model B "connected" = at least one active interface
         // (the NE relay or an app-owned radio); otherwise defer to the app's own

--- a/Sources/ColumbaApp/ViewModels/SettingsViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/SettingsViewModel.swift
@@ -539,7 +539,10 @@ public final class SettingsViewModel {
         // Build connected interface string from all active interfaces.
         var activeInterfaces: [String] = []
 
-        let configuredInterfaces = InterfaceRepository().getEnabledInterfaces()
+        // Pass the complete persisted snapshot. The presenter owns enabled-state
+        // filtering and needs disabled IDs to distinguish teardown-in-progress
+        // entries from genuinely unmapped runtime-created interfaces.
+        let configuredInterfaces = InterfaceRepository().interfaces
 
         if modelB {
             // Model B: the NE owns MULTIPLE relays (one `ne-tcp-relay-<entityId>` per

--- a/Sources/ColumbaApp/ViewModels/SettingsViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/SettingsViewModel.swift
@@ -71,25 +71,40 @@ public struct IdentityInfo: Equatable {
 
 enum NetworkInterfacePresentation {
     static func listText(_ descriptions: [String]) -> String {
-        descriptions.isEmpty ? "No active interface" : descriptions.joined(separator: "\n")
+        descriptions.isEmpty
+            ? String(localized: "No active interface")
+            : descriptions.joined(separator: "\n")
     }
 
-    static func connectedTCPDescriptions(
+    static func tcpDescriptions(
         configuredInterfaces: [InterfaceEntity],
-        connectedEntityIds: Set<String>
+        runtimeStates: [String: InterfaceState]
     ) -> [String] {
-        configuredInterfaces.compactMap { entity in
+        let connectedEntityIds = Set(runtimeStates.compactMap { entityId, state in
+            state == .connected ? entityId : nil
+        })
+        let knownEntityIds = Set(configuredInterfaces.map(\.id))
+
+        var descriptions = configuredInterfaces.compactMap { entity -> String? in
             guard entity.enabled, connectedEntityIds.contains(entity.id) else { return nil }
 
             switch entity.config {
             case .tcpClient(let config):
-                return "TCP (\(config.targetHost):\(String(config.targetPort)))"
+                return String(localized: "TCP") + " (\(config.targetHost):\(String(config.targetPort)))"
             case .tcpServer(let config):
-                return "TCP Server (\(config.listenIp):\(String(config.listenPort)))"
+                return String(localized: "TCP Server") + " (\(config.listenIp):\(String(config.listenPort)))"
             default:
                 return nil
             }
         }
+
+        // Runtime-created TCP interfaces have no persisted name or endpoint to show.
+        // Keep one generic row per connected unknown ID so mixed configured/legacy
+        // states still account for every active connection. Known disabled entries
+        // stay omitted even if teardown has not removed their runtime object yet.
+        let unknownConnectedCount = connectedEntityIds.subtracting(knownEntityIds).count
+        descriptions.append(contentsOf: repeatElement(String(localized: "TCP"), count: unknownConnectedCount))
+        return descriptions
     }
 }
 
@@ -529,33 +544,25 @@ public final class SettingsViewModel {
         if modelB {
             // Model B: the NE owns MULTIPLE relays (one `ne-tcp-relay-<entityId>` per
             // enabled tcpClient). Label the card with every relay that is actually online.
-            let onlineIds = Set(await appServices.neTcpRelayStatuses().filter { $0.online }.map { $0.entityId })
-            activeInterfaces.append(contentsOf: NetworkInterfacePresentation.connectedTCPDescriptions(
+            let onlineStates = Dictionary(uniqueKeysWithValues: await appServices.neTcpRelayStatuses().map {
+                ($0.entityId, $0.online ? InterfaceState.connected : InterfaceState.disconnected)
+            })
+            activeInterfaces.append(contentsOf: NetworkInterfacePresentation.tcpDescriptions(
                 configuredInterfaces: configuredInterfaces,
-                connectedEntityIds: onlineIds
+                runtimeStates: onlineStates
             ))
         } else {
             // Shipping Python: every configured TCP interface has its own runtime entry.
-            // Build the card from all connected entity IDs instead of the legacy
-            // `tcpInterface` convenience accessor, whose dictionary-first value can be
-            // a disconnected interface while another connection is carrying traffic.
-            var connectedTCPIds: Set<String> = []
-            for (entityId, tcpInterface) in appServices.tcpInterfaces
-                where await tcpInterface.state == .connected {
-                connectedTCPIds.insert(entityId)
+            // Send the complete state snapshot through the same presentation seam so a
+            // disconnected dictionary-first entry cannot hide other connected entries.
+            var runtimeTCPStates: [String: InterfaceState] = [:]
+            for (entityId, tcpInterface) in appServices.tcpInterfaces {
+                runtimeTCPStates[entityId] = await tcpInterface.state
             }
-
-            let tcpDescriptions = NetworkInterfacePresentation.connectedTCPDescriptions(
+            activeInterfaces.append(contentsOf: NetworkInterfacePresentation.tcpDescriptions(
                 configuredInterfaces: configuredInterfaces,
-                connectedEntityIds: connectedTCPIds
-            )
-            activeInterfaces.append(contentsOf: tcpDescriptions)
-
-            // Preserve a truthful fallback for legacy runtime-created TCP entries
-            // that are not backed by a persisted InterfaceEntity.
-            if !connectedTCPIds.isEmpty, tcpDescriptions.isEmpty {
-                activeInterfaces.append("TCP")
-            }
+                runtimeStates: runtimeTCPStates
+            ))
         }
         if let auto = appServices.autoInterface, await auto.peerCount > 0 {
             let count = await auto.peerCount

--- a/Sources/ColumbaApp/Views/Settings/SettingsView.swift
+++ b/Sources/ColumbaApp/Views/Settings/SettingsView.swift
@@ -360,14 +360,15 @@ struct SettingsView: View {
                 }
 
                 if vm.isConnected {
-                    HStack {
-                        Text("Interface:")
+                    HStack(alignment: .top) {
+                        Text("Interfaces:")
                             .font(.subheadline)
                             .foregroundStyle(Theme.textSecondary)
 
                         Text(vm.connectedInterface)
                             .font(.subheadline)
                             .foregroundStyle(Theme.textPrimary)
+                            .fixedSize(horizontal: false, vertical: true)
                     }
                 }
 

--- a/Tests/ColumbaAppTests/RuntimeFlavorTests.swift
+++ b/Tests/ColumbaAppTests/RuntimeFlavorTests.swift
@@ -14,6 +14,40 @@ import XCTest
 #endif
 
 final class RuntimeFlavorTests: XCTestCase {
+    func testNetworkCardListsEveryConnectedTCPInterface() {
+        let interfaces = [
+            InterfaceEntity(
+                id: "primary",
+                name: "Primary Relay",
+                type: .tcpClient,
+                config: .tcpClient(TCPClientConfig(targetHost: "relay-one.example", targetPort: 4242))
+            ),
+            InterfaceEntity(
+                id: "secondary",
+                name: "Secondary Relay",
+                type: .tcpClient,
+                config: .tcpClient(TCPClientConfig(targetHost: "relay-two.example", targetPort: 4243))
+            ),
+            InterfaceEntity(
+                id: "offline",
+                name: "Offline Relay",
+                type: .tcpClient,
+                config: .tcpClient(TCPClientConfig(targetHost: "offline.example", targetPort: 4244))
+            ),
+        ]
+
+        XCTAssertEqual(
+            NetworkInterfacePresentation.connectedTCPDescriptions(
+                configuredInterfaces: interfaces,
+                connectedEntityIds: ["primary", "secondary"]
+            ),
+            [
+                "TCP (relay-one.example:4242)",
+                "TCP (relay-two.example:4243)",
+            ]
+        )
+    }
+
     func testDisconnectedInterfaceBannerOffersDirectRecovery() {
         XCTAssertEqual(
             InterfaceConnectivityBannerContent.forConnectionState(isConnected: false),

--- a/Tests/ColumbaAppTests/RuntimeFlavorTests.swift
+++ b/Tests/ColumbaAppTests/RuntimeFlavorTests.swift
@@ -36,9 +36,13 @@ final class RuntimeFlavorTests: XCTestCase {
             ),
         ]
 
-        let descriptions = NetworkInterfacePresentation.connectedTCPDescriptions(
+        let descriptions = NetworkInterfacePresentation.tcpDescriptions(
             configuredInterfaces: interfaces,
-            connectedEntityIds: ["primary", "secondary"]
+            runtimeStates: [
+                "primary": .connected,
+                "secondary": .connected,
+                "offline": .disconnected,
+            ]
         )
 
         XCTAssertEqual(
@@ -51,6 +55,42 @@ final class RuntimeFlavorTests: XCTestCase {
         XCTAssertEqual(
             NetworkInterfacePresentation.listText(descriptions),
             "TCP (relay-one.example:4242)\nTCP (relay-two.example:4243)"
+        )
+    }
+
+    func testNetworkCardAccountsForServerUnknownAndDisabledTCPStates() {
+        let interfaces = [
+            InterfaceEntity(
+                id: "server",
+                name: "Local Server",
+                type: .tcpServer,
+                config: .tcpServer(TCPServerConfig(listenIp: "0.0.0.0", listenPort: 4242))
+            ),
+            InterfaceEntity(
+                id: "disabled",
+                name: "Disabled Relay",
+                type: .tcpClient,
+                enabled: false,
+                config: .tcpClient(TCPClientConfig(targetHost: "disabled.example", targetPort: 4243))
+            ),
+        ]
+
+        XCTAssertEqual(
+            NetworkInterfacePresentation.tcpDescriptions(
+                configuredInterfaces: interfaces,
+                runtimeStates: [
+                    "server": .connected,
+                    "disabled": .connected,
+                    "legacy-one": .connected,
+                    "legacy-two": .connected,
+                    "legacy-offline": .disconnected,
+                ]
+            ),
+            [
+                "TCP Server (0.0.0.0:4242)",
+                "TCP",
+                "TCP",
+            ]
         )
     }
 

--- a/Tests/ColumbaAppTests/RuntimeFlavorTests.swift
+++ b/Tests/ColumbaAppTests/RuntimeFlavorTests.swift
@@ -36,15 +36,21 @@ final class RuntimeFlavorTests: XCTestCase {
             ),
         ]
 
+        let descriptions = NetworkInterfacePresentation.connectedTCPDescriptions(
+            configuredInterfaces: interfaces,
+            connectedEntityIds: ["primary", "secondary"]
+        )
+
         XCTAssertEqual(
-            NetworkInterfacePresentation.connectedTCPDescriptions(
-                configuredInterfaces: interfaces,
-                connectedEntityIds: ["primary", "secondary"]
-            ),
+            descriptions,
             [
                 "TCP (relay-one.example:4242)",
                 "TCP (relay-two.example:4243)",
             ]
+        )
+        XCTAssertEqual(
+            NetworkInterfacePresentation.listText(descriptions),
+            "TCP (relay-one.example:4242)\nTCP (relay-two.example:4243)"
         )
     }
 

--- a/Tests/static/test_network_card_interface_list.py
+++ b/Tests/static/test_network_card_interface_list.py
@@ -13,6 +13,8 @@ class NetworkCardInterfaceListContractTests(unittest.TestCase):
         source = SETTINGS_VM.read_text()
         refresh = source[source.index("public func refreshConnectionState() async") :]
 
+        self.assertIn("let configuredInterfaces = InterfaceRepository().interfaces", refresh)
+        self.assertNotIn("InterfaceRepository().getEnabledInterfaces()", refresh)
         self.assertIn("for (entityId, tcpInterface) in appServices.tcpInterfaces", refresh)
         self.assertIn("runtimeTCPStates[entityId] = await tcpInterface.state", refresh)
         self.assertIn("runtimeStates: runtimeTCPStates", refresh)

--- a/Tests/static/test_network_card_interface_list.py
+++ b/Tests/static/test_network_card_interface_list.py
@@ -1,0 +1,36 @@
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SETTINGS_VM = ROOT / "Sources/ColumbaApp/ViewModels/SettingsViewModel.swift"
+SETTINGS_VIEW = ROOT / "Sources/ColumbaApp/Views/Settings/SettingsView.swift"
+LOCALIZATIONS = ROOT / "Sources/ColumbaApp/Resources/Localizable.xcstrings"
+
+
+class NetworkCardInterfaceListContractTests(unittest.TestCase):
+    def test_shipping_runtime_passes_every_tcp_state_to_presentation(self):
+        source = SETTINGS_VM.read_text()
+        refresh = source[source.index("public func refreshConnectionState() async") :]
+
+        self.assertIn("for (entityId, tcpInterface) in appServices.tcpInterfaces", refresh)
+        self.assertIn("runtimeTCPStates[entityId] = await tcpInterface.state", refresh)
+        self.assertIn("runtimeStates: runtimeTCPStates", refresh)
+        self.assertNotIn("appServices.tcpInterface,", refresh)
+
+    def test_card_renders_plural_multiline_interface_section(self):
+        source = SETTINGS_VIEW.read_text()
+
+        self.assertIn('Text("Interfaces:")', source)
+        self.assertIn("Text(vm.connectedInterface)", source)
+        self.assertIn(".fixedSize(horizontal: false, vertical: true)", source)
+
+    def test_new_user_visible_labels_are_localized(self):
+        catalog = LOCALIZATIONS.read_text()
+
+        for key in ("Interfaces:", "No active interface", "TCP", "TCP Server"):
+            self.assertIn(f'"{key}":', catalog)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- derive the Settings Network card from every runtime TCP interface state instead of the legacy arbitrary first-interface accessor
- list all connected TCP clients and servers on separate lines while excluding disconnected and disabled interfaces
- preserve connected AutoInterface, RNode, and Bluetooth entries, with localized fallback rows for runtime-created TCP interfaces
- add native and static regression coverage for multiple connected interfaces, disconnected entries, disabled teardown, unknown runtime entries, production wiring, and multiline presentation

## Root cause

`AppServices.isConnected` correctly aggregates all runtime interfaces, but `SettingsViewModel` used `appServices.tcpInterface`, a backward-compatible accessor returning an arbitrary dictionary value. When that value was the disconnected TCP interface, the card could display `Connected` with `No active interface` even though other TCP interfaces were connected.

## Verification

- red regression proved the presentation seam was absent before implementation
- shipping native suite: 327 tests passed
- static suite: 277 tests passed, 1 skipped
- Model B simulator build passed
- localization catalog JSON validation passed
- `git diff --check` passed
- two independent exact-head reviews approved
- signed physical-device build passed strict verification
- data-preserving iPhone installation, launch, and process verification passed
- real-device acceptance confirmed the Network card correctly listed the connected interfaces

## Risk and rollback

Risk is limited to Network-card status presentation. Runtime interface lifecycle and connection behavior are unchanged. Rollback is a normal revert of this PR.
