### PR TITLE
fix(ios): persist theme selection and keep user on Settings when selecting a theme

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,6 +76,7 @@ jobs:
             Tests.static.test_ios_stamp_runtime_hardening \
             Tests.static.test_async_propagation_fallback \
             Tests.static.test_privacy_settings_contract \
+            Tests.static.test_theme_selection_navigation_contract \
             Tests.static.test_ui_screenshotter_readiness \
             Tests.static.test_collect_maestro_screenshots
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -358,7 +358,7 @@ jobs:
           export PATH="$HOME/.maestro/bin:$PATH"
           mkdir -p ui-screenshots
           screenshot_status=0
-          for flow in contacts-list.yml chats-list.yml settings.yml map.yml interface-connectivity-banner.yml; do
+          for flow in contacts-list.yml chats-list.yml settings.yml theme-persistence.yml map.yml interface-connectivity-banner.yml; do
             if ! (
               cd ui-screenshots
               maestro --device "$DEVICE_ID" test "$GITHUB_WORKSPACE/flows/$flow"

--- a/Columba.xcodeproj/project.pbxproj
+++ b/Columba.xcodeproj/project.pbxproj
@@ -356,6 +356,7 @@
 		RFT002 /* RuntimeFlavorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = RFT001 /* RuntimeFlavorTests.swift */; };
 		RMLT002 /* RuntimeActivityMonitorLeaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = RMLT001 /* RuntimeActivityMonitorLeaseTests.swift */; };
 		RMLT003 /* RuntimeActivityMonitorLeaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = RMLT001 /* RuntimeActivityMonitorLeaseTests.swift */; };
+		TMP002 /* ThemeManagerPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = TMP001 /* ThemeManagerPersistenceTests.swift */; };
 		T003 /* MicronParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FT03 /* MicronParserTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -600,6 +601,7 @@
 		PXIF /* ProxyIPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyIPC.swift; sourceTree = "<group>"; };
 		RFT001 /* RuntimeFlavorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RuntimeFlavorTests.swift; sourceTree = "<group>"; };
 		RMLT001 /* RuntimeActivityMonitorLeaseTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RuntimeActivityMonitorLeaseTests.swift; sourceTree = "<group>"; };
+		TMP001 /* ThemeManagerPersistenceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThemeManagerPersistenceTests.swift; sourceTree = "<group>"; };
 		SRB002 /* SwiftRNSBackend.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SwiftRNSBackend.swift; path = Sources/RNSBackendSwift/SwiftRNSBackend.swift; sourceTree = SOURCE_ROOT; };
 		TPROD /* ColumbaAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ColumbaAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -1043,6 +1045,7 @@
 				6C8CFC274AF9EF63E9A75238 /* PythonConfigWriterTests.swift */,
 				RFT001 /* RuntimeFlavorTests.swift */,
 				RMLT001 /* RuntimeActivityMonitorLeaseTests.swift */,
+				TMP001 /* ThemeManagerPersistenceTests.swift */,
 			);
 			path = Tests/ColumbaAppTests;
 			sourceTree = "<group>";
@@ -1728,6 +1731,7 @@
 				26D564FAEE8E3C750E8E2442 /* PythonConfigWriterTests.swift in Sources */,
 				RFT002 /* RuntimeFlavorTests.swift in Sources */,
 				RMLT002 /* RuntimeActivityMonitorLeaseTests.swift in Sources */,
+				TMP002 /* ThemeManagerPersistenceTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/ColumbaApp/App/ColumbaApp.swift
+++ b/Sources/ColumbaApp/App/ColumbaApp.swift
@@ -142,7 +142,6 @@ struct ColumbaApp: App {
             #endif
             .preferredColorScheme(ThemeManager.shared.resolvedColorScheme)
             .tint(Theme.accentColor)
-            .id(ThemeManager.shared.themeVersion)
             .onOpenURL { url in
                 guard url.scheme == "lxma" else { return }
                 #if DEBUG

--- a/Sources/ColumbaApp/Theme/ThemeManager.swift
+++ b/Sources/ColumbaApp/Theme/ThemeManager.swift
@@ -27,18 +27,24 @@ final class ThemeManager {
     private let defaults: UserDefaults
 
     // MARK: - State
+    //
+    // Persistence-sensitive state. These are `private(set)` so the only
+    // writers are the mutation methods below (each of which persists the
+    // aggregate state) and `restore()`. A direct write from any other module
+    // location would change live theme state without updating `theme_state`,
+    // silently losing that change on relaunch.
 
     /// User's color scheme preference.
-    var colorSchemePreference: ColorSchemePreference = .dark
+    private(set) var colorSchemePreference: ColorSchemePreference = .dark
 
     /// Currently active preset (nil if using custom theme).
-    var activePresetId: PresetThemeId? = .plum
+    private(set) var activePresetId: PresetThemeId? = .plum
 
     /// Currently active custom theme ID (nil if using preset).
-    var activeCustomThemeId: UUID? = nil
+    private(set) var activeCustomThemeId: UUID? = nil
 
     /// All user-created custom themes.
-    var customThemes: [CustomThemeData] = []
+    private(set) var customThemes: [CustomThemeData] = []
 
     // MARK: - Resolved Colors
 

--- a/Sources/ColumbaApp/Theme/ThemeManager.swift
+++ b/Sources/ColumbaApp/Theme/ThemeManager.swift
@@ -146,22 +146,33 @@ final class ThemeManager {
     func selectPreset(_ preset: PresetThemeId) {
         activePresetId = preset
         activeCustomThemeId = nil
-        persistSelection()
+        persistState()
         themeVersion += 1
     }
 
     /// Select a custom theme by ID.
     func selectCustomTheme(_ id: UUID) {
+        guard customThemes.contains(where: { $0.id == id }) else {
+            let changed = activeCustomThemeId != nil || activePresetId != .plum
+            activeCustomThemeId = nil
+            activePresetId = .plum
+            persistState()
+            if changed {
+                themeVersion += 1
+            }
+            return
+        }
+
         activeCustomThemeId = id
         activePresetId = nil
-        persistSelection()
+        persistState()
         themeVersion += 1
     }
 
     /// Set color scheme preference.
     func setColorScheme(_ pref: ColorSchemePreference) {
         colorSchemePreference = pref
-        persistSelection()
+        persistState()
         themeVersion += 1
     }
 
@@ -170,15 +181,17 @@ final class ThemeManager {
     /// Add a new custom theme and select it.
     func addCustomTheme(_ theme: CustomThemeData) {
         customThemes.append(theme)
-        persistCustomThemes()
-        selectCustomTheme(theme.id)
+        activeCustomThemeId = theme.id
+        activePresetId = nil
+        persistState()
+        themeVersion += 1
     }
 
     /// Update an existing custom theme.
     func updateCustomTheme(_ theme: CustomThemeData) {
         if let index = customThemes.firstIndex(where: { $0.id == theme.id }) {
             customThemes[index] = theme
-            persistCustomThemes()
+            persistState()
             if activeCustomThemeId == theme.id {
                 themeVersion += 1
             }
@@ -187,55 +200,75 @@ final class ThemeManager {
 
     /// Delete a custom theme. If it was active, fall back to plum preset.
     func deleteCustomTheme(_ id: UUID) {
+        let countBeforeDeletion = customThemes.count
         customThemes.removeAll { $0.id == id }
-        persistCustomThemes()
-        if activeCustomThemeId == id {
+        let removedTheme = customThemes.count != countBeforeDeletion
+        let wasActive = activeCustomThemeId == id
+        if wasActive {
             activeCustomThemeId = nil
             activePresetId = .plum
-            persistSelection()
             themeVersion += 1
+        }
+        if removedTheme || wasActive {
+            persistState()
         }
     }
 
     // MARK: - Persistence
 
+    private static let stateKey = "theme_state"
     private static let colorSchemeKey = "theme_colorScheme"
     private static let presetIdKey = "theme_presetId"
     private static let customThemeIdKey = "theme_customThemeId"
     private static let customThemesKey = "theme_customThemes"
 
-    private func persistSelection() {
-        defaults.set(colorSchemePreference.rawValue, forKey: Self.colorSchemeKey)
-        defaults.set(activePresetId?.rawValue, forKey: Self.presetIdKey)
-        defaults.set(activeCustomThemeId?.uuidString, forKey: Self.customThemeIdKey)
+    private struct PersistedThemeState: Codable {
+        let colorSchemeRawValue: String
+        let presetRawValue: String?
+        let customThemeID: UUID?
+        let customThemes: [CustomThemeData]
     }
 
-    private func persistCustomThemes() {
-        if let data = try? JSONEncoder().encode(customThemes) {
-            defaults.set(data, forKey: Self.customThemesKey)
+    private func persistState() {
+        let state = PersistedThemeState(
+            colorSchemeRawValue: colorSchemePreference.rawValue,
+            presetRawValue: activePresetId?.rawValue,
+            customThemeID: activeCustomThemeId,
+            customThemes: customThemes
+        )
+        if let data = try? JSONEncoder().encode(state) {
+            defaults.set(data, forKey: Self.stateKey)
         }
     }
 
     private func restore() {
-        let restoredColorScheme: ColorSchemePreference = {
-            guard let raw = defaults.string(forKey: Self.colorSchemeKey) else {
-                return .dark
-            }
-            return ColorSchemePreference(rawValue: raw) ?? .dark
-        }()
+        let state = defaults.data(forKey: Self.stateKey).flatMap {
+            try? JSONDecoder().decode(PersistedThemeState.self, from: $0)
+        }
 
-        let restoredCustomThemes: [CustomThemeData] = {
+        let restoredColorScheme = ColorSchemePreference(
+            rawValue: state?.colorSchemeRawValue
+                ?? defaults.string(forKey: Self.colorSchemeKey)
+                ?? ""
+        ) ?? .dark
+        let restoredCustomThemes = state?.customThemes ?? {
             guard let data = defaults.data(forKey: Self.customThemesKey),
                   let themes = try? JSONDecoder().decode([CustomThemeData].self, from: data) else {
                 return []
             }
             return themes
         }()
-
-        let restoredPresetId = defaults.string(forKey: Self.presetIdKey)
-            .flatMap(PresetThemeId.init(rawValue:))
-        let restoredCustomThemeId = defaults.string(forKey: Self.customThemeIdKey)
-            .flatMap(UUID.init(uuidString:))
+        let restoredPresetRawValue: String?
+        let restoredCustomThemeId: UUID?
+        if let state {
+            restoredPresetRawValue = state.presetRawValue
+            restoredCustomThemeId = state.customThemeID
+        } else {
+            restoredPresetRawValue = defaults.string(forKey: Self.presetIdKey)
+            restoredCustomThemeId = defaults.string(forKey: Self.customThemeIdKey)
+                .flatMap(UUID.init(uuidString:))
+        }
+        let restoredPresetId = restoredPresetRawValue.flatMap(PresetThemeId.init(rawValue:))
 
         colorSchemePreference = restoredColorScheme
         customThemes = restoredCustomThemes

--- a/Sources/ColumbaApp/Theme/ThemeManager.swift
+++ b/Sources/ColumbaApp/Theme/ThemeManager.swift
@@ -40,9 +40,6 @@ final class ThemeManager {
     /// All user-created custom themes.
     var customThemes: [CustomThemeData] = []
 
-    /// Bumped on every theme change to force root view re-render via `.id()`.
-    var themeVersion: Int = 0
-
     // MARK: - Resolved Colors
 
     /// The active color palette (from preset or custom theme).
@@ -147,33 +144,26 @@ final class ThemeManager {
         activePresetId = preset
         activeCustomThemeId = nil
         persistState()
-        themeVersion += 1
     }
 
     /// Select a custom theme by ID.
     func selectCustomTheme(_ id: UUID) {
         guard customThemes.contains(where: { $0.id == id }) else {
-            let changed = activeCustomThemeId != nil || activePresetId != .plum
             activeCustomThemeId = nil
             activePresetId = .plum
             persistState()
-            if changed {
-                themeVersion += 1
-            }
             return
         }
 
         activeCustomThemeId = id
         activePresetId = nil
         persistState()
-        themeVersion += 1
     }
 
     /// Set color scheme preference.
     func setColorScheme(_ pref: ColorSchemePreference) {
         colorSchemePreference = pref
         persistState()
-        themeVersion += 1
     }
 
     // MARK: - Custom Theme CRUD
@@ -184,7 +174,6 @@ final class ThemeManager {
         activeCustomThemeId = theme.id
         activePresetId = nil
         persistState()
-        themeVersion += 1
     }
 
     /// Update an existing custom theme.
@@ -192,9 +181,6 @@ final class ThemeManager {
         if let index = customThemes.firstIndex(where: { $0.id == theme.id }) {
             customThemes[index] = theme
             persistState()
-            if activeCustomThemeId == theme.id {
-                themeVersion += 1
-            }
         }
     }
 
@@ -207,7 +193,6 @@ final class ThemeManager {
         if wasActive {
             activeCustomThemeId = nil
             activePresetId = .plum
-            themeVersion += 1
         }
         if removedTheme || wasActive {
             persistState()

--- a/Sources/ColumbaApp/Theme/ThemeManager.swift
+++ b/Sources/ColumbaApp/Theme/ThemeManager.swift
@@ -6,6 +6,7 @@
 //  and custom theme CRUD. Persists selections to UserDefaults.
 //
 
+import Foundation
 import SwiftUI
 import RNSAPI
 import Observation
@@ -22,27 +23,22 @@ final class ThemeManager {
 
     static let shared = ThemeManager()
 
+    @ObservationIgnored
+    private let defaults: UserDefaults
+
     // MARK: - State
 
     /// User's color scheme preference.
-    var colorSchemePreference: ColorSchemePreference = .dark {
-        didSet { persist() }
-    }
+    var colorSchemePreference: ColorSchemePreference = .dark
 
     /// Currently active preset (nil if using custom theme).
-    var activePresetId: PresetThemeId? = .plum {
-        didSet { persist() }
-    }
+    var activePresetId: PresetThemeId? = .plum
 
     /// Currently active custom theme ID (nil if using preset).
-    var activeCustomThemeId: UUID? = nil {
-        didSet { persist() }
-    }
+    var activeCustomThemeId: UUID? = nil
 
     /// All user-created custom themes.
-    var customThemes: [CustomThemeData] = [] {
-        didSet { persistCustomThemes() }
-    }
+    var customThemes: [CustomThemeData] = []
 
     /// Bumped on every theme change to force root view re-render via `.id()`.
     var themeVersion: Int = 0
@@ -139,7 +135,8 @@ final class ThemeManager {
 
     // MARK: - Init
 
-    private init() {
+    internal init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
         restore()
     }
 
@@ -149,6 +146,7 @@ final class ThemeManager {
     func selectPreset(_ preset: PresetThemeId) {
         activePresetId = preset
         activeCustomThemeId = nil
+        persistSelection()
         themeVersion += 1
     }
 
@@ -156,12 +154,14 @@ final class ThemeManager {
     func selectCustomTheme(_ id: UUID) {
         activeCustomThemeId = id
         activePresetId = nil
+        persistSelection()
         themeVersion += 1
     }
 
     /// Set color scheme preference.
     func setColorScheme(_ pref: ColorSchemePreference) {
         colorSchemePreference = pref
+        persistSelection()
         themeVersion += 1
     }
 
@@ -170,6 +170,7 @@ final class ThemeManager {
     /// Add a new custom theme and select it.
     func addCustomTheme(_ theme: CustomThemeData) {
         customThemes.append(theme)
+        persistCustomThemes()
         selectCustomTheme(theme.id)
     }
 
@@ -177,6 +178,7 @@ final class ThemeManager {
     func updateCustomTheme(_ theme: CustomThemeData) {
         if let index = customThemes.firstIndex(where: { $0.id == theme.id }) {
             customThemes[index] = theme
+            persistCustomThemes()
             if activeCustomThemeId == theme.id {
                 themeVersion += 1
             }
@@ -186,9 +188,11 @@ final class ThemeManager {
     /// Delete a custom theme. If it was active, fall back to plum preset.
     func deleteCustomTheme(_ id: UUID) {
         customThemes.removeAll { $0.id == id }
+        persistCustomThemes()
         if activeCustomThemeId == id {
             activeCustomThemeId = nil
             activePresetId = .plum
+            persistSelection()
             themeVersion += 1
         }
     }
@@ -200,8 +204,7 @@ final class ThemeManager {
     private static let customThemeIdKey = "theme_customThemeId"
     private static let customThemesKey = "theme_customThemes"
 
-    private func persist() {
-        let defaults = UserDefaults.standard
+    private func persistSelection() {
         defaults.set(colorSchemePreference.rawValue, forKey: Self.colorSchemeKey)
         defaults.set(activePresetId?.rawValue, forKey: Self.presetIdKey)
         defaults.set(activeCustomThemeId?.uuidString, forKey: Self.customThemeIdKey)
@@ -209,33 +212,41 @@ final class ThemeManager {
 
     private func persistCustomThemes() {
         if let data = try? JSONEncoder().encode(customThemes) {
-            UserDefaults.standard.set(data, forKey: Self.customThemesKey)
+            defaults.set(data, forKey: Self.customThemesKey)
         }
     }
 
     private func restore() {
-        let defaults = UserDefaults.standard
-
-        if let raw = defaults.string(forKey: Self.colorSchemeKey),
-           let pref = ColorSchemePreference(rawValue: raw) {
-            colorSchemePreference = pref
-        }
-
-        if let raw = defaults.string(forKey: Self.presetIdKey),
-           let preset = PresetThemeId(rawValue: raw) {
-            activePresetId = preset
-        }
-
-        if let raw = defaults.string(forKey: Self.customThemeIdKey) {
-            activeCustomThemeId = UUID(uuidString: raw)
-            if activeCustomThemeId != nil {
-                activePresetId = nil
+        let restoredColorScheme: ColorSchemePreference = {
+            guard let raw = defaults.string(forKey: Self.colorSchemeKey) else {
+                return .dark
             }
-        }
+            return ColorSchemePreference(rawValue: raw) ?? .dark
+        }()
 
-        if let data = defaults.data(forKey: Self.customThemesKey),
-           let themes = try? JSONDecoder().decode([CustomThemeData].self, from: data) {
-            customThemes = themes
+        let restoredCustomThemes: [CustomThemeData] = {
+            guard let data = defaults.data(forKey: Self.customThemesKey),
+                  let themes = try? JSONDecoder().decode([CustomThemeData].self, from: data) else {
+                return []
+            }
+            return themes
+        }()
+
+        let restoredPresetId = defaults.string(forKey: Self.presetIdKey)
+            .flatMap(PresetThemeId.init(rawValue:))
+        let restoredCustomThemeId = defaults.string(forKey: Self.customThemeIdKey)
+            .flatMap(UUID.init(uuidString:))
+
+        colorSchemePreference = restoredColorScheme
+        customThemes = restoredCustomThemes
+
+        if let customThemeId = restoredCustomThemeId,
+           restoredCustomThemes.contains(where: { $0.id == customThemeId }) {
+            activeCustomThemeId = customThemeId
+            activePresetId = nil
+        } else {
+            activeCustomThemeId = nil
+            activePresetId = restoredPresetId ?? .plum
         }
     }
 }

--- a/Sources/ColumbaApp/Views/Settings/AppearanceCard.swift
+++ b/Sources/ColumbaApp/Views/Settings/AppearanceCard.swift
@@ -95,6 +95,13 @@ struct AppearanceCard: View {
                                 .font(.system(size: 12, weight: .medium))
                             Text(pref.displayName)
                                 .font(.system(size: 13, weight: .medium))
+                            if themeManager.colorSchemePreference == pref {
+                                Image(systemName: "checkmark")
+                                    .font(.system(size: 10, weight: .bold))
+                                    .accessibilityIdentifier(
+                                        "appearance_color_scheme_\(pref.rawValue)_selected"
+                                    )
+                            }
                         }
                         .foregroundStyle(
                             themeManager.colorSchemePreference == pref ? .white : Theme.textSecondary
@@ -149,6 +156,7 @@ struct AppearanceCard: View {
                         Image(systemName: "checkmark")
                             .font(.system(size: 16, weight: .bold))
                             .foregroundStyle(.white)
+                            .accessibilityIdentifier("appearance_theme_\(preset.rawValue)_selected")
                     }
                 }
                 .overlay {
@@ -198,6 +206,9 @@ struct AppearanceCard: View {
                         Image(systemName: "checkmark")
                             .font(.system(size: 12, weight: .bold))
                             .foregroundStyle(.white)
+                            .accessibilityIdentifier(
+                                "appearance_custom_theme_\(theme.id.uuidString)_selected"
+                            )
                     }
                 }
 

--- a/Sources/ColumbaApp/Views/Settings/AppearanceCard.swift
+++ b/Sources/ColumbaApp/Views/Settings/AppearanceCard.swift
@@ -228,5 +228,9 @@ struct AppearanceCard: View {
         .onTapGesture {
             themeManager.selectCustomTheme(theme.id)
         }
+        .accessibilityIdentifier("appearance_custom_theme_\(theme.id.uuidString)")
+        .accessibilityAddTraits(
+            themeManager.activeCustomThemeId == theme.id ? .isSelected : []
+        )
     }
 }

--- a/Sources/ColumbaApp/Views/Settings/AppearanceCard.swift
+++ b/Sources/ColumbaApp/Views/Settings/AppearanceCard.swift
@@ -108,6 +108,10 @@ struct AppearanceCard: View {
                         )
                         .clipShape(Capsule())
                     }
+                    .accessibilityIdentifier("appearance_color_scheme_\(pref.rawValue)")
+                    .accessibilityAddTraits(
+                        themeManager.colorSchemePreference == pref ? .isSelected : []
+                    )
                 }
             }
         }
@@ -154,6 +158,12 @@ struct AppearanceCard: View {
                     .font(.caption2)
                     .foregroundStyle(Theme.textSecondary)
             }
+            .accessibilityIdentifier("appearance_theme_\(preset.rawValue)")
+            .accessibilityAddTraits(
+                themeManager.activePresetId == preset && themeManager.activeCustomThemeId == nil
+                    ? .isSelected
+                    : []
+            )
         }
     }
 

--- a/Sources/ColumbaApp/Views/Settings/AppearanceCard.swift
+++ b/Sources/ColumbaApp/Views/Settings/AppearanceCard.swift
@@ -112,6 +112,11 @@ struct AppearanceCard: View {
                     .accessibilityAddTraits(
                         themeManager.colorSchemePreference == pref ? .isSelected : []
                     )
+                    .accessibilityValue(
+                        themeManager.colorSchemePreference == pref
+                            ? Text("Selected")
+                            : Text("Not selected")
+                    )
                 }
             }
         }
@@ -163,6 +168,11 @@ struct AppearanceCard: View {
                 themeManager.activePresetId == preset && themeManager.activeCustomThemeId == nil
                     ? .isSelected
                     : []
+            )
+            .accessibilityValue(
+                themeManager.activePresetId == preset && themeManager.activeCustomThemeId == nil
+                    ? Text("Selected")
+                    : Text("Not selected")
             )
         }
     }
@@ -231,6 +241,11 @@ struct AppearanceCard: View {
         .accessibilityIdentifier("appearance_custom_theme_\(theme.id.uuidString)")
         .accessibilityAddTraits(
             themeManager.activeCustomThemeId == theme.id ? .isSelected : []
+        )
+        .accessibilityValue(
+            themeManager.activeCustomThemeId == theme.id
+                ? Text("Selected")
+                : Text("Not selected")
         )
     }
 }

--- a/Sources/ColumbaApp/Views/Settings/AppearanceCard.swift
+++ b/Sources/ColumbaApp/Views/Settings/AppearanceCard.swift
@@ -98,9 +98,6 @@ struct AppearanceCard: View {
                             if themeManager.colorSchemePreference == pref {
                                 Image(systemName: "checkmark")
                                     .font(.system(size: 10, weight: .bold))
-                                    .accessibilityIdentifier(
-                                        "appearance_color_scheme_\(pref.rawValue)_selected"
-                                    )
                             }
                         }
                         .foregroundStyle(
@@ -156,7 +153,6 @@ struct AppearanceCard: View {
                         Image(systemName: "checkmark")
                             .font(.system(size: 16, weight: .bold))
                             .foregroundStyle(.white)
-                            .accessibilityIdentifier("appearance_theme_\(preset.rawValue)_selected")
                     }
                 }
                 .overlay {
@@ -206,9 +202,6 @@ struct AppearanceCard: View {
                         Image(systemName: "checkmark")
                             .font(.system(size: 12, weight: .bold))
                             .foregroundStyle(.white)
-                            .accessibilityIdentifier(
-                                "appearance_custom_theme_\(theme.id.uuidString)_selected"
-                            )
                     }
                 }
 

--- a/Tests/ColumbaAppTests/ThemeManagerPersistenceTests.swift
+++ b/Tests/ColumbaAppTests/ThemeManagerPersistenceTests.swift
@@ -1,0 +1,147 @@
+//
+//  ThemeManagerPersistenceTests.swift
+//  ColumbaAppTests
+//
+//  Regression coverage for theme persistence across ThemeManager instances.
+//
+
+import Foundation
+import SwiftUI
+import XCTest
+@testable import ColumbaApp
+
+@available(iOS 17.0, macOS 14.0, *)
+@MainActor
+final class ThemeManagerPersistenceTests: XCTestCase {
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "test.Columba.ThemeManagerPersistence.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    func testColorSchemePreferenceRestoresAcrossManagerInstances() {
+        do {
+            let first = ThemeManager(defaults: defaults)
+            first.setColorScheme(.light)
+        }
+
+        let second = ThemeManager(defaults: defaults)
+        XCTAssertEqual(second.colorSchemePreference, .light)
+        XCTAssertEqual(second.resolvedColorScheme, .light)
+        XCTAssertFalse(second.isDarkMode)
+        XCTAssertEqual(second.activeColors, PresetThemeId.plum.colors)
+    }
+
+    func testPresetSelectionRestoresPresetAndResolvedColors() {
+        do {
+            let first = ThemeManager(defaults: defaults)
+            first.selectPreset(.ocean)
+        }
+
+        let second = ThemeManager(defaults: defaults)
+        XCTAssertEqual(second.activePresetId, .ocean)
+        XCTAssertNil(second.activeCustomThemeId)
+        XCTAssertEqual(second.activeColors, PresetThemeId.ocean.colors)
+        XCTAssertEqual(second.accentColor, Color(hex: PresetThemeId.ocean.colors.accentHex))
+    }
+
+    func testCustomThemeAndSelectionRestoreAcrossManagerInstances() {
+        let custom = CustomThemeData(
+            id: UUID(),
+            name: "Sunlit Relay",
+            primaryHue: 38,
+            saturation: 0.72,
+            brightness: 0.64,
+            harmonized: true,
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+
+        do {
+            let first = ThemeManager(defaults: defaults)
+            first.addCustomTheme(custom)
+        }
+
+        let second = ThemeManager(defaults: defaults)
+        XCTAssertEqual(second.customThemes, [custom])
+        XCTAssertEqual(second.activeCustomThemeId, custom.id)
+        XCTAssertNil(second.activePresetId)
+        XCTAssertEqual(second.activeColors, custom.generateColors())
+        XCTAssertEqual(second.accentColor, Color(hex: custom.generateColors().accentHex))
+    }
+
+    func testSelectionPersistenceKeepsPresetAndCustomIDsMutuallyExclusive() {
+        let custom = CustomThemeData(id: UUID(), name: "Custom")
+
+        do {
+            let first = ThemeManager(defaults: defaults)
+            first.selectPreset(.teal)
+            XCTAssertEqual(defaults.string(forKey: "theme_presetId"), PresetThemeId.teal.rawValue)
+            XCTAssertNil(defaults.object(forKey: "theme_customThemeId"))
+
+            first.addCustomTheme(custom)
+            XCTAssertNil(defaults.object(forKey: "theme_presetId"))
+            XCTAssertEqual(defaults.string(forKey: "theme_customThemeId"), custom.id.uuidString)
+
+            first.selectPreset(.forest)
+            XCTAssertEqual(defaults.string(forKey: "theme_presetId"), PresetThemeId.forest.rawValue)
+            XCTAssertNil(defaults.object(forKey: "theme_customThemeId"))
+        }
+
+        let second = ThemeManager(defaults: defaults)
+        XCTAssertEqual(second.activePresetId, .forest)
+        XCTAssertNil(second.activeCustomThemeId)
+        XCTAssertEqual(second.activeColors, PresetThemeId.forest.colors)
+    }
+
+    func testValidCustomIDWinsOverPersistedPresetAndInvalidIDsFallBackToPlum() {
+        let custom = CustomThemeData(id: UUID(), name: "Custom", primaryHue: 210)
+
+        do {
+            let first = ThemeManager(defaults: defaults)
+            first.addCustomTheme(custom)
+            defaults.set(PresetThemeId.rose.rawValue, forKey: "theme_presetId")
+        }
+
+        let customWins = ThemeManager(defaults: defaults)
+        XCTAssertEqual(customWins.activeCustomThemeId, custom.id)
+        XCTAssertNil(customWins.activePresetId)
+        XCTAssertEqual(customWins.activeColors, custom.generateColors())
+
+        defaults.set("not-a-preset", forKey: "theme_presetId")
+        defaults.set("not-a-uuid", forKey: "theme_customThemeId")
+        defaults.removeObject(forKey: "theme_customThemes")
+
+        let invalidIDs = ThemeManager(defaults: defaults)
+        XCTAssertEqual(invalidIDs.activePresetId, .plum)
+        XCTAssertNil(invalidIDs.activeCustomThemeId)
+        XCTAssertEqual(invalidIDs.activeColors, PresetThemeId.plum.colors)
+    }
+
+    func testMissingCustomThemeFallsBackToValidPresetThenPlum() {
+        let missingCustomID = UUID()
+        defaults.set(missingCustomID.uuidString, forKey: "theme_customThemeId")
+        defaults.set(PresetThemeId.lavender.rawValue, forKey: "theme_presetId")
+
+        let validPreset = ThemeManager(defaults: defaults)
+        XCTAssertEqual(validPreset.activePresetId, .lavender)
+        XCTAssertNil(validPreset.activeCustomThemeId)
+        XCTAssertEqual(validPreset.activeColors, PresetThemeId.lavender.colors)
+
+        defaults.removeObject(forKey: "theme_presetId")
+        let noValidSelection = ThemeManager(defaults: defaults)
+        XCTAssertEqual(noValidSelection.activePresetId, .plum)
+        XCTAssertNil(noValidSelection.activeCustomThemeId)
+        XCTAssertEqual(noValidSelection.activeColors, PresetThemeId.plum.colors)
+    }
+}

--- a/Tests/ColumbaAppTests/ThemeManagerPersistenceTests.swift
+++ b/Tests/ColumbaAppTests/ThemeManagerPersistenceTests.swift
@@ -86,16 +86,8 @@ final class ThemeManagerPersistenceTests: XCTestCase {
         do {
             let first = ThemeManager(defaults: defaults)
             first.selectPreset(.teal)
-            XCTAssertEqual(defaults.string(forKey: "theme_presetId"), PresetThemeId.teal.rawValue)
-            XCTAssertNil(defaults.object(forKey: "theme_customThemeId"))
-
             first.addCustomTheme(custom)
-            XCTAssertNil(defaults.object(forKey: "theme_presetId"))
-            XCTAssertEqual(defaults.string(forKey: "theme_customThemeId"), custom.id.uuidString)
-
             first.selectPreset(.forest)
-            XCTAssertEqual(defaults.string(forKey: "theme_presetId"), PresetThemeId.forest.rawValue)
-            XCTAssertNil(defaults.object(forKey: "theme_customThemeId"))
         }
 
         let second = ThemeManager(defaults: defaults)
@@ -104,23 +96,39 @@ final class ThemeManagerPersistenceTests: XCTestCase {
         XCTAssertEqual(second.activeColors, PresetThemeId.forest.colors)
     }
 
-    func testValidCustomIDWinsOverPersistedPresetAndInvalidIDsFallBackToPlum() {
-        let custom = CustomThemeData(id: UUID(), name: "Custom", primaryHue: 210)
+    func testAggregatePresetSelectionDoesNotFallBackToStaleLegacyCustomID() {
+        let custom = CustomThemeData(id: UUID(), name: "Legacy Custom")
+        defaults.set(custom.id.uuidString, forKey: "theme_customThemeId")
+        defaults.set(try! JSONEncoder().encode([custom]), forKey: "theme_customThemes")
 
         do {
             let first = ThemeManager(defaults: defaults)
-            first.addCustomTheme(custom)
-            defaults.set(PresetThemeId.rose.rawValue, forKey: "theme_presetId")
+            XCTAssertEqual(first.activeCustomThemeId, custom.id)
+            first.selectPreset(.midnight)
         }
+
+        let second = ThemeManager(defaults: defaults)
+        XCTAssertEqual(second.activePresetId, .midnight)
+        XCTAssertNil(second.activeCustomThemeId)
+        XCTAssertEqual(second.activeColors, PresetThemeId.midnight.colors)
+    }
+
+    func testLegacyCustomIDWinsOverPersistedPreset() {
+        let custom = CustomThemeData(id: UUID(), name: "Custom", primaryHue: 210)
+
+        defaults.set(PresetThemeId.rose.rawValue, forKey: "theme_presetId")
+        defaults.set(custom.id.uuidString, forKey: "theme_customThemeId")
+        defaults.set(try! JSONEncoder().encode([custom]), forKey: "theme_customThemes")
 
         let customWins = ThemeManager(defaults: defaults)
         XCTAssertEqual(customWins.activeCustomThemeId, custom.id)
         XCTAssertNil(customWins.activePresetId)
         XCTAssertEqual(customWins.activeColors, custom.generateColors())
+    }
 
+    func testInvalidLegacyIDsFallBackToPlum() {
         defaults.set("not-a-preset", forKey: "theme_presetId")
         defaults.set("not-a-uuid", forKey: "theme_customThemeId")
-        defaults.removeObject(forKey: "theme_customThemes")
 
         let invalidIDs = ThemeManager(defaults: defaults)
         XCTAssertEqual(invalidIDs.activePresetId, .plum)
@@ -143,5 +151,24 @@ final class ThemeManagerPersistenceTests: XCTestCase {
         XCTAssertEqual(noValidSelection.activePresetId, .plum)
         XCTAssertNil(noValidSelection.activeCustomThemeId)
         XCTAssertEqual(noValidSelection.activeColors, PresetThemeId.plum.colors)
+    }
+
+    func testUnknownCustomSelectionFallsBackToPlumAndPersistsSafely() {
+        let unknownID = UUID()
+
+        do {
+            let first = ThemeManager(defaults: defaults)
+            first.selectPreset(.ocean)
+            first.selectCustomTheme(unknownID)
+
+            XCTAssertNil(first.activeCustomThemeId)
+            XCTAssertEqual(first.activePresetId, .plum)
+            XCTAssertEqual(first.activeColors, PresetThemeId.plum.colors)
+        }
+
+        let second = ThemeManager(defaults: defaults)
+        XCTAssertNil(second.activeCustomThemeId)
+        XCTAssertEqual(second.activePresetId, .plum)
+        XCTAssertEqual(second.activeColors, PresetThemeId.plum.colors)
     }
 }

--- a/Tests/ColumbaAppTests/ThemeManagerPersistenceTests.swift
+++ b/Tests/ColumbaAppTests/ThemeManagerPersistenceTests.swift
@@ -13,6 +13,13 @@ import XCTest
 @available(iOS 17.0, macOS 14.0, *)
 @MainActor
 final class ThemeManagerPersistenceTests: XCTestCase {
+    private struct PersistedThemeStateFixture: Codable {
+        let colorSchemeRawValue: String
+        let presetRawValue: String?
+        let customThemeID: UUID?
+        let customThemes: [CustomThemeData]
+    }
+
     private var defaults: UserDefaults!
     private var suiteName: String!
 
@@ -41,6 +48,15 @@ final class ThemeManagerPersistenceTests: XCTestCase {
         XCTAssertEqual(second.resolvedColorScheme, .light)
         XCTAssertFalse(second.isDarkMode)
         XCTAssertEqual(second.activeColors, PresetThemeId.plum.colors)
+    }
+
+    func testLegacyColorSchemePreferenceRestoresWhenAggregateStateIsAbsent() {
+        defaults.set(ColorSchemePreference.light.rawValue, forKey: "theme_colorScheme")
+
+        let manager = ThemeManager(defaults: defaults)
+
+        XCTAssertEqual(manager.colorSchemePreference, .light)
+        XCTAssertEqual(manager.resolvedColorScheme, .light)
     }
 
     func testPresetSelectionRestoresPresetAndResolvedColors() {
@@ -113,6 +129,23 @@ final class ThemeManagerPersistenceTests: XCTestCase {
         XCTAssertEqual(second.activeColors, PresetThemeId.midnight.colors)
     }
 
+    func testAggregateCustomSelectionDoesNotFallBackToStaleLegacyPresetID() {
+        let state = PersistedThemeStateFixture(
+            colorSchemeRawValue: ColorSchemePreference.dark.rawValue,
+            presetRawValue: nil,
+            customThemeID: UUID(),
+            customThemes: []
+        )
+        defaults.set(PresetThemeId.rose.rawValue, forKey: "theme_presetId")
+        defaults.set(try! JSONEncoder().encode(state), forKey: "theme_state")
+
+        let manager = ThemeManager(defaults: defaults)
+
+        XCTAssertEqual(manager.activePresetId, .plum)
+        XCTAssertNil(manager.activeCustomThemeId)
+        XCTAssertEqual(manager.activeColors, PresetThemeId.plum.colors)
+    }
+
     func testLegacyCustomIDWinsOverPersistedPreset() {
         let custom = CustomThemeData(id: UUID(), name: "Custom", primaryHue: 210)
 
@@ -151,6 +184,31 @@ final class ThemeManagerPersistenceTests: XCTestCase {
         XCTAssertEqual(noValidSelection.activePresetId, .plum)
         XCTAssertNil(noValidSelection.activeCustomThemeId)
         XCTAssertEqual(noValidSelection.activeColors, PresetThemeId.plum.colors)
+    }
+
+    func testCustomThemeUpdatesAndDeletesPersistAcrossManagerInstances() {
+        let custom = CustomThemeData(id: UUID(), name: "Original")
+        var updated = custom
+        updated.name = "Updated"
+        updated.primaryHue = 120
+
+        do {
+            let first = ThemeManager(defaults: defaults)
+            first.addCustomTheme(custom)
+            first.updateCustomTheme(updated)
+        }
+
+        let afterUpdate = ThemeManager(defaults: defaults)
+        XCTAssertEqual(afterUpdate.customThemes, [updated])
+        XCTAssertEqual(afterUpdate.activeCustomThemeId, updated.id)
+        XCTAssertEqual(afterUpdate.activeColors, updated.generateColors())
+
+        afterUpdate.deleteCustomTheme(updated.id)
+
+        let afterDelete = ThemeManager(defaults: defaults)
+        XCTAssertTrue(afterDelete.customThemes.isEmpty)
+        XCTAssertEqual(afterDelete.activePresetId, .plum)
+        XCTAssertNil(afterDelete.activeCustomThemeId)
     }
 
     func testUnknownCustomSelectionFallsBackToPlumAndPersistsSafely() {

--- a/Tests/static/test_theme_selection_navigation_contract.py
+++ b/Tests/static/test_theme_selection_navigation_contract.py
@@ -1,0 +1,91 @@
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+APP_ROOT = ROOT / "Sources/ColumbaApp/App/ColumbaApp.swift"
+THEME_MANAGER = ROOT / "Sources/ColumbaApp/Theme/ThemeManager.swift"
+UI_FLOW = ROOT / "flows/theme-persistence.yml"
+
+
+class ThemeSelectionNavigationContractTests(unittest.TestCase):
+    """Theme changes must re-render in place via @Observable, never by
+    tearing down the root view tree.
+
+    The old design bumped a ``themeVersion`` counter on every theme change and
+    applied ``.id(themeVersion)`` to the root view. That forced SwiftUI to
+    destroy and recreate the entire tree, which reset ``MainTabView``'s
+    ``selectedTab`` @State to ``.chats`` -- so selecting a theme in Settings
+    bounced the user to the Chats screen.
+    """
+
+    def test_app_root_does_not_force_rebuild_on_theme_change(self) -> None:
+        source = APP_ROOT.read_text(encoding="utf-8")
+
+        # No view identity keyed to the theme version anywhere in the app root.
+        self.assertNotRegex(
+            source,
+            r"\.id\(\s*ThemeManager\.shared\.themeVersion\s*\)",
+            "App root must not apply .id(themeVersion): it tears down the "
+            "whole view tree and resets MainTabView.selectedTab to .chats.",
+        )
+        # No reference to the counter itself either, so a re-introduction has
+        # to be an explicit, reviewed change.
+        self.assertNotIn("themeVersion", source)
+
+    def test_theme_manager_does_not_expose_rebuild_counter(self) -> None:
+        source = THEME_MANAGER.read_text(encoding="utf-8")
+
+        self.assertNotIn("themeVersion", source)
+        # Selection methods still persist state, so behavior is unchanged.
+        self.assertIn("func selectPreset(_ preset: PresetThemeId)", source)
+        self.assertIn("persistState()", source)
+
+    def test_theme_facade_still_delegates_to_observable_manager(self) -> None:
+        theme = (
+            ROOT / "Sources/ColumbaApp/Theme/Theme.swift"
+        ).read_text(encoding="utf-8")
+
+        # Views keep live-updating because the Theme facade reads tracked
+        # properties of the @Observable ThemeManager; that is what replaces
+        # the forced root rebuild.
+        self.assertIn("ThemeManager.shared.accentColor", theme)
+        # The root applies the resolved color scheme through the same
+        # observable manager, so light/dark switches propagate without a
+        # view-tree rebuild.
+        app_root = APP_ROOT.read_text(encoding="utf-8")
+        self.assertIn("ThemeManager.shared.resolvedColorScheme", app_root)
+        manager = THEME_MANAGER.read_text(encoding="utf-8")
+        self.assertIn("@Observable", manager)
+
+    def test_flow_asserts_in_place_change_and_persistence(self) -> None:
+        flow = UI_FLOW.read_text(encoding="utf-8")
+
+        # After each theme change the flow must assert the user is still on
+        # the Settings screen rather than navigating back and reopening.
+        self.assertNotIn("Changing the scheme rebuilds the root", flow)
+        self.assertNotIn("returns to Chats", flow)
+        # The user only navigates to Settings twice: once at the start and
+        # once after the relaunch. The old rebuild-and-reopen behavior tapped
+        # the Settings tab after every theme change (4 taps total); if that
+        # returns, this fails.
+        self.assertEqual(
+            flow.count('id: "tab_settings|gearshape.fill"'),
+            2,
+            "Theme changes must be asserted in place, not by re-navigating "
+            "to Settings after each change.",
+        )
+        # In-place assertions: still on Settings immediately after each
+        # theme interaction, plus the initial and post-restart navigations.
+        self.assertGreaterEqual(flow.count('id: "screen_settings"'), 4)
+        # In-place selection assertions on the same screen.
+        self.assertIn('id: "appearance_color_scheme_light"', flow)
+        self.assertIn('id: "appearance_theme_ocean"', flow)
+        self.assertIn("selected: true", flow)
+        # Persistence across a real relaunch is still covered.
+        self.assertIn("- killApp", flow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tests/static/test_theme_selection_navigation_contract.py
+++ b/Tests/static/test_theme_selection_navigation_contract.py
@@ -42,6 +42,29 @@ class ThemeSelectionNavigationContractTests(unittest.TestCase):
         self.assertIn("func selectPreset(_ preset: PresetThemeId)", source)
         self.assertIn("persistState()", source)
 
+    def test_persisted_theme_state_is_not_externally_writable(self) -> None:
+        source = THEME_MANAGER.read_text(encoding="utf-8")
+
+        # The persistence-sensitive properties must be private(set). With the
+        # old automatic-persistence observers gone, an internal setter would
+        # let a future caller change live theme state without updating
+        # `theme_state`, silently losing the change on relaunch. Only the
+        # mutation methods (which call persistState()) and restore() may
+        # write them, and that requires an explicit, reviewed change here.
+        for prop in (
+            "colorSchemePreference",
+            "activePresetId",
+            "activeCustomThemeId",
+            "customThemes",
+        ):
+            self.assertRegex(
+                source,
+                rf"private\(set\) var {prop}:",
+                f"{prop} must be private(set): only ThemeManager mutation "
+                "methods and restore() may write persistence-sensitive "
+                "theme state.",
+            )
+
     def test_theme_facade_still_delegates_to_observable_manager(self) -> None:
         theme = (
             ROOT / "Sources/ColumbaApp/Theme/Theme.swift"

--- a/flows/theme-persistence.yml
+++ b/flows/theme-persistence.yml
@@ -36,8 +36,7 @@ tags:
 - tapOn:
     id: "appearance_color_scheme_light"
 - assertVisible:
-    id: "appearance_color_scheme_light"
-    text: ".*Selected.*"
+    id: "appearance_color_scheme_light_selected"
 - scrollUntilVisible:
     element:
       id: "appearance_theme_ocean"
@@ -46,8 +45,7 @@ tags:
 - tapOn:
     id: "appearance_theme_ocean"
 - assertVisible:
-    id: "appearance_theme_ocean"
-    text: ".*Selected.*"
+    id: "appearance_theme_ocean_selected"
 
 # Relaunch without clearState/clearKeychain so persisted preferences are read.
 - killApp
@@ -75,14 +73,12 @@ tags:
       id: "appearance_color_scheme_light"
     timeout: 10000
 - assertVisible:
-    id: "appearance_color_scheme_light"
-    text: ".*Selected.*"
+    id: "appearance_color_scheme_light_selected"
 - scrollUntilVisible:
     element:
       id: "appearance_theme_ocean"
     direction: DOWN
     timeout: 20000
 - assertVisible:
-    id: "appearance_theme_ocean"
-    text: ".*Selected.*"
+    id: "appearance_theme_ocean_selected"
 - takeScreenshot: "theme-persistence"

--- a/flows/theme-persistence.yml
+++ b/flows/theme-persistence.yml
@@ -4,9 +4,8 @@ tags:
   - regression
   - screenshot
 ---
-# Verify the color-scheme and preset selections survive app termination.
-# The Appearance card has no safe header-level identifier, so its localized
-# visible title is used only to expand the existing shipping card.
+# Verify color-scheme and preset selections after the app's intentional
+# themeVersion root rebuild, then again after process termination and relaunch.
 - launchApp:
     clearState: true
     clearKeychain: true
@@ -35,8 +34,30 @@ tags:
     timeout: 10000
 - tapOn:
     id: "appearance_color_scheme_light"
-- assertVisible:
-    id: "appearance_color_scheme_light_selected"
+
+# Changing the scheme rebuilds the root and returns to Chats. Reopen Appearance
+# and prove Light is selected before choosing the Ocean preset.
+- extendedWaitUntil:
+    visible:
+      id: "screen_chats"
+    timeout: 10000
+- tapOn:
+    id: "tab_settings|gearshape.fill"
+- extendedWaitUntil:
+    visible:
+      id: "screen_settings"
+    timeout: 10000
+- scrollUntilVisible:
+    element:
+      text: "Appearance"
+    direction: DOWN
+    timeout: 20000
+- tapOn:
+    text: "Appearance"
+- extendedWaitUntil:
+    visible:
+      id: "appearance_color_scheme_light_selected"
+    timeout: 10000
 - scrollUntilVisible:
     element:
       id: "appearance_theme_ocean"
@@ -44,10 +65,36 @@ tags:
     timeout: 20000
 - tapOn:
     id: "appearance_theme_ocean"
-- assertVisible:
-    id: "appearance_theme_ocean_selected"
 
-# Relaunch without clearState/clearKeychain so persisted preferences are read.
+# Preset selection also rebuilds the root. Reopen and prove Ocean is selected.
+- extendedWaitUntil:
+    visible:
+      id: "screen_chats"
+    timeout: 10000
+- tapOn:
+    id: "tab_settings|gearshape.fill"
+- extendedWaitUntil:
+    visible:
+      id: "screen_settings"
+    timeout: 10000
+- scrollUntilVisible:
+    element:
+      text: "Appearance"
+    direction: DOWN
+    timeout: 20000
+- tapOn:
+    text: "Appearance"
+- extendedWaitUntil:
+    visible:
+      id: "appearance_color_scheme_light_selected"
+    timeout: 10000
+- scrollUntilVisible:
+    element:
+      id: "appearance_theme_ocean_selected"
+    direction: DOWN
+    timeout: 20000
+
+# Relaunch without clearing state so the new ThemeManager restores the record.
 - killApp
 - launchApp:
     stopApp: false
@@ -70,15 +117,11 @@ tags:
     text: "Appearance"
 - extendedWaitUntil:
     visible:
-      id: "appearance_color_scheme_light"
+      id: "appearance_color_scheme_light_selected"
     timeout: 10000
-- assertVisible:
-    id: "appearance_color_scheme_light_selected"
 - scrollUntilVisible:
     element:
-      id: "appearance_theme_ocean"
+      id: "appearance_theme_ocean_selected"
     direction: DOWN
     timeout: 20000
-- assertVisible:
-    id: "appearance_theme_ocean_selected"
 - takeScreenshot: "theme-persistence"

--- a/flows/theme-persistence.yml
+++ b/flows/theme-persistence.yml
@@ -37,7 +37,7 @@ tags:
     id: "appearance_color_scheme_light"
 - assertVisible:
     id: "appearance_color_scheme_light"
-    selected: true
+    text: ".*Selected.*"
 - scrollUntilVisible:
     element:
       id: "appearance_theme_ocean"
@@ -47,7 +47,7 @@ tags:
     id: "appearance_theme_ocean"
 - assertVisible:
     id: "appearance_theme_ocean"
-    selected: true
+    text: ".*Selected.*"
 
 # Relaunch without clearState/clearKeychain so persisted preferences are read.
 - killApp
@@ -76,7 +76,7 @@ tags:
     timeout: 10000
 - assertVisible:
     id: "appearance_color_scheme_light"
-    selected: true
+    text: ".*Selected.*"
 - scrollUntilVisible:
     element:
       id: "appearance_theme_ocean"
@@ -84,5 +84,5 @@ tags:
     timeout: 20000
 - assertVisible:
     id: "appearance_theme_ocean"
-    selected: true
+    text: ".*Selected.*"
 - takeScreenshot: "theme-persistence"

--- a/flows/theme-persistence.yml
+++ b/flows/theme-persistence.yml
@@ -56,7 +56,8 @@ tags:
     text: "Appearance"
 - extendedWaitUntil:
     visible:
-      id: "appearance_color_scheme_light_selected"
+      id: "appearance_color_scheme_light"
+      selected: true
     timeout: 10000
 - scrollUntilVisible:
     element:
@@ -86,11 +87,13 @@ tags:
     text: "Appearance"
 - extendedWaitUntil:
     visible:
-      id: "appearance_color_scheme_light_selected"
+      id: "appearance_color_scheme_light"
+      selected: true
     timeout: 10000
 - scrollUntilVisible:
     element:
-      id: "appearance_theme_ocean_selected"
+      id: "appearance_theme_ocean"
+      selected: true
     direction: DOWN
     timeout: 20000
 
@@ -117,11 +120,13 @@ tags:
     text: "Appearance"
 - extendedWaitUntil:
     visible:
-      id: "appearance_color_scheme_light_selected"
+      id: "appearance_color_scheme_light"
+      selected: true
     timeout: 10000
 - scrollUntilVisible:
     element:
-      id: "appearance_theme_ocean_selected"
+      id: "appearance_theme_ocean"
+      selected: true
     direction: DOWN
     timeout: 20000
 - takeScreenshot: "theme-persistence"

--- a/flows/theme-persistence.yml
+++ b/flows/theme-persistence.yml
@@ -1,0 +1,88 @@
+appId: network.columba.Columba
+name: theme-persistence
+tags:
+  - regression
+  - screenshot
+---
+# Verify the color-scheme and preset selections survive app termination.
+# The Appearance card has no safe header-level identifier, so its localized
+# visible title is used only to expand the existing shipping card.
+- launchApp:
+    clearState: true
+    clearKeychain: true
+    arguments:
+      ui-screenshotter: true
+- extendedWaitUntil:
+    visible:
+      id: "screen_chats"
+    timeout: 30000
+- tapOn:
+    id: "tab_settings|gearshape.fill"
+- extendedWaitUntil:
+    visible:
+      id: "screen_settings"
+    timeout: 10000
+- scrollUntilVisible:
+    element:
+      text: "Appearance"
+    direction: DOWN
+    timeout: 20000
+- tapOn:
+    text: "Appearance"
+- extendedWaitUntil:
+    visible:
+      id: "appearance_color_scheme_light"
+    timeout: 10000
+- tapOn:
+    id: "appearance_color_scheme_light"
+- assertVisible:
+    id: "appearance_color_scheme_light"
+    selected: true
+- scrollUntilVisible:
+    element:
+      id: "appearance_theme_ocean"
+    direction: DOWN
+    timeout: 20000
+- tapOn:
+    id: "appearance_theme_ocean"
+- assertVisible:
+    id: "appearance_theme_ocean"
+    selected: true
+
+# Relaunch without clearState/clearKeychain so persisted preferences are read.
+- killApp
+- launchApp:
+    stopApp: false
+- extendedWaitUntil:
+    visible:
+      id: "screen_chats"
+    timeout: 30000
+- tapOn:
+    id: "tab_settings|gearshape.fill"
+- extendedWaitUntil:
+    visible:
+      id: "screen_settings"
+    timeout: 10000
+- scrollUntilVisible:
+    element:
+      text: "Appearance"
+    direction: DOWN
+    timeout: 20000
+- tapOn:
+    text: "Appearance"
+- extendedWaitUntil:
+    visible:
+      id: "appearance_color_scheme_light"
+    timeout: 10000
+- assertVisible:
+    id: "appearance_color_scheme_light"
+    selected: true
+- scrollUntilVisible:
+    element:
+      id: "appearance_theme_ocean"
+    direction: DOWN
+    timeout: 20000
+- assertVisible:
+    id: "appearance_theme_ocean"
+    selected: true
+- takeScreenshot: "theme-persistence"

--- a/flows/theme-persistence.yml
+++ b/flows/theme-persistence.yml
@@ -4,8 +4,10 @@ tags:
   - regression
   - screenshot
 ---
-# Verify color-scheme and preset selections after the app's intentional
-# themeVersion root rebuild, then again after process termination and relaunch.
+# Selecting a color scheme or theme must change it in place and KEEP the user
+# on the Settings screen, then persist across process termination and relaunch.
+# (Regression: the old themeVersion root rebuild tore down the whole view tree
+# and bounced the user back to Chats on every theme change.)
 - launchApp:
     clearState: true
     clearKeychain: true
@@ -35,25 +37,12 @@ tags:
 - tapOn:
     id: "appearance_color_scheme_light"
 
-# Changing the scheme rebuilds the root and returns to Chats. Reopen Appearance
-# and prove Light is selected before choosing the Ocean preset.
-- extendedWaitUntil:
-    visible:
-      id: "screen_chats"
-    timeout: 10000
-- tapOn:
-    id: "tab_settings|gearshape.fill"
+# The scheme changes in place: still on Settings, Light selected, and the
+# theme grid is still reachable without leaving the screen.
 - extendedWaitUntil:
     visible:
       id: "screen_settings"
     timeout: 10000
-- scrollUntilVisible:
-    element:
-      text: "Appearance"
-    direction: DOWN
-    timeout: 20000
-- tapOn:
-    text: "Appearance"
 - extendedWaitUntil:
     visible:
       id: "appearance_color_scheme_light"
@@ -67,35 +56,27 @@ tags:
 - tapOn:
     id: "appearance_theme_ocean"
 
-# Preset selection also rebuilds the root. Reopen and prove Ocean is selected.
-- extendedWaitUntil:
-    visible:
-      id: "screen_chats"
-    timeout: 10000
-- tapOn:
-    id: "tab_settings|gearshape.fill"
+# Preset selection also changes in place: still on Settings, Ocean selected,
+# and the earlier Light scheme selection is intact on the same screen.
 - extendedWaitUntil:
     visible:
       id: "screen_settings"
     timeout: 10000
+- extendedWaitUntil:
+    visible:
+      id: "appearance_theme_ocean"
+      selected: true
+    timeout: 10000
 - scrollUntilVisible:
     element:
-      text: "Appearance"
-    direction: DOWN
+      id: "appearance_color_scheme_light"
+    direction: UP
     timeout: 20000
-- tapOn:
-    text: "Appearance"
 - extendedWaitUntil:
     visible:
       id: "appearance_color_scheme_light"
       selected: true
     timeout: 10000
-- scrollUntilVisible:
-    element:
-      id: "appearance_theme_ocean"
-      selected: true
-    direction: DOWN
-    timeout: 20000
 
 # Relaunch without clearing state so the new ThemeManager restores the record.
 - killApp
@@ -126,7 +107,11 @@ tags:
 - scrollUntilVisible:
     element:
       id: "appearance_theme_ocean"
-      selected: true
     direction: DOWN
     timeout: 20000
+- extendedWaitUntil:
+    visible:
+      id: "appearance_theme_ocean"
+      selected: true
+    timeout: 10000
 - takeScreenshot: "theme-persistence"


### PR DESCRIPTION
## What this PR does

Fixes issue #182 (selected theme doesn't persist across app restarts) and a related bug found while verifying it: tapping a theme color bounced the user back to the Chats tab instead of staying on Settings.

### Theme persistence

- Theme selection (preset, custom, and color scheme) is now persisted atomically and restored on launch, so the user's chosen theme survives an app restart.
- Custom themes (name, background, foreground, accent) are persisted with full CRUD semantics.
- A legacy/migration path covers pre-existing stored state.

### In-place theme selection (no navigation)

- Root cause: `ThemeManager.themeVersion` was applied as `.id(themeVersion)` on the entire root view. Every theme change forced a full SwiftUI teardown + rebuild, which re-initialized `MainTabView`'s `@State selectedTab` back to `.chats`, flinging the user to Chats.
- Fix: removed the forced `.id()` rebuild and the now-dead `themeVersion` counter. `ThemeManager` is `@Observable` and the `Theme` facade reads its tracked properties, so all views already re-render automatically on change. No navigation change was needed.

## Verification

- **Red→green E2E on device-class simulator (iPhone 17, iOS 26.4, Maestro):**
  - Unfixed head: tapping a preset failed the "still on Settings" assertion (landed on Chats) - bug reproduced.
  - Fixed head: same flow passes - theme changes in place, stays on Settings.
- **Shipping XCTest suite:** 351/351 passed at the fixed head (0 failed, 0 skipped).
- **Static contracts:** 120 tests OK, including a new `Tests/static/test_theme_selection_navigation_contract.py` that fails if the forced-rebuild mechanism is ever re-added.
- **Physical iPhone:** signed device build at the fixed head installed in-place; theme selection stays on Settings and persists across relaunch (confirmed on device).
- **Regression flow:** `flows/theme-persistence.yml` updated to assert the user STAYS on Settings after each change (no re-navigation) and that the selection persists across a real relaunch.

## Files changed (fix commit c478b772)

- `Sources/ColumbaApp/App/ColumbaApp.swift` - removed `.id(themeVersion)` forced rebuild
- `Sources/ColumbaApp/Theme/ThemeManager.swift` - removed dead `themeVersion` counter + bumps
- `flows/theme-persistence.yml` - assert in-place selection + relaunch persistence
- `Tests/static/test_theme_selection_navigation_contract.py` - new static guard
- `.github/workflows/tests.yml` - register the new static contract

## Branch

10 commits on `fix/ios-theme-persistence`, top commit `c478b772`.

Closes #182
