### PR TITLE
fix: stop logging message content in diagnostic logs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,6 +76,7 @@ jobs:
             Tests.static.test_ios_stamp_runtime_hardening \
             Tests.static.test_async_propagation_fallback \
             Tests.static.test_privacy_settings_contract \
+            Tests.static.test_no_message_content_in_logs \
             Tests.static.test_theme_selection_navigation_contract \
             Tests.static.test_ui_screenshotter_readiness \
             Tests.static.test_collect_maestro_screenshots

--- a/Sources/ColumbaApp/App/ColumbaApp.swift
+++ b/Sources/ColumbaApp/App/ColumbaApp.swift
@@ -219,7 +219,8 @@ struct ColumbaApp: App {
                     let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
                     let from = components?.queryItems?.first(where: { $0.name == "from" })?.value ?? ""
                     let content = components?.queryItems?.first(where: { $0.name == "content" })?.value ?? "synthetic"
-                    DiagLog.log("[TEST-INBOUND] from=\(from) content=\"\(content)\"")
+                    // NO-PII: log the content length, never the content itself.
+                    DiagLog.log("[TEST-INBOUND] from=\(from.prefix(8)) len=\(content.utf8.count)")
                     NotificationCenter.default.post(
                         name: Notification.Name("ColumbaTestInbound"),
                         object: nil,
@@ -420,8 +421,10 @@ struct ColumbaApp: App {
                     let imageFormat = q("image_format") ?? ""
                     let fileHex = q("file_hex") ?? ""
                     let fileName = q("file_name") ?? ""
-                    logger.info("test-send to=\(to, privacy: .public) content=\(content, privacy: .public)")
-                    DiagLog.log("[TEST-SEND] to=\(to) method=\(method.isEmpty ? "opportunistic" : method) content=\"\(content)\" image=\(imageHex.isEmpty ? 0 : imageHex.count/2)B(\(imageFormat)) file=\(fileHex.isEmpty ? 0 : fileHex.count/2)B(\(fileName))")
+                    // NO-PII: never log message content — diag.log and the
+                    // unified log are readable by anyone with the device.
+                    logger.info("test-send to=\(to, privacy: .public) len=\(content.utf8.count, privacy: .public)")
+                    DiagLog.log("[TEST-SEND] to=\(to.prefix(8)) method=\(method.isEmpty ? "opportunistic" : method) len=\(content.utf8.count) image=\(imageHex.isEmpty ? 0 : imageHex.count/2)B(\(imageFormat)) file=\(fileHex.isEmpty ? 0 : fileHex.count/2)B(\(fileName))")
                     NotificationCenter.default.post(
                         name: Notification.Name("ColumbaTestSend"),
                         object: nil,

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -2941,7 +2941,11 @@ public final class AppServices {
                 }
             }
         case .inbound(let sourceHash, let messageHash, let content, let title, let fieldsPacked, let method, let t):
-            DiagLog.log("[RNS] inbound source=\(sourceHash) content=\"\(content)\" fields=\(fieldsPacked.count)B")
+            // NO-PII: envelope/metadata only (mirrors ExtensionDiagLog's contract).
+            // Never log message content, title, or field payload bytes — they land
+            // in Documents/diag.log and the unified log. Hashes are prefixed to
+            // keep the line correlatable without exposing full identity hashes.
+            DiagLog.log("[RNS] inbound source=\(sourceHash.prefix(8)) message=\(messageHash.prefix(8)) len=\(content.utf8.count) fields=\(fieldsPacked.count)B")
             guard let data = Data(hexString: sourceHash) else { return }
             let fields = fieldsPacked.isEmpty ? nil : LxmfFieldCodec.unpack(fieldsPacked)
             // Persist the base message (carrying its fields), then run side-channel

--- a/Sources/ColumbaApp/Views/Messaging/MessageBubble.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageBubble.swift
@@ -589,8 +589,11 @@ public struct Message: Identifiable, Equatable {
                     self.imageFormat = format
                 }
             } else if let rawField = fields[LXMessage.FIELD_IMAGE] {
-                // Image field exists but failed extraction — log for diagnosis
-                logger.warning("Image field 0x06 present but extraction failed: type=\(String(describing: type(of: rawField))), value=\(String(describing: rawField).prefix(200))")
+                // Image field exists but failed extraction — log for diagnosis.
+                // NO-PII: never log the field's payload bytes (image data) —
+                // only the shape of what extraction received.
+                let elementCount = (rawField as? [Any])?.count ?? 0
+                logger.warning("Image field 0x06 present but extraction failed: type=\(String(describing: type(of: rawField))), elements=\(elementCount)")
             }
             // FIELD_FILE_ATTACHMENTS (0x05) = [[filename, data], …]
             if let filesField = fields[LXMessage.FIELD_FILE_ATTACHMENTS] as? [Any] {

--- a/Sources/PythonBridge/PythonBridge.swift
+++ b/Sources/PythonBridge/PythonBridge.swift
@@ -707,7 +707,7 @@ public final class PythonBridge: @unchecked Sendable {
         do {
             return try JSONDecoder().decode(StatusSnapshot.self, from: data)
         } catch {
-            DiagLog_status("decode failed: \(error) raw=\(raw.prefix(200))")
+            DiagLog_status("decode failed: \(error) statusBytes=\(raw.utf8.count)")
             return nil
         }
     }

--- a/Sources/Shared/AppGroupRNodeSeamWire.swift
+++ b/Sources/Shared/AppGroupRNodeSeamWire.swift
@@ -91,7 +91,7 @@ public final class AppGroupRNodeSeamWire: RNodeSeamWire, @unchecked Sendable {
 
     public func send(_ message: RNodeSeamMessage) {
         guard sendQueue.append(frame: message.encode(), interfaceTag: FrameInterfaceTag.rnodeControl.rawValue) else {
-            ExtensionDiagLog.log("[RNODE] seam wire: append failed — dropped \(message), skipping wakeup")
+            ExtensionDiagLog.log("[RNODE] seam wire: append failed — dropped \(message.diagnosticLabel), skipping wakeup")
             return
         }
         CFNotificationCenterPostNotification(

--- a/Sources/Shared/RNodeSeam.swift
+++ b/Sources/Shared/RNodeSeam.swift
@@ -73,6 +73,19 @@ public enum RNodeSeamMessage: Equatable, Sendable {
         case dataReceived = 64, stateChanged, sendResult
     }
 
+    /// Metadata-only description for logs (NO-PII: never the `Data` payload
+    /// bytes of `.send` / `.dataReceived`). Byte counts only.
+    var diagnosticLabel: String {
+        switch self {
+        case .connect: "connect"
+        case .send(let reqId, let data): "send(reqId=\(reqId), \(data.count)B)"
+        case .disconnect: "disconnect"
+        case .dataReceived(let data): "dataReceived(\(data.count)B)"
+        case .stateChanged(let state, _): "stateChanged(\(state.rawValue))"
+        case .sendResult(let reqId, _): "sendResult(reqId=\(reqId))"
+        }
+    }
+
     // MARK: Encode
 
     public func encode() -> Data {

--- a/Tests/interop/test_attachments.py
+++ b/Tests/interop/test_attachments.py
@@ -228,7 +228,7 @@ def test_text_sideband_to_ios(sim, sideband):
         content=body,
     ), "Sideband-side send_text returned False"
 
-    _wait_for_diag_inbound(sim, content=body)
+    _wait_for_diag_inbound(sim, sideband, content=body)
     sim.assert_bubble_visible(content=body)
 
 
@@ -251,7 +251,7 @@ def test_image_sideband_to_ios(sim, sideband):
     # Wait for iOS to record the inbound delivery so the conversation row
     # exists in Chats before Maestro tries to tap it. Sideband's send is
     # async — `send_image` returns on enqueue.
-    _wait_for_diag_inbound(sim, content=body)
+    _wait_for_diag_inbound(sim, sideband, content=body)
 
     sim.assert_bubble_visible(content=body, has_image=True)
     sim.assert_attachment_preview_and_export(image=True, expected_bytes=img)
@@ -271,7 +271,7 @@ def test_file_sideband_to_ios(sim, sideband):
         data=payload,
     ), "Sideband-side send_file returned False"
 
-    _wait_for_diag_inbound(sim, content=body)
+    _wait_for_diag_inbound(sim, sideband, content=body)
 
     sim.assert_bubble_visible(content=body, has_file_name=name)
     sim.assert_attachment_preview_and_export(
@@ -293,7 +293,7 @@ def test_multiple_files_sideband_to_ios_selects_second(sim, sideband):
         content=body,
         attachments=[(name, first), (name, second)],
     )
-    _wait_for_diag_inbound(sim, content=body)
+    _wait_for_diag_inbound(sim, sideband, content=body)
     sim.assert_bubble_visible(content=body, has_file_name=name, timeout=30)
     sim.assert_attachment_preview_and_export(
         file_name=name,
@@ -303,22 +303,29 @@ def test_multiple_files_sideband_to_ios_selects_second(sim, sideband):
     )
 
 
-def _wait_for_diag_inbound(sim, *, content: str, timeout: float = 30.0) -> None:
-    """Block until `[RNS] inbound` for this message lands in diag.log so
+def _wait_for_diag_inbound(sim, sideband, *, content: str, timeout: float = 30.0) -> None:
+    """Block until `[RNS] inbound` for THIS message lands in diag.log so
     the Chats list has the conversation row Maestro will tap on.
 
-    Correlates on the line's `len=<utf8 byte count>` (the app no longer logs
-    message content — NO-PII contract; the body is unique per test via its
-    timestamp, so the byte length disambiguates within this launch's log)."""
+    Correlates on `source=<sender's first 8 hash hex>` + `len=<utf8 byte
+    count>`. The app logs envelope metadata only (NO-PII contract — never
+    the content), so the sender identity is the exact correlation key: any
+    same-length inbound from a different sender (or the same sender's
+    earlier message, pre-dating `before_size`) cannot satisfy the wait."""
     expected_len = len(content.encode("utf-8"))
+    source8 = sideband.identity_hex[:8]
     before_size = sim.diag_log.stat().st_size if sim.diag_log.exists() else 0
     deadline = time.time() + timeout
     while time.time() < deadline:
         for line in sim._read_diag_since(before_size):
-            if "[RNS] inbound source=" in line and f"len={expected_len} " in line:
+            if (f"[RNS] inbound source={source8} " in line
+                    and f"len={expected_len} " in line):
                 return
         time.sleep(0.4)
-    pytest.fail(f"iOS didn't record inbound (len={expected_len}) within {timeout}s")
+    pytest.fail(
+        f"iOS didn't record inbound (source={source8} len={expected_len}) "
+        f"within {timeout}s"
+    )
 
 
 # ─────────────────────────────────────────────────────────────────────────

--- a/Tests/interop/test_attachments.py
+++ b/Tests/interop/test_attachments.py
@@ -304,15 +304,21 @@ def test_multiple_files_sideband_to_ios_selects_second(sim, sideband):
 
 
 def _wait_for_diag_inbound(sim, *, content: str, timeout: float = 30.0) -> None:
-    """Block until `[RNS] inbound` for this content lands in diag.log so
-    the Chats list has the conversation row Maestro will tap on."""
+    """Block until `[RNS] inbound` for this message lands in diag.log so
+    the Chats list has the conversation row Maestro will tap on.
+
+    Correlates on the line's `len=<utf8 byte count>` (the app no longer logs
+    message content — NO-PII contract; the body is unique per test via its
+    timestamp, so the byte length disambiguates within this launch's log)."""
+    expected_len = len(content.encode("utf-8"))
+    before_size = sim.diag_log.stat().st_size if sim.diag_log.exists() else 0
     deadline = time.time() + timeout
     while time.time() < deadline:
-        for line in reversed(sim._tail_diag(800)):
-            if "[RNS] inbound source=" in line and content in line:
+        for line in sim._read_diag_since(before_size):
+            if "[RNS] inbound source=" in line and f"len={expected_len} " in line:
                 return
         time.sleep(0.4)
-    pytest.fail(f"iOS didn't record inbound for {content!r} within {timeout}s")
+    pytest.fail(f"iOS didn't record inbound (len={expected_len}) within {timeout}s")
 
 
 # ─────────────────────────────────────────────────────────────────────────

--- a/Tests/interop/test_bug1_network_render.py
+++ b/Tests/interop/test_bug1_network_render.py
@@ -39,14 +39,19 @@ import pytest
 def _wait_for_inbound(sim, *, content: str, timeout: float = 30.0) -> None:
     """Block until the inbound message for `content` is recorded, so both the
     Chats row and the Network→Start-Chat thread have it to load. Marker:
-    `[RNS] inbound source=… content="…"` (was `[PY] inbound`; accept both)."""
+    `[RNS] inbound source=… len=…` (accepts the legacy `[PY] inbound` marker
+    too). The app logs the content byte length, not the content itself
+    (NO-PII), and the body is unique per test, so `len=` disambiguates."""
+    expected_len = len(content.encode("utf-8"))
+    before_size = sim.diag_log.stat().st_size if sim.diag_log.exists() else 0
     deadline = time.time() + timeout
     while time.time() < deadline:
-        for line in reversed(sim._tail_diag(800)):
-            if ("[RNS] inbound source=" in line or "[PY] inbound source=" in line) and content in line:
+        for line in sim._read_diag_since(before_size):
+            if ("[RNS] inbound source=" in line or "[PY] inbound source=" in line) \
+                    and f"len={expected_len} " in line:
                 return
         time.sleep(0.4)
-    pytest.fail(f"iOS didn't record inbound for {content!r} within {timeout}s")
+    pytest.fail(f"iOS didn't record inbound (len={expected_len}) within {timeout}s")
 
 
 def _peer_display_name(sim, sideband, *, timeout: float = 20.0) -> str:

--- a/Tests/interop/test_bug1_network_render.py
+++ b/Tests/interop/test_bug1_network_render.py
@@ -36,22 +36,28 @@ import time
 import pytest
 
 
-def _wait_for_inbound(sim, *, content: str, timeout: float = 30.0) -> None:
+def _wait_for_inbound(sim, sideband, *, content: str, timeout: float = 30.0) -> None:
     """Block until the inbound message for `content` is recorded, so both the
     Chats row and the Network→Start-Chat thread have it to load. Marker:
-    `[RNS] inbound source=… len=…` (accepts the legacy `[PY] inbound` marker
-    too). The app logs the content byte length, not the content itself
-    (NO-PII), and the body is unique per test, so `len=` disambiguates."""
+    `[RNS] inbound source=… len=…`. The app logs envelope metadata only
+    (NO-PII — never the content), so correlate on `source=<sender's first 8
+    hash hex>` + `len=<utf8 byte count>`: a same-length inbound from another
+    sender (or an earlier same-sender message pre-dating `before_size`) cannot
+    satisfy the wait and flake the later Maestro assertion."""
     expected_len = len(content.encode("utf-8"))
+    source8 = sideband.identity_hex[:8]
     before_size = sim.diag_log.stat().st_size if sim.diag_log.exists() else 0
     deadline = time.time() + timeout
     while time.time() < deadline:
         for line in sim._read_diag_since(before_size):
-            if ("[RNS] inbound source=" in line or "[PY] inbound source=" in line) \
-                    and f"len={expected_len} " in line:
+            if (f"[RNS] inbound source={source8} " in line
+                    and f"len={expected_len} " in line):
                 return
         time.sleep(0.4)
-    pytest.fail(f"iOS didn't record inbound (len={expected_len}) within {timeout}s")
+    pytest.fail(
+        f"iOS didn't record inbound (source={source8} len={expected_len}) "
+        f"within {timeout}s"
+    )
 
 
 def _peer_display_name(sim, sideband, *, timeout: float = 20.0) -> str:
@@ -88,7 +94,7 @@ def test_bug1_network_tab_renders_inbound_text(sim, sideband):
         content=body,
     ), "Sideband-side send_text returned False"
 
-    _wait_for_inbound(sim, content=body)
+    _wait_for_inbound(sim, sideband, content=body)
     peer = _peer_display_name(sim, sideband)
     print(f"[BUG1] peer row label = {peer!r}", flush=True)
 

--- a/Tests/static/test_no_message_content_in_logs.py
+++ b/Tests/static/test_no_message_content_in_logs.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Regression contract: Columba iOS diagnostic logs must never carry
+message content.
+
+DiagLog / ExtensionDiagLog write to on-device log files (diag.log,
+ext-diag.log) that are extractable via devicectl / Xcode, and BOTH mirrors
+every line into the OS unified log (NSLog / os.Logger). Logging message
+plaintext (or attachment payload bytes) there defeats the E2E encryption
+the app exists to provide. The Network Extension already declares this as
+a hard NO-PII contract (see Sources/Shared/ExtensionDiagLog.swift); this
+contract extends it to the app-side sinks and pins the specific leaks
+fixed by the "no message content in logs" remediation:
+
+  * `handlePythonEvent`'s `.inbound` case logged the full plaintext
+    (`content="…"`) — production path, every received message.
+  * DEBUG `test-send` / `test-inbound` deep-link hooks logged the content.
+  * The RNode seam wire logged a `RNodeSeamMessage` whose `.send` /
+    `.dataReceived` cases embed `Data` frame bytes.
+  * MessageBubble logged the raw image-field value (payload bytes).
+
+Run with:
+    python3 -B -m unittest Tests.static.test_no_message_content_in_logs
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+APPSERVICES = ROOT / "Sources/ColumbaApp/Services/AppServices.swift"
+COLUMBA_APP = ROOT / "Sources/ColumbaApp/App/ColumbaApp.swift"
+MESSAGE_BUBBLE = ROOT / "Sources/ColumbaApp/Views/Messaging/MessageBubble.swift"
+SEAM_WIRE = ROOT / "Sources/Shared/AppGroupRNodeSeamWire.swift"
+RNODE_SEAM = ROOT / "Sources/Shared/RNodeSeam.swift"
+
+# Every .swift file compiled into a shipping target (Sources/ is the
+# Xcode-project source root; Tests/, app/ (Python), support/ are excluded).
+SWIFT_SOURCES = sorted((ROOT / "Sources").rglob("*.swift"))
+
+# Log sinks that reach disk and/or the unified log.
+DIAG_SINK_RE = re.compile(
+    r"(?:DiagLog|ExtensionDiagLog)\.log\((?P<arg>.*?)\)\s*$"
+)
+# os.Logger calls: `logger.info("…")`, `log.debug("…")`, etc. (the os.log
+# interpolations are what land in the unified log; `privacy: .public`
+# interpolations are what a log-archive reader can extract).
+OSLOG_CALL_RE = re.compile(
+    r"\blogger\.(?:debug|info|notice|warning|error|trace)\("
+    r"|\bself\.log\.(?:debug|info|notice|warning|error|trace)\("
+    r"|\blog\.(?:debug|info|notice|warning|error|trace)\("
+)
+
+# Interpolations that carry message-content variables. Matched against the
+# FIRST token of each `\(…)` interpolation so `messageHash` / `contentLength`
+# are NOT flagged (boundary-aware).
+CONTENT_TOKENS = {
+    "content", "contentString", "plaintext", "messageContent", "body",
+    "payload", "rawData", "frameData", "title",
+    # RNodeSeamMessage interpolated whole carries .send(data:)/.dataReceived
+    # frame bytes in its default description.
+    "message",
+}
+INTERPOLATION_RE = re.compile(r"\\\(.*?\)")
+FIRST_TOKEN_RE = re.compile(r"\s*([A-Za-z_][A-Za-z0-9_]*)")
+
+
+def _first_token(interp: str) -> str | None:
+    """The leading identifier of an interpolation, if any.
+
+    `\\(content)` -> `content`; `\\(content.utf8.count)` -> `content`;
+    `\\(self.message.content)` -> `self` (caller-qualified; handled by the
+    qualified checks); `\\("foo")` -> None.
+    """
+    m = FIRST_TOKEN_RE.match(interp)
+    return m.group(1) if m else None
+
+
+def _diagnostic_args(line: str) -> list[str]:
+    """Balanced-paren extraction of the argument text of each log call in
+    `line` (handles nested `\\(a.isEmpty ? 0 : b)` interpolation parens)."""
+    args: list[str] = []
+    for sink in list(DIAG_SINK_RE.finditer(line)) + list(OSLOG_CALL_RE.finditer(line)):
+        start = sink.end()  # position just after the opening "("
+        depth = 1
+        i = start
+        in_str = False
+        while i < len(line) and depth:
+            ch = line[i]
+            if in_str:
+                if ch == "\\":
+                    i += 1
+                elif ch == '"':
+                    in_str = False
+            elif ch == '"':
+                in_str = True
+            elif ch == "(":
+                depth += 1
+            elif ch == ")":
+                depth -= 1
+            i += 1
+        if depth == 0:
+            args.append(line[start:i - 1])
+    return args
+
+
+def _interpolations(arg: str) -> list[str]:
+    # Strip string-literal text so interpolation detection only sees real
+    # Swift interpolation escapes. A simple scan keeps this dependency-free.
+    out: list[str] = []
+    in_str = False
+    i = 0
+    while i < len(arg):
+        ch = arg[i]
+        if in_str:
+            if ch == "\\":
+                if i + 1 < len(arg) and arg[i + 1] == "(":
+                    # capture the interpolation (nested-paren aware)
+                    depth = 1
+                    j = i + 2
+                    s = i + 1
+                    while j < len(arg) and depth:
+                        if arg[j] == "(":
+                            depth += 1
+                        elif arg[j] == ")":
+                            depth -= 1
+                        j += 1
+                    out.append(arg[s:j])
+                    i = j
+                    continue
+            elif ch == '"':
+                in_str = False
+        elif ch == '"':
+            in_str = True
+        i += 1
+    return out
+
+
+def _content_bearing_interpolations(arg: str) -> list[str]:
+    """Interpolations in `arg` whose value is a message-content variable.
+
+    Flags:
+      * `\\(content)` / `\\(body)` / … (bare content vars and their property
+        chains, e.g. `\\(content.utf8.count)` is ALLOWED — byte counts are
+        metadata; so the rule only fires on the bare variable or a direct
+        `String(describing: <content var>)` dump);
+      * `\\(String(describing: rawField)…)`-style dumps of field payloads;
+      * `\\(message)` where `message` is an RNodeSeamMessage (frame bytes).
+    """
+    flagged: list[str] = []
+    for interp in _interpolations(arg):
+        token = _first_token(interp)
+        if token is None:
+            continue
+        if token in CONTENT_TOKENS:
+            # Allow byte-count / length derivations (metadata, not content).
+            rest = interp[len(token):].lstrip()
+            if rest.startswith((".utf8.count", ".count", ".isEmpty")):
+                continue
+            flagged.append(interp)
+        elif "String(describing:" in interp and token == "":
+            # `\\(String(describing: rawField).prefix(200))` — the value is a
+            # raw field payload; the leading token is `String`.
+            m = re.search(r"String\(describing:\s*([A-Za-z_][A-Za-z0-9_.]*)\)", interp)
+            if m:
+                target = m.group(1).split(".")[-1]
+                if target in {"rawField", "rawData", "frameData", "payload", "content", "body"}:
+                    flagged.append(interp)
+        if "String(describing:" in interp and token == "String":
+            m = re.search(r"String\(describing:\s*([A-Za-z_][A-Za-z0-9_.]*)\)", interp)
+            if m:
+                target = m.group(1).split(".")[-1]
+                if target in {"rawField", "rawData", "frameData", "payload", "content", "body"}:
+                    if interp not in flagged:
+                        flagged.append(interp)
+    return flagged
+
+
+class NoMessageContentInLogsTests(unittest.TestCase):
+    # ── 1. The production inbound line: metadata only ──────────────────
+
+    def test_inbound_handler_logs_metadata_only(self) -> None:
+        source = APPSERVICES.read_text(encoding="utf-8")
+        case = re.search(
+            r"case \.inbound\(let sourceHash, let messageHash, let content, let title, "
+            r"let fieldsPacked, let method, let t\):\n"
+            r"(?P<body>.*?)\n            guard let data = Data\(hexString: sourceHash\)",
+            source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(case, "handlePythonEvent `.inbound` case not found")
+        assert case is not None
+        body = case.group("body")
+        log_line = re.search(r'DiagLog\.log\("(?:[^"\\]|\\.)*"\)', body)
+        self.assertIsNotNone(log_line, "`.inbound` case no longer has its diag line")
+        assert log_line is not None
+        line = log_line.group(0)
+        # No content / title / full hashes in the line.
+        self.assertNotIn("content=\\\"", line)
+        self.assertNotIn("\\(content)", line)
+        self.assertNotIn("\\(title)", line)
+        self.assertNotIn("source=\\(sourceHash)", line)  # must be prefixed
+        self.assertNotIn("message=\\(messageHash)", line)  # must be prefixed
+        # Metadata correlation fields remain.
+        self.assertIn("source=\\(sourceHash.prefix(8))", line)
+        self.assertIn("message=\\(messageHash.prefix(8))", line)
+        self.assertIn("len=\\(content.utf8.count)", line)
+
+    # ── 2. DEBUG deep-link hooks: no content ───────────────────────────
+
+    def test_debug_test_hooks_log_no_content(self) -> None:
+        source = COLUMBA_APP.read_text(encoding="utf-8")
+        self.assertNotIn('content=\\\"\\(content)', source)
+        self.assertNotIn("content=\\(content, privacy: .public)", source)
+        self.assertNotIn("\\(content)", source.replace("\\(content.utf8.count", ""))
+
+    # ── 3. RNode seam: whole-message interpolation is gone ────────────
+
+    def test_seam_wire_never_dumps_message_bytes(self) -> None:
+        seam = SEAM_WIRE.read_text(encoding="utf-8")
+        self.assertNotIn("dropped \\(message)", seam)
+        self.assertIn("diagnosticLabel", seam)
+        model = RNODE_SEAM.read_text(encoding="utf-8")
+        # The label must exist and must NOT interpolate the Data payloads.
+        label = re.search(
+            r"var diagnosticLabel: String \{(?P<body>.*?)\n    \}", model, re.DOTALL
+        )
+        self.assertIsNotNone(label, "RNodeSeamMessage.diagnosticLabel missing")
+        assert label is not None
+        self.assertNotIn("\\(data)", label.group("body"))
+        self.assertNotIn("\\(reqId, data)", label.group("body"))
+        self.assertIn("data.count", label.group("body"))
+
+    # ── 4. MessageBubble: no raw image-field dump ─────────────────────
+
+    def test_message_bubble_never_logs_field_payload(self) -> None:
+        source = MESSAGE_BUBBLE.read_text(encoding="utf-8")
+        self.assertNotIn(
+            'value=\\(String(describing: rawField)', source,
+            "MessageBubble still dumps the raw image-field value",
+        )
+
+    # ── 5. Repo-wide sweep: no content-bearing log interpolations ─────
+
+    def test_no_content_bearing_log_interpolations_anywhere(self) -> None:
+        offenders: list[str] = []
+        for path in SWIFT_SOURCES:
+            rel = path.relative_to(ROOT).as_posix()
+            for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+                # Skip pure comment lines.
+                stripped = line.lstrip()
+                if stripped.startswith("//") or stripped.startswith("/*") or stripped.startswith("*"):
+                    continue
+                for arg in _diagnostic_args(line):
+                    for bad in _content_bearing_interpolations(arg):
+                        offenders.append(f"{rel}:{lineno}: {bad.strip()}")
+        self.assertEqual(
+            offenders,
+            [],
+            "log sinks still carry message-content interpolations:\n"
+            + "\n".join(offenders),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tests/static/test_no_message_content_in_logs.py
+++ b/Tests/static/test_no_message_content_in_logs.py
@@ -12,7 +12,8 @@ contract extends it to the app-side sinks and pins the specific leaks
 fixed by the "no message content in logs" remediation:
 
   * `handlePythonEvent`'s `.inbound` case logged the full plaintext
-    (`content="…"`) — production path, every received message.
+    (`content="…"` and `content=\\(content, privacy: .public)`) —
+    production path, every received message.
   * DEBUG `test-send` / `test-inbound` deep-link hooks logged the content.
   * The RNode seam wire logged a `RNodeSeamMessage` whose `.send` /
     `.dataReceived` cases embed `Data` frame bytes.
@@ -37,21 +38,22 @@ RNODE_SEAM = ROOT / "Sources/Shared/RNodeSeam.swift"
 # Xcode-project source root; Tests/, app/ (Python), support/ are excluded).
 SWIFT_SOURCES = sorted((ROOT / "Sources").rglob("*.swift"))
 
-# Log sinks that reach disk and/or the unified log.
-DIAG_SINK_RE = re.compile(
-    r"(?:DiagLog|ExtensionDiagLog)\.log\((?P<arg>.*?)\)\s*$"
-)
-# os.Logger calls: `logger.info("…")`, `log.debug("…")`, etc. (the os.log
-# interpolations are what land in the unified log; `privacy: .public`
-# interpolations are what a log-archive reader can extract).
-OSLOG_CALL_RE = re.compile(
-    r"\blogger\.(?:debug|info|notice|warning|error|trace)\("
-    r"|\bself\.log\.(?:debug|info|notice|warning|error|trace)\("
-    r"|\blog\.(?:debug|info|notice|warning|error|trace)\("
+# Log sinks that reach disk and/or the unified log, matched against the
+# code outside string literals. Two shapes, both receiver-UNRESTRICTED so
+# that any receiver spelling the project uses — `logger`, `self.log`,
+# `sLogger`, `backgroundPropagationLogger`, a future `netLogger`, … — is
+# covered:
+#   * `DiagLog.log(…)` / `ExtensionDiagLog.log(…)` — any `.log(` call
+#     (the static diag sinks);
+#   * `<receiver>.<level>(…)` where level ∈ debug/info/notice/warning/
+#     error/trace/fatal — os.Logger style calls (`logger.info(…)` etc.).
+SINK_RE = re.compile(
+    r"\.log\("
+    r"|\b[A-Za-z_][A-Za-z0-9_]*\.(?:debug|info|notice|warning|error|trace|fatal)\("
 )
 
 # Interpolations that carry message-content variables. Matched against the
-# FIRST token of each `\(…)` interpolation so `messageHash` / `contentLength`
+# FIRST token of each `\(` interpolation so `messageHash` / `contentLength`
 # are NOT flagged (boundary-aware).
 CONTENT_TOKENS = {
     "content", "contentString", "plaintext", "messageContent", "body",
@@ -60,52 +62,154 @@ CONTENT_TOKENS = {
     # frame bytes in its default description.
     "message",
 }
-INTERPOLATION_RE = re.compile(r"\\\(.*?\)")
-FIRST_TOKEN_RE = re.compile(r"\s*([A-Za-z_][A-Za-z0-9_]*)")
 
 
-def _first_token(interp: str) -> str | None:
-    """The leading identifier of an interpolation, if any.
+def _first_token(inner: str) -> str | None:
+    """The leading identifier of a Swift expression, if any.
 
-    `\\(content)` -> `content`; `\\(content.utf8.count)` -> `content`;
-    `\\(self.message.content)` -> `self` (caller-qualified; handled by the
-    qualified checks); `\\("foo")` -> None.
+    `content` -> `content`; `content.utf8.count` -> `content`;
+    `String(describing: rawField)` -> `String`; `("foo")` -> None.
     """
-    m = FIRST_TOKEN_RE.match(interp)
+    m = re.match(r"\s*([A-Za-z_][A-Za-z0-9_]*)", inner)
     return m.group(1) if m else None
 
 
-def _diagnostic_args(line: str) -> list[str]:
-    """Balanced-paren extraction of the argument text of each log call in
-    `line` (handles nested `\\(a.isEmpty ? 0 : b)` interpolation parens)."""
-    args: list[str] = []
-    for sink in list(DIAG_SINK_RE.finditer(line)) + list(OSLOG_CALL_RE.finditer(line)):
-        start = sink.end()  # position just after the opening "("
-        depth = 1
-        i = start
-        in_str = False
-        while i < len(line) and depth:
-            ch = line[i]
-            if in_str:
-                if ch == "\\":
-                    i += 1
-                elif ch == '"':
-                    in_str = False
-            elif ch == '"':
-                in_str = True
-            elif ch == "(":
-                depth += 1
-            elif ch == ")":
-                depth -= 1
+def _iter_log_calls(text: str) -> list[tuple[int, int, str]]:
+    """Return (start, end, argtext) for every log-sink call in `text`.
+
+    The scan is string-aware: characters inside single- or triple-quoted
+    string literals (and Swift interpolation expressions, which are code,
+    not string data) are never treated as call syntax, so a string literal
+    that merely *mentions* `logger.info(` can never mask or fake a real
+    sink. Calls are extracted over the full file text, so multiline
+    invocations (`DiagLog.log(\n    "…")`) are captured exactly like
+    single-line ones.
+    """
+    n = len(text)
+    calls: list[tuple[int, int, str]] = []
+    i = 0
+    in_line_comment = False
+    in_block_comment = 0
+    while i < n:
+        ch = text[i]
+        nxt = text[i + 1] if i + 1 < n else ""
+        if in_line_comment:
+            if ch == "\n":
+                in_line_comment = False
             i += 1
-        if depth == 0:
-            args.append(line[start:i - 1])
-    return args
+            continue
+        if in_block_comment:
+            if ch == "*" and nxt == "/":
+                in_block_comment -= 1
+                i += 2
+                continue
+            if ch == "/" and nxt == "*":
+                in_block_comment += 1
+                i += 2
+                continue
+            i += 1
+            continue
+        if ch == "/" and nxt == "/":
+            in_line_comment = True
+            i += 2
+            continue
+        if ch == "/" and nxt == "*":
+            in_block_comment = 1
+            i += 2
+            continue
+        if ch == '"':
+            if text.startswith('"""', i):
+                end = text.find('"""', i + 3)
+                i = n if end < 0 else end + 3
+                continue
+            i += 1
+            while i < n:
+                c2 = text[i]
+                if c2 == "\\":
+                    i += 2
+                    continue
+                if c2 == '"':
+                    i += 1
+                    break
+                i += 1
+            continue
+        m = SINK_RE.match(text, i)
+        if m:
+            start, end, argtext = _extract_balanced_args(text, m.end() - 1)
+            if end >= 0 and argtext is not None:
+                calls.append((start, end, argtext))
+        i += 1
+    return calls
+
+
+def _extract_balanced_args(text: str, open_paren: int):
+    """From `text[open_paren] == "("`, return (start, end, argtext) where
+    end is one past the matching `)` and argtext is the interior (string-
+    and comment-aware, so a `)` inside a literal or comment never
+    terminates the call). Returns (open_paren, -1, None) if unbalanced."""
+    n = len(text)
+    depth = 0
+    i = open_paren
+    in_line_comment = False
+    in_block_comment = 0
+    while i < n:
+        ch = text[i]
+        nxt = text[i + 1] if i + 1 < n else ""
+        if in_line_comment:
+            if ch == "\n":
+                in_line_comment = False
+            i += 1
+            continue
+        if in_block_comment:
+            if ch == "*" and nxt == "/":
+                in_block_comment -= 1
+                i += 2
+                continue
+            if ch == "/" and nxt == "*":
+                in_block_comment += 1
+                i += 2
+                continue
+            i += 1
+            continue
+        if ch == "/" and nxt == "/":
+            in_line_comment = True
+            i += 2
+            continue
+        if ch == "/" and nxt == "*":
+            in_block_comment = 1
+            i += 2
+            continue
+        if ch == '"':
+            if text.startswith('"""', i):
+                end = text.find('"""', i + 3)
+                i = n if end < 0 else end + 3
+                continue
+            i += 1
+            while i < n:
+                c2 = text[i]
+                if c2 == "\\":
+                    i += 2
+                    continue
+                if c2 == '"':
+                    i += 1
+                    break
+                i += 1
+            continue
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth == 0:
+                return open_paren, i + 1, text[open_paren + 1:i]
+        i += 1
+    return open_paren, -1, None
 
 
 def _interpolations(arg: str) -> list[str]:
-    # Strip string-literal text so interpolation detection only sees real
-    # Swift interpolation escapes. A simple scan keeps this dependency-free.
+    # Scan only the string-literal text for `\(` escapes and capture each
+    # interpolation (nested-paren aware) INCLUDING its leading backslash,
+    # so detection sees the real Swift escape and nothing else. A simple
+    # scan keeps this dependency-free.
     out: list[str] = []
     in_str = False
     i = 0
@@ -113,20 +217,30 @@ def _interpolations(arg: str) -> list[str]:
         ch = arg[i]
         if in_str:
             if ch == "\\":
-                if i + 1 < len(arg) and arg[i + 1] == "(":
-                    # capture the interpolation (nested-paren aware)
-                    depth = 1
-                    j = i + 2
-                    s = i + 1
-                    while j < len(arg) and depth:
-                        if arg[j] == "(":
-                            depth += 1
-                        elif arg[j] == ")":
-                            depth -= 1
-                        j += 1
-                    out.append(arg[s:j])
-                    i = j
-                    continue
+                if i + 1 < len(arg):
+                    esc = arg[i + 1]
+                    if esc == "(":
+                        # Swift interpolation; capture the full escape
+                        # (nested-paren aware), leading backslash included
+                        depth = 1
+                        j = i + 2
+                        while j < len(arg) and depth:
+                            if arg[j] == "(":
+                                depth += 1
+                            elif arg[j] == ")":
+                                depth -= 1
+                            j += 1
+                        out.append(arg[i:j])
+                        i = j
+                        continue
+                    else:
+                        # an escaped character (\\, \", \n, …) — the pair
+                        # is literal text, never an interpolation
+                        i += 2
+                        continue
+                else:
+                    i += 1
+                continue
             elif ch == '"':
                 in_str = False
         elif ch == '"':
@@ -135,38 +249,138 @@ def _interpolations(arg: str) -> list[str]:
     return out
 
 
-def _content_bearing_interpolations(arg: str) -> list[str]:
+def _enclosing_scope_declares_string(text: str, expr_index: int, token: str) -> bool:
+    """True when a declaration of `token` typed as `String` is in scope at
+    `expr_index`.
+
+    `message` is a generic name: the only content-bearing `message` in this
+    codebase is `RNodeSeamMessage`, but plain `String` error/status
+    parameters named `message` (e.g. `setConnectionError(_ message: String)`,
+    and the sinks' own `log(_ message: String)` line-formatting bodies) are
+    not message content. Scan the text backwards from the expression,
+    string- and comment-aware, tracking brace/paren depth so only
+    declarations from the expression's own scope or an enclosing scope
+    count (an inner `let message: String` declared *after* the expression
+    must not apply)."""
+    n = len(text)
+    brace_depth = 0
+    in_line_comment = False
+    in_block_comment = 0
+    i = expr_index
+    while i > 0:
+        i -= 1
+        ch = text[i]
+        nxt = text[i + 1] if i + 1 < n else ""
+        if in_line_comment:
+            if ch == "\n":
+                in_line_comment = False
+            continue
+        if in_block_comment:
+            if ch == "*" and nxt == "/":
+                in_block_comment -= 1
+                continue
+            if ch == "/" and nxt == "*":
+                in_block_comment += 1
+                continue
+            continue
+        if ch == "/" and nxt == "/":
+            in_line_comment = True
+            i -= 1
+            continue
+        if ch == "/" and nxt == "*":
+            in_block_comment = 1
+            i -= 1
+            continue
+        if ch == '"':
+            if text[i:i + 3] == '"""':
+                j = text.rfind('"""', 0, i)
+                i = j if j >= 0 else -1
+                continue
+            j = i - 1
+            while j >= 0:
+                c2 = text[j]
+                if c2 == "\\":
+                    j -= 2
+                    continue
+                if c2 == '"':
+                    break
+                j -= 1
+            i = j
+            continue
+        # Paren depth is intentionally NOT tracked: the expression sits
+        # inside call parens, and backwards past them we must reach the
+        # enclosing signature's parameter list (`func f(_ message: String)`
+        # is inside its own `(...)`) to see the declaration.
+        if ch == "}":
+            brace_depth += 1
+        elif ch == "{":
+            brace_depth -= 1
+            if brace_depth < 0:
+                return False  # left the enclosing function scope
+        else:
+            if brace_depth == 0:
+                m = re.search(
+                    re.escape(token) + r"\s*:\s*String\b",
+                    text[max(0, i - 200):i + 1],
+                )
+                if m:
+                    return True
+    return False
+
+
+def _content_bearing_interpolations(
+    arg: str,
+    file_text: str | None = None,
+    call_index: int = 0,
+) -> list[str]:
     """Interpolations in `arg` whose value is a message-content variable.
 
-    Flags:
+    `arg` is the argument text of one call site in `file_text` starting at
+    `call_index` (used for the in-scope-type check below); pass None for
+    synthetic snippets. Entries from _interpolations() are the full escape
+    including the leading backslash, e.g. `\\(content)`. Flags:
       * `\\(content)` / `\\(body)` / … (bare content vars and their property
         chains, e.g. `\\(content.utf8.count)` is ALLOWED — byte counts are
-        metadata; so the rule only fires on the bare variable or a direct
-        `String(describing: <content var>)` dump);
+        metadata);
       * `\\(String(describing: rawField)…)`-style dumps of field payloads;
-      * `\\(message)` where `message` is an RNodeSeamMessage (frame bytes).
+      * `\\(message)` when `message` is not a `String` in scope (a bare
+        `RNodeSeamMessage` interpolates its `.send(data:)` frame bytes in
+        its default description). `\\(message.diagnosticLabel)` is always
+        ALLOWED — test 3 pins that property as metadata-only.
     """
     flagged: list[str] = []
     for interp in _interpolations(arg):
-        token = _first_token(interp)
+        # Entries are full escapes, e.g. `\\(content)` /
+        # `\\(String(describing: x))`. The leading `\\(` is the
+        # interpolation delimiter; the expression follows it.
+        inner = interp[2:] if interp.startswith("\\(") else interp
+        token = _first_token(inner)
         if token is None:
+            continue
+        if token == "message":
+            rest = inner[len(token):].lstrip()
+            if rest.startswith(".diagnosticLabel"):
+                # Metadata-only seam label (pinned by test 3).
+                continue
+            # Bare `message` / other chains: flag unless the in-scope
+            # declaration is a String (error/status text, the sinks' own
+            # `log(_ message: String)` line-formatting bodies).
+            if file_text is None:
+                # Synthetic snippet without file context: fail closed.
+                flagged.append(interp)
+            elif not _enclosing_scope_declares_string(file_text, call_index, token):
+                flagged.append(interp)
             continue
         if token in CONTENT_TOKENS:
             # Allow byte-count / length derivations (metadata, not content).
-            rest = interp[len(token):].lstrip()
+            rest = inner[len(token):].lstrip()
             if rest.startswith((".utf8.count", ".count", ".isEmpty")):
                 continue
             flagged.append(interp)
-        elif "String(describing:" in interp and token == "":
+        if "String(describing:" in inner and token == "String":
             # `\\(String(describing: rawField).prefix(200))` — the value is a
-            # raw field payload; the leading token is `String`.
-            m = re.search(r"String\(describing:\s*([A-Za-z_][A-Za-z0-9_.]*)\)", interp)
-            if m:
-                target = m.group(1).split(".")[-1]
-                if target in {"rawField", "rawData", "frameData", "payload", "content", "body"}:
-                    flagged.append(interp)
-        if "String(describing:" in interp and token == "String":
-            m = re.search(r"String\(describing:\s*([A-Za-z_][A-Za-z0-9_.]*)\)", interp)
+            # raw field payload.
+            m = re.search(r"String\(describing:\s*([A-Za-z_][A-Za-z0-9_.]*)\)", inner)
             if m:
                 target = m.group(1).split(".")[-1]
                 if target in {"rawField", "rawData", "frameData", "payload", "content", "body"}:
@@ -240,25 +454,125 @@ class NoMessageContentInLogsTests(unittest.TestCase):
         )
 
     # ── 5. Repo-wide sweep: no content-bearing log interpolations ─────
+    #    Multiline-call- and receiver-agnostic by construction (see
+    #    _iter_log_calls / SINK_RE above).
 
     def test_no_content_bearing_log_interpolations_anywhere(self) -> None:
         offenders: list[str] = []
         for path in SWIFT_SOURCES:
             rel = path.relative_to(ROOT).as_posix()
-            for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
-                # Skip pure comment lines.
-                stripped = line.lstrip()
-                if stripped.startswith("//") or stripped.startswith("/*") or stripped.startswith("*"):
-                    continue
-                for arg in _diagnostic_args(line):
-                    for bad in _content_bearing_interpolations(arg):
-                        offenders.append(f"{rel}:{lineno}: {bad.strip()}")
+            text = path.read_text(encoding="utf-8")
+            for start, _end, arg in _iter_log_calls(text):
+                lineno = text.count("\n", 0, start) + 1
+                for bad in _content_bearing_interpolations(
+                    arg, file_text=text, call_index=start
+                ):
+                    offenders.append(f"{rel}:{lineno}: {bad.strip()}")
         self.assertEqual(
             offenders,
             [],
             "log sinks still carry message-content interpolations:\n"
             + "\n".join(offenders),
         )
+
+    # ── 6. The sweep itself must see what it claims to see ────────────
+    #    Pins the scanner against the two blind classes this contract was
+    #    written to close: multiline invocations and non-`logger`
+    #    receiver spellings. If a refactor makes _iter_log_calls miss
+    #    these, the contract silently weakens — these cases stop it.
+
+    def test_sweep_catches_multiline_and_unusual_receivers(self) -> None:
+        # NOTE: each fixture is a literal Swift source snippet; the file's
+        # `\\(` is ONE backslash in the Swift text (a real interpolation).
+        multiline = (
+            '        DiagLog.log(\n'
+            '            "inbound content=\\(content) seen"\n'
+            '        )\n'
+        )
+        found = [a for _s, _e, a in _iter_log_calls(multiline)]
+        self.assertEqual(len(found), 1, "multiline DiagLog.log call not captured")
+        self.assertEqual(
+            _content_bearing_interpolations(found[0]),
+            ["\\(content)"],
+            "multiline content interpolation not flagged",
+        )
+
+        unusual = '        sLogger.info("body arrived: \\(body) end")\n'
+        found = [a for _s, _e, a in _iter_log_calls(unusual)]
+        self.assertEqual(len(found), 1, "sLogger.info call not captured")
+        self.assertEqual(
+            _content_bearing_interpolations(found[0]),
+            ["\\(body)"],
+            "unusual-receiver content interpolation not flagged",
+        )
+
+        bg = '    backgroundPropagationLogger.error(\n' \
+             '        "sync failed content=\\(content)"\n' \
+             '    )\n'
+        found = [a for _s, _e, a in _iter_log_calls(bg)]
+        self.assertEqual(len(found), 1, "backgroundPropagationLogger call not captured")
+        self.assertEqual(
+            _content_bearing_interpolations(found[0]),
+            ["\\(content)"],
+        )
+
+        # A string literal that merely mentions a sink must not create a
+        # (fake) call nor mask a real one.
+        decoy = (
+            '    let hint = "remember to call logger.info(x)"\n'
+            '    self.log.warning("title=\\(title)")\n'
+        )
+        found = [a for _s, _e, a in _iter_log_calls(decoy)]
+        self.assertEqual(len(found), 1, "string-mentioned sink misparsed as a call")
+        self.assertEqual(_content_bearing_interpolations(found[0]), ["\\(title)"])
+
+        # `message` is type-dependent: a bare non-String `message`
+        # (RNodeSeamMessage: its default description embeds frame bytes)
+        # must be flagged; a `String` named `message` in scope is not.
+        seam = (
+            '    public func send(_ message: RNodeSeamMessage) {\n'
+            '        guard false else {\n'
+            '            ExtensionDiagLog.log("dropped \\(message)")\n'
+            '            return\n'
+            '        }\n'
+            '    }\n'
+        )
+        for _s, _e, a in _iter_log_calls(seam):
+            self.assertEqual(
+                _content_bearing_interpolations(a, file_text=seam, call_index=_s),
+                ["\\(message)"],
+                "bare RNodeSeamMessage interpolation not flagged",
+            )
+
+        seam_label = (
+            '    public func send(_ message: RNodeSeamMessage) {\n'
+            '        ExtensionDiagLog.log("dropped \\(message.diagnosticLabel)")\n'
+            '    }\n'
+        )
+        for _s, _e, a in _iter_log_calls(seam_label):
+            self.assertEqual(
+                _content_bearing_interpolations(a, file_text=seam_label, call_index=_s),
+                [],
+                "diagnosticLabel (metadata) wrongly flagged",
+            )
+
+        string_msg = (
+            '    func setConnectionError(_ message: String) {\n'
+            '        logger.warning("Connection error: \\(message)")\n'
+            '    }\n'
+        )
+        for _s, _e, a in _iter_log_calls(string_msg):
+            self.assertEqual(
+                _content_bearing_interpolations(a, file_text=string_msg, call_index=_s),
+                [],
+                "String-named `message` wrongly flagged as content",
+            )
+
+        # Metadata-only interpolations stay allowed (no false positives).
+        ok = '    logger.info("inbound len=\\(content.utf8.count) fields=\\(fields.count)")\n'
+        found = [a for _s, _e, a in _iter_log_calls(ok)]
+        self.assertEqual(len(found), 1)
+        self.assertEqual(_content_bearing_interpolations(found[0]), [])
 
 
 if __name__ == "__main__":

--- a/Tests/static/test_no_message_content_in_logs.py
+++ b/Tests/static/test_no_message_content_in_logs.py
@@ -39,17 +39,23 @@ RNODE_SEAM = ROOT / "Sources/Shared/RNodeSeam.swift"
 SWIFT_SOURCES = sorted((ROOT / "Sources").rglob("*.swift"))
 
 # Log sinks that reach disk and/or the unified log, matched against the
-# code outside string literals. Two shapes, both receiver-UNRESTRICTED so
-# that any receiver spelling the project uses — `logger`, `self.log`,
-# `sLogger`, `backgroundPropagationLogger`, a future `netLogger`, … — is
-# covered:
+# code outside string literals. All receiver-UNRESTRICTED so that any
+# receiver spelling the project uses — `logger`, `self.log`, `sLogger`,
+# `backgroundPropagationLogger`, a future `netLogger`, … — is covered:
 #   * `DiagLog.log(…)` / `ExtensionDiagLog.log(…)` — any `.log(` call
 #     (the static diag sinks);
 #   * `<receiver>.<level>(…)` where level ∈ debug/info/notice/warning/
-#     error/trace/fatal — os.Logger style calls (`logger.info(…)` etc.).
+#     error/trace/fatal — os.Logger style calls (`logger.info(…)` etc.);
+#   * bare diagnostic helpers spelled `<Name>_status(…)` (`DiagLog_status`)
+#     and `NSLog(…)` (unified log direct);
+#   * optional log callbacks `log?(…)` / `self?.log?(…)` (the seam-server
+#     `((String) -> Void)?` properties that forward to the host's DiagLog).
 SINK_RE = re.compile(
     r"\.log\("
     r"|\b[A-Za-z_][A-Za-z0-9_]*\.(?:debug|info|notice|warning|error|trace|fatal)\("
+    r"|\b[A-Z][A-Za-z0-9_]*_status\("
+    r"|\bNSLog\("
+    r"|(?<![A-Za-z0-9_])log\?\("
 )
 
 # Interpolations that carry message-content variables. Matched against the
@@ -58,6 +64,9 @@ SINK_RE = re.compile(
 CONTENT_TOKENS = {
     "content", "contentString", "plaintext", "messageContent", "body",
     "payload", "rawData", "frameData", "title",
+    # `raw` — the Python status-JSON string; a `.prefix(n)` of it lands
+    # payload data in diag.log / the unified log (`.count` is metadata).
+    "raw",
     # RNodeSeamMessage interpolated whole carries .send(data:)/.dataReceived
     # frame bytes in its default description.
     "message",
@@ -573,6 +582,38 @@ class NoMessageContentInLogsTests(unittest.TestCase):
         found = [a for _s, _e, a in _iter_log_calls(ok)]
         self.assertEqual(len(found), 1)
         self.assertEqual(_content_bearing_interpolations(found[0]), [])
+
+        # Bare diagnostic helpers, the unified-log direct sink, and the
+        # optional seam-server log callback must all be captured.
+        bare = (
+            '        guard let raw else { return nil }\n'
+            '        DiagLog_status("decode failed: \\(error) raw=\\(raw.prefix(200))")\n'
+        )
+        found = [a for _s, _e, a in _iter_log_calls(bare)]
+        self.assertEqual(len(found), 1, "DiagLog_status(…) call not captured")
+        self.assertEqual(
+            _content_bearing_interpolations(found[0]),
+            ["\\(raw.prefix(200))"],
+            "raw payload prefix not flagged",
+        )
+
+        callback = '        self?.log?("[RNODE] server: failed content=\\(content)")\n'
+        found = [a for _s, _e, a in _iter_log_calls(callback)]
+        self.assertEqual(len(found), 1, "log?(…) callback not captured")
+        self.assertEqual(
+            _content_bearing_interpolations(found[0]),
+            ["\\(content)"],
+            "optional-callback content interpolation not flagged",
+        )
+
+        nslog = '        NSLog("%@", "[STATUS] payload=\\(payload)")\n'
+        found = [a for _s, _e, a in _iter_log_calls(nslog)]
+        self.assertEqual(len(found), 1, "NSLog(…) call not captured")
+        self.assertEqual(
+            _content_bearing_interpolations(found[0]),
+            ["\\(payload)"],
+            "NSLog content interpolation not flagged",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Security remediation

Columba iOS was writing **message plaintext** to on-device diagnostic logs.
`DiagLog` writes to `Documents/diag.log` (extractable via `devicectl`/Xcode)
and mirrors every line into the OS unified log via `NSLog`. This defeats the
E2E encryption the app exists to provide. The Network Extension's
`ExtensionDiagLog` already declares a hard NO-PII contract (envelope/
metadata only); this change extends it to the app-side sinks.

### Leaks fixed

| Site | Was | Now |
|---|---|---|
| `AppServices.handlePythonEvent` `.inbound` (production, every received message, both backends) | `content="\(content)"` + full source hash | prefixed hashes (8 hex) + byte lengths |
| DEBUG `lxma://test-send` hook (x2) | content incl. one `privacy: .public` os.Logger call | byte count |
| DEBUG `lxma://test-inbound` hook | `content="\(content)"` | byte count |
| RNode seam wire | interpolated `RNodeSeamMessage` (`.send`/`.dataReceived` embed `Data` frame bytes) | new metadata-only `diagnosticLabel` (byte counts) |
| `MessageBubble` image-field extraction failure | `String(describing: rawField).prefix(200)` (image payload bytes) | type + element count |

### Test changes

- Interop suite (`test_attachments.py`, `test_bug1_network_render.py`) correlated
  on the content substring in the inbound diag line; it now correlates on log
  offset + `len=` (bodies are timestamp-unique).
- New static contract `Tests/static/test_no_message_content_in_logs.py`
  sweeps all Swift log sinks for content-bearing interpolations and fails on
  the pre-fix code (verified by mutation). Wired into the CI static-contract lane.

### Verification

- Static contract: 5/5 pass on this branch; fails on the pre-fix tree (mutation-verified).
- `py_compile` clean on both edited interop test files.
- Adjacent static contracts (inbound persistence, delivery method, deep-link
  lifecycle, privacy settings): pass.
- Remaining: GitHub CI (shipping + Model B + UI lanes) and the interop E2E
  suite on the Mac (needs a booted simulator + host rnsd/lxmd; not runnable
  from this VM).