### PR TITLE
Fix image-quality sheet clipping at large Dynamic Type (#181)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -349,6 +349,10 @@ jobs:
       - name: Run screenshot flows
         env:
           MAESTRO_CLI_ANALYSIS_NOTIFICATION_DISABLED: 'true'
+          # Cold simulator boot + first-run data migration can exceed the
+          # 60s default before the XCUITest driver is ready (observed
+          # ~110s), which fails the first flows with IOSDriverTimeoutException.
+          MAESTRO_DRIVER_STARTUP_TIMEOUT: '180000'
         run: |
           set -euo pipefail
           DEVICE_ID="${{ steps.sim.outputs.device_id }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,6 +77,7 @@ jobs:
             Tests.static.test_async_propagation_fallback \
             Tests.static.test_privacy_settings_contract \
             Tests.static.test_theme_selection_navigation_contract \
+            Tests.static.test_image_quality_sheet_dynamic_size \
             Tests.static.test_ui_screenshotter_readiness \
             Tests.static.test_collect_maestro_screenshots
 

--- a/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
@@ -842,12 +842,17 @@ struct MessagingView: View {
 
     // Image-quality bottom sheet. Kept as a standalone computed property so
     // its view + closures stay out of `body` (which is at the type-checker's
-    // expression-complexity limit). Sizing: a @ScaledMetric detent grows with
-    // Dynamic Type, and the options scroll inside as a safety net, so the
-    // header and Cancel/Attach buttons are never clipped at large text sizes
-    // (issue #181).
+    // expression-complexity limit). Sizing: the detent height is a
+    // @ScaledMetric that grows with Dynamic Type, and the content is pinned
+    // to exactly that height (`.frame(height:)`): the header and the
+    // Cancel/Attach buttons stay pinned while the quality options scroll in
+    // between. Without the fixed frame the sheet proposes unbounded height to
+    // the content and clips both ends instead of letting the ScrollView take
+    // effect (issue #181: header off the top, buttons off the bottom at
+    // large accessibility text).
     private var imageQualityPickerSheet: some View {
         ImageQualityPickerSheet(
+            sheetHeight: imageQualitySheetHeight,
             selectedPreset: $selectedImagePreset,
             onConfirm: {
                 if let raw = pendingRawImage {
@@ -1165,6 +1170,7 @@ struct MessagingView: View {
 
 @available(iOS 17.0, macOS 14.0, *)
 private struct ImageQualityPickerSheet: View {
+    var sheetHeight: CGFloat
     @Binding var selectedPreset: SettingsViewModel.ImageQualityPreset
     var onConfirm: () -> Void
     var onCancel: () -> Void
@@ -1239,6 +1245,13 @@ private struct ImageQualityPickerSheet: View {
             .padding(.horizontal, 16)
             .padding(.bottom, 8)
         }
+        // Pin the whole content to exactly the (Dynamic-Type-scaled) detent
+        // height. This is what makes the ScrollView between the header and the
+        // buttons actually take effect: instead of the sheet proposing
+        // unbounded height and clipping both ends, the rows now scroll and the
+        // header + Cancel/Attach stay fully visible at every text size
+        // (issue #181).
+        .frame(height: sheetHeight)
         .background(Theme.backgroundSecondary)
     }
 }

--- a/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
@@ -626,24 +626,12 @@ struct MessagingView: View {
             nomadNetDestination(for: target)
         }
         .sheet(isPresented: $showQualityPicker) {
-            ImageQualityPickerSheet(
-                selectedPreset: $selectedImagePreset,
-                onConfirm: {
-                    if let raw = pendingRawImage {
-                        attachedImage = raw.resizedToFit(maxDimension: selectedImagePreset.maxDimension)
-                        // Remember choice for next time
-                        UserDefaults.standard.set(selectedImagePreset.rawValue, forKey: "image_quality_preset")
-                    }
-                    pendingRawImage = nil
-                    showQualityPicker = false
-                },
-                onCancel: {
-                    pendingRawImage = nil
-                    showQualityPicker = false
-                }
-            )
-            .presentationDetents([.height(340)])
-            .presentationDragIndicator(.visible)
+            // Presented via a computed property (not inlined in the body):
+            // this body sits at the edge of the Swift type-checker's
+            // expression-complexity budget, and inlining the sheet's view +
+            // closures makes it fail with "unable to type-check in
+            // reasonable time". Kept out of the body for that reason.
+            imageQualityPickerSheet
         }
         // Codec picker → place the voice call. The active/outgoing call UI
         // (VoiceCallScreen) is presented app-root in MainTabView off
@@ -843,6 +831,40 @@ struct MessagingView: View {
                 .fill(appServices.isConnected ? Color.green : Color.gray)
                 .frame(width: 8, height: 8)
         }
+    }
+
+    // Base height of the image-quality bottom sheet, scaled by the user's
+    // Dynamic Type size. @ScaledMetric grows the detent in lockstep with the
+    // (larger) text so the sheet makes room for it instead of clipping its
+    // content - the reported issue #181 had the header pushed off the top and
+    // the Cancel/Attach buttons off the bottom at large accessibility text.
+    @ScaledMetric(relativeTo: .body) private var imageQualitySheetHeight: CGFloat = 340
+
+    // Image-quality bottom sheet. Kept as a standalone computed property so
+    // its view + closures stay out of `body` (which is at the type-checker's
+    // expression-complexity limit). Sizing: a @ScaledMetric detent grows with
+    // Dynamic Type, and the options scroll inside as a safety net, so the
+    // header and Cancel/Attach buttons are never clipped at large text sizes
+    // (issue #181).
+    private var imageQualityPickerSheet: some View {
+        ImageQualityPickerSheet(
+            selectedPreset: $selectedImagePreset,
+            onConfirm: {
+                if let raw = pendingRawImage {
+                    attachedImage = raw.resizedToFit(maxDimension: selectedImagePreset.maxDimension)
+                    // Remember choice for next time
+                    UserDefaults.standard.set(selectedImagePreset.rawValue, forKey: "image_quality_preset")
+                }
+                pendingRawImage = nil
+                showQualityPicker = false
+            },
+            onCancel: {
+                pendingRawImage = nil
+                showQualityPicker = false
+            }
+        )
+        .presentationDetents([.height(imageQualitySheetHeight)])
+        .presentationDragIndicator(.visible)
     }
 
     @State private var isSyncing = false
@@ -1154,38 +1176,47 @@ private struct ImageQualityPickerSheet: View {
                 .foregroundStyle(Theme.textPrimary)
                 .padding(.top, 8)
 
-            VStack(spacing: 8) {
-                ForEach(SettingsViewModel.ImageQualityPreset.allCases) { preset in
-                    Button {
-                        selectedPreset = preset
-                    } label: {
-                        HStack(spacing: 12) {
-                            Image(systemName: selectedPreset == preset ? "checkmark.circle.fill" : "circle")
-                                .font(.system(size: 20))
-                                .foregroundStyle(selectedPreset == preset ? Theme.accentColor : .gray)
+            // The quality options scroll independently while the header and
+            // the Cancel/Attach buttons stay pinned. The sheet's height is a
+            // @ScaledMetric that grows with the user's Dynamic Type size, so
+            // at large text sizes the sheet grows instead of clipping its
+            // content (the header used to be pushed off the top and the
+            // action buttons off the bottom of the screen - issue #181).
+            ScrollView {
+                VStack(spacing: 8) {
+                    ForEach(SettingsViewModel.ImageQualityPreset.allCases) { preset in
+                        Button {
+                            selectedPreset = preset
+                        } label: {
+                            HStack(spacing: 12) {
+                                Image(systemName: selectedPreset == preset ? "checkmark.circle.fill" : "circle")
+                                    .font(.system(size: 20))
+                                    .foregroundStyle(selectedPreset == preset ? Theme.accentColor : .gray)
 
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text(preset.rawValue)
-                                    .font(.subheadline.weight(.medium))
-                                    .foregroundStyle(Theme.textPrimary)
-                                Text(preset.description)
-                                    .font(.caption)
-                                    .foregroundStyle(.gray)
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(preset.rawValue)
+                                        .font(.subheadline.weight(.medium))
+                                        .foregroundStyle(Theme.textPrimary)
+                                    Text(preset.description)
+                                        .font(.caption)
+                                        .foregroundStyle(.gray)
+                                }
+
+                                Spacer()
                             }
-
-                            Spacer()
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 10)
+                            .background(
+                                selectedPreset == preset
+                                    ? Theme.accentColor.opacity(0.15)
+                                    : Color.clear
+                            )
+                            .clipShape(RoundedRectangle(cornerRadius: 10))
                         }
-                        .padding(.horizontal, 16)
-                        .padding(.vertical, 10)
-                        .background(
-                            selectedPreset == preset
-                                ? Theme.accentColor.opacity(0.15)
-                                : Color.clear
-                        )
-                        .clipShape(RoundedRectangle(cornerRadius: 10))
                     }
                 }
             }
+            .scrollBounceBehavior(.basedOnSize)
             .padding(.horizontal, 16)
 
             HStack(spacing: 12) {

--- a/Tests/static/test_image_quality_sheet_dynamic_size.py
+++ b/Tests/static/test_image_quality_sheet_dynamic_size.py
@@ -13,16 +13,20 @@ The fix (see MessagingView.swift):
   1. The sheet's detent height is a `@ScaledMetric` that grows in lockstep
      with the user's Dynamic Type size, so the sheet makes room for larger
      text instead of clipping it.
-  2. The quality options live in a `ScrollView` as a safety net so that at
-     the largest text sizes the header and the Cancel/Attach buttons stay
-     visible and the options scroll, instead of the content being clipped.
-  3. The sheet's view + closures live in the `imageQualityPickerSheet`
+  2. The sheet's content is pinned to exactly that height with
+     `.frame(height: sheetHeight)`. Without this the sheet proposes unbounded
+     height to the content and clips both ends; with it, the header and the
+     Cancel/Attach buttons stay pinned while the quality options scroll.
+  3. The quality options live in a `ScrollView` so that at the largest text
+     sizes the options scroll instead of pushing the action buttons off the
+     screen.
+  4. The sheet's view + closures live in the `imageQualityPickerSheet`
      computed property rather than inline in `MessagingView.body`: the body
      sits at the Swift type-checker's expression-complexity limit, and
      inlining the sheet's closures makes it fail with "unable to type-check
      in reasonable time".
 
-This contract pins all three halves so the clipping (or the compile
+This contract pins all four halves so the clipping (or the compile
 regression) cannot silently return.
 """
 
@@ -108,6 +112,12 @@ class ImageQualitySheetDynamicSizeTests(unittest.TestCase):
 
     def test_picker_options_scroll_and_header_buttons_stay_pinned(self) -> None:
         body = _picker_body(self.source)
+
+        # The sheet's content must be pinned to exactly the (Dynamic-Type-
+        # scaled) detent height. This is the half that actually stops the
+        # clipping: without it the sheet proposes unbounded height and
+        # overflows both ends (issue #181).
+        self.assertIn(".frame(height: sheetHeight)", body)
 
         # The quality options are wrapped in a ScrollView so they can scroll
         # at very large text sizes instead of pushing the action buttons off

--- a/Tests/static/test_image_quality_sheet_dynamic_size.py
+++ b/Tests/static/test_image_quality_sheet_dynamic_size.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Regression contract: the image-quality bottom sheet must not clip its
+content at large Dynamic Type sizes (issue #181).
+
+A user with enlarged accessibility text reported the image-quality bottom
+sheet (shown after choosing a photo to attach) pushing its "Image Quality"
+header off the top of the sheet and its Cancel/Attach action buttons off the
+bottom of the screen. The sheet was pinned to a fixed 340pt detent with a
+non-scrolling body, so once the rows grew with the text size the content
+overflowed the sheet in both directions.
+
+The fix (see MessagingView.swift):
+  1. The sheet's detent height is a `@ScaledMetric` that grows in lockstep
+     with the user's Dynamic Type size, so the sheet makes room for larger
+     text instead of clipping it.
+  2. The quality options live in a `ScrollView` as a safety net so that at
+     the largest text sizes the header and the Cancel/Attach buttons stay
+     visible and the options scroll, instead of the content being clipped.
+  3. The sheet's view + closures live in the `imageQualityPickerSheet`
+     computed property rather than inline in `MessagingView.body`: the body
+     sits at the Swift type-checker's expression-complexity limit, and
+     inlining the sheet's closures makes it fail with "unable to type-check
+     in reasonable time".
+
+This contract pins all three halves so the clipping (or the compile
+regression) cannot silently return.
+"""
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MESSAGING_VIEW = ROOT / "Sources/ColumbaApp/Views/Messaging/MessagingView.swift"
+
+
+def _sheet_block(source: str, state_var: str) -> str:
+    """Return the `.sheet(isPresented: $<state_var>) { ... }` modifier block.
+
+    Bounded by the opening brace of the sheet content closure and the next
+    `        }` line, so the assertions run against exactly this sheet.
+    """
+    marker = f".sheet(isPresented: ${state_var}) {{"
+    start = source.find(marker)
+    assert start != -1, f"could not find sheet for {state_var}"
+    end = source.find("\n        }", start)
+    assert end != -1, f"could not bound sheet for {state_var}"
+    return source[start:end]
+
+
+def _computed_property(source: str, name: str) -> str:
+    """Return the `private var <name>: some View { ... }` property body."""
+    start = source.find(f"private var {name}: some View {{")
+    assert start != -1, f"computed property {name} not found"
+    end = source.find("\n    }", start)
+    assert end != -1, f"could not bound computed property {name}"
+    return source[start:end + 6]
+
+
+def _scaled_metric(source: str, name: str) -> str:
+    """Return the `@ScaledMetric ... private var <name>: CGFloat = <n>` line."""
+    idx = source.find(f"private var {name}: CGFloat")
+    assert idx != -1, f"scaled metric {name} not found"
+    # Back up to the @ScaledMetric attribute on the preceding line.
+    line_start = source.rfind("\n", 0, idx) + 1
+    attr_start = source.rfind("\n", 0, line_start - 1) + 1
+    line_end = source.find("\n", idx)
+    return source[attr_start:line_end + 1]
+
+
+def _picker_body(source: str) -> str:
+    """Return the `ImageQualityPickerSheet` struct body."""
+    start = source.find("private struct ImageQualityPickerSheet")
+    assert start != -1, "ImageQualityPickerSheet not found"
+    end = source.find("// MARK: - UIImage Resize Helper", start)
+    assert end != -1, "could not bound ImageQualityPickerSheet"
+    return source[start:end]
+
+
+class ImageQualitySheetDynamicSizeTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.source = MESSAGING_VIEW.read_text(encoding="utf-8")
+
+    def test_quality_sheet_height_is_dynamic_type_scaled(self) -> None:
+        metric = _scaled_metric(self.source, "imageQualitySheetHeight")
+
+        # The detent height must be a Dynamic Type-scaled metric so the sheet
+        # grows to make room for larger text (the user's ask for a dynamic
+        # sheet size).
+        self.assertIn("@ScaledMetric", metric)
+        self.assertIn("relativeTo:", metric)
+
+        prop = _computed_property(self.source, "imageQualityPickerSheet")
+        # The sheet must present with the scaled height, not a hard-coded
+        # pixel constant.
+        self.assertIn(".presentationDetents([.height(imageQualitySheetHeight)])", prop)
+        self.assertNotIn(".height(340)", prop)
+        # ...and the confirm/cancel actions must still be wired.
+        self.assertIn("ImageQualityPickerSheet(", prop)
+        self.assertIn("showQualityPicker = false", prop)
+
+    def test_quality_sheet_is_extracted_out_of_body(self) -> None:
+        # The body presents the sheet via the computed property (keeps the
+        # body under the type-checker's complexity limit).
+        block = _sheet_block(self.source, "showQualityPicker")
+        self.assertIn("imageQualityPickerSheet", block)
+        self.assertNotIn("ImageQualityPickerSheet(", block)
+
+    def test_picker_options_scroll_and_header_buttons_stay_pinned(self) -> None:
+        body = _picker_body(self.source)
+
+        # The quality options are wrapped in a ScrollView so they can scroll
+        # at very large text sizes instead of pushing the action buttons off
+        # the screen.
+        self.assertIn("ScrollView {", body)
+        # ...and only bounce when they actually overflow, so at normal text
+        # sizes the sheet is static (matches SyncStatusBottomSheet).
+        self.assertIn(".scrollBounceBehavior(.basedOnSize)", body)
+
+        # The header and the two action buttons remain real views (not moved
+        # into the scrollable region), so they stay visible and tappable.
+        self.assertIn('Text("Image Quality")', body)
+        self.assertIn('Button("Cancel")', body)
+        self.assertIn('Button("Attach")', body)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The image-quality bottom sheet (shown after picking a photo to attach) was pinned to a fixed 340pt detent with a non-scrolling body. At enlarged accessibility text (repro: iPhone 14 Pro, iOS large text), the header was clipped off the top of the sheet and the Cancel/Attach buttons off the bottom of the screen.

## Changes

- The detent height is now a `@ScaledMetric` (340pt at the default size) that grows in lockstep with the user's Dynamic Type size.
- The sheet content is pinned to exactly that scaled height (`.frame(height:)`), so the `ScrollView` between the header and the action buttons actually engages: the quality options scroll while the header and the Cancel/Attach buttons stay fully visible at every text size.
- The sheet is extracted into the `imageQualityPickerSheet` computed property: `MessagingView.body` is at the Swift type-checker expression-complexity limit, and inlining the sheet closures fails the build with "unable to type-check this expression in reasonable time" (verified by A/B build).

Only the image-quality sheet changes; the emoji and text-size pickers keep their existing sizing.

## Verification

- New static contract test (`Tests/static/test_image_quality_sheet_dynamic_size.py`): red on the baseline, green on the fix. Full static suite: 289 passed, 1 skipped, 267 subtests.
- Full XCTest suite: 351 tests, 0 regressions (3 pre-existing `MessageBubbleLayoutTests` pixel-geometry failures, identical on baseline).
- On-device: iPhone 14 Pro at large text - Image Quality sheet shows header + all options + full Cancel/Attach row on screen (confirmed by the reporter).

## Linked issue

Fixes #181