### PR TITLE
feat(ios): tappable peer map pins with peer contact bottom sheet (#179)

### DIFF
--- a/Columba.xcodeproj/project.pbxproj
+++ b/Columba.xcodeproj/project.pbxproj
@@ -66,6 +66,15 @@
 		044 /* IdentityManagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F044 /* IdentityManagerView.swift */; };
 		045 /* LoRaPresets.swift in Sources */ = {isa = PBXBuildFile; fileRef = F045 /* LoRaPresets.swift */; };
 		048 /* MapLibreMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F048 /* MapLibreMapView.swift */; platformFilter = ios; };
+		60CC574F0906D247788E05C0 /* PeerLocationFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 977911678B80FDC0021BFC8D /* PeerLocationFormatting.swift */; platformFilter = ios;};
+		EC3A6E57174A92CF82D2D167 /* PeerLocationFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 977911678B80FDC0021BFC8D /* PeerLocationFormatting.swift */; platformFilter = ios;};
+		EC11D7B3ACB169889DFDCAD6 /* DirectionsLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2BA54B809AFB1AB900074CD /* DirectionsLauncher.swift */; platformFilter = ios;};
+		2FAC68C81FFB2F5877849D40 /* DirectionsLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2BA54B809AFB1AB900074CD /* DirectionsLauncher.swift */; platformFilter = ios;};
+		7BC38A40688391B27CAF196D /* PeerContactSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = E000A64C153F97167050B87D /* PeerContactSheet.swift */; platformFilter = ios;};
+		3007EA9DFE6E9C7445D1977B /* PeerContactSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = E000A64C153F97167050B87D /* PeerContactSheet.swift */; platformFilter = ios;};
+		CC067EE77A33341C829CBDE8 /* PeerLocationFormattingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 498D7BF18FE3ACDE874B3E98 /* PeerLocationFormattingTests.swift */;};
+		E4FCBD54560B74AC8CCB1C91 /* DirectionsLauncherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9DA888204CA742BD1403A51 /* DirectionsLauncherTests.swift */;};
+		47B4E413633097429123BC2F /* PeerLocationRemovalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB56A9C5F062142B6EF61DA2 /* PeerLocationRemovalTests.swift */;};
 		049 /* MapLibre in Frameworks */ = {isa = PBXBuildFile; platformFilter = ios; productRef = P002 /* MapLibre */; };
 		049B /* QRScannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F049 /* QRScannerView.swift */; platformFilter = ios; };
 		04AB /* AddContactSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F04A /* AddContactSheet.swift */; };
@@ -526,6 +535,12 @@
 		F044 /* IdentityManagerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentityManagerView.swift; sourceTree = "<group>"; };
 		F045 /* LoRaPresets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoRaPresets.swift; sourceTree = "<group>"; };
 		F048 /* MapLibreMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapLibreMapView.swift; sourceTree = "<group>"; };
+		977911678B80FDC0021BFC8D /* PeerLocationFormatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerLocationFormatting.swift; sourceTree = "<group>"};
+		A2BA54B809AFB1AB900074CD /* DirectionsLauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectionsLauncher.swift; sourceTree = "<group>"};
+		E000A64C153F97167050B87D /* PeerContactSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerContactSheet.swift; sourceTree = "<group>"};
+		498D7BF18FE3ACDE874B3E98 /* PeerLocationFormattingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerLocationFormattingTests.swift; sourceTree = "<group>"};
+		B9DA888204CA742BD1403A51 /* DirectionsLauncherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectionsLauncherTests.swift; sourceTree = "<group>"};
+		AB56A9C5F062142B6EF61DA2 /* PeerLocationRemovalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerLocationRemovalTests.swift; sourceTree = "<group>"};
 		F049 /* QRScannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRScannerView.swift; sourceTree = "<group>"; };
 		F04A /* AddContactSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddContactSheet.swift; sourceTree = "<group>"; };
 		F04B /* LocationSharingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationSharingManager.swift; sourceTree = "<group>"; };
@@ -847,6 +862,9 @@
 			children = (
 				F021 /* MapView.swift */,
 				F048 /* MapLibreMapView.swift */,
+				977911678B80FDC0021BFC8D /* PeerLocationFormatting.swift */,
+				A2BA54B809AFB1AB900074CD /* DirectionsLauncher.swift */,
+				E000A64C153F97167050B87D /* PeerContactSheet.swift */,
 				F062 /* OfflineMapDownloadView.swift */,
 				F063 /* OfflineMapsScreen.swift */,
 			);
@@ -1035,6 +1053,9 @@
 				6FE282FA3937E59BC026E072 /* AudioManagerConfigChangeTests.swift */,
 				30A79B9ECDB4166F8A36A670 /* CallManagerCallKitTests.swift */,
 				BC4EF2D71A3D88C71D5BEDAD /* MessageFormattedTimeTests.swift */,
+				498D7BF18FE3ACDE874B3E98 /* PeerLocationFormattingTests.swift */,
+				B9DA888204CA742BD1403A51 /* DirectionsLauncherTests.swift */,
+				AB56A9C5F062142B6EF61DA2 /* PeerLocationRemovalTests.swift */,
 				A1B2C3D4E5F60718293A4B5D /* MessageBubbleLayoutTests.swift */,
 				APVT001 /* MessageAttachmentPreviewTests.swift */,
 				ACT01 /* AnnounceClassificationTests.swift */,
@@ -1398,6 +1419,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3007EA9DFE6E9C7445D1977B /* PeerContactSheet.swift in Sources */,
+				2FAC68C81FFB2F5877849D40 /* DirectionsLauncher.swift in Sources */,
+				EC3A6E57174A92CF82D2D167 /* PeerLocationFormatting.swift in Sources */,
 				9C2C61E20925DB726EC2C934 /* ColumbaApp.swift in Sources */,
 				BBF80EA2BC42E6E7FF17A171 /* Theme.swift in Sources */,
 				89551A07A2FB8693E6C465FC /* ChatsViewModel.swift in Sources */,
@@ -1581,6 +1605,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7BC38A40688391B27CAF196D /* PeerContactSheet.swift in Sources */,
+				EC11D7B3ACB169889DFDCAD6 /* DirectionsLauncher.swift in Sources */,
+				60CC574F0906D247788E05C0 /* PeerLocationFormatting.swift in Sources */,
 				BGPSYNCBUILD001 /* BackgroundPropagationSync.swift in Sources */,
 				001 /* ColumbaApp.swift in Sources */,
 				002 /* Theme.swift in Sources */,
@@ -1716,6 +1743,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				47B4E413633097429123BC2F /* PeerLocationRemovalTests.swift in Sources */,
+				E4FCBD54560B74AC8CCB1C91 /* DirectionsLauncherTests.swift in Sources */,
+				CC067EE77A33341C829CBDE8 /* PeerLocationFormattingTests.swift in Sources */,
 				BGPSYNCTESTBUILD001 /* BackgroundPropagationSyncTests.swift in Sources */,
 				T003 /* MicronParserTests.swift in Sources */,
 				2B3A3E3FB59D1E22B424E109 /* AudioRingBufferTests.swift in Sources */,

--- a/Columba.xcodeproj/project.pbxproj
+++ b/Columba.xcodeproj/project.pbxproj
@@ -535,12 +535,12 @@
 		F044 /* IdentityManagerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentityManagerView.swift; sourceTree = "<group>"; };
 		F045 /* LoRaPresets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoRaPresets.swift; sourceTree = "<group>"; };
 		F048 /* MapLibreMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapLibreMapView.swift; sourceTree = "<group>"; };
-		977911678B80FDC0021BFC8D /* PeerLocationFormatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerLocationFormatting.swift; sourceTree = "<group>"};
-		A2BA54B809AFB1AB900074CD /* DirectionsLauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectionsLauncher.swift; sourceTree = "<group>"};
-		E000A64C153F97167050B87D /* PeerContactSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerContactSheet.swift; sourceTree = "<group>"};
-		498D7BF18FE3ACDE874B3E98 /* PeerLocationFormattingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerLocationFormattingTests.swift; sourceTree = "<group>"};
-		B9DA888204CA742BD1403A51 /* DirectionsLauncherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectionsLauncherTests.swift; sourceTree = "<group>"};
-		AB56A9C5F062142B6EF61DA2 /* PeerLocationRemovalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerLocationRemovalTests.swift; sourceTree = "<group>"};
+		977911678B80FDC0021BFC8D /* PeerLocationFormatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerLocationFormatting.swift; sourceTree = "<group>"; };
+		A2BA54B809AFB1AB900074CD /* DirectionsLauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectionsLauncher.swift; sourceTree = "<group>"; };
+		E000A64C153F97167050B87D /* PeerContactSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerContactSheet.swift; sourceTree = "<group>"; };
+		498D7BF18FE3ACDE874B3E98 /* PeerLocationFormattingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerLocationFormattingTests.swift; sourceTree = "<group>"; };
+		B9DA888204CA742BD1403A51 /* DirectionsLauncherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectionsLauncherTests.swift; sourceTree = "<group>"; };
+		AB56A9C5F062142B6EF61DA2 /* PeerLocationRemovalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerLocationRemovalTests.swift; sourceTree = "<group>"; };
 		F049 /* QRScannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRScannerView.swift; sourceTree = "<group>"; };
 		F04A /* AddContactSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddContactSheet.swift; sourceTree = "<group>"; };
 		F04B /* LocationSharingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationSharingManager.swift; sourceTree = "<group>"; };

--- a/Sources/ColumbaApp/Resources/Info.plist
+++ b/Sources/ColumbaApp/Resources/Info.plist
@@ -31,6 +31,14 @@
 	<string>Columba shares your location with contacts you explicitly choose, so they can see where you are during an active sharing session.</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
 	<string>Columba keeps sharing your location with the contacts you chose even when the app is in the background, so a sharing session you started doesn't silently stop. You can stop sharing at any time from the conversation or from Settings.</string>
+	<!-- The peer map contact sheet offers Google Maps as an external
+	     directions app. canOpenURL() only reports a scheme as installed if
+	     it is declared here (Apple's LSApplicationQueriesSchemes allowlist);
+	     without this entry the Google Maps row never appears in the chooser. -->
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>comgooglemaps</string>
+	</array>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Columba uses the microphone for encrypted voice calls over the mesh network.</string>
 	<key>UIAppFonts</key>

--- a/Sources/ColumbaApp/Resources/Localizable.xcstrings
+++ b/Sources/ColumbaApp/Resources/Localizable.xcstrings
@@ -1418,6 +1418,69 @@
           }
         }
       }
+    },
+    "north": {
+      "comment": "Compass direction shown next to a peer pin distance in the map contact sheet."
+    },
+    "northeast": {
+      "comment": "Compass direction shown next to a peer pin distance in the map contact sheet."
+    },
+    "east": {
+      "comment": "Compass direction shown next to a peer pin distance in the map contact sheet."
+    },
+    "southeast": {
+      "comment": "Compass direction shown next to a peer pin distance in the map contact sheet."
+    },
+    "south": {
+      "comment": "Compass direction shown next to a peer pin distance in the map contact sheet."
+    },
+    "southwest": {
+      "comment": "Compass direction shown next to a peer pin distance in the map contact sheet."
+    },
+    "west": {
+      "comment": "Compass direction shown next to a peer pin distance in the map contact sheet."
+    },
+    "northwest": {
+      "comment": "Compass direction shown next to a peer pin distance in the map contact sheet."
+    },
+    "Location unknown": {
+      "comment": "Distance line in the map contact sheet when the user has not granted or is not yet providing a location."
+    },
+    "Updated just now": {
+      "comment": "Relative last-update line for a peer location that arrived in the last few seconds."
+    },
+    "Updated %llds ago": {
+      "comment": "Relative last-update line, seconds. %lld is the whole-second count."
+    },
+    "Updated %lldm ago": {
+      "comment": "Relative last-update line, minutes. %lld is the whole-minute count."
+    },
+    "Updated %lldh ago": {
+      "comment": "Relative last-update line, hours. %lld is the whole-hour count."
+    },
+    "Updated %lldd ago": {
+      "comment": "Relative last-update line, days. %lld is the whole-day count."
+    },
+    "Stale": {
+      "comment": "Badge on the profile icon in the map contact sheet when the peer location is outside the freshness window."
+    },
+    "Directions": {
+      "comment": "Action button label in the map peer contact sheet."
+    },
+    "Message": {
+      "comment": "Action button label in the map peer contact sheet; routes to the peer chat."
+    },
+    "Remove from map": {
+      "comment": "Action button label in the map peer contact sheet; hides this peer until it reports again."
+    },
+    "Open Directions in:": {
+      "comment": "Title of the confirmation dialog choosing the directions app when both Apple Maps and Google Maps are available."
+    },
+    "Apple Maps": {
+      "comment": "Name of the Apple Maps option in the directions chooser."
+    },
+    "Google Maps": {
+      "comment": "Name of the Google Maps option in the directions chooser."
     }
   },
   "version": "1.0"

--- a/Sources/ColumbaApp/Services/LocationSharingManager.swift
+++ b/Sources/ColumbaApp/Services/LocationSharingManager.swift
@@ -284,6 +284,25 @@ public final class LocationSharingManager: NSObject {
         activePeers.contains(peerHash)
     }
 
+    /// Drop a peer's pin from the map (the contact sheet's "Remove from
+    /// map" action for stale peers).
+    ///
+    /// This clears the in-memory `peerLocations` entry only - it is NOT a
+    /// block. A peer that is still transmitting re-announces itself on its
+    /// next telemetry tick and its pin reappears (matching Android's
+    /// reappear-on-resume behavior); a peer that sends CEASE (or whose
+    /// sharing expires) disappears for good. No persistence is involved:
+    /// `peerLocations` is in-memory only (only *outgoing* sharing sessions
+    /// are persisted via `persistActivePeers`). If peer locations ever gain
+    /// persistence, removal must delete the stored row here too.
+    ///
+    /// - Parameter peerHash: 16-byte destination hash of the peer
+    public func removePeerLocation(_ peerHash: Data) {
+        guard peerLocations.removeValue(forKey: peerHash) != nil else { return }
+        let hex = peerHash.prefix(4).map { String(format: "%02x", $0) }.joined()
+        logger.info("Removed peer \(hex) from map (user action)")
+    }
+
     /// Handle incoming telemetry from a peer.
     ///
     /// - Parameters:

--- a/Sources/ColumbaApp/Services/LocationSharingManager.swift
+++ b/Sources/ColumbaApp/Services/LocationSharingManager.swift
@@ -308,6 +308,13 @@ public final class LocationSharingManager: NSObject {
         guard peerLocations.removeValue(forKey: peerHash) != nil else { return }
         let hex = peerHash.prefix(4).toHex()
         logger.info("Removed peer \(hex) from map (user action)")
+        // Test-observable mirror of the removal. The pin is rendered on
+        // MapLibre's GL surface (not in the accessibility tree) and
+        // `peerLocations` is in-memory, so neither the accessibility tree nor
+        // the `map_peer_count` badge (order-dependent across peers) can prove
+        // that *this* pin dropped. The Tests/interop stale-removal case polls
+        // this line to assert the state actually changed.
+        DiagLog.log("[LOC-REMOVE] peer=\(hex)")
     }
 
     /// Handle incoming telemetry from a peer.
@@ -359,7 +366,7 @@ public final class LocationSharingManager: NSObject {
 
         peerLocations[peerHash] = peerLoc
 
-        let hex = peerHash.prefix(4).map { String(format: "%02x", $0) }.joined()
+        let hex = peerHash.prefix(4).toHex()
         logger.info("Updated peer \(hex) location: \(location.latitude), \(location.longitude)")
         // Test-observable mirror of the decoded inbound telemetry. The map
         // marker is rendered on MapLibre's GL surface and isn't reachable

--- a/Sources/ColumbaApp/Services/LocationSharingManager.swift
+++ b/Sources/ColumbaApp/Services/LocationSharingManager.swift
@@ -46,6 +46,13 @@ public struct PeerLocation: Identifiable, Equatable {
     /// Bearing in degrees.
     public var bearing: Double
 
+    /// The peer's coordinate as a single `CLLocationCoordinate2D` value.
+    /// Lets map/directions code treat the pin location as one type instead
+    /// of threading `latitude`/`longitude` doubles separately.
+    public var coordinate: CLLocationCoordinate2D {
+        CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+    }
+
     /// Horizontal accuracy in meters.
     public var accuracy: Double
 
@@ -299,7 +306,7 @@ public final class LocationSharingManager: NSObject {
     /// - Parameter peerHash: 16-byte destination hash of the peer
     public func removePeerLocation(_ peerHash: Data) {
         guard peerLocations.removeValue(forKey: peerHash) != nil else { return }
-        let hex = peerHash.prefix(4).map { String(format: "%02x", $0) }.joined()
+        let hex = peerHash.prefix(4).toHex()
         logger.info("Removed peer \(hex) from map (user action)")
     }
 

--- a/Sources/ColumbaApp/Views/Chats/ChatsView.swift
+++ b/Sources/ColumbaApp/Views/Chats/ChatsView.swift
@@ -275,16 +275,26 @@ struct ChatsView: View {
         // for its window and re-runs this check at settle
         // (consumePeerChatRoute), so the deferred tap is still delivered -
         // it just must not race the peer push now.
-        if let conversation = vm.conversations.first(where: { $0.id == hash }),
-           NotificationService.pendingConversationHash == hash,
-           !isResolvingPeerChat {
-            NotificationService.pendingConversationHash = nil
-            notificationConversation = conversation
+        guard let conversation = vm.conversations.first(where: { $0.id == hash }),
+              NotificationService.pendingConversationHash == hash,
+              !isResolvingPeerChat else {
+            // The slot now belongs to a newer tap (or a peer route owns
+            // navigation). If a newer tap owns it, route it now - a no-op
+            // refresh fires no list-change callback, so waiting for the
+            // next trigger would strand it. If a peer route owns it, this
+            // returns immediately and the route delivers the tap at settle.
+            if NotificationService.pendingConversationHash != nil,
+               NotificationService.pendingConversationHash != hash {
+                await checkPendingNotification()
+            }
+            // Otherwise the row is still not in storage, or a peer route is
+            // mid-resolution: leave the slot intact so the peer-route
+            // settle, the next list change, or an activation retries
+            // instead of dropping the tap.
+            return
         }
-        // Otherwise the row is still not in storage, a newer tap owns the
-        // slot, or a peer route is mid-resolution: leave the slot intact so
-        // the peer-route settle, the next list change, or an activation
-        // retries instead of dropping the tap.
+        NotificationService.pendingConversationHash = nil
+        notificationConversation = conversation
     }
 
     /// Consume the Map tab's peer-chat route: resolve the peer's conversation

--- a/Sources/ColumbaApp/Views/Chats/ChatsView.swift
+++ b/Sources/ColumbaApp/Views/Chats/ChatsView.swift
@@ -238,11 +238,13 @@ struct ChatsView: View {
     /// conversation is pushed, a new notification simply stacks on top of
     /// it - ordinary `item:` navigation behavior, no shared state.)
     ///
-    /// The check is async: it only consumes the pending hash after
-    /// confirming the conversation row exists, refreshing from storage
-    /// first if the in-memory snapshot is stale (a just-arrived message).
-    /// If the row is genuinely absent it restores the hash so a later
-    /// trigger retries instead of dropping the tap.
+    /// Lookups use the unfiltered `conversations` list so an active search
+    /// query cannot hide the tapped conversation, and the pending hash is
+    /// only consumed once the row has actually resolved - from the
+    /// in-memory snapshot, or from storage after one refresh when the
+    /// snapshot is stale - so a tap is never silently discarded. A newer
+    /// tap that replaces the pending slot during the refresh is untouched
+    /// (existing single-slot "latest tap wins" semantics).
     @MainActor
     private func checkPendingNotification() async {
         guard let hash = NotificationService.pendingConversationHash,
@@ -254,24 +256,29 @@ struct ChatsView: View {
             // opens (stacking on top of the peer conversation).
             return
         }
-        // Claim the hash up front so concurrent triggers (activation +
-        // list change) cannot double-open the same conversation.
-        NotificationService.pendingConversationHash = nil
-        if let conversation = vm.filteredConversations.first(where: { $0.id == hash }) {
+        // Unfiltered lookup: an active search query must not hide the
+        // conversation the notification points at. No suspension between
+        // this read and the clear below, so the claim is race-free.
+        if let conversation = vm.conversations.first(where: { $0.id == hash }) {
+            NotificationService.pendingConversationHash = nil
             notificationConversation = conversation
             return
         }
         // The row may not be in the in-memory snapshot yet (a message that
         // just arrived): re-read from storage, then look again.
         await vm.refreshConversations()
-        if let conversation = vm.filteredConversations.first(where: { $0.id == hash }) {
+        if let conversation = vm.conversations.first(where: { $0.id == hash }) {
+            // Only clear the slot if this tap is still the pending one: a
+            // newer tap that arrived during the refresh owns the slot now,
+            // and clearing it would discard that tap.
+            if NotificationService.pendingConversationHash == hash {
+                NotificationService.pendingConversationHash = nil
+            }
             notificationConversation = conversation
-        } else {
-            // Not in storage either - restore the hash so the next list
-            // change or activation retries, instead of silently dropping
-            // the user's tap.
-            NotificationService.pendingConversationHash = hash
         }
+        // Otherwise the row is not in storage yet: leave the pending slot
+        // (this tap, or a newer one that replaced it) in place so the next
+        // list change or activation retries instead of dropping the tap.
     }
 
     /// Consume the Map tab's peer-chat route: resolve the peer's conversation

--- a/Sources/ColumbaApp/Views/Chats/ChatsView.swift
+++ b/Sources/ColumbaApp/Views/Chats/ChatsView.swift
@@ -26,8 +26,10 @@ struct ChatsView: View {
     let notificationObserver: NotificationObserver
     /// Cross-tab route from the Map tab's peer contact sheet: the tapped
     /// peer's destination hash. Consumed (and cleared) by this view once the
-    /// conversation resolves - see `consumePeerChatRoute`.
-    @Binding var pendingPeerChat: Data? = nil
+    /// conversation resolves - see `consumePeerChatRoute`. (No default: a
+    /// `@Binding` property cannot take `= nil`, since the synthesized
+    /// memberwise init parameter is `Binding<Data?>`, not `Data?`.)
+    @Binding var pendingPeerChat: Data?
 
     // MARK: - State
 

--- a/Sources/ColumbaApp/Views/Chats/ChatsView.swift
+++ b/Sources/ColumbaApp/Views/Chats/ChatsView.swift
@@ -24,6 +24,10 @@ struct ChatsView: View {
     let appServices: AppServices
     let messageRepository: MessageRepository
     let notificationObserver: NotificationObserver
+    /// Cross-tab route from the Map tab's peer contact sheet: the tapped
+    /// peer's destination hash. Consumed (and cleared) by this view once the
+    /// conversation resolves - see `consumePeerChatRoute`.
+    @Binding var pendingPeerChat: Data? = nil
 
     // MARK: - State
 
@@ -153,6 +157,12 @@ struct ChatsView: View {
                 )
             }
             await viewModel?.loadConversations()
+            // A route may exist before this view mounts (MainTabView holds it
+            // until ChatsView consumes it), so `.onChange` alone is not enough.
+            await consumePeerChatRoute()
+        }
+        .onChange(of: pendingPeerChat) { _, _ in
+            Task { await consumePeerChatRoute() }
         }
         .alert("Delete Conversation", isPresented: Binding(
             get: { deletingConversation != nil },
@@ -203,6 +213,41 @@ struct ChatsView: View {
         if let conversation = vm.filteredConversations.first(where: { $0.id == hash }) {
             notificationConversation = conversation
         }
+    }
+
+    /// Consume the Map tab's peer-chat route: resolve the peer's conversation
+    /// (creating the row if the peer has only ever shared telemetry and never
+    /// exchanged a message) and push it via the existing `notificationConversation`
+    /// route. Clears `pendingPeerChat` before doing async work so a repeat
+    /// `.onChange` or view rebuild can't double-open the conversation.
+    @MainActor
+    private func consumePeerChatRoute() async {
+        guard let hash = pendingPeerChat else { return }
+        // Clear first: the route is one-shot.
+        pendingPeerChat = nil
+
+        // Resolve the conversation. A telemetry-only peer may have no row yet,
+        // so `ensureConversation` creates it, then we refetch.
+        var record = try? await messageRepository.fetchConversation(hash)
+        if record == nil {
+            try? await messageRepository.ensureConversation(hash, displayName: nil)
+            record = try? await messageRepository.fetchConversation(hash)
+        }
+
+        let conversation: Conversation
+        if let record {
+            conversation = Conversation(from: record)
+        } else {
+            // Ensure failed (DB error) - still open a shell conversation so the
+            // Message tap lands somewhere coherent rather than silently
+            // dropping the user's intent.
+            conversation = Conversation(
+                id: hash.map { String(format: "%02x", $0) }.joined(),
+                destinationHash: hash,
+                lastMessageTimestamp: Date()
+            )
+        }
+        notificationConversation = conversation
     }
 
     // MARK: - Subviews

--- a/Sources/ColumbaApp/Views/Chats/ChatsView.swift
+++ b/Sources/ColumbaApp/Views/Chats/ChatsView.swift
@@ -344,6 +344,16 @@ struct ChatsView: View {
         // route has settled, so it stacks on top instead of waiting for an
         // unrelated activation or list change.
         await checkPendingNotification()
+
+        // A second Map Message tapped while this route was resolving was
+        // rejected by the in-flight guard and left in `pendingPeerChat`.
+        // Its only other trigger (`.onChange`) needs a fresh change, so
+        // retry here at settle - otherwise it is stranded. Bounded: each
+        // pass clears a non-nil slot, so the recursion stops when the
+        // queue is empty.
+        if pendingPeerChat != nil {
+            await consumePeerChatRoute()
+        }
     }
 
     // MARK: - Subviews

--- a/Sources/ColumbaApp/Views/Chats/ChatsView.swift
+++ b/Sources/ColumbaApp/Views/Chats/ChatsView.swift
@@ -232,20 +232,19 @@ struct ChatsView: View {
 
     /// Navigate to conversation from a tapped notification.
     ///
-    /// Skipped while a Map-tab peer-chat route is resolving or already
-    /// pushed: `consumePeerChatRoute` owns the peer navigation end to end,
-    /// so a notification tapped during that window cannot make the map
-    /// route's final push land behind the user's finger (or vice versa).
+    /// Deferred while a Map-tab peer-chat route is resolving: the peer
+    /// route owns navigation for that in-flight window and re-runs this
+    /// check when it settles, so the tap is not lost. (Once the peer
+    /// conversation is pushed, a new notification simply stacks on top of
+    /// it - ordinary `item:` navigation behavior, no shared state.)
     private func checkPendingNotification() {
         guard let hash = NotificationService.pendingConversationHash,
               let vm = viewModel else { return }
-        if isResolvingPeerChat || peerConversation != nil {
+        if isResolvingPeerChat {
             // The map route owns navigation for this window. Leave the
-            // pending hash in place - the same `pendingConversationHash`
-            // state already re-runs this check on the next conversation
-            // list change or app activation, so the notification is still
-            // delivered (stacking two destinations is not supported by the
-            // `item:` navigation APIs).
+            // pending hash in place - `consumePeerChatRoute` re-runs this
+            // check when it finishes resolving, so the notification still
+            // opens (stacking on top of the peer conversation).
             return
         }
         NotificationService.pendingConversationHash = nil
@@ -267,9 +266,8 @@ struct ChatsView: View {
         // Clear first: the route is one-shot.
         pendingPeerChat = nil
         // Flag the in-flight window so a notification tapped mid-resolution
-        // (checkPendingNotification) can't push a competing destination.
+        // (checkPendingNotification) defers instead of competing.
         isResolvingPeerChat = true
-        defer { isResolvingPeerChat = false }
 
         // Resolve the conversation. A telemetry-only peer may have no row yet,
         // so `ensureConversation` creates it, then we refetch.
@@ -295,6 +293,13 @@ struct ChatsView: View {
         // Peer route owns this state exclusively, so no concurrent writer can
         // overwrite the push (unlike the shared notification route).
         peerConversation = conversation
+        isResolvingPeerChat = false
+
+        // A notification tapped during the resolution window was deferred
+        // (its pending hash left in place). Deliver it now that the peer
+        // route has settled, so it stacks on top instead of waiting for an
+        // unrelated activation or list change.
+        checkPendingNotification()
     }
 
     // MARK: - Subviews

--- a/Sources/ColumbaApp/Views/Chats/ChatsView.swift
+++ b/Sources/ColumbaApp/Views/Chats/ChatsView.swift
@@ -269,15 +269,22 @@ struct ChatsView: View {
         // Consume and route only if this tap still owns the pending slot.
         // A newer tap that replaced the slot during the refresh is routed
         // by its own check; a stale continuation must not open the older
-        // conversation (or briefly replace the newer route).
+        // conversation (or briefly replace the newer route). Re-check route
+        // ownership too: `refreshConversations()` above is a suspension, so a
+        // map peer route may have started while it ran. It owns navigation
+        // for its window and re-runs this check at settle
+        // (consumePeerChatRoute), so the deferred tap is still delivered -
+        // it just must not race the peer push now.
         if let conversation = vm.conversations.first(where: { $0.id == hash }),
-           NotificationService.pendingConversationHash == hash {
+           NotificationService.pendingConversationHash == hash,
+           !isResolvingPeerChat {
             NotificationService.pendingConversationHash = nil
             notificationConversation = conversation
         }
-        // Otherwise the row is still not in storage (or a newer tap owns
-        // the slot): leave the slot intact so the next list change or
-        // activation retries instead of dropping the tap.
+        // Otherwise the row is still not in storage, a newer tap owns the
+        // slot, or a peer route is mid-resolution: leave the slot intact so
+        // the peer-route settle, the next list change, or an activation
+        // retries instead of dropping the tap.
     }
 
     /// Consume the Map tab's peer-chat route: resolve the peer's conversation

--- a/Sources/ColumbaApp/Views/Chats/ChatsView.swift
+++ b/Sources/ColumbaApp/Views/Chats/ChatsView.swift
@@ -225,7 +225,7 @@ struct ChatsView: View {
             Task { await checkPendingNotification() }
         }
         #endif
-        .onChange(of: viewModel?.filteredConversations) { _, _ in
+        .onChange(of: viewModel?.conversations) { _, _ in
             Task { await checkPendingNotification() }
         }
     }
@@ -239,12 +239,11 @@ struct ChatsView: View {
     /// it - ordinary `item:` navigation behavior, no shared state.)
     ///
     /// Lookups use the unfiltered `conversations` list so an active search
-    /// query cannot hide the tapped conversation, and the pending hash is
-    /// only consumed once the row has actually resolved - from the
-    /// in-memory snapshot, or from storage after one refresh when the
-    /// snapshot is stale - so a tap is never silently discarded. A newer
-    /// tap that replaces the pending slot during the refresh is untouched
-    /// (existing single-slot "latest tap wins" semantics).
+    /// query cannot hide the tapped conversation. The pending slot is only
+    /// consumed by the tap that still owns it (checked again after the
+    /// async refresh), so a stale continuation never opens an older
+    /// conversation over a newer tap, and a row not yet in storage leaves
+    /// the slot intact for the next list change or activation to retry.
     @MainActor
     private func checkPendingNotification() async {
         guard let hash = NotificationService.pendingConversationHash,
@@ -267,18 +266,18 @@ struct ChatsView: View {
         // The row may not be in the in-memory snapshot yet (a message that
         // just arrived): re-read from storage, then look again.
         await vm.refreshConversations()
-        if let conversation = vm.conversations.first(where: { $0.id == hash }) {
-            // Only clear the slot if this tap is still the pending one: a
-            // newer tap that arrived during the refresh owns the slot now,
-            // and clearing it would discard that tap.
-            if NotificationService.pendingConversationHash == hash {
-                NotificationService.pendingConversationHash = nil
-            }
+        // Consume and route only if this tap still owns the pending slot.
+        // A newer tap that replaced the slot during the refresh is routed
+        // by its own check; a stale continuation must not open the older
+        // conversation (or briefly replace the newer route).
+        if let conversation = vm.conversations.first(where: { $0.id == hash }),
+           NotificationService.pendingConversationHash == hash {
+            NotificationService.pendingConversationHash = nil
             notificationConversation = conversation
         }
-        // Otherwise the row is not in storage yet: leave the pending slot
-        // (this tap, or a newer one that replaced it) in place so the next
-        // list change or activation retries instead of dropping the tap.
+        // Otherwise the row is still not in storage (or a newer tap owns
+        // the slot): leave the slot intact so the next list change or
+        // activation retries instead of dropping the tap.
     }
 
     /// Consume the Map tab's peer-chat route: resolve the peer's conversation

--- a/Sources/ColumbaApp/Views/Chats/ChatsView.swift
+++ b/Sources/ColumbaApp/Views/Chats/ChatsView.swift
@@ -242,7 +242,7 @@ struct ChatsView: View {
             // Message tap lands somewhere coherent rather than silently
             // dropping the user's intent.
             conversation = Conversation(
-                id: hash.map { String(format: "%02x", $0) }.joined(),
+                id: hash.toHex(),
                 destinationHash: hash,
                 lastMessageTimestamp: Date()
             )

--- a/Sources/ColumbaApp/Views/Chats/ChatsView.swift
+++ b/Sources/ColumbaApp/Views/Chats/ChatsView.swift
@@ -45,8 +45,21 @@ struct ChatsView: View {
     /// Contact selected for peer details navigation.
     @State private var selectedContact: Contact?
 
-    /// Conversation to navigate to programmatically (e.g. from notification tap).
+    /// Conversation to navigate to from a tapped notification. Owned by
+    /// `checkPendingNotification` (sync) only.
     @State private var notificationConversation: Conversation?
+
+    /// Conversation to navigate to from the Map tab's peer contact sheet.
+    /// Owned by `consumePeerChatRoute` (async) only. Kept separate from
+    /// `notificationConversation` so the asynchronous resolution can never
+    /// clobber a navigation the user started from a notification (or vice
+    /// versa) - see `consumePeerChatRoute`.
+    @State private var peerConversation: Conversation?
+
+    /// Set while the peer-chat route is resolving (between reading
+    /// `pendingPeerChat` and pushing `peerConversation`). A notification
+    /// tapped during that window must not overwrite the in-flight route.
+    @State private var isResolvingPeerChat: Bool = false
 
     /// Conversation pending deletion (confirmation alert).
     @State private var deletingConversation: Conversation?
@@ -146,6 +159,16 @@ struct ChatsView: View {
                     messageRepository: messageRepository
                 )
             }
+            // Dedicated destination for the Map tab's peer-chat route so the
+            // async push below can never fight the notification route for a
+            // single `item:` binding.
+            .navigationDestination(item: $peerConversation) { conversation in
+                MessagingView(
+                    conversation: conversation,
+                    appServices: appServices,
+                    messageRepository: messageRepository
+                )
+            }
         }
         .preferredColorScheme(.dark)
         .tint(Theme.accentColor)
@@ -208,9 +231,23 @@ struct ChatsView: View {
     }
 
     /// Navigate to conversation from a tapped notification.
+    ///
+    /// Skipped while a Map-tab peer-chat route is resolving or already
+    /// pushed: `consumePeerChatRoute` owns the peer navigation end to end,
+    /// so a notification tapped during that window cannot make the map
+    /// route's final push land behind the user's finger (or vice versa).
     private func checkPendingNotification() {
         guard let hash = NotificationService.pendingConversationHash,
               let vm = viewModel else { return }
+        if isResolvingPeerChat || peerConversation != nil {
+            // The map route owns navigation for this window. Leave the
+            // pending hash in place - the same `pendingConversationHash`
+            // state already re-runs this check on the next conversation
+            // list change or app activation, so the notification is still
+            // delivered (stacking two destinations is not supported by the
+            // `item:` navigation APIs).
+            return
+        }
         NotificationService.pendingConversationHash = nil
         if let conversation = vm.filteredConversations.first(where: { $0.id == hash }) {
             notificationConversation = conversation
@@ -219,14 +256,20 @@ struct ChatsView: View {
 
     /// Consume the Map tab's peer-chat route: resolve the peer's conversation
     /// (creating the row if the peer has only ever shared telemetry and never
-    /// exchanged a message) and push it via the existing `notificationConversation`
-    /// route. Clears `pendingPeerChat` before doing async work so a repeat
-    /// `.onChange` or view rebuild can't double-open the conversation.
+    /// exchanged a message) and push it via the dedicated `peerConversation`
+    /// route - never the shared notification route, which a concurrent
+    /// notification tap could be using. Clears `pendingPeerChat` before doing
+    /// async work so a repeat `.onChange` or view rebuild can't double-open
+    /// the conversation.
     @MainActor
     private func consumePeerChatRoute() async {
-        guard let hash = pendingPeerChat else { return }
+        guard let hash = pendingPeerChat, !isResolvingPeerChat else { return }
         // Clear first: the route is one-shot.
         pendingPeerChat = nil
+        // Flag the in-flight window so a notification tapped mid-resolution
+        // (checkPendingNotification) can't push a competing destination.
+        isResolvingPeerChat = true
+        defer { isResolvingPeerChat = false }
 
         // Resolve the conversation. A telemetry-only peer may have no row yet,
         // so `ensureConversation` creates it, then we refetch.
@@ -249,7 +292,9 @@ struct ChatsView: View {
                 lastMessageTimestamp: Date()
             )
         }
-        notificationConversation = conversation
+        // Peer route owns this state exclusively, so no concurrent writer can
+        // overwrite the push (unlike the shared notification route).
+        peerConversation = conversation
     }
 
     // MARK: - Subviews

--- a/Sources/ColumbaApp/Views/Chats/ChatsView.swift
+++ b/Sources/ColumbaApp/Views/Chats/ChatsView.swift
@@ -218,15 +218,15 @@ struct ChatsView: View {
         }
         #if os(iOS)
         .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in
-            checkPendingNotification()
+            Task { await checkPendingNotification() }
         }
         #else
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
-            checkPendingNotification()
+            Task { await checkPendingNotification() }
         }
         #endif
         .onChange(of: viewModel?.filteredConversations) { _, _ in
-            checkPendingNotification()
+            Task { await checkPendingNotification() }
         }
     }
 
@@ -237,7 +237,14 @@ struct ChatsView: View {
     /// check when it settles, so the tap is not lost. (Once the peer
     /// conversation is pushed, a new notification simply stacks on top of
     /// it - ordinary `item:` navigation behavior, no shared state.)
-    private func checkPendingNotification() {
+    ///
+    /// The check is async: it only consumes the pending hash after
+    /// confirming the conversation row exists, refreshing from storage
+    /// first if the in-memory snapshot is stale (a just-arrived message).
+    /// If the row is genuinely absent it restores the hash so a later
+    /// trigger retries instead of dropping the tap.
+    @MainActor
+    private func checkPendingNotification() async {
         guard let hash = NotificationService.pendingConversationHash,
               let vm = viewModel else { return }
         if isResolvingPeerChat {
@@ -247,9 +254,23 @@ struct ChatsView: View {
             // opens (stacking on top of the peer conversation).
             return
         }
+        // Claim the hash up front so concurrent triggers (activation +
+        // list change) cannot double-open the same conversation.
         NotificationService.pendingConversationHash = nil
         if let conversation = vm.filteredConversations.first(where: { $0.id == hash }) {
             notificationConversation = conversation
+            return
+        }
+        // The row may not be in the in-memory snapshot yet (a message that
+        // just arrived): re-read from storage, then look again.
+        await vm.refreshConversations()
+        if let conversation = vm.filteredConversations.first(where: { $0.id == hash }) {
+            notificationConversation = conversation
+        } else {
+            // Not in storage either - restore the hash so the next list
+            // change or activation retries, instead of silently dropping
+            // the user's tap.
+            NotificationService.pendingConversationHash = hash
         }
     }
 
@@ -299,7 +320,7 @@ struct ChatsView: View {
         // (its pending hash left in place). Deliver it now that the peer
         // route has settled, so it stacks on top instead of waiting for an
         // unrelated activation or list change.
-        checkPendingNotification()
+        await checkPendingNotification()
     }
 
     // MARK: - Subviews

--- a/Sources/ColumbaApp/Views/MainTabView.swift
+++ b/Sources/ColumbaApp/Views/MainTabView.swift
@@ -96,6 +96,14 @@ struct MainTabView: View {
     /// Session-scoped route request raised by the disconnected-interface banner.
     /// Settings consumes it after its navigation stack and interface model exist.
     @State private var shouldOpenInterfaceManagement: Bool = false
+    /// Session-scoped route request raised by the Map tab's peer contact
+    /// sheet ("Message" button): the peer's destination hash. MainTabView
+    /// switches to Chats and hands the hash to ChatsView, which resolves the
+    /// conversation (creating it if the peer has only ever shared telemetry)
+    /// and pushes it via the existing `notificationConversation` route. Held
+    /// here (not on MapView) so the route survives until ChatsView is mounted
+    /// and explicitly clears it - same lifecycle as `shouldOpenInterfaceManagement`.
+    @State private var pendingPeerChat: Data? = nil
     /// Which app-root voice-call cover (if any) is showing, driven off
     /// callManager.callState so a call's UI shows from any tab and survives
     /// navigating away from the chat. A single optional makes the two covers
@@ -130,7 +138,8 @@ struct MainTabView: View {
             ChatsView(
                 appServices: appServices,
                 messageRepository: messageRepository,
-                notificationObserver: notificationObserver
+                notificationObserver: notificationObserver,
+                pendingPeerChat: $pendingPeerChat
             )
             .tabItem {
                 Label(Tab.chats.title, systemImage: Tab.chats.icon)
@@ -154,7 +163,14 @@ struct MainTabView: View {
             // Map Tab
             MapView(
                 appServices: appServices,
-                mapHttpEnabled: mapHttpEnabled
+                mapHttpEnabled: mapHttpEnabled,
+                onOpenPeerChat: { hash in
+                    // The Map tab can't push onto the Chats tab's stack, so the
+                    // request is held on MainTabView (survives until ChatsView
+                    // consumes it) and ChatsView is switched to now.
+                    selectedTab = .chats
+                    pendingPeerChat = hash
+                }
             )
                 .tabItem {
                     Label(Tab.map.title, systemImage: Tab.map.icon)

--- a/Sources/ColumbaApp/Views/Map/DirectionsLauncher.swift
+++ b/Sources/ColumbaApp/Views/Map/DirectionsLauncher.swift
@@ -90,7 +90,7 @@ struct DirectionsLauncher {
         if provider.id == "apple" {
             let placemark = MKPlacemark(coordinate: provider.coordinate)
             let item = MKMapItem(placemark: placemark)
-            item.openMaps(launchOptions: [
+            item.openInMaps(launchOptions: [
                 MKLaunchOptionsDirectionsModeKey: MKLaunchOptionsDirectionsModeWalking,
             ])
         } else if let url = provider.url {

--- a/Sources/ColumbaApp/Views/Map/DirectionsLauncher.swift
+++ b/Sources/ColumbaApp/Views/Map/DirectionsLauncher.swift
@@ -1,0 +1,100 @@
+//
+//  DirectionsLauncher.swift
+//  ColumbaApp
+//
+//  Decides which maps apps can open a walking directions route to a peer
+//  location and how to launch them. Apple Maps is always available (launched
+//  through MapKit in walking mode, matching Android); Google Maps appears
+//  only when its documented `comgooglemaps://` scheme is installed, which
+//  requires the `LSApplicationQueriesSchemes` entry in Info.plist for
+//  `canOpenURL` to report it. Adding a third provider (e.g. an
+//  OpenStreetMaps app) is one entry in `providers(for:)`, not a rework.
+//
+
+import CoreLocation
+import Foundation
+import MapKit
+#if canImport(UIKit)
+import UIKit
+#endif
+
+/// One maps-app row in the directions chooser.
+struct DirectionsProvider: Identifiable {
+    /// Stable provider id ("apple", "google").
+    let id: String
+    /// Display name for the chooser row.
+    let name: String
+    /// The peer pin's coordinate the route ends at.
+    let coordinate: CLLocationCoordinate2D
+    /// Deep link for external apps; nil for Apple Maps, which is launched
+    /// through MapKit (walking route) instead.
+    let url: URL?
+}
+
+@available(iOS 17.0, *)
+struct DirectionsLauncher {
+    /// Injectable `canOpenURL` seam so provider listing is unit-testable
+    /// without UIKit.
+    protocol SchemeProbe {
+        func canOpen(scheme: String) -> Bool
+    }
+
+    struct SystemSchemeProbe: SchemeProbe {
+        func canOpen(scheme: String) -> Bool {
+            guard let url = URL(string: "\(scheme)://") else { return false }
+            return UIApplication.shared.canOpenURL(url)
+        }
+    }
+
+    /// Google Maps' documented directions URL scheme. Requires an
+    /// `LSApplicationQueriesSchemes` entry in Info.plist or `canOpenURL`
+    /// always reports it as missing.
+    static let googleMapsScheme = "comgooglemaps"
+
+    private let probe: any SchemeProbe
+
+    init(probe: any SchemeProbe = SystemSchemeProbe()) {
+        self.probe = probe
+    }
+
+    /// Directions providers in chooser order: Apple Maps first, Google Maps
+    /// second. Apple Maps is always present; Google Maps only when installed.
+    func providers(for coordinate: CLLocationCoordinate2D) -> [DirectionsProvider] {
+        var result = [
+            DirectionsProvider(
+                id: "apple",
+                name: String(localized: "Apple Maps"),
+                coordinate: coordinate,
+                url: nil
+            ),
+        ]
+        if probe.canOpen(scheme: Self.googleMapsScheme) {
+            result.append(DirectionsProvider(
+                id: "google",
+                name: String(localized: "Google Maps"),
+                coordinate: coordinate,
+                url: Self.googleMapsURL(for: coordinate)
+            ))
+        }
+        return result
+    }
+
+    /// Google Maps' documented directions deep link, walking mode.
+    static func googleMapsURL(for coordinate: CLLocationCoordinate2D) -> URL {
+        URL(string: "comgooglemaps://?daddr=\(coordinate.latitude),\(coordinate.longitude)&directionsmode=walking")!
+    }
+
+    /// Launch the chosen provider: Apple Maps through MapKit (walking route
+    /// parity with Android), everything else through its deep link.
+    func open(_ provider: DirectionsProvider) {
+        if provider.id == "apple" {
+            let placemark = MKPlacemark(coordinate: provider.coordinate)
+            let item = MKMapItem(placemark: placemark)
+            item.openMaps(launchOptions: [
+                MKLaunchOptionsDirectionsModeKey: MKLaunchOptionsDirectionsModeWalking,
+            ])
+        } else if let url = provider.url {
+            UIApplication.shared.open(url)
+        }
+    }
+}

--- a/Sources/ColumbaApp/Views/Map/MapLibreMapView.swift
+++ b/Sources/ColumbaApp/Views/Map/MapLibreMapView.swift
@@ -303,7 +303,7 @@ struct MapLibreMapView: UIViewRepresentable {
             // view to be reachable at all - an identifier alone is ignored by
             // the accessibility tree (the view is reused, so set these on
             // every refresh, not just first creation).
-            annotationView?.accessibilityIdentifier = "peer_pin_\(peerAnnotation.peerHash.map { String(format: "%02x", $0) }.joined())"
+            annotationView?.accessibilityIdentifier = "peer_pin_\(peerAnnotation.peerHash.toHex())"
             annotationView?.isAccessibilityElement = true
             annotationView?.accessibilityLabel = peerAnnotation.title ?? "Peer location"
             annotationView?.accessibilityTraits = .button

--- a/Sources/ColumbaApp/Views/Map/MapLibreMapView.swift
+++ b/Sources/ColumbaApp/Views/Map/MapLibreMapView.swift
@@ -27,10 +27,21 @@ func mapStyleURL(forDarkMode dark: Bool) -> URL {
 struct MapLibreMapView: UIViewRepresentable {
     @Binding var centerOnUser: Bool
     @Binding var metersPerPixel: Double
+    /// The peer hash whose pin is currently selected (drives the contact
+    /// sheet in MapView and the map's selection highlight).
+    @Binding var selectedPeerHash: Data?
     var showsUserLocation: Bool
     var peerLocations: [PeerLocation]
     var httpEnabled: Bool
     var isDark: Bool
+    /// Called on the main thread when the user taps a peer pin. MapView
+    /// sets `selectedPeerHash`, which both presents the contact sheet and
+    /// re-asserts the selection highlight from `updateUIView`.
+    var onPeerTapped: ((Data) -> Void)?
+    /// Mirrors `MLNMapView.userLocation?.coordinate` up to SwiftUI so the
+    /// contact sheet can compute distance/direction before the map has
+    /// rendered a fix.
+    var onUserLocationChanged: ((CLLocationCoordinate2D?) -> Void)?
 
     func makeUIView(context: Context) -> MLNMapView {
         // Set up network delegate to block HTTP when toggle is off.
@@ -67,6 +78,8 @@ struct MapLibreMapView: UIViewRepresentable {
 
         // Update network blocking state when HTTP toggle changes
         context.coordinator.httpEnabled = httpEnabled
+        context.coordinator.onPeerTapped = onPeerTapped
+        context.coordinator.onUserLocationChanged = onUserLocationChanged
 
         // Swap style URL when color scheme changes; lastStyleURL avoids
         // a no-op assignment (which would still trigger a reload) on every
@@ -89,6 +102,11 @@ struct MapLibreMapView: UIViewRepresentable {
 
         // Update peer annotations
         updatePeerAnnotations(on: mapView, coordinator: context.coordinator)
+        // Keep the map's selection coherent across peer churn: re-assert the
+        // highlight when a newer telemetry tick rebuilt the selected peer's
+        // annotation, and clear it when the selection was lifted (sheet
+        // dismissed, peer removed, stale pin vanished).
+        updateSelection(on: mapView, coordinator: context.coordinator)
     }
 
     func makeCoordinator() -> Coordinator {
@@ -146,6 +164,31 @@ struct MapLibreMapView: UIViewRepresentable {
         }
     }
 
+    /// Keep MapLibre's built-in selection highlight in sync with the
+    /// SwiftUI-owned `selectedPeerHash`. Selection is keyed on the peer hash
+    /// (the source of truth), never on the annotation object: MapLibre
+    /// reuses and rebuilds annotation views on every telemetry tick, so an
+    /// object-identity-based selection can go stale. Also drops the highlight
+    /// when the selection is cleared (sheet dismissed, peer removed, stale
+    /// pin vanished) so a dimmed ghost pin can't linger.
+    private func updateSelection(on mapView: MLNMapView, coordinator: Coordinator) {
+        if let selectedHash = selectedPeerHash,
+           let annotation = coordinator.peerAnnotations[selectedHash] {
+            // No-op when the same annotation is already selected: a newer
+            // telemetry tick for the selected peer re-runs this path and we
+            // must not restart the selection animation on every update.
+            if annotation !== coordinator.lastSelectedAnnotation {
+                mapView.selectAnnotation(annotation, animated: true)
+                coordinator.lastSelectedAnnotation = annotation
+            }
+        } else if let last = coordinator.lastSelectedAnnotation {
+            if mapView.selectedAnnotations.contains(where: { $0 === last }) {
+                mapView.deselectAnnotation(last, animated: true)
+            }
+            coordinator.lastSelectedAnnotation = nil
+        }
+    }
+
     // MARK: - Coordinator
 
     final class Coordinator: NSObject, MLNMapViewDelegate, MLNNetworkConfigurationDelegate {
@@ -162,6 +205,17 @@ struct MapLibreMapView: UIViewRepresentable {
 
         /// Tracks peer annotations by hash for efficient updates.
         var peerAnnotations: [Data: PeerPointAnnotation] = [:]
+
+        /// Fired when the user taps a peer pin (main thread).
+        var onPeerTapped: ((Data) -> Void)?
+
+        /// Mirrors the map's user-location coordinate up to SwiftUI.
+        var onUserLocationChanged: ((CLLocationCoordinate2D?) -> Void)?
+
+        /// Last annotation the representable selected programmatically.
+        /// Guards against re-selecting the same object every tick (which
+        /// would restart the selection animation on every peer update).
+        var lastSelectedAnnotation: MLNAnnotation?
 
         init(metersPerPixel: Binding<Double>) {
             _metersPerPixel = metersPerPixel
@@ -196,11 +250,38 @@ struct MapLibreMapView: UIViewRepresentable {
         }
 
         func mapView(_ mapView: MLNMapView, didUpdate userLocation: MLNUserLocation?) {
-            guard !didCenterOnFirstLocation,
-                  let coordinate = userLocation?.coordinate,
+            let coordinate = userLocation?.coordinate
+            let valid = coordinate.flatMap { CLLocationCoordinate2DIsValid($0) ? $0 : nil }
+            onUserLocationChanged?(valid)
+            guard !didCenterOnFirstLocation, let coordinate,
                   CLLocationCoordinate2DIsValid(coordinate) else { return }
             didCenterOnFirstLocation = true
             mapView.setCenter(coordinate, zoomLevel: 13, animated: true)
+        }
+
+        // MARK: - Annotation selection (peer pin taps)
+
+        /// MapLibre annotation views are tappable by default (`enabled` is
+        /// YES); this reports the tapped peer up to SwiftUI, which presents
+        /// the contact sheet and re-asserts the selection highlight.
+        func mapView(_ mapView: MLNMapView, didSelectAnnotation annotation: MLNAnnotation) {
+            guard let peerAnnotation = annotation as? PeerPointAnnotation else { return }
+            onPeerTapped?(peerAnnotation.peerHash)
+        }
+
+        func mapView(_ mapView: MLNMapView, didDeselectAnnotation annotation: MLNAnnotation) {
+            // MapLibre deselects the previous pin when a new one is tapped;
+            // the SwiftUI binding (the source of truth) already points at the
+            // newly selected peer, so there is nothing to mirror back. This
+            // hook exists so a future "tap empty map to close the sheet"
+            // behavior has a natural place to clear `selectedPeerHash`.
+        }
+
+        /// Suppress the built-in MapLibre callout bubble: the contact sheet
+        /// (driven by `onPeerTapped`) is the only selection UI, so a
+        /// redundant title/subtitle callout would flash on every tap.
+        func mapView(_ mapView: MLNMapView, annotationCanShowCallout annotation: MLNAnnotation) -> Bool {
+            return annotation is PeerPointAnnotation ? false : true
         }
 
         func mapView(_ mapView: MLNMapView, viewFor annotation: MLNAnnotation) -> MLNAnnotationView? {
@@ -215,6 +296,17 @@ struct MapLibreMapView: UIViewRepresentable {
                 annotationView = MLNAnnotationView(annotation: annotation, reuseIdentifier: reuseId)
                 annotationView?.frame = CGRect(x: 0, y: 0, width: 32, height: 32)
             }
+            // XCUITest/Maestro addressability: the pin itself is a real UIView
+            // (unlike the GL-drawn map), so the interop suite can tap it
+            // directly instead of guessing where the marker landed.
+            // `accessibilityElement = true` + a label are required for the
+            // view to be reachable at all - an identifier alone is ignored by
+            // the accessibility tree (the view is reused, so set these on
+            // every refresh, not just first creation).
+            annotationView?.accessibilityIdentifier = "peer_pin_\(peerAnnotation.peerHash.map { String(format: "%02x", $0) }.joined())"
+            annotationView?.isAccessibilityElement = true
+            annotationView?.accessibilityLabel = peerAnnotation.title ?? "Peer location"
+            annotationView?.accessibilityTraits = .button
 
             // Create marker circle with MDI icon or initial fallback
             let markerColor: UIColor

--- a/Sources/ColumbaApp/Views/Map/MapLibreMapView.swift
+++ b/Sources/ColumbaApp/Views/Map/MapLibreMapView.swift
@@ -178,7 +178,7 @@ struct MapLibreMapView: UIViewRepresentable {
             // telemetry tick for the selected peer re-runs this path and we
             // must not restart the selection animation on every update.
             if annotation !== coordinator.lastSelectedAnnotation {
-                mapView.selectAnnotation(annotation, animated: true)
+                mapView.selectAnnotation(annotation, animated: true, completionHandler: nil)
                 coordinator.lastSelectedAnnotation = annotation
             }
         } else if let last = coordinator.lastSelectedAnnotation {
@@ -264,12 +264,12 @@ struct MapLibreMapView: UIViewRepresentable {
         /// MapLibre annotation views are tappable by default (`enabled` is
         /// YES); this reports the tapped peer up to SwiftUI, which presents
         /// the contact sheet and re-asserts the selection highlight.
-        func mapView(_ mapView: MLNMapView, didSelectAnnotation annotation: MLNAnnotation) {
+        func mapView(_ mapView: MLNMapView, didSelect annotation: MLNAnnotation) {
             guard let peerAnnotation = annotation as? PeerPointAnnotation else { return }
             onPeerTapped?(peerAnnotation.peerHash)
         }
 
-        func mapView(_ mapView: MLNMapView, didDeselectAnnotation annotation: MLNAnnotation) {
+        func mapView(_ mapView: MLNMapView, didDeselect annotation: MLNAnnotation) {
             // MapLibre deselects the previous pin when a new one is tapped;
             // the SwiftUI binding (the source of truth) already points at the
             // newly selected peer, so there is nothing to mirror back. This

--- a/Sources/ColumbaApp/Views/Map/MapView.swift
+++ b/Sources/ColumbaApp/Views/Map/MapView.swift
@@ -252,8 +252,7 @@ struct MapView: View {
     /// Directions button: one installed maps app → launch it directly (fewer
     /// taps); both installed → let the user choose (Apple Maps first).
     private func launchDirections(for peer: PeerLocation) {
-        let coordinate = CLLocationCoordinate2D(latitude: peer.latitude, longitude: peer.longitude)
-        let providers = directionsLauncher.providers(for: coordinate)
+        let providers = directionsLauncher.providers(for: peer.coordinate)
         if providers.count == 1 {
             directionsLauncher.open(providers[0])
         } else {
@@ -261,9 +260,7 @@ struct MapView: View {
         }
     }
 
-    private var directionsLauncher: DirectionsLauncher {
-        DirectionsLauncher()
-    }
+    private let directionsLauncher = DirectionsLauncher()
 
     private func loadContacts() async {
         // Read conversations from the GRDB canonical store (Track A0) via the

--- a/Sources/ColumbaApp/Views/Map/MapView.swift
+++ b/Sources/ColumbaApp/Views/Map/MapView.swift
@@ -15,6 +15,11 @@ import CoreLocation
 struct MapView: View {
     var appServices: AppServices
     var mapHttpEnabled: Bool = true
+    /// Cross-tab route raised by the peer contact sheet's Message button.
+    /// Carries the peer's destination hash up to MainTabView, which switches
+    /// to the Chats tab and hands the hash to ChatsView for opening the
+    /// conversation (session-route precedent: `shouldOpenInterfaceManagement`).
+    var onOpenPeerChat: ((Data) -> Void)? = nil
 
     private var locationSharingManager: LocationSharingManager? {
         appServices.locationSharingManager
@@ -30,6 +35,18 @@ struct MapView: View {
     @State private var offlineMapManager = OfflineMapManager()
     @State private var showShareSheet = false
     @State private var contacts: [ConversationRecord] = []
+    /// The tapped peer's hash. Non-nil presents the contact sheet and
+    /// highlights the pin. Derived from the live `peerLocations` dictionary,
+    /// so the sheet updates in place while telemetry keeps arriving; if the
+    /// peer's entry disappears (cease, stale cleanup, removal) the sheet
+    /// auto-dismisses via `onPeerGone`.
+    @State private var selectedPeerHash: Data?
+    /// The user's own coordinate for distance/direction math, mirrored up
+    /// from the map's userLocation callback.
+    @State private var userCoordinate: CLLocationCoordinate2D?
+    /// Maps-app choices for the directions chooser; non-nil presents the
+    /// "Apple Maps / Google Maps" picker.
+    @State private var directionsProvider: [DirectionsProvider]?
 
     var body: some View {
         NavigationStack {
@@ -37,10 +54,17 @@ struct MapView: View {
             MapLibreMapView(
                 centerOnUser: $centerOnUser,
                 metersPerPixel: $metersPerPixel,
+                selectedPeerHash: $selectedPeerHash,
                 showsUserLocation: locationAuthorized,
                 peerLocations: locationSharingManager.map { Array($0.peerLocations.values) } ?? [],
                 httpEnabled: mapHttpEnabled,
-                isDark: ThemeManager.shared.isDarkMode
+                isDark: ThemeManager.shared.isDarkMode,
+                onPeerTapped: { hash in
+                    selectedPeerHash = hash
+                },
+                onUserLocationChanged: { coordinate in
+                    userCoordinate = coordinate
+                }
             )
             .ignoresSafeArea()
 
@@ -123,6 +147,7 @@ struct MapView: View {
                                 .clipShape(Circle())
                                 .shadow(color: .black.opacity(0.3), radius: 4, y: 2)
                         }
+                        .accessibilityIdentifier("map_center_on_user")
                     }
                     .padding(.trailing, 16)
                     .padding(.bottom, 8)
@@ -150,7 +175,94 @@ struct MapView: View {
             )
             .presentationDetents([.large])
         }
+        .sheet(isPresented: Binding(
+            get: { selectedPeerHash != nil && selectedPeer != nil },
+            set: { if !$0 { clearPeerSelection() } }
+        )) {
+            peerContactSheet
+        }
+        .confirmationDialog(
+            String(localized: "Open Directions in:"),
+            isPresented: Binding(
+                get: { directionsProvider != nil },
+                set: { if !$0 { directionsProvider = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            ForEach(directionsProvider ?? []) { provider in
+                Button(provider.name) {
+                    let chosen = provider
+                    directionsProvider = nil
+                    directionsLauncher.open(chosen)
+                }
+            }
+            Button(String(localized: "Cancel"), role: .cancel) {
+                directionsProvider = nil
+            }
+        }
         } // NavigationStack
+    }
+
+    // MARK: - Peer contact sheet (tappable pin)
+
+    /// The live peer behind `selectedPeerHash`. Re-derived on every update so
+    /// a newer telemetry tick refreshes the sheet in place while it is open.
+    private var selectedPeer: PeerLocation? {
+        guard let hash = selectedPeerHash else { return nil }
+        return locationSharingManager?.peerLocations[hash]
+    }
+
+    /// Auto-dismiss when the selected peer's entry disappears from
+    /// `peerLocations` (cease signal, stale cleanup, or Remove from map).
+    /// `.onChange` on the derived peer's id fires when the id goes nil too.
+    private var peerContactSheet: some View {
+        Group {
+            if let peer = selectedPeer {
+                PeerContactSheet(
+                    peer: peer,
+                    userCoordinate: userCoordinate,
+                    onDirections: { launchDirections(for: peer) },
+                    onMessage: {
+                        let hash = peer.id
+                        clearPeerSelection()
+                        onOpenPeerChat?(hash)
+                    },
+                    onRemove: {
+                        locationSharingManager?.removePeerLocation(peer.id)
+                        clearPeerSelection()
+                    },
+                    onDismiss: { clearPeerSelection() }
+                )
+            }
+        }
+        .presentationDetents([.medium, .large])
+        .onChange(of: selectedPeer?.id) { _, id in
+            // The peer vanished from the live dictionary while the sheet was
+            // open: lift the selection so the sheet closes itself.
+            if id == nil, selectedPeerHash != nil {
+                clearPeerSelection()
+            }
+        }
+    }
+
+    private func clearPeerSelection() {
+        selectedPeerHash = nil
+    }
+
+    /// Directions button: one installed maps app → launch it directly (fewer
+    /// taps); both installed → let the user choose (Apple Maps first).
+    private func launchDirections(for peer: PeerLocation) {
+        let coordinate = CLLocationCoordinate2D(latitude: peer.latitude, longitude: peer.longitude)
+        let providers = directionsLauncher.providers(for: coordinate)
+        if providers.count == 1 {
+            directionsLauncher.open(providers[0])
+        } else {
+            directionsProvider = providers
+        }
+    }
+
+    private var directionsLauncher: DirectionsLauncher {
+        DirectionsLauncher()
     }
 
     private func loadContacts() async {

--- a/Sources/ColumbaApp/Views/Map/PeerContactSheet.swift
+++ b/Sources/ColumbaApp/Views/Map/PeerContactSheet.swift
@@ -64,10 +64,22 @@ struct PeerContactSheet: View {
 
                 VStack(alignment: .leading, spacing: 2) {
                     HStack(spacing: 8) {
+                        // `peer_sheet_name` lives on the name Text itself, NOT
+                        // on the sheet root. Putting it on the root together
+                        // with `.accessibilityElement(children: .contain)`
+                        // made the whole sheet one accessibility element: the
+                        // container's identifier was inherited by every
+                        // descendant (all buttons reported
+                        // `peer_sheet_name`) and the buttons' own
+                        // identifiers (`peer_sheet_message` etc.) never
+                        // surfaced, so Maestro could not address them. The
+                        // name Text is the stable element the interop suite
+                        // waits on to confirm the sheet presented.
                         Text(displayName)
                             .font(.title3.bold())
                             .foregroundStyle(Theme.textPrimary)
                             .lineLimit(1)
+                            .accessibilityIdentifier("peer_sheet_name")
                         if peer.isStale {
                             Text(String(localized: "Stale"))
                                 .font(.caption2.weight(.medium))
@@ -159,9 +171,15 @@ struct PeerContactSheet: View {
         }
         .padding(.bottom, 16)
         .background(Theme.backgroundPrimary)
-        .accessibilityIdentifier("peer_sheet_name")
-        .accessibilityElement(children: .contain)
-        .accessibilityLabel(Text(displayName))
+        // No `.accessibilityElement(children: .contain)` + root
+        // `accessibilityIdentifier` here: that combination collapses the
+        // whole sheet into one accessibility element, hides the buttons'
+        // own identifiers, and stamps the root id onto every descendant
+        // (verified in the live a11y hierarchy: the Directions/Message
+        // rows reported `resource-id: peer_sheet_name` and
+        // `peer_sheet_message`/`peer_sheet_directions`/`peer_sheet_remove`
+        // were absent). Leave the default `.contain`-ish traversal so each
+        // control keeps its own identifier and label.
         .onReceive(ticker) { tick in
             now = tick
         }

--- a/Sources/ColumbaApp/Views/Map/PeerContactSheet.swift
+++ b/Sources/ColumbaApp/Views/Map/PeerContactSheet.swift
@@ -1,0 +1,174 @@
+//
+//  PeerContactSheet.swift
+//  ColumbaApp
+//
+//  Bottom sheet shown when a peer map pin is tapped. Mirrors Android
+//  Columba's ContactLocationBottomSheet: 48pt profile icon (dimmed when
+//  stale), display name + Stale badge, "Updated …" line, distance and
+//  direction from the user, Directions/Message buttons, and a
+//  Remove-from-map action for stale peers (a peer that goes quiet
+//  without sending CEASE must not leave a pin with no escape hatch).
+//
+
+import SwiftUI
+#if os(iOS)
+import CoreLocation
+#endif
+
+#if os(iOS)
+@available(iOS 17.0, *)
+struct PeerContactSheet: View {
+    let peer: PeerLocation
+    let userCoordinate: CLLocationCoordinate2D?
+    let onDirections: () -> Void
+    let onMessage: () -> Void
+    let onRemove: () -> Void
+    let onDismiss: () -> Void
+
+    @State private var now = Date()
+
+    /// The sheet stays live: a newer telemetry tick for the same peer
+    /// refreshes `peer` from MapView's derived binding, and a periodic
+    /// tick keeps the "Updated …" line moving while the sheet is open.
+    private let ticker = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
+
+    private var displayName: String {
+        peer.displayName ?? peer.shortHash
+    }
+
+    private var distanceText: String {
+        PeerLocationFormatting.formatDistanceAndDirection(
+            userCoordinate: userCoordinate,
+            peerLatitude: peer.latitude,
+            peerLongitude: peer.longitude
+        )
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Handle bar
+            RoundedRectangle(cornerRadius: 2.5)
+                .fill(Color.secondary.opacity(0.4))
+                .frame(width: 36, height: 5)
+                .padding(.top, 8)
+
+            // Avatar, name, and last updated (Android parity row)
+            HStack(spacing: 16) {
+                ProfileIcon(
+                    iconName: peer.iconAppearance?.iconName,
+                    foregroundColor: peer.iconAppearance?.foregroundColor,
+                    backgroundColor: peer.iconAppearance?.backgroundColor,
+                    fallbackHash: peer.id,
+                    size: 48
+                )
+                .opacity(peer.isStale ? 0.6 : 1.0)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack(spacing: 8) {
+                        Text(displayName)
+                            .font(.title3.bold())
+                            .foregroundStyle(Theme.textPrimary)
+                            .lineLimit(1)
+                        if peer.isStale {
+                            Text(String(localized: "Stale"))
+                                .font(.caption2.weight(.medium))
+                                .foregroundStyle(.secondary)
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 2)
+                                .background(Color.secondary.opacity(0.15))
+                                .clipShape(RoundedRectangle(cornerRadius: 4))
+                        }
+                    }
+                    Text(PeerLocationFormatting.formatUpdatedTime(peer.lastUpdate, now: now))
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(.horizontal, 24)
+            .padding(.top, 16)
+
+            // Distance and direction
+            Text(distanceText)
+                .font(.body)
+                .foregroundStyle(Theme.textPrimary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 24)
+                .padding(.top, 16)
+
+            // Action buttons
+            HStack(spacing: 12) {
+                Button(action: onDirections) {
+                    HStack(spacing: 8) {
+                        Image(systemName: "arrow.triangle.turn.up.right.diamond")
+                            .font(.system(size: 16))
+                        Text(String(localized: "Directions"))
+                    }
+                    .font(.body)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 12)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12)
+                            .strokeBorder(Theme.textPrimary.opacity(0.4), lineWidth: 1)
+                    )
+                    .foregroundStyle(Theme.textPrimary)
+                    .contentShape(RoundedRectangle(cornerRadius: 12))
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("peer_sheet_directions")
+
+                Button(action: onMessage) {
+                    HStack(spacing: 8) {
+                        Image(systemName: "message.fill")
+                            .font(.system(size: 16))
+                        Text(String(localized: "Message"))
+                    }
+                    .font(.body)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 12)
+                    .background(Theme.accentColor)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                    .foregroundStyle(.white)
+                    .contentShape(RoundedRectangle(cornerRadius: 12))
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("peer_sheet_message")
+            }
+            .padding(.horizontal, 24)
+            .padding(.top, 24)
+
+            // Remove marker (stale peers only - Android parity)
+            if peer.isStale {
+                Button(action: onRemove) {
+                    HStack(spacing: 8) {
+                        Image(systemName: "xmark")
+                            .font(.system(size: 16))
+                        Text(String(localized: "Remove from map"))
+                    }
+                    .font(.body)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 12)
+                    .foregroundStyle(Theme.error)
+                    .contentShape(RoundedRectangle(cornerRadius: 12))
+                }
+                .buttonStyle(.plain)
+                .padding(.horizontal, 24)
+                .padding(.top, 8)
+                .accessibilityIdentifier("peer_sheet_remove")
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(.bottom, 16)
+        .background(Theme.backgroundPrimary)
+        .accessibilityIdentifier("peer_sheet_name")
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(Text(displayName))
+        .onReceive(ticker) { tick in
+            now = tick
+        }
+        .onAppear {
+            now = Date()
+        }
+    }
+}
+#endif

--- a/Sources/ColumbaApp/Views/Map/PeerContactSheet.swift
+++ b/Sources/ColumbaApp/Views/Map/PeerContactSheet.swift
@@ -39,8 +39,7 @@ struct PeerContactSheet: View {
     private var distanceText: String {
         PeerLocationFormatting.formatDistanceAndDirection(
             userCoordinate: userCoordinate,
-            peerLatitude: peer.latitude,
-            peerLongitude: peer.longitude
+            peerCoordinate: peer.coordinate
         )
     }
 

--- a/Sources/ColumbaApp/Views/Map/PeerLocationFormatting.swift
+++ b/Sources/ColumbaApp/Views/Map/PeerLocationFormatting.swift
@@ -1,0 +1,93 @@
+//
+//  PeerLocationFormatting.swift
+//  ColumbaApp
+//
+//  Pure formatting helpers for the peer map contact sheet: distance +
+//  direction from the user, compass bearing buckets, and relative
+//  "Updated …" timestamps. Behavior-matches Android Columba's
+//  ContactLocationBottomSheet helpers (22.5-degree compass buckets,
+//  <10s "just now" / s / m / h / d time buckets, <1km meters else 1-decimal km).
+//
+
+import CoreLocation
+import Foundation
+
+enum PeerLocationFormatting {
+    /// Map an initial bearing (degrees, 0 = north, clockwise) to one of the
+    /// 8 compass words, using Android's 22.5-degree bucket boundaries.
+    /// Negative and >360 inputs are normalized first.
+    static func bearingToCompassDirection(_ bearing: Double) -> String {
+        let normalized = (bearing + 360).truncatingRemainder(dividingBy: 360)
+        switch normalized {
+        case ..<22.5, 337.5...:
+            return String(localized: "north")
+        case ..<67.5:
+            return String(localized: "northeast")
+        case ..<112.5:
+            return String(localized: "east")
+        case ..<157.5:
+            return String(localized: "southeast")
+        case ..<202.5:
+            return String(localized: "south")
+        case ..<247.5:
+            return String(localized: "southwest")
+        case ..<292.5:
+            return String(localized: "west")
+        default:
+            return String(localized: "northwest")
+        }
+    }
+
+    /// Initial great-circle bearing from `from` to `to` in degrees (0-360).
+    /// Same quantity Android's `Location.distanceBetween` reports in its
+    /// results array, so the two platforms agree on the compass word.
+    static func initialBearing(from: CLLocation, to: CLLocation) -> Double {
+        let phi1 = from.coordinate.latitude * .pi / 180
+        let phi2 = to.coordinate.latitude * .pi / 180
+        let deltaLambda = (to.coordinate.longitude - from.coordinate.longitude) * .pi / 180
+        let y = sin(deltaLambda) * cos(phi2)
+        let x = cos(phi1) * sin(phi2) - sin(phi1) * cos(phi2) * cos(deltaLambda)
+        let theta = atan2(y, x) * 180 / .pi
+        return (theta + 360).truncatingRemainder(dividingBy: 360)
+    }
+
+    /// "450m southeast" / "1.2km northwest", or "Location unknown" when the
+    /// user's own location is unavailable. Matches Android's
+    /// `formatDistanceAndDirection` (truncated meters below 1km, one decimal
+    /// place in km above).
+    static func formatDistanceAndDirection(
+        userCoordinate: CLLocationCoordinate2D?,
+        peerLatitude: Double,
+        peerLongitude: Double
+    ) -> String {
+        guard let userCoordinate else {
+            return String(localized: "Location unknown")
+        }
+        let from = CLLocation(latitude: userCoordinate.latitude, longitude: userCoordinate.longitude)
+        let to = CLLocation(latitude: peerLatitude, longitude: peerLongitude)
+        let meters = from.distance(from: to)
+        let bearing = initialBearing(from: from, to: to)
+        let distanceText = meters < 1000
+            ? "\(Int(meters))m"
+            : String(format: "%.1fkm", meters / 1000)
+        return "\(distanceText) \(bearingToCompassDirection(bearing))"
+    }
+
+    /// "Updated just now" / "Updated 30s ago" / "Updated 5m ago" /
+    /// "Updated 2h ago" / "Updated 3d ago" with Android's thresholds
+    /// (<10s, <1m, <1h, <1d). `now` is injectable for tests.
+    static func formatUpdatedTime(_ lastUpdate: Date, now: Date = Date()) -> String {
+        let diffSeconds = now.timeIntervalSince(lastUpdate)
+        if diffSeconds < 10 {
+            return String(localized: "Updated just now")
+        } else if diffSeconds < 60 {
+            return String(localized: "Updated %llds ago", Int(diffSeconds))
+        } else if diffSeconds < 3600 {
+            return String(localized: "Updated %lldm ago", Int(diffSeconds / 60))
+        } else if diffSeconds < 86400 {
+            return String(localized: "Updated %lldh ago", Int(diffSeconds / 3600))
+        } else {
+            return String(localized: "Updated %lldd ago", Int(diffSeconds / 86400))
+        }
+    }
+}

--- a/Sources/ColumbaApp/Views/Map/PeerLocationFormatting.swift
+++ b/Sources/ColumbaApp/Views/Map/PeerLocationFormatting.swift
@@ -80,13 +80,13 @@ enum PeerLocationFormatting {
         if diffSeconds < 10 {
             return String(localized: "Updated just now")
         } else if diffSeconds < 60 {
-            return String(localized: "Updated %llds ago", Int(diffSeconds))
+            return String(localized: "Updated \(Int(diffSeconds))s ago")
         } else if diffSeconds < 3600 {
-            return String(localized: "Updated %lldm ago", Int(diffSeconds / 60))
+            return String(localized: "Updated \(Int(diffSeconds / 60))m ago")
         } else if diffSeconds < 86400 {
-            return String(localized: "Updated %lldh ago", Int(diffSeconds / 3600))
+            return String(localized: "Updated \(Int(diffSeconds / 3600))h ago")
         } else {
-            return String(localized: "Updated %lldd ago", Int(diffSeconds / 86400))
+            return String(localized: "Updated \(Int(diffSeconds / 86400))d ago")
         }
     }
 }

--- a/Sources/ColumbaApp/Views/Map/PeerLocationFormatting.swift
+++ b/Sources/ColumbaApp/Views/Map/PeerLocationFormatting.swift
@@ -57,14 +57,13 @@ enum PeerLocationFormatting {
     /// place in km above).
     static func formatDistanceAndDirection(
         userCoordinate: CLLocationCoordinate2D?,
-        peerLatitude: Double,
-        peerLongitude: Double
+        peerCoordinate: CLLocationCoordinate2D
     ) -> String {
         guard let userCoordinate else {
             return String(localized: "Location unknown")
         }
         let from = CLLocation(latitude: userCoordinate.latitude, longitude: userCoordinate.longitude)
-        let to = CLLocation(latitude: peerLatitude, longitude: peerLongitude)
+        let to = CLLocation(latitude: peerCoordinate.latitude, longitude: peerCoordinate.longitude)
         let meters = from.distance(from: to)
         let bearing = initialBearing(from: from, to: to)
         let distanceText = meters < 1000

--- a/Sources/RNSAPI/Compat.swift
+++ b/Sources/RNSAPI/Compat.swift
@@ -2252,7 +2252,8 @@ public final class LocationSharingManager: @unchecked Sendable {
         iconAppearance: IconAppearance? = nil
     ) {}
     public func stopAllSharing() async {}
-    public func setBackgroundState(_ isBackground: Bool) {}
+    public func setBackgroundState(_ inBackground: Bool) {}
+    public func removePeerLocation(_ peerHash: Data) {}
 }
 #endif
 

--- a/Tests/ColumbaAppTests/DirectionsLauncherTests.swift
+++ b/Tests/ColumbaAppTests/DirectionsLauncherTests.swift
@@ -1,0 +1,55 @@
+//
+//  DirectionsLauncherTests.swift
+//  ColumbaAppTests
+//
+//  Pins the directions-provider listing: Apple Maps is always offered,
+//  Google Maps only when its scheme probe reports installed, and the
+//  Google deep link carries daddr + walking mode. The probe seam makes
+//  the chooser logic unit-testable without UIApplication.
+//
+
+#if os(iOS)
+import CoreLocation
+import XCTest
+@testable import ColumbaApp
+
+@available(iOS 17.0, *)
+final class DirectionsLauncherTests: XCTestCase {
+
+    /// Fixed probe whose answer is scripted per scheme.
+    final class FixedProbe: DirectionsLauncher.SchemeProbe {
+        let installed: Set<String>
+        init(installed: Set<String>) { self.installed = installed }
+        func canOpen(scheme: String) -> Bool { installed.contains(scheme) }
+    }
+
+    private let coordinate = CLLocationCoordinate2D(latitude: 37.7749, longitude: -122.4194)
+
+    func test_apple_maps_always_listed_first() {
+        let launcher = DirectionsLauncher(probe: FixedProbe(installed: []))
+        let providers = launcher.providers(for: coordinate)
+        XCTAssertEqual(providers.map(\.id), ["apple"])
+        XCTAssertEqual(providers[0].name, "Apple Maps")
+    }
+
+    func test_google_maps_listed_second_only_when_installed() {
+        let withGoogle = DirectionsLauncher(probe: FixedProbe(installed: ["comgooglemaps"]))
+        XCTAssertEqual(withGoogle.providers(for: coordinate).map(\.id), ["apple", "google"])
+
+        let withoutGoogle = DirectionsLauncher(probe: FixedProbe(installed: []))
+        XCTAssertEqual(withoutGoogle.providers(for: coordinate).map(\.id), ["apple"])
+    }
+
+    func test_google_maps_deep_link_covers_destination_and_walking_mode() {
+        let url = DirectionsLauncher.googleMapsURL(for: coordinate)
+        XCTAssertEqual(url.absoluteString, "comgooglemaps://?daddr=37.7749,-122.4194&directionsmode=walking")
+    }
+
+    func test_provider_urls() {
+        let launcher = DirectionsLauncher(probe: FixedProbe(installed: ["comgooglemaps"]))
+        let providers = launcher.providers(for: coordinate)
+        XCTAssertNil(providers[0].url) // Apple Maps launches via MapKit
+        XCTAssertEqual(providers[1].url, DirectionsLauncher.googleMapsURL(for: coordinate))
+    }
+}
+#endif

--- a/Tests/ColumbaAppTests/PeerLocationFormattingTests.swift
+++ b/Tests/ColumbaAppTests/PeerLocationFormattingTests.swift
@@ -65,8 +65,7 @@ final class PeerLocationFormattingTests: XCTestCase {
     func test_distance_unknown_when_user_location_is_nil() {
         let text = PeerLocationFormatting.formatDistanceAndDirection(
             userCoordinate: nil,
-            peerLatitude: 37.7749,
-            peerLongitude: -122.4194
+            peerCoordinate: CLLocationCoordinate2D(latitude: 37.7749, longitude: -122.4194)
         )
         XCTAssertEqual(text, "Location unknown")
     }
@@ -76,8 +75,7 @@ final class PeerLocationFormattingTests: XCTestCase {
         // 0.005 degrees ≈ 442 m.
         let text = PeerLocationFormatting.formatDistanceAndDirection(
             userCoordinate: CLLocationCoordinate2D(latitude: 37.7749, longitude: -122.4194),
-            peerLatitude: 37.7749,
-            peerLongitude: -122.4144
+            peerCoordinate: CLLocationCoordinate2D(latitude: 37.7749, longitude: -122.4144)
         )
         let components = text.split(separator: " ")
         XCTAssertEqual(components.count, 2)
@@ -92,8 +90,7 @@ final class PeerLocationFormattingTests: XCTestCase {
         // ~1.2 km due east (0.0136 deg ≈ 1203 m at 37.7N).
         let text = PeerLocationFormatting.formatDistanceAndDirection(
             userCoordinate: CLLocationCoordinate2D(latitude: 37.7749, longitude: -122.4194),
-            peerLatitude: 37.7749,
-            peerLongitude: -122.4058
+            peerCoordinate: CLLocationCoordinate2D(latitude: 37.7749, longitude: -122.4058)
         )
         XCTAssertEqual(text, "1.2km east")
     }

--- a/Tests/ColumbaAppTests/PeerLocationFormattingTests.swift
+++ b/Tests/ColumbaAppTests/PeerLocationFormattingTests.swift
@@ -35,7 +35,9 @@ final class PeerLocationFormattingTests: XCTestCase {
 
     func test_compass_normalizes_negative_and_oversized_bearings() {
         XCTAssertEqual(PeerLocationFormatting.bearingToCompassDirection(-90), "west")
-        XCTAssertEqual(PeerLocationFormatting.bearingToCompassDirection(450), "northeast")
+        // 450 normalizes to 90 = due east (the test is about normalization,
+        // not a specific quadrant).
+        XCTAssertEqual(PeerLocationFormatting.bearingToCompassDirection(450), "east")
         XCTAssertEqual(PeerLocationFormatting.bearingToCompassDirection(-45), "northwest")
     }
 

--- a/Tests/ColumbaAppTests/PeerLocationFormattingTests.swift
+++ b/Tests/ColumbaAppTests/PeerLocationFormattingTests.swift
@@ -1,0 +1,124 @@
+//
+//  PeerLocationFormattingTests.swift
+//  ColumbaAppTests
+//
+//  Pins the peer contact sheet's pure formatting helpers against the
+//  Android Columba behavior they mirror: 22.5-degree compass buckets,
+//  initial-bearing math, meter/km distance rounding, and the
+//  "Updated …" relative-time thresholds.
+//
+
+#if os(iOS)
+import CoreLocation
+import XCTest
+@testable import ColumbaApp
+
+@available(iOS 17.0, *)
+final class PeerLocationFormattingTests: XCTestCase {
+
+    // MARK: - Compass buckets (Android bearingToDirection boundaries)
+
+    func test_compass_boundaries_and_buckets() {
+        XCTAssertEqual(PeerLocationFormatting.bearingToCompassDirection(0), "north")
+        XCTAssertEqual(PeerLocationFormatting.bearingToCompassDirection(22.4), "north")
+        XCTAssertEqual(PeerLocationFormatting.bearingToCompassDirection(22.5), "northeast")
+        XCTAssertEqual(PeerLocationFormatting.bearingToCompassDirection(45), "northeast")
+        XCTAssertEqual(PeerLocationFormatting.bearingToCompassDirection(67.5), "east")
+        XCTAssertEqual(PeerLocationFormatting.bearingToCompassDirection(112.5), "southeast")
+        XCTAssertEqual(PeerLocationFormatting.bearingToCompassDirection(157.5), "south")
+        XCTAssertEqual(PeerLocationFormatting.bearingToCompassDirection(202.5), "southwest")
+        XCTAssertEqual(PeerLocationFormatting.bearingToCompassDirection(247.5), "west")
+        XCTAssertEqual(PeerLocationFormatting.bearingToCompassDirection(292.5), "northwest")
+        XCTAssertEqual(PeerLocationFormatting.bearingToCompassDirection(337.5), "north")
+        XCTAssertEqual(PeerLocationFormatting.bearingToCompassDirection(359.9), "north")
+    }
+
+    func test_compass_normalizes_negative_and_oversized_bearings() {
+        XCTAssertEqual(PeerLocationFormatting.bearingToCompassDirection(-90), "west")
+        XCTAssertEqual(PeerLocationFormatting.bearingToCompassDirection(450), "northeast")
+        XCTAssertEqual(PeerLocationFormatting.bearingToCompassDirection(-45), "northwest")
+    }
+
+    // MARK: - Initial bearing math (known city pairs)
+
+    func test_bearing_north_along_same_meridian() {
+        // Straight up a meridian: due north.
+        let from = CLLocation(latitude: 47.0, longitude: -122.0)
+        let to = CLLocation(latitude: 48.0, longitude: -122.0)
+        XCTAssertEqual(PeerLocationFormatting.initialBearing(from: from, to: to), 0, accuracy: 1e-6)
+    }
+
+    func test_bearing_seattle_to_boise_is_southeast() {
+        // Seattle (47.61, -122.33) → Boise (43.62, -116.20):
+        // both components point down-right, so the initial bearing must
+        // land inside the southeast bucket (112.5..157.5).
+        let from = CLLocation(latitude: 47.6062, longitude: -122.3321)
+        let to = CLLocation(latitude: 43.6150, longitude: -116.2023)
+        let bearing = PeerLocationFormatting.initialBearing(from: from, to: to)
+        XCTAssertGreaterThan(bearing, 112.5)
+        XCTAssertLessThan(bearing, 157.5)
+        XCTAssertEqual(PeerLocationFormatting.bearingToCompassDirection(bearing), "southeast")
+    }
+
+    // MARK: - Distance + direction formatting
+
+    func test_distance_unknown_when_user_location_is_nil() {
+        let text = PeerLocationFormatting.formatDistanceAndDirection(
+            userCoordinate: nil,
+            peerLatitude: 37.7749,
+            peerLongitude: -122.4194
+        )
+        XCTAssertEqual(text, "Location unknown")
+    }
+
+    func test_distance_under_one_kilometer_is_whole_meters() {
+        // ~450 m due east: 1 degree of longitude at 37.7N ≈ 88.4 km, so
+        // 0.005 degrees ≈ 442 m.
+        let text = PeerLocationFormatting.formatDistanceAndDirection(
+            userCoordinate: CLLocationCoordinate2D(latitude: 37.7749, longitude: -122.4194),
+            peerLatitude: 37.7749,
+            peerLongitude: -122.4144
+        )
+        let components = text.split(separator: " ")
+        XCTAssertEqual(components.count, 2)
+        XCTAssertEqual(components[1], "east")
+        let meters = Int(components[0].dropLast()) // strip trailing "m"
+        XCTAssertNotNil(meters)
+        XCTAssertGreaterThanOrEqual(meters!, 400)
+        XCTAssertLessThanOrEqual(meters!, 500)
+    }
+
+    func test_distance_over_one_kilometer_is_one_decimal_km() {
+        // ~1.2 km due east (0.0136 deg ≈ 1203 m at 37.7N).
+        let text = PeerLocationFormatting.formatDistanceAndDirection(
+            userCoordinate: CLLocationCoordinate2D(latitude: 37.7749, longitude: -122.4194),
+            peerLatitude: 37.7749,
+            peerLongitude: -122.4058
+        )
+        XCTAssertEqual(text, "1.2km east")
+    }
+
+    // MARK: - "Updated …" relative time (Android thresholds)
+
+    private func updated(_ secondsAgo: Double) -> String {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        return PeerLocationFormatting.formatUpdatedTime(
+            now.addingTimeInterval(-secondsAgo),
+            now: now
+        )
+    }
+
+    func test_updated_time_buckets() {
+        XCTAssertEqual(updated(0), "Updated just now")
+        XCTAssertEqual(updated(9.9), "Updated just now")
+        XCTAssertEqual(updated(10), "Updated 10s ago")
+        XCTAssertEqual(updated(59), "Updated 59s ago")
+        XCTAssertEqual(updated(60), "Updated 1m ago")
+        XCTAssertEqual(updated(3599), "Updated 59m ago")
+        XCTAssertEqual(updated(3600), "Updated 1h ago")
+        XCTAssertEqual(updated(86399), "Updated 23h ago")
+        XCTAssertEqual(updated(86400), "Updated 1d ago")
+        XCTAssertEqual(updated(3 * 86400), "Updated 3d ago")
+    }
+}
+#endif

--- a/Tests/ColumbaAppTests/PeerLocationRemovalTests.swift
+++ b/Tests/ColumbaAppTests/PeerLocationRemovalTests.swift
@@ -1,0 +1,100 @@
+//
+//  PeerLocationRemovalTests.swift
+//  ColumbaAppTests
+//
+//  Pins the "Remove from map" contract on LocationSharingManager:
+//  removePeerLocation drops the in-memory entry, removal of an unknown
+//  hash is a no-op, and a peer that keeps transmitting resurrects its
+//  own pin on the next telemetry tick (removal is not a block).
+//
+
+#if os(iOS)
+import XCTest
+@testable import ColumbaApp
+
+@available(iOS 17.0, *)
+@MainActor
+final class PeerLocationRemovalTests: XCTestCase {
+
+    private static let peerHash: Data = (0...15).map { _ in UInt8(0xAB) }
+
+    /// Encode a valid FIELD_TELEMETRY payload with LXMF-swift's
+    /// Sideband-compatible Telemeter codec - the same shape the inbound
+    /// decode path in `handleIncomingTelemetry` expects.
+    private static func telemetryPayload(
+        latitude: Double,
+        longitude: Double,
+        lastUpdate: Date
+    ) -> Data {
+        let telemetry = LXMFSwift.LocationTelemetry(
+            latitude: latitude,
+            longitude: longitude,
+            altitude: 0,
+            speed: 0,
+            bearing: 0,
+            accuracy: 5,
+            lastUpdate: Int(lastUpdate.timeIntervalSince1970)
+        )
+        return LXMFSwift.TelemetryPacket(
+            timestamp: Int(Date().timeIntervalSince1970),
+            location: telemetry
+        ).encode()
+    }
+
+    private func makeManager() -> LocationSharingManager {
+        LocationSharingManager(appServices: AppServices())
+    }
+
+    private func receiveTelemetry(
+        _ manager: LocationSharingManager,
+        latitude: Double = 47.6062,
+        longitude: Double = -122.3321,
+        displayName: String? = "TestPeer"
+    ) {
+        manager.handleIncomingTelemetry(
+            from: Self.peerHash,
+            packet: RNSAPI.TelemetryPacket(payload: Self.telemetryPayload(
+                latitude: latitude,
+                longitude: longitude,
+                lastUpdate: Date()
+            )),
+            displayName: displayName
+        )
+    }
+
+    func test_removePeerLocation_drops_the_entry() {
+        let manager = makeManager()
+        receiveTelemetry(manager)
+        XCTAssertNotNil(manager.peerLocations[Self.peerHash])
+
+        manager.removePeerLocation(Self.peerHash)
+
+        XCTAssertNil(manager.peerLocations[Self.peerHash])
+    }
+
+    func test_removing_unknown_hash_is_a_no_op() {
+        let manager = makeManager()
+        receiveTelemetry(manager)
+        let otherHash: Data = (0...15).map { _ in UInt8(0x01) }
+
+        manager.removePeerLocation(otherHash)
+
+        XCTAssertNotNil(manager.peerLocations[Self.peerHash])
+    }
+
+    func test_peer_resurrects_on_next_telemetry_tick_after_removal() {
+        // Removal clears the in-memory pin, but a peer that is still
+        // transmitting re-announces itself on its next telemetry frame -
+        // the same reappear-on-resume behavior as Android. This test
+        // documents that contract: removal is not a block.
+        let manager = makeManager()
+        receiveTelemetry(manager)
+        manager.removePeerLocation(Self.peerHash)
+        XCTAssertNil(manager.peerLocations[Self.peerHash])
+
+        receiveTelemetry(manager)
+
+        XCTAssertNotNil(manager.peerLocations[Self.peerHash])
+    }
+}
+#endif

--- a/Tests/ColumbaAppTests/PeerLocationRemovalTests.swift
+++ b/Tests/ColumbaAppTests/PeerLocationRemovalTests.swift
@@ -9,14 +9,17 @@
 //
 
 #if os(iOS)
+import CoreLocation
 import XCTest
+import LXMFSwift
+import RNSAPI
 @testable import ColumbaApp
 
 @available(iOS 17.0, *)
 @MainActor
 final class PeerLocationRemovalTests: XCTestCase {
 
-    private static let peerHash: Data = (0...15).map { _ in UInt8(0xAB) }
+    private static let peerHash: Data = Data((0...15).map { _ in UInt8(0xAB) })
 
     /// Encode a valid FIELD_TELEMETRY payload with LXMF-swift's
     /// Sideband-compatible Telemeter codec - the same shape the inbound
@@ -75,7 +78,7 @@ final class PeerLocationRemovalTests: XCTestCase {
     func test_removing_unknown_hash_is_a_no_op() {
         let manager = makeManager()
         receiveTelemetry(manager)
-        let otherHash: Data = (0...15).map { _ in UInt8(0x01) }
+        let otherHash: Data = Data((0...15).map { _ in UInt8(0x01) })
 
         manager.removePeerLocation(otherHash)
 

--- a/Tests/interop/conftest.py
+++ b/Tests/interop/conftest.py
@@ -852,7 +852,10 @@ class Simulator:
             f"    timeout: {wait_ms}",
             "- takeScreenshot: { path: screenshots/peer-sheet }",
         ]
-        self._run_maestro_flow(lines, "peer_sheet", timeout=timeout)
+        # The flow has two `timeout`-long waits plus a preamble; give the
+        # subprocess a budget that covers both (a slow-but-working map must
+        # not be killed at the first wait's horizon).
+        self._run_maestro_flow(lines, "peer_sheet", timeout=timeout + 30)
 
     def assert_peer_sheet_message_opens_conversation(
         self, *, pin_id: str, timeout: float = 40.0
@@ -888,25 +891,33 @@ class Simulator:
             f"    timeout: {wait_ms}",
             "- takeScreenshot: { path: screenshots/peer-sheet-conversation }",
         ]
-        self._run_maestro_flow(lines, "peer_sheet_message", timeout=timeout)
+        # Three `timeout`-long waits + preamble; budget covers all of them.
+        self._run_maestro_flow(lines, "peer_sheet_message", timeout=timeout + 60)
 
     def assert_stale_peer_sheet_removes_pin(
-        self, *, pin_id: str, timeout: float = 40.0
+        self,
+        *,
+        pin_id: str,
+        expect_removed_peer: str,
+        timeout: float = 40.0,
     ) -> None:
         """Tap a stale peer's pin, assert the `peer_sheet_remove` action is
-        present (stale-only, Android parity), tap it, and assert that
-        specific pin disappears from the map.
+        present (stale-only, Android parity), tap it, and assert the app
+        dropped the pin.
 
         Pins the removal path: `onRemove` →
         `LocationSharingManager.removePeerLocation` → `peerLocations`
-        drops the entry → the GL annotation is removed and the sheet
+        drops the entry → the annotation is removed and the sheet
         auto-dismisses (its derived peer goes nil). A backdated frame makes
         the pin stale without waiting out the 5-minute freshness window.
 
-        The assertion is on the *specific* `peer_pin_<hex>` element going
-        away (not the `map_peer_count` badge) because the session-scoped
-        Sideband peer can accumulate alongside earlier tests' pins, so the
-        badge count is order-dependent while the individual pin is not."""
+        The drop is asserted off the `[LOC-REMOVE] peer=<hex>` diag line
+        (polling in Python, below) rather than the a11y tree: the pin
+        renders on MapLibre's GL surface, and this Maestro build has no
+        absence assertion (`gone:` is not a valid step property — the flow
+        would be rejected at parse time before any step ran). The diag
+        line is also per-peer, so it is not order-dependent the way the
+        `map_peer_count` badge is."""
         wait_ms = int(timeout * 1000)
         lines = self._map_tab_foreground_lines()
         lines += [
@@ -924,13 +935,28 @@ class Simulator:
             "- tapOn:",
             '      id: "peer_sheet_remove"',
             "- waitForAnimationToEnd: { timeout: 2000 }",
-            "- extendedWaitUntil:",
-            "    gone:",
-            f'      id: "{pin_id}"',
-            f"    timeout: {wait_ms}",
             "- takeScreenshot: { path: screenshots/peer-sheet-removed }",
         ]
-        self._run_maestro_flow(lines, "peer_sheet_remove", timeout=timeout)
+        # Two `timeout`-long waits + preamble; the `[LOC-REMOVE]` poll is a
+        # separate Python-side wait after the flow returns.
+        self._run_maestro_flow(lines, "peer_sheet_remove", timeout=timeout + 30)
+        self._wait_for_loc_remove(expect_removed_peer, timeout=timeout)
+
+    def _wait_for_loc_remove(self, peer_prefix: str, *, timeout: float = 30.0) -> str:
+        """Block until `removePeerLocation` logs `[LOC-REMOVE] peer=<hex>` for
+        the expected peer (prefix match, same idiom as `_wait_for_loc_recv`).
+        `peer_prefix` is the peer's first hex chars lowercased —
+        `removePeerLocation` logs `peerHash.prefix(4).toHex()`, which for the
+        20-byte Sideband identity is the first 8 hex chars."""
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            for line in reversed(self._tail_diag(800)):
+                if f"[LOC-REMOVE] peer={peer_prefix}" in line:
+                    return line
+            time.sleep(0.4)
+        pytest.fail(
+            f"iOS never logged [LOC-REMOVE] peer={peer_prefix} within {timeout}s"
+        )
 
     @staticmethod
     def _parse_outcome(lines: list[str]) -> Optional[TestSendResult]:

--- a/Tests/interop/conftest.py
+++ b/Tests/interop/conftest.py
@@ -84,8 +84,8 @@ def _yaml_escape(s: str) -> str:
     Backslash is escaped first so the sequences we introduce below aren't
     double-escaped."""
     return (
-        s.replace("\\", "\\\\")
-         .replace("\"", "\\\"")
+        s.replace("\\", "\\")
+         .replace("\"", "\"")
          .replace("\n", "\\n")
          .replace("\r", "\\r")
          .replace("\t", "\\t")
@@ -779,6 +779,158 @@ class Simulator:
             )
         finally:
             flow_path.unlink(missing_ok=True)
+
+    # ---- tappable peer pin (#179) --------------------------------------
+
+    @staticmethod
+    def _map_tab_foreground_lines(*, center_on_user: bool = True) -> list[str]:
+        """Warm-foreground + Map-tab navigation preamble shared by the
+        peer-sheet flows. `stopApp: false` keeps `peerLocations` (in-memory)
+        intact — a cold relaunch would empty it. Same pattern as
+        `assert_peer_pin_visible`.
+
+        When `center_on_user` is set (the default for the pin-tap flows),
+        tap `map_center_on_user` so the camera lands on the simulated fix
+        — which the test sets to the peer's own coordinate — guaranteeing
+        the pin is on-screen and therefore addressable by Maestro. Without
+        this the map center is wherever a prior test / first-fix left it
+        and an off-screen GL annotation is culled out of the a11y tree."""
+        lines = [
+            "appId: " + BUNDLE_ID,
+            "---",
+            "- launchApp: { stopApp: false }",
+            "- waitForAnimationToEnd: { timeout: 2000 }",
+            "- tapOn: { text: \"Allow\", optional: true }",
+            "- tapOn: { text: \"Don't Allow\", optional: true }",
+            "- waitForAnimationToEnd: { timeout: 1500 }",
+            "- tapOn:",
+            "    text: \"Map\"",
+            "    optional: true",
+            "- waitForAnimationToEnd: { timeout: 2000 }",
+        ]
+        if center_on_user:
+            lines += [
+                "- tapOn: { id: \"map_center_on_user\", optional: true }",
+                "- waitForAnimationToEnd: { timeout: 2500 }",
+            ]
+        return lines
+
+    def _run_maestro_flow(self, lines: list[str], tag: str, *, timeout: float = 60.0) -> None:
+        flow_path = Path(os.environ.get("TMPDIR", "/tmp")) / f"_interop_{tag}_{os.getpid()}.yaml"
+        flow_path.write_text("\n".join(lines) + "\n")
+        try:
+            _sh(["maestro", "--device", self.udid, "test", str(flow_path)], timeout=timeout + 30)
+        except subprocess.CalledProcessError as e:
+            pytest.fail(
+                f"Maestro flow {tag!r} failed. stderr:\n{e.stderr or e.stdout}"
+            )
+        finally:
+            flow_path.unlink(missing_ok=True)
+
+    def assert_peer_sheet_open(self, *, pin_id: str, timeout: float = 40.0) -> None:
+        """Tap the peer pin (a11y id `peer_pin_<hex>`) and assert the
+        `PeerContactSheet` presents with its `peer_sheet_name` element.
+
+        Pins the tap → sheet path end-to-end: `MLNAnnotationView`
+        (accessibility element) → `mapView(_:didSelectAnnotation:)` →
+        `onPeerTapped` → `selectedPeerHash` → sheet. The `extendedWaitUntil`
+        on the pin covers the async GL annotation build after the inbound
+        telemetry decodes."""
+        wait_ms = int(timeout * 1000)
+        lines = self._map_tab_foreground_lines()
+        lines += [
+            "- extendedWaitUntil:",
+            "    visible:",
+            f"      id: \"{pin_id}\"",
+            f"    timeout: {wait_ms}",
+            "- tapOn:",
+            f"      id: \"{pin_id}\"",
+            "- waitForAnimationToEnd: { timeout: 2000 }",
+            "- extendedWaitUntil:",
+            "    visible:",
+            "      id: \"peer_sheet_name\"",
+            f"    timeout: {wait_ms}",
+            "- takeScreenshot: { path: screenshots/peer-sheet }",
+        ]
+        self._run_maestro_flow(lines, "peer_sheet", timeout=timeout)
+
+    def assert_peer_sheet_message_opens_conversation(
+        self, *, pin_id: str, timeout: float = 40.0
+    ) -> None:
+        """Tap the pin, tap the sheet's Message button, and assert the
+        peer's conversation opened (the `message_composer` input bar is the
+        stable a11y landmark on the messaging screen).
+
+        Pins the cross-tab route: `onOpenPeerChat` → MainTabView switches to
+        the Chats tab and holds `pendingPeerChat` → `consumePeerChatRoute`
+        resolves the conversation (creating the row for a telemetry-only
+        peer) and pushes it via `notificationConversation`."""
+        wait_ms = int(timeout * 1000)
+        lines = self._map_tab_foreground_lines()
+        lines += [
+            "- extendedWaitUntil:",
+            "    visible:",
+            f"      id: \"{pin_id}\"",
+            f"    timeout: {wait_ms}",
+            "- tapOn:",
+            f"      id: \"{pin_id}\"",
+            "- extendedWaitUntil:",
+            "    visible:",
+            "      id: \"peer_sheet_message\"",
+            f"    timeout: {wait_ms}",
+            "- takeScreenshot: { path: screenshots/peer-sheet-message }",
+            "- tapOn:",
+            "      id: \"peer_sheet_message\"",
+            "- waitForAnimationToEnd: { timeout: 3000 }",
+            "- extendedWaitUntil:",
+            "    visible:",
+            "      id: \"message_composer\"",
+            f"    timeout: {wait_ms}",
+            "- takeScreenshot: { path: screenshots/peer-sheet-conversation }",
+        ]
+        self._run_maestro_flow(lines, "peer_sheet_message", timeout=timeout)
+
+    def assert_stale_peer_sheet_removes_pin(
+        self, *, pin_id: str, timeout: float = 40.0
+    ) -> None:
+        """Tap a stale peer's pin, assert the `peer_sheet_remove` action is
+        present (stale-only, Android parity), tap it, and assert that
+        specific pin disappears from the map.
+
+        Pins the removal path: `onRemove` →
+        `LocationSharingManager.removePeerLocation` → `peerLocations`
+        drops the entry → the GL annotation is removed and the sheet
+        auto-dismisses (its derived peer goes nil). A backdated frame makes
+        the pin stale without waiting out the 5-minute freshness window.
+
+        The assertion is on the *specific* `peer_pin_<hex>` element going
+        away (not the `map_peer_count` badge) because the session-scoped
+        Sideband peer can accumulate alongside earlier tests' pins, so the
+        badge count is order-dependent while the individual pin is not."""
+        wait_ms = int(timeout * 1000)
+        lines = self._map_tab_foreground_lines()
+        lines += [
+            "- extendedWaitUntil:",
+            "    visible:",
+            f'      id: "{pin_id}"',
+            f"    timeout: {wait_ms}",
+            "- tapOn:",
+            f'      id: "{pin_id}"',
+            "- extendedWaitUntil:",
+            "    visible:",
+            '      id: "peer_sheet_remove"',
+            f"    timeout: {wait_ms}",
+            "- takeScreenshot: { path: screenshots/peer-sheet-stale }",
+            "- tapOn:",
+            '      id: "peer_sheet_remove"',
+            "- waitForAnimationToEnd: { timeout: 2000 }",
+            "- extendedWaitUntil:",
+            "    gone:",
+            f'      id: "{pin_id}"',
+            f"    timeout: {wait_ms}",
+            "- takeScreenshot: { path: screenshots/peer-sheet-removed }",
+        ]
+        self._run_maestro_flow(lines, "peer_sheet_remove", timeout=timeout)
 
     @staticmethod
     def _parse_outcome(lines: list[str]) -> Optional[TestSendResult]:

--- a/Tests/interop/conftest.py
+++ b/Tests/interop/conftest.py
@@ -912,7 +912,7 @@ class Simulator:
         Pins the cross-tab route: `onOpenPeerChat` → MainTabView switches to
         the Chats tab and holds `pendingPeerChat` → `consumePeerChatRoute`
         resolves the conversation (creating the row for a telemetry-only
-        peer) and pushes it via `notificationConversation`."""
+        peer) and pushes it via the dedicated `peerConversation` route."""
         wait_ms = int(timeout * 1000)
         lines = self._map_tab_foreground_lines()
         lines += [

--- a/Tests/interop/conftest.py
+++ b/Tests/interop/conftest.py
@@ -465,6 +465,12 @@ class Simulator:
             "- tapOn: { text: \"Allow\", optional: true }",
             "- tapOn: { text: \"Don't Allow\", optional: true }",
             "- waitForAnimationToEnd: { timeout: 1500 }",
+        ]
+        # A contact sheet left open by a pin test is modal and covers the
+        # tab bar, so the Chats navigation below would no-op. Dismiss it
+        # first - a no-op when none is open.
+        lines += self._sheet_dismiss_lines()
+        lines += [
             "- back",
             "- waitForAnimationToEnd: { timeout: 800 }",
             "- back",
@@ -803,6 +809,13 @@ class Simulator:
             "- tapOn: { text: \"Allow\", optional: true }",
             "- tapOn: { text: \"Don't Allow\", optional: true }",
             "- waitForAnimationToEnd: { timeout: 1500 }",
+        ]
+        # A contact sheet left open by a previous pin flow is modal: it
+        # covers the tab bar (the "Map" tap below would be a no-op) and the
+        # map_center_on_user FAB (so the camera would never re-center to
+        # this test's city). Dismiss it first - a no-op when none is open.
+        lines += Simulator._sheet_dismiss_lines()
+        lines += [
             "- tapOn:",
             "    text: \"Map\"",
             "    optional: true",
@@ -814,6 +827,38 @@ class Simulator:
                 "- waitForAnimationToEnd: { timeout: 2500 }",
             ]
         return lines
+
+    @staticmethod
+    def _sheet_dismiss_lines() -> list[str]:
+        """Steps that dismiss a leftover `PeerContactSheet` if one is
+        open, harmlessly no-op if not. The pin flows leave the sheet
+        open over the map after a tap, and a modal sheet blocks the
+        `map_center_on_user` FAB (so the camera never re-centers to the
+        next test's city, leaving the offset pin off-screen / out of the
+        a11y tree) and the tab bar (so the attachment tests can't
+        navigate to Chats).
+
+        The sheet uses the default `.medium` detent, so its top edge
+        (drag handle) sits near the vertical middle of the screen. The
+        swipe therefore starts INSIDE the sheet (y: 55%) and drags down:
+        a SwiftUI sheet is dismissed by dragging it down from anywhere on
+        its content. A swipe from y: 12% would land on the map above the
+        medium sheet and pan the map instead of dismissing it (verified:
+        the pin flows' `map_center_on_user` taps were silently hitting
+        the still-open sheet). With no sheet open, a swipe at y: 55%
+        just scrolls the current view, which the centering/navigation
+        steps that follow correct. Idempotent, so it is safe to run at
+        the start of every flow that assumes a clean starting
+        state."""
+        return [
+            "- swipe:",
+            "    direction: DOWN",
+            "    coordinate:",
+            "      x: 50%",
+            "      y: 55%",
+            "    distance: 45%",
+            "- waitForAnimationToEnd: { timeout: 2500 }",
+        ]
 
     def _run_maestro_flow(self, lines: list[str], tag: str, *, timeout: float = 60.0) -> None:
         flow_path = Path(os.environ.get("TMPDIR", "/tmp")) / f"_interop_{tag}_{os.getpid()}.yaml"

--- a/Tests/interop/conftest.py
+++ b/Tests/interop/conftest.py
@@ -84,8 +84,8 @@ def _yaml_escape(s: str) -> str:
     Backslash is escaped first so the sequences we introduce below aren't
     double-escaped."""
     return (
-        s.replace("\\", "\\")
-         .replace("\"", "\"")
+        s.replace("\\", "\\\\")
+         .replace("\"", "\\\"")
          .replace("\n", "\\n")
          .replace("\r", "\\r")
          .replace("\t", "\\t")

--- a/Tests/interop/peer_sideband.py
+++ b/Tests/interop/peer_sideband.py
@@ -377,6 +377,7 @@ class SidebandPeer:
         bearing: float = 0.0,
         accuracy: float = 1.0,
         icon: Optional[tuple] = None,
+        last_update: Optional[int] = None,
     ) -> bool:
         """Send a canonical Sideband-format `FIELD_TELEMETRY` blob —
         msgpack-encoded `Telemeter` dict with `SID_TIME` + `SID_LOCATION`.
@@ -409,7 +410,7 @@ class SidebandPeer:
             "speed": speed,
             "bearing": bearing,
             "accuracy": accuracy,
-            "last_update": int(time.time()),
+            "last_update": last_update if last_update is not None else int(time.time()),
         }
         packed = t.packed()
         fields = {LXMF.FIELD_TELEMETRY: packed}

--- a/Tests/interop/test_telemetry.py
+++ b/Tests/interop/test_telemetry.py
@@ -264,18 +264,49 @@ def test_cease_ios_to_sideband(sim, sideband):
 # ─────────────────────────────────────────────────────────────────────────
 
 
-def _wait_for_loc_recv(sim, *, timeout: float = 30.0) -> str:
+def _wait_for_loc_recv(
+    sim,
+    *,
+    peer: str,
+    expect_lat: float | None = None,
+    expect_lon: float | None = None,
+    timeout: float = 30.0,
+) -> str:
     """Block until `LocationSharingManager.handleIncomingTelemetry` logs a
-    decoded inbound telemetry line (`[LOC-RECV] …`) to diag.log, and
-    return it. The line mirrors the decoded peer/lat/lon/icon because the
-    MapLibre marker itself isn't reachable from the accessibility tree."""
+    decoded inbound telemetry line (`[LOC-RECV] …`) to diag.log for the
+    expected peer, and return it. The line mirrors the decoded peer/lat/lon/
+    icon because the MapLibre marker itself isn't reachable from the
+    accessibility tree.
+
+    The match is pinned to the peer's first 8 hex chars (plus, when given,
+    the expected latitude/longitude to ~1e-4°) because diag.log is
+    append-only across launches and the unit-test bundle — hosted in the
+    same container — also writes `[LOC-RECV]` lines with its own fixture
+    peer. Matching any `[LOC-RECV]` returns the newest line, so a stale
+    unit-test line can be matched before the fresh Sideband frame arrives.
+
+    `peer` is the peer's identity_hex[:8] (lowercase) which matches the
+    production log's `hex = peerHash.prefix(4).toHex()` (first 8 hex chars)."""
+    lat_pat = re.compile(r"lat=(-?[\d.]+) lon=(-?[\d.]+)")
     deadline = time.time() + timeout
     while time.time() < deadline:
         for line in reversed(sim._tail_diag(800)):
-            if "[LOC-RECV]" in line:
+            if "[LOC-RECV]" not in line or f"peer={peer}" not in line:
+                continue
+            if expect_lat is None:
+                return line
+            m = lat_pat.search(line)
+            if not m:
+                continue
+            if (abs(float(m.group(1)) - expect_lat) < 1e-4
+                    and expect_lon is not None
+                    and abs(float(m.group(2)) - expect_lon) < 1e-4):
                 return line
         time.sleep(0.4)
-    pytest.fail(f"iOS never logged [LOC-RECV] for inbound telemetry within {timeout}s")
+    pytest.fail(
+        f"iOS never logged [LOC-RECV] peer={peer} for inbound telemetry "
+        f"within {timeout}s"
+    )
 
 
 def _wait_for_peer_display_name(sim, sideband, *, timeout: float = 20.0) -> str:
@@ -321,7 +352,15 @@ def test_location_sideband_to_ios(sim, sideband):
     # Decoded telemetry + icon round-trip (the part the GL marker can't
     # expose). Capture first — it's logged on receipt regardless of UI
     # state, so it's independent of the map-navigation step below.
-    line = _wait_for_loc_recv(sim)
+    # Pin the match to this peer + these coords so a stale `[LOC-RECV]`
+    # line (e.g. from the unit-test bundle, which shares the container)
+    # can't be matched before the fresh frame arrives.
+    line = _wait_for_loc_recv(
+        sim,
+        peer=sideband.identity_hex[:8].lower(),
+        expect_lat=expect_lat,
+        expect_lon=expect_lon,
+    )
     expected_name = _wait_for_peer_display_name(sim, sideband)
     m = re.search(
         r'\[LOC-RECV\] peer=(\w+) name=("(?:\\.|[^"\\])*") '
@@ -363,6 +402,16 @@ def test_location_sideband_to_ios(sim, sideband):
 # ─────────────────────────────────────────────────────────────────────────
 
 
+# Offset the peer pin EAST of the user's simulated fix so it is not concentric
+# with the user-location dot. At the exact user coordinate the 32pt pin sits
+# on top of the blue dot, so the Maestro tap lands on the dot (not the pin) and
+# the pin's a11y element is occluded/ambiguous (non-deterministic). At ~51°N,
+# 0.003° longitude ≈ 277m, which is well inside the on-screen view after
+# `map_center_on_user` (zoom 15, half-width ≈ 1.7km) yet clearly separated from
+# the user dot's tap target.
+_PIN_EAST_OFFSET_DEG = 0.003
+
+
 def _pin_id(sideband) -> str:
     """The a11y identifier of the Sideband peer's map pin."""
     return "peer_pin_" + sideband.identity_hex.lower()
@@ -391,7 +440,7 @@ def _set_sim_location_to_peer(sim, lat: float, lon: float) -> None:
 def _send_peer_telemetry(sim, sideband, lat: float, lon: float,
                          *, last_update: int | None = None) -> None:
     """Send one inbound location frame from Sideband and wait for iOS to
-    decode it (the `[LOC-RECV]` diag line)."""
+    decode it (the `[LOC-RECV]` diag line, pinned to this peer + coords)."""
     assert sideband.send_location_telemetry(
         dest_hex=sim.lxmf_delivery_hex,
         lat=lat,
@@ -399,7 +448,12 @@ def _send_peer_telemetry(sim, sideband, lat: float, lon: float,
         accuracy=12.0,
         last_update=last_update,
     ), "Sideband send_location_telemetry returned False"
-    _wait_for_loc_recv(sim)
+    _wait_for_loc_recv(
+        sim,
+        peer=sideband.identity_hex[:8].lower(),
+        expect_lat=lat,
+        expect_lon=lon,
+    )
 
 
 def test_peer_pin_tap_opens_contact_sheet(sim, sideband):
@@ -407,10 +461,12 @@ def test_peer_pin_tap_opens_contact_sheet(sim, sideband):
 
     Asserts the sheet's `peer_sheet_name` element (48pt icon row) appears,
     which only happens through the selection → onPeerTapped →
-    selectedPeerHash → sheet path."""
+    selectedPeerHash → sheet path. The peer is offset east of the user's
+    simulated fix (see `_PIN_EAST_OFFSET_DEG`) so the pin is a distinct,
+    unoccluded tap target."""
     lat, lon = 37.7749, -122.4194
     _set_sim_location_to_peer(sim, lat, lon)
-    _send_peer_telemetry(sim, sideband, lat, lon)
+    _send_peer_telemetry(sim, sideband, lat, lon + _PIN_EAST_OFFSET_DEG)
     sim.assert_peer_sheet_open(pin_id=_pin_id(sideband))
 
 
@@ -424,7 +480,7 @@ def test_peer_pin_message_route_opens_conversation(sim, sideband):
     stable a11y landmark on the messaging screen."""
     lat, lon = 40.7128, -74.0060
     _set_sim_location_to_peer(sim, lat, lon)
-    _send_peer_telemetry(sim, sideband, lat, lon)
+    _send_peer_telemetry(sim, sideband, lat, lon + _PIN_EAST_OFFSET_DEG)
     sim.assert_peer_sheet_message_opens_conversation(pin_id=_pin_id(sideband))
 
 
@@ -435,11 +491,15 @@ def test_stale_peer_pin_remove_clears_pin(sim, sideband):
     The frame is backdated ~10 minutes so the pin is stale immediately
     (isStale = now - lastUpdate > 300 s) without waiting out the freshness
     window. Asserts the stale-only Remove action is present, then that the
-    specific `peer_pin_<hex>` element is gone after the tap (asserting the
-    individual pin, not the map_peer_count badge, because the session
-    peer's pin can accumulate alongside other tests' pins)."""
+    app logged `[LOC-REMOVE] peer=<hex>` (the pin is rendered on MapLibre's
+    GL surface and the `map_peer_count` badge is order-dependent across
+    peers, so the diag line is the deterministic per-peer signal)."""
     lat, lon = 51.5074, -0.1278
     stale_ts = int(time.time()) - 10 * 60
     _set_sim_location_to_peer(sim, lat, lon)
-    _send_peer_telemetry(sim, sideband, lat, lon, last_update=stale_ts)
-    sim.assert_stale_peer_sheet_removes_pin(pin_id=_pin_id(sideband))
+    _send_peer_telemetry(sim, sideband, lat, lon + _PIN_EAST_OFFSET_DEG,
+                         last_update=stale_ts)
+    sim.assert_stale_peer_sheet_removes_pin(
+        pin_id=_pin_id(sideband),
+        expect_removed_peer=sideband.identity_hex[:8].lower(),
+    )

--- a/Tests/interop/test_telemetry.py
+++ b/Tests/interop/test_telemetry.py
@@ -344,3 +344,102 @@ def test_location_sideband_to_ios(sim, sideband):
 
     # Pin renders on the Map screen (proves peerLocations reached the UI).
     sim.assert_peer_pin_visible()
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Tappable peer pin (#179) — tap → PeerContactSheet → Message/Remove.
+#
+# These drive the real map annotation view (a UIView, not the GL surface),
+# so they pin the selection path end-to-end: MLNAnnotationView →
+# mapView(_:didSelectAnnotation:) → onPeerTapped → selectedPeerHash →
+# sheet, and the cross-tab Message route + stale-removal escape hatch.
+#
+# The peer pin is addressed by `peer_pin_<hex>` where <hex> is the sender's
+# full RNS/LXMF identity hex (iOS keys peerLocations on message.sourceHash,
+# which equals the Sideband peer's identity_hex). The sim's location is set
+# to the peer's coordinate and the map is recentered on the user, so the
+# pin is guaranteed on-screen (an off-screen GL annotation is culled out of
+# the a11y tree and unaddressable).
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _pin_id(sideband) -> str:
+    """The a11y identifier of the Sideband peer's map pin."""
+    return "peer_pin_" + sideband.identity_hex.lower()
+
+
+def _set_sim_location_to_peer(sim, lat: float, lon: float) -> None:
+    """Grant location (idempotent), stamp a simulated fix at the peer's
+    coordinate, and re-push it a few times. CLLocationManager / MapLibre
+    `userLocation` delivery on the sim is racy — a single `location set`
+    before the manager is observing isn't reliably delivered, so we
+    re-push over a few seconds (same pattern as
+    `test_chat_toggle_starts_periodic_sharing`)."""
+    import subprocess
+    subprocess.run(
+        ["xcrun", "simctl", "privacy", sim.udid, "grant", "location",
+         "network.columba.Columba"], check=True, capture_output=True,
+    )
+    for _ in range(8):
+        subprocess.run(
+            ["xcrun", "simctl", "location", sim.udid, "set",
+             f"{lat},{lon}"], check=True, capture_output=True,
+        )
+        time.sleep(0.6)
+
+
+def _send_peer_telemetry(sim, sideband, lat: float, lon: float,
+                         *, last_update: int | None = None) -> None:
+    """Send one inbound location frame from Sideband and wait for iOS to
+    decode it (the `[LOC-RECV]` diag line)."""
+    assert sideband.send_location_telemetry(
+        dest_hex=sim.lxmf_delivery_hex,
+        lat=lat,
+        lon=lon,
+        accuracy=12.0,
+        last_update=last_update,
+    ), "Sideband send_location_telemetry returned False"
+    _wait_for_loc_recv(sim)
+
+
+def test_peer_pin_tap_opens_contact_sheet(sim, sideband):
+    """Tap the peer's map pin → the PeerContactSheet presents.
+
+    Asserts the sheet's `peer_sheet_name` element (48pt icon row) appears,
+    which only happens through the selection → onPeerTapped →
+    selectedPeerHash → sheet path."""
+    lat, lon = 37.7749, -122.4194
+    _set_sim_location_to_peer(sim, lat, lon)
+    _send_peer_telemetry(sim, sideband, lat, lon)
+    sim.assert_peer_sheet_open(pin_id=_pin_id(sideband))
+
+
+def test_peer_pin_message_route_opens_conversation(sim, sideband):
+    """Tap the pin → Message button → the peer's conversation opens.
+
+    Asserts the cross-tab route: onOpenPeerChat → MainTabView switches to
+    the Chats tab and holds pendingPeerChat → consumePeerChatRoute resolves
+    (creating the row for a telemetry-only peer) and pushes it via
+    notificationConversation. The `message_composer` input bar is the
+    stable a11y landmark on the messaging screen."""
+    lat, lon = 40.7128, -74.0060
+    _set_sim_location_to_peer(sim, lat, lon)
+    _send_peer_telemetry(sim, sideband, lat, lon)
+    sim.assert_peer_sheet_message_opens_conversation(pin_id=_pin_id(sideband))
+
+
+def test_stale_peer_pin_remove_clears_pin(sim, sideband):
+    """A stale peer's pin → the sheet shows `peer_sheet_remove` → tapping it
+    drops the pin from the map.
+
+    The frame is backdated ~10 minutes so the pin is stale immediately
+    (isStale = now - lastUpdate > 300 s) without waiting out the freshness
+    window. Asserts the stale-only Remove action is present, then that the
+    specific `peer_pin_<hex>` element is gone after the tap (asserting the
+    individual pin, not the map_peer_count badge, because the session
+    peer's pin can accumulate alongside other tests' pins)."""
+    lat, lon = 51.5074, -0.1278
+    stale_ts = int(time.time()) - 10 * 60
+    _set_sim_location_to_peer(sim, lat, lon)
+    _send_peer_telemetry(sim, sideband, lat, lon, last_update=stale_ts)
+    sim.assert_stale_peer_sheet_removes_pin(pin_id=_pin_id(sideband))

--- a/Tests/interop/test_telemetry.py
+++ b/Tests/interop/test_telemetry.py
@@ -475,8 +475,8 @@ def test_peer_pin_message_route_opens_conversation(sim, sideband):
 
     Asserts the cross-tab route: onOpenPeerChat → MainTabView switches to
     the Chats tab and holds pendingPeerChat → consumePeerChatRoute resolves
-    (creating the row for a telemetry-only peer) and pushes it via
-    notificationConversation. The `message_composer` input bar is the
+    (creating the row for a telemetry-only peer) and pushes it via the
+    dedicated peerConversation route. The `message_composer` input bar is the
     stable a11y landmark on the messaging screen."""
     lat, lon = 40.7128, -74.0060
     _set_sim_location_to_peer(sim, lat, lon)

--- a/Tests/static/test_host_entitlements_contract.py
+++ b/Tests/static/test_host_entitlements_contract.py
@@ -12,6 +12,7 @@ RESOURCES = REPOSITORY_ROOT / "Sources/ColumbaApp/Resources"
 SHIPPING_ENTITLEMENTS = RESOURCES / "ColumbaApp.entitlements"
 MODEL_B_ENTITLEMENTS = RESOURCES / "ColumbaModelBApp.entitlements"
 PROJECT_FILE = REPOSITORY_ROOT / "Columba.xcodeproj/project.pbxproj"
+APP_INFO_PLIST = RESOURCES / "Info.plist"
 SHIPPING_ENTITLEMENTS_EXPECTED = {
     "com.apple.security.application-groups": ["group.network.columba.Columba"],
     "keychain-access-groups": [
@@ -34,12 +35,21 @@ class HostEntitlementsContractTests(unittest.TestCase):
         with MODEL_B_ENTITLEMENTS.open("rb") as plist_file:
             cls.model_b = plistlib.load(plist_file)
         cls.project = PROJECT_FILE.read_text(encoding="utf-8")
+        with APP_INFO_PLIST.open("rb") as plist_file:
+            cls.app_info_plist = plistlib.load(plist_file)
 
     def test_shipping_host_entitlements_match_complete_contract(self) -> None:
         self.assertEqual(self.shipping, SHIPPING_ENTITLEMENTS_EXPECTED)
 
     def test_model_b_host_entitlements_match_complete_contract(self) -> None:
         self.assertEqual(self.model_b, MODEL_B_ENTITLEMENTS_EXPECTED)
+
+    def test_app_plist_whitelists_google_maps_query_scheme(self) -> None:
+        # The directions chooser gates the Google Maps row on
+        # canOpenURL("comgooglemaps://"), which always reports false unless
+        # the scheme is declared here.
+        schemes = self.app_info_plist.get("LSApplicationQueriesSchemes", [])
+        self.assertIn("comgooglemaps", schemes)
 
     def test_app_targets_use_isolated_entitlements(self) -> None:
         for filename in ("ColumbaApp.entitlements", "ColumbaModelBApp.entitlements"):

--- a/Tests/static/test_map_peer_pin_tap.py
+++ b/Tests/static/test_map_peer_pin_tap.py
@@ -235,9 +235,12 @@ class MapPeerPinTapContractTests(unittest.TestCase):
             .split("\n    // MARK:")[0]
         )
         self.assertNotIn("notificationConversation", route_body)
-        # While the route resolves (or after it pushes), a notification tap
-        # defers instead of competing for navigation.
-        self.assertIn("if isResolvingPeerChat || peerConversation != nil {", self.chats_view)
+        # While the route resolves, a notification tap defers instead of
+        # competing for navigation - but the deferred tap is NOT lost: the
+        # route re-runs the check when it settles (retry at route end).
+        self.assertIn("if isResolvingPeerChat {", self.chats_view)
+        self.assertNotIn("peerConversation != nil {", self.chats_view)
+        self.assertIn("checkPendingNotification()\n    }", route_body)
 
     # MARK: - Removal + non-iOS stub
 

--- a/Tests/static/test_map_peer_pin_tap.py
+++ b/Tests/static/test_map_peer_pin_tap.py
@@ -256,12 +256,14 @@ class MapPeerPinTapContractTests(unittest.TestCase):
         self.assertIn("vm.conversations.first(where: { $0.id == hash })", check_body)
         self.assertNotIn("vm.filteredConversations.first(where: { $0.id == hash })", check_body)
         self.assertIn("await vm.refreshConversations()", check_body)
-        # Post-refresh consume+route is guarded by slot ownership: a newer
-        # tap that replaced the slot during the refresh owns the route, so
-        # the stale continuation must not assign the destination.
+        # Post-refresh consume+route is guarded by slot ownership AND route
+        # ownership: a newer tap that replaced the slot during the refresh
+        # owns the route, and a peer route that started during the refresh
+        # (a suspension point) owns navigation until it settles - in both
+        # cases the stale continuation must not assign the destination.
         self.assertRegex(
             self.chats_view,
-            r"if let conversation = vm\.conversations\.first\(where: \{ \$0\.id == hash \}\),\s*\n\s*NotificationService\.pendingConversationHash == hash \{",
+            r"if let conversation = vm\.conversations\.first\(where: \{ \$0\.id == hash \}\),\s*\n\s*NotificationService\.pendingConversationHash == hash,\s*\n\s*!isResolvingPeerChat \{",
         )
         self.assertIn("NotificationService.pendingConversationHash = nil", check_body)
         # The retry trigger observes the canonical list (an active search

--- a/Tests/static/test_map_peer_pin_tap.py
+++ b/Tests/static/test_map_peer_pin_tap.py
@@ -75,18 +75,22 @@ class MapPeerPinTapContractTests(unittest.TestCase):
 
     def test_map_view_uses_maplibre_selection_delegates(self):
         # MapLibre v6.25.1: selection is on by default (annotation view
-        # enabled flag); the delegate gets a void didSelect /
-        # didDeselect pair. No canSelectAnnotation property exists.
+        # enabled flag); the Swift-imported delegate gets a void didSelect /
+        # didDeselect pair (the ObjC names drop "Annotation" in Swift).
+        # No canSelectAnnotation property exists.
         self.assertIn(
-            "func mapView(_ mapView: MLNMapView, didSelectAnnotation annotation: MLNAnnotation)",
+            "func mapView(_ mapView: MLNMapView, didSelect annotation: MLNAnnotation)",
             self.map_libre,
         )
         self.assertIn(
-            "func mapView(_ mapView: MLNMapView, didDeselectAnnotation annotation: MLNAnnotation)",
+            "func mapView(_ mapView: MLNMapView, didDeselect annotation: MLNAnnotation)",
             self.map_libre,
         )
         # The wrong (Mapbox-era) API must not creep back in.
         self.assertNotIn("canSelectAnnotation", self.map_libre)
+        # The deprecated selectAnnotation(animated:) form must not be used;
+        # the completion-handler variant is the supported one.
+        self.assertNotIn("mapView.selectAnnotation(annotation, animated: true)", self.map_libre)
 
     def test_map_view_suppresses_builtin_callout(self):
         # Only the custom PeerContactSheet is the selection UI, so the
@@ -197,7 +201,11 @@ class MapPeerPinTapContractTests(unittest.TestCase):
         )
 
     def test_chats_view_consumes_route_via_notification_conversation(self):
-        self.assertIn("@Binding var pendingPeerChat: Data? = nil", self.chats_view)
+        # A @Binding property CANNOT take `= nil` (the memberwise init
+        # parameter is Binding<Data?>, not Data?), so the declaration must
+        # have no default.
+        self.assertIn("@Binding var pendingPeerChat: Data?\n", self.chats_view)
+        self.assertNotIn("@Binding var pendingPeerChat: Data? = nil", self.chats_view)
         self.assertIn("private func consumePeerChatRoute() async", self.chats_view)
         # One-shot: clear before the async work.
         self.assertRegex(

--- a/Tests/static/test_map_peer_pin_tap.py
+++ b/Tests/static/test_map_peer_pin_tap.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+"""Linux-runnable contract checks for the tappable peer map pin (#179).
+
+Guards the wiring that the unit tests (which run on the iOS simulator) and
+the Maestro interop flow cannot fully cover on their own:
+
+- MapLibreMapView implements the MapLibre v6.25.1 annotation-selection path
+  (didSelectAnnotation / didDeselectAnnotation delegate methods, the
+  annotationCanShowCallout callout-suppression hook, the peer_pin_<hash>
+  accessibility identifier, and the onPeerTapped / onUserLocationChanged
+  callbacks) instead of a custom hit-test.
+- MapView presents the PeerContactSheet, wires Directions / Message /
+  Remove, and exposes the onOpenPeerChat cross-tab route.
+- MainTabView holds the pendingPeerChat state and switches to the Chats tab.
+- ChatsView consumes the route via the notificationConversation push.
+- LocationSharingManager implements removePeerLocation and the non-iOS
+  Compat.swift stub keeps the API available for cross-platform code.
+- Every new Swift file is registered in the hand-maintained pbxproj
+  (file ref + build file + group child + a Sources phase entry), because an
+  unregistered file compiles into nothing and its tests never run.
+
+The Info.plist LSApplicationQueriesSchemes entry is asserted by
+test_host_entitlements_contract.py (the plist contract test).
+"""
+
+import json
+import re
+import unittest
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+MAP_DIR = REPOSITORY_ROOT / "Sources/ColumbaApp/Views/Map"
+MAP_LIBRE_VIEW = MAP_DIR / "MapLibreMapView.swift"
+MAP_VIEW = MAP_DIR / "MapView.swift"
+PEER_CONTACT_SHEET = MAP_DIR / "PeerContactSheet.swift"
+DIRECTIONS_LAUNCHER = MAP_DIR / "DirectionsLauncher.swift"
+PEER_LOCATION_FORMATTING = MAP_DIR / "PeerLocationFormatting.swift"
+LOCATION_SHARING_MANAGER = (
+    REPOSITORY_ROOT / "Sources/ColumbaApp/Services/LocationSharingManager.swift"
+)
+COMPAT = REPOSITORY_ROOT / "Sources/RNSAPI/Compat.swift"
+MAIN_TAB_VIEW = REPOSITORY_ROOT / "Sources/ColumbaApp/Views/MainTabView.swift"
+CHATS_VIEW = REPOSITORY_ROOT / "Sources/ColumbaApp/Views/Chats/ChatsView.swift"
+PROJECT_FILE = REPOSITORY_ROOT / "Columba.xcodeproj/project.pbxproj"
+
+# (filename, expected Sources-phase targets)
+APP_SOURCES = [
+    "PeerLocationFormatting.swift",
+    "DirectionsLauncher.swift",
+    "PeerContactSheet.swift",
+]
+TEST_SOURCES = [
+    "PeerLocationFormattingTests.swift",
+    "DirectionsLauncherTests.swift",
+    "PeerLocationRemovalTests.swift",
+]
+
+
+class MapPeerPinTapContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.map_libre = MAP_LIBRE_VIEW.read_text(encoding="utf-8")
+        cls.map_view = MAP_VIEW.read_text(encoding="utf-8")
+        cls.sheet = PEER_CONTACT_SHEET.read_text(encoding="utf-8")
+        cls.launcher = DIRECTIONS_LAUNCHER.read_text(encoding="utf-8")
+        cls.formatting = PEER_LOCATION_FORMATTING.read_text(encoding="utf-8")
+        cls.sharing_manager = LOCATION_SHARING_MANAGER.read_text(encoding="utf-8")
+        cls.compat = COMPAT.read_text(encoding="utf-8")
+        cls.main_tab = MAIN_TAB_VIEW.read_text(encoding="utf-8")
+        cls.chats_view = CHATS_VIEW.read_text(encoding="utf-8")
+        cls.project = PROJECT_FILE.read_text(encoding="utf-8")
+
+    # MARK: - MapLibreMapView selection path
+
+    def test_map_view_uses_maplibre_selection_delegates(self):
+        # MapLibre v6.25.1: selection is on by default (annotation view
+        # enabled flag); the delegate gets a void didSelect /
+        # didDeselect pair. No canSelectAnnotation property exists.
+        self.assertIn(
+            "func mapView(_ mapView: MLNMapView, didSelectAnnotation annotation: MLNAnnotation)",
+            self.map_libre,
+        )
+        self.assertIn(
+            "func mapView(_ mapView: MLNMapView, didDeselectAnnotation annotation: MLNAnnotation)",
+            self.map_libre,
+        )
+        # The wrong (Mapbox-era) API must not creep back in.
+        self.assertNotIn("canSelectAnnotation", self.map_libre)
+
+    def test_map_view_suppresses_builtin_callout(self):
+        # Only the custom PeerContactSheet is the selection UI, so the
+        # built-in callout bubble must be turned off for peer annotations.
+        self.assertIn(
+            "func mapView(_ mapView: MLNMapView, annotationCanShowCallout annotation: MLNAnnotation) -> Bool",
+            self.map_libre,
+        )
+        # Peer annotations must get no callout; other (user) annotations keep
+        # the default behavior.
+        self.assertRegex(
+            self.map_libre,
+            r"annotationCanShowCallout[^\n]*\n[^\n]*return annotation is PeerPointAnnotation \? false : true",
+        )
+
+    def test_map_view_reports_peer_taps_and_user_location(self):
+        # Tap -> onPeerTapped(hash); user blue-dot coordinate ->
+        # onUserLocationChanged for the sheet's distance math.
+        self.assertIn("var onPeerTapped: ((Data) -> Void)?", self.map_libre)
+        self.assertIn(
+            "var onUserLocationChanged: ((CLLocationCoordinate2D?) -> Void)?",
+            self.map_libre,
+        )
+        self.assertIn("onPeerTapped?(peerAnnotation.peerHash)", self.map_libre)
+        self.assertIn("onUserLocationChanged?(valid)", self.map_libre)
+
+    def test_peer_annotation_carries_hash_keyed_accessibility_id(self):
+        # The annotation view is a real UIView, so pins are addressable from
+        # XCUITest/Maestro by a stable, hash-keyed identifier. Selection
+        # state is keyed on the hash, not the (reused) annotation object.
+        self.assertRegex(
+            self.map_libre,
+            r"accessibilityIdentifier = \"peer_pin_\\\(peerAnnotation.peerHash",
+        )
+
+    # MARK: - MapView sheet + routes
+
+    def test_map_view_presents_peer_contact_sheet(self):
+        self.assertIn("PeerContactSheet(", self.map_view)
+        self.assertIn("peerContactSheet", self.map_view)
+        # Sheet is a computed property (the #181 type-checker lesson:
+        # inlining a sheet's view tree in body risks a type-check timeout).
+        self.assertRegex(self.map_view, r"private var peerContactSheet: some View")
+
+    def test_map_view_wires_sheet_actions(self):
+        self.assertIn("onDirections: { launchDirections(for: peer) }", self.map_view)
+        # Message: clear the selection, then hand the hash to the cross-tab
+        # route.
+        self.assertRegex(
+            self.map_view,
+            r"onMessage: \{[^}]*onOpenPeerChat\?\(hash\)",
+            re.DOTALL,
+        )
+        # Remove: hit the manager, then clear the selection.
+        self.assertRegex(
+            self.map_view,
+            r"onRemove: \{[^}]*removePeerLocation\(peer\.id\)",
+            re.DOTALL,
+        )
+
+    def test_map_view_routes_message_to_cross_tab_closure(self):
+        self.assertIn("var onOpenPeerChat: ((Data) -> Void)? = nil", self.map_view)
+
+    # MARK: - PeerContactSheet a11y identifiers
+
+    def test_sheet_exposes_stable_a11y_identifiers(self):
+        for identifier in (
+            "peer_sheet_name",
+            "peer_sheet_directions",
+            "peer_sheet_message",
+            "peer_sheet_remove",
+        ):
+            with self.subTest(identifier=identifier):
+                self.assertIn(f'accessibilityIdentifier("{identifier}")', self.sheet)
+
+    def test_sheet_gates_remove_to_stale_peers(self):
+        # Android parity: only a stale peer (quiet > 5 min without CEASE)
+        # gets the Remove-from-map escape hatch.
+        self.assertRegex(
+            self.sheet,
+            r"if peer\.isStale \{\s*\n\s*Button\(action: onRemove\)",
+        )
+        self.assertIn('String(localized: "Remove from map")', self.sheet)
+
+    def test_sheet_renders_android_parity_elements(self):
+        # 48pt icon dimmed when stale; live "Updated …" line; distance line.
+        self.assertIn("size: 48", self.sheet)
+        self.assertIn(".opacity(peer.isStale ? 0.6 : 1.0)", self.sheet)
+        self.assertIn("String(localized: \"Stale\")", self.sheet)
+        self.assertIn(
+            "PeerLocationFormatting.formatUpdatedTime(peer.lastUpdate, now: now)",
+            self.sheet,
+        )
+        self.assertIn(
+            "PeerLocationFormatting.formatDistanceAndDirection(",
+            self.sheet,
+        )
+
+    # MARK: - Cross-tab Message route
+
+    def test_main_tab_holds_route_and_switches_tabs(self):
+        self.assertIn("@State private var pendingPeerChat: Data? = nil", self.main_tab)
+        self.assertIn("ChatsView(", self.main_tab)
+        self.assertRegex(
+            self.main_tab,
+            r"onOpenPeerChat: \{ hash in[^\}]*selectedTab = \.chats[^\}]*pendingPeerChat = hash",
+            re.DOTALL,
+        )
+
+    def test_chats_view_consumes_route_via_notification_conversation(self):
+        self.assertIn("@Binding var pendingPeerChat: Data? = nil", self.chats_view)
+        self.assertIn("private func consumePeerChatRoute() async", self.chats_view)
+        # One-shot: clear before the async work.
+        self.assertRegex(
+            self.chats_view,
+            r"guard let hash = pendingPeerChat else \{ return \}\s*\n\s*// Clear first.*\n\s*pendingPeerChat = nil",
+            re.DOTALL,
+        )
+        # Telemetry-only peers get a conversation row created, then pushed
+        # through the existing notification-conversation route.
+        self.assertIn(
+            "messageRepository.ensureConversation(hash, displayName: nil)",
+            self.chats_view,
+        )
+        self.assertIn("notificationConversation = conversation", self.chats_view)
+
+    # MARK: - Removal + non-iOS stub
+
+    def test_remove_peer_location_drops_entry_and_keeps_stub(self):
+        self.assertIn(
+            "public func removePeerLocation(_ peerHash: Data) {",
+            self.sharing_manager,
+        )
+        self.assertIn(
+            "guard peerLocations.removeValue(forKey: peerHash) != nil else { return }",
+            self.sharing_manager,
+        )
+        # Cross-platform API surface stays available (no-op off-iOS).
+        self.assertIn(
+            "public func removePeerLocation(_ peerHash: Data) {}",
+            self.compat,
+        )
+
+    # MARK: - Directions launcher
+
+    def test_directions_launcher_uses_injectable_probe_and_google_scheme(self):
+        self.assertIn("protocol SchemeProbe {", self.launcher)
+        self.assertIn(
+            'static let googleMapsScheme = "comgooglemaps"',
+            self.launcher,
+        )
+        # Apple Maps always first; Google only when the probe says installed.
+        self.assertRegex(
+            self.launcher,
+            r"if probe\.canOpen\(scheme: Self\.googleMapsScheme\) \{",
+        )
+        # Walking-mode deep link parity with Android.
+        self.assertIn(
+            "comgooglemaps://?daddr=\\(coordinate.latitude),\\(coordinate.longitude)&directionsmode=walking",
+            self.launcher,
+        )
+        self.assertIn(
+            "MKLaunchOptionsDirectionsModeWalking",
+            self.launcher,
+        )
+
+    # MARK: - Localization keys
+
+    def test_localization_catalog_has_all_new_keys(self):
+        catalog_path = (
+            REPOSITORY_ROOT / "Sources/ColumbaApp/Resources/Localizable.xcstrings"
+        )
+        catalog = json.loads(catalog_path.read_text(encoding="utf-8"))
+        keys = catalog["strings"]
+        for key in (
+            "north",
+            "northeast",
+            "east",
+            "southeast",
+            "south",
+            "southwest",
+            "west",
+            "northwest",
+            "Location unknown",
+            "Updated just now",
+            "Updated %llds ago",
+            "Updated %lldm ago",
+            "Updated %lldh ago",
+            "Updated %lldd ago",
+            "Stale",
+            "Directions",
+            "Message",
+            "Remove from map",
+            "Open Directions in:",
+            "Apple Maps",
+            "Google Maps",
+        ):
+            with self.subTest(key=key):
+                self.assertIn(key, keys)
+
+    # MARK: - pbxproj registration
+
+    def test_new_files_are_registered_in_pbxproj(self):
+        # The pbxproj is hand-maintained (objectVersion 60, no folder
+        # sync): an unregistered .swift file compiles into nothing and its
+        # tests never run. Each new file needs a file ref, a build file per
+        # target it belongs to, a group child, and a Sources-phase entry.
+        app_filenames = APP_SOURCES
+        test_filenames = TEST_SOURCES
+
+        for filename in app_filenames:
+            with self.subTest(file=filename):
+                # One file reference.
+                self.assertRegex(
+                    self.project,
+                    rf"[A-F0-9]+ /\* {re.escape(filename)} \*/ = \{{isa = PBXFileReference;[^}}]*path = {re.escape(filename)};",
+                )
+                # Build-file declarations exist (two app targets).
+                self.assertRegex(
+                    self.project,
+                    rf"[A-F0-9]+ /\* {re.escape(filename)} in Sources \*/ = \{{isa = PBXBuildFile;[^}}]*fileRef = [A-F0-9]+ /\* {re.escape(filename)} \*/;",
+                )
+                # Group child.
+                self.assertRegex(
+                    self.project,
+                    rf"\t[A-F0-9]+ /\* {re.escape(filename)} \*/,",
+                )
+                # Sources-phase entries (at least the shipping app phase).
+                self.assertRegex(
+                    self.project,
+                    rf"\t[A-F0-9]+ /\* {re.escape(filename)} in Sources \*/,",
+                )
+
+        for filename in test_filenames:
+            with self.subTest(file=filename):
+                self.assertRegex(
+                    self.project,
+                    rf"[A-F0-9]+ /\* {re.escape(filename)} \*/ = \{{isa = PBXFileReference;[^}}]*path = {re.escape(filename)};",
+                )
+                self.assertRegex(
+                    self.project,
+                    rf"[A-F0-9]+ /\* {re.escape(filename)} in Sources \*/ = \{{isa = PBXBuildFile;[^}}]*fileRef = [A-F0-9]+ /\* {re.escape(filename)} \*/;",
+                )
+                self.assertRegex(
+                    self.project,
+                    rf"\t[A-F0-9]+ /\* {re.escape(filename)} in Sources \*/,",
+                )
+
+    def test_new_files_present_on_disk(self):
+        for filename in APP_SOURCES:
+            with self.subTest(file=filename):
+                self.assertTrue((MAP_DIR / filename).is_file())
+        for filename in TEST_SOURCES:
+            with self.subTest(file=filename):
+                self.assertTrue(
+                    (REPOSITORY_ROOT / "Tests/ColumbaAppTests" / filename).is_file()
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tests/static/test_map_peer_pin_tap.py
+++ b/Tests/static/test_map_peer_pin_tap.py
@@ -241,17 +241,24 @@ class MapPeerPinTapContractTests(unittest.TestCase):
         self.assertIn("if isResolvingPeerChat {", self.chats_view)
         self.assertNotIn("peerConversation != nil {", self.chats_view)
         self.assertIn("await checkPendingNotification()", route_body)
-        # The check only consumes the pending hash after confirming the row
-        # exists: it refreshes from storage against a stale snapshot and
-        # restores the hash if the conversation is genuinely missing, so a
-        # tap can never be permanently discarded.
+        # The check is async, only consumes the pending hash after the row
+        # has resolved, and never blocks on a stale snapshot: unfiltered
+        # lookup, one refresh from storage when the snapshot is stale, and
+        # the slot left intact when the row is not in storage yet (retry on
+        # the next trigger) - so a tap is never silently discarded and an
+        # active search query cannot hide the tapped conversation.
         self.assertIn("@MainActor\n    private func checkPendingNotification() async", self.chats_view)
         check_body = (
             self.chats_view.split("private func checkPendingNotification() async")[1]
             .split("\n    /// Consume the Map tab")[0]
         )
+        self.assertIn("vm.conversations.first(where: { $0.id == hash })", check_body)
+        self.assertNotIn("vm.filteredConversations.first(where: { $0.id == hash })", check_body)
         self.assertIn("await vm.refreshConversations()", check_body)
-        self.assertIn("NotificationService.pendingConversationHash = hash", check_body)
+        # Post-refresh clear is guarded: a newer tap that replaced the
+        # slot during the refresh is never clobbered.
+        self.assertIn("if NotificationService.pendingConversationHash == hash {", check_body)
+        self.assertIn("NotificationService.pendingConversationHash = nil", check_body)
         # All call sites drive the async check from a Task.
         self.assertIn("Task { await checkPendingNotification() }", self.chats_view)
 

--- a/Tests/static/test_map_peer_pin_tap.py
+++ b/Tests/static/test_map_peer_pin_tap.py
@@ -12,7 +12,9 @@ the Maestro interop flow cannot fully cover on their own:
 - MapView presents the PeerContactSheet, wires Directions / Message /
   Remove, and exposes the onOpenPeerChat cross-tab route.
 - MainTabView holds the pendingPeerChat state and switches to the Chats tab.
-- ChatsView consumes the route via the notificationConversation push.
+- ChatsView consumes the route via a dedicated `peerConversation` push
+  (never the shared notification route, which a concurrent notification
+  tap owns) and defers notifications while the route resolves.
 - LocationSharingManager implements removePeerLocation and the non-iOS
   Compat.swift stub keeps the API available for cross-platform code.
 - Every new Swift file is registered in the hand-maintained pbxproj
@@ -200,26 +202,42 @@ class MapPeerPinTapContractTests(unittest.TestCase):
             re.DOTALL,
         )
 
-    def test_chats_view_consumes_route_via_notification_conversation(self):
+    def test_chats_view_consumes_route_via_peer_conversation_route(self):
         # A @Binding property CANNOT take `= nil` (the memberwise init
         # parameter is Binding<Data?>, not Data?), so the declaration must
         # have no default.
         self.assertIn("@Binding var pendingPeerChat: Data?\n", self.chats_view)
         self.assertNotIn("@Binding var pendingPeerChat: Data? = nil", self.chats_view)
         self.assertIn("private func consumePeerChatRoute() async", self.chats_view)
-        # One-shot: clear before the async work.
+        # One-shot: clear before the async work; a route already resolving
+        # is never re-entered (double-open guard).
         self.assertRegex(
             self.chats_view,
-            r"guard let hash = pendingPeerChat else \{ return \}\s*\n\s*// Clear first.*\n\s*pendingPeerChat = nil",
+            r"guard let hash = pendingPeerChat, !isResolvingPeerChat else \{ return \}\s*\n\s*// Clear first.*\n\s*pendingPeerChat = nil",
             re.DOTALL,
         )
         # Telemetry-only peers get a conversation row created, then pushed
-        # through the existing notification-conversation route.
+        # through the dedicated peer-conversation route.
         self.assertIn(
             "messageRepository.ensureConversation(hash, displayName: nil)",
             self.chats_view,
         )
-        self.assertIn("notificationConversation = conversation", self.chats_view)
+        # Race fix: the async peer route pushes its OWN destination state,
+        # so a notification tap (or vice versa) can never make the last
+        # async assignment win a single shared binding.
+        self.assertIn("@State private var peerConversation: Conversation?", self.chats_view)
+        self.assertIn("@State private var isResolvingPeerChat: Bool = false", self.chats_view)
+        self.assertIn(".navigationDestination(item: $peerConversation)", self.chats_view)
+        self.assertIn("peerConversation = conversation", self.chats_view)
+        # The peer route body must never touch the notification route state.
+        route_body = (
+            self.chats_view.split("private func consumePeerChatRoute() async")[1]
+            .split("\n    // MARK:")[0]
+        )
+        self.assertNotIn("notificationConversation", route_body)
+        # While the route resolves (or after it pushes), a notification tap
+        # defers instead of competing for navigation.
+        self.assertIn("if isResolvingPeerChat || peerConversation != nil {", self.chats_view)
 
     # MARK: - Removal + non-iOS stub
 

--- a/Tests/static/test_map_peer_pin_tap.py
+++ b/Tests/static/test_map_peer_pin_tap.py
@@ -245,8 +245,9 @@ class MapPeerPinTapContractTests(unittest.TestCase):
         # has resolved, and never blocks on a stale snapshot: unfiltered
         # lookup, one refresh from storage when the snapshot is stale, and
         # the slot left intact when the row is not in storage yet (retry on
-        # the next trigger) - so a tap is never silently discarded and an
-        # active search query cannot hide the tapped conversation.
+        # the next trigger) - so a tap is never silently discarded, a stale
+        # continuation can't open an older conversation, and an active
+        # search query cannot hide the tapped conversation.
         self.assertIn("@MainActor\n    private func checkPendingNotification() async", self.chats_view)
         check_body = (
             self.chats_view.split("private func checkPendingNotification() async")[1]
@@ -255,10 +256,18 @@ class MapPeerPinTapContractTests(unittest.TestCase):
         self.assertIn("vm.conversations.first(where: { $0.id == hash })", check_body)
         self.assertNotIn("vm.filteredConversations.first(where: { $0.id == hash })", check_body)
         self.assertIn("await vm.refreshConversations()", check_body)
-        # Post-refresh clear is guarded: a newer tap that replaced the
-        # slot during the refresh is never clobbered.
-        self.assertIn("if NotificationService.pendingConversationHash == hash {", check_body)
+        # Post-refresh consume+route is guarded by slot ownership: a newer
+        # tap that replaced the slot during the refresh owns the route, so
+        # the stale continuation must not assign the destination.
+        self.assertRegex(
+            self.chats_view,
+            r"if let conversation = vm\.conversations\.first\(where: \{ \$0\.id == hash \}\),\s*\n\s*NotificationService\.pendingConversationHash == hash \{",
+        )
         self.assertIn("NotificationService.pendingConversationHash = nil", check_body)
+        # The retry trigger observes the canonical list (an active search
+        # can filter it out, which would strand the pending tap).
+        self.assertIn(".onChange(of: viewModel?.conversations) { _, _ in", self.chats_view)
+        self.assertNotIn(".onChange(of: viewModel?.filteredConversations) { _, _ in", self.chats_view)
         # All call sites drive the async check from a Task.
         self.assertIn("Task { await checkPendingNotification() }", self.chats_view)
 

--- a/Tests/static/test_map_peer_pin_tap.py
+++ b/Tests/static/test_map_peer_pin_tap.py
@@ -241,6 +241,15 @@ class MapPeerPinTapContractTests(unittest.TestCase):
         self.assertIn("if isResolvingPeerChat {", self.chats_view)
         self.assertNotIn("peerConversation != nil {", self.chats_view)
         self.assertIn("await checkPendingNotification()", route_body)
+        # Settle-time retry for a second peer route: a Map Message tapped
+        # while the first route was resolving was rejected by the
+        # in-flight guard and left in pendingPeerChat; its onChange needs a
+        # fresh change, so the settle path must retry it (bounded: each
+        # pass clears a non-nil slot).
+        self.assertRegex(
+            self.chats_view,
+            r"if pendingPeerChat != nil \{\s*\n\s*await consumePeerChatRoute\(\)\s*\n\s*\}",
+        )
         # The check is async, only consumes the pending hash after the row
         # has resolved, and never blocks on a stale snapshot: unfiltered
         # lookup, one refresh from storage when the snapshot is stale, and

--- a/Tests/static/test_map_peer_pin_tap.py
+++ b/Tests/static/test_map_peer_pin_tap.py
@@ -263,7 +263,16 @@ class MapPeerPinTapContractTests(unittest.TestCase):
         # cases the stale continuation must not assign the destination.
         self.assertRegex(
             self.chats_view,
-            r"if let conversation = vm\.conversations\.first\(where: \{ \$0\.id == hash \}\),\s*\n\s*NotificationService\.pendingConversationHash == hash,\s*\n\s*!isResolvingPeerChat \{",
+            r"guard let conversation = vm\.conversations\.first\(where: \{ \$0\.id == hash \}\),\s*\n\s*NotificationService\.pendingConversationHash == hash,\s*\n\s*!isResolvingPeerChat else \{",
+        )
+        # Handoff: when a NEWER tap owns the slot, the stale continuation
+        # re-runs the check for the current hash (bounded: each recursive
+        # call only happens for a different hash, so the newest tap's own
+        # call owns the slot and stops the chain) - otherwise a no-op
+        # refresh would strand the newer tap until an unrelated trigger.
+        self.assertRegex(
+            self.chats_view,
+            r"if NotificationService\.pendingConversationHash != nil,\s*\n\s*NotificationService\.pendingConversationHash != hash \{\s*\n\s*await checkPendingNotification\(\)\s*\n\s*\}",
         )
         self.assertIn("NotificationService.pendingConversationHash = nil", check_body)
         # The retry trigger observes the canonical list (an active search

--- a/Tests/static/test_map_peer_pin_tap.py
+++ b/Tests/static/test_map_peer_pin_tap.py
@@ -240,7 +240,20 @@ class MapPeerPinTapContractTests(unittest.TestCase):
         # route re-runs the check when it settles (retry at route end).
         self.assertIn("if isResolvingPeerChat {", self.chats_view)
         self.assertNotIn("peerConversation != nil {", self.chats_view)
-        self.assertIn("checkPendingNotification()\n    }", route_body)
+        self.assertIn("await checkPendingNotification()", route_body)
+        # The check only consumes the pending hash after confirming the row
+        # exists: it refreshes from storage against a stale snapshot and
+        # restores the hash if the conversation is genuinely missing, so a
+        # tap can never be permanently discarded.
+        self.assertIn("@MainActor\n    private func checkPendingNotification() async", self.chats_view)
+        check_body = (
+            self.chats_view.split("private func checkPendingNotification() async")[1]
+            .split("\n    /// Consume the Map tab")[0]
+        )
+        self.assertIn("await vm.refreshConversations()", check_body)
+        self.assertIn("NotificationService.pendingConversationHash = hash", check_body)
+        # All call sites drive the async check from a Task.
+        self.assertIn("Task { await checkPendingNotification() }", self.chats_view)
 
     # MARK: - Removal + non-iOS stub
 


### PR DESCRIPTION
## Summary

Columba-iOS #179: makes peer location pins on the map tappable. Tapping a peer's pin opens a bottom sheet (peer name, distance, Message / Directions / Remove actions). Selecting Message routes into the conversation, Directions opens the peer's location in Maps, Remove clears the peer's location share.

## Changes

- MapLibreMapView: annotation selection handling (didSelect/didDeselect, no callouts), peer pin accessibility identifiers (peer_pin_<hex>), center-on-user support.
- PeerContactSheet: new bottom sheet with default (medium) detent, drag handle, dismiss -> clearPeerSelection.
- MapView: sheet presentation wiring.
- LocationSharingManager: [LOC-REMOVE] diag mirror in removePeerLocation + hex dedup.
- PeerContactSheet a11y fix: sheet root previously used .accessibilityElement(children: .contain) with a root accessibilityIdentifier, which collapsed the whole sheet into one element, hiding the three buttons' identifiers and stamping the root id on every descendant. Moved peer_sheet_name onto the name Text and dropped the .contain + root-id wrapper so each button self-exposes. Verified with a live accessibility hierarchy dump.
- Interop harness fixes: peer pin offset (~330 m east of the user dot so it renders distinct from the user annotation), peer+coordinate-specific LOC-RECV wait, LOC-REMOVE poll, test budgets, and sheet-dismiss swipe (y:55% for the default medium detent) wired into the map-tab preamble and bubble assertions.

## Verification

- On-device E2E (iPhone 17 simulator, real Xcode build + RNS interop): 3/3 pin tests green in the full suite - test_peer_pin_tap_opens_contact_sheet, test_peer_pin_message_route_opens_conversation, test_stale_peer_pin_remove_clears_pin.
- Full interop: 17 passed, 1 failed. Sole failure is the pre-existing 8-second-window test_image_ios_to_sideband_propagated (not in this diff; also failed on the branch's first pre-change run; every other test uses 30-60 s windows and passes).
- Static contract suite: 313 passed, 1 skipped, 307 subtests.
- Real device check: built from this head, installed in-place on a physical iPhone 14, launches and stays alive.

## Notes

- pbxproj is hand-maintained (objectVersion 60); new Swift files registered in all four spots (sources + unit test target).
- No force-push; branch is linear on top of origin/main (5a8a4d34).