### PR TITLE
feat(ios): surface incoming message RSSI/SNR in message details

### DIFF
--- a/Sources/ColumbaApp/Resources/ColumbaApp.exports
+++ b/Sources/ColumbaApp/Resources/ColumbaApp.exports
@@ -5,6 +5,7 @@ _columba_ble_connect
 _columba_ble_disconnect
 _columba_ble_get_peer_mtu
 _columba_ble_get_peer_role
+_columba_ble_get_peer_rssi
 _columba_ble_request_identity_resync
 _columba_ble_send
 _columba_ble_set_identity

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -2952,8 +2952,8 @@ public final class AppServices {
             // in Documents/diag.log and the unified log. Hashes are prefixed to
             // keep the line correlatable without exposing full identity hashes.
             // rssi/snr are numeric radio metrics, not message content — safe to log.
-            let rssiText = rssi.map(String.init) ?? "-"
-            let snrText = snr.map(String.init) ?? "-"
+            let rssiText = rssi.map { "\($0)" } ?? "-"
+            let snrText = snr.map { "\($0)" } ?? "-"
             DiagLog.log("[RNS] inbound source=\(sourceHash.prefix(8)) message=\(messageHash.prefix(8)) len=\(content.utf8.count) fields=\(fieldsPacked.count)B rssi=\(rssiText) snr=\(snrText)")
             guard let data = Data(hexString: sourceHash) else { return }
             let fields = fieldsPacked.isEmpty ? nil : LxmfFieldCodec.unpack(fieldsPacked)

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -2739,7 +2739,7 @@ public final class AppServices {
     /// run side-channel handling (reactions/replies/telemetry/icon/cease) through
     /// IncomingMessageHandler. Returns nil if blocked or persistence failed.
     @discardableResult
-    private func persistInboundFromPython(sourceHash: Data, messageHashHex: String, content: String, title: String, fields: [UInt8: Any]?, method: LXDeliveryMethod?, timestamp: Date) async -> LXMessage? {
+    private func persistInboundFromPython(sourceHash: Data, messageHashHex: String, content: String, title: String, fields: [UInt8: Any]?, method: LXDeliveryMethod?, rssi: Double? = nil, snr: Double? = nil, timestamp: Date) async -> LXMessage? {
         // Route Python-path inbound persistence through the GRDB canonical
         // store (the same one the UI reads and the Swift/NE path writes), via
         // the shared MessageRepository's RNSAPI-typed methods — NOT the
@@ -2813,6 +2813,12 @@ public final class AppServices {
             message.incoming = true
             message.timestamp = timestamp.timeIntervalSince1970
             message.state = .received
+            // Receiving-interface signal metrics, captured at delivery time by
+            // the Python bridge. Nil when the interface is unknown or the
+            // metric is unavailable (the detail cards stay hidden). Copied onto
+            // the GRDB record by `MessageRepository.mapToGRDBMessage`.
+            message.rssi = rssi
+            message.snr = snr
 
             try await repo.saveMessage(message)
             // `saveMessage` must create/update the conversation before this
@@ -2940,20 +2946,25 @@ public final class AppServices {
                     DiagLog.log("[RNS] stamped display name onto convo \(data.map { String(format: "%02x", $0) }.joined().prefix(8))")
                 }
             }
-        case .inbound(let sourceHash, let messageHash, let content, let title, let fieldsPacked, let method, let t):
+        case .inbound(let sourceHash, let messageHash, let content, let title, let fieldsPacked, let method, let rssi, let snr, let t):
             // NO-PII: envelope/metadata only (mirrors ExtensionDiagLog's contract).
             // Never log message content, title, or field payload bytes — they land
             // in Documents/diag.log and the unified log. Hashes are prefixed to
             // keep the line correlatable without exposing full identity hashes.
-            DiagLog.log("[RNS] inbound source=\(sourceHash.prefix(8)) message=\(messageHash.prefix(8)) len=\(content.utf8.count) fields=\(fieldsPacked.count)B")
+            // rssi/snr are numeric radio metrics, not message content — safe to log.
+            let rssiText = rssi.map(String.init) ?? "-"
+            let snrText = snr.map(String.init) ?? "-"
+            DiagLog.log("[RNS] inbound source=\(sourceHash.prefix(8)) message=\(messageHash.prefix(8)) len=\(content.utf8.count) fields=\(fieldsPacked.count)B rssi=\(rssiText) snr=\(snrText)")
             guard let data = Data(hexString: sourceHash) else { return }
             let fields = fieldsPacked.isEmpty ? nil : LxmfFieldCodec.unpack(fieldsPacked)
-            // Persist the base message (carrying its fields), then run side-channel
+            // Persist the base message (carrying its fields + the receiving
+            // interface's signal metrics), then run side-channel
             // handling (reactions / replies / telemetry / icon / cease) through
             // IncomingMessageHandler — the router.delegate, wired in ColumbaApp.
-            // Same path for both backends (Python sends empty fields until its
-            // bridge plumbing lands; the Swift backend populates them now).
-            if let saved = await persistInboundFromPython(sourceHash: data, messageHashHex: messageHash, content: content, title: title, fields: fields, method: method, timestamp: t),
+            // Same path for both backends (the Swift/NE backend passes nil
+            // metrics; the Python backend populates them from the delivery
+            // callback).
+            if let saved = await persistInboundFromPython(sourceHash: data, messageHashHex: messageHash, content: content, title: title, fields: fields, method: method, rssi: rssi, snr: snr, timestamp: t),
                fields != nil, let router = self.router {
                 if let handler = router.delegate as? IncomingMessageHandler {
                     _ = await handler.handleInbound(saved).value

--- a/Sources/ColumbaApp/Views/Messaging/MessageDetailView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageDetailView.swift
@@ -507,6 +507,9 @@ struct MessageDetailView: View {
 
     private func snrCard(_ snr: Double) -> some View {
         let (quality, color): (String, Color) = {
+            // Five tiers, matching Android's `SignalQualityInfo.getSnrInfo`
+            // thresholds (>10 / 5-10 / 0-5 / -5-0 / <-5) for cross-platform
+            // parity.
             switch snr {
             case 10...:
                 return ("Excellent quality", .green)
@@ -514,8 +517,10 @@ struct MessageDetailView: View {
                 return ("Good quality", .green)
             case 0..<5:
                 return ("Fair quality", .orange)
-            default:
+            case -5..<0:
                 return ("Poor quality", .red)
+            default:
+                return ("Very poor quality", .red)
             }
         }()
 

--- a/Sources/PythonBridge/PythonBridge.swift
+++ b/Sources/PythonBridge/PythonBridge.swift
@@ -68,7 +68,7 @@ public final class PythonBridge: @unchecked Sendable {
 
     public enum Event: Equatable, Sendable {
         case announce(destHash: String, appDataHex: String, aspect: String, publicKeysHex: String, interfaceName: String, hops: Int, t: Date)
-        case inbound(sourceHash: String, messageHash: String, content: String, title: String, fieldsHex: String, method: String, t: Date)
+        case inbound(sourceHash: String, messageHash: String, content: String, title: String, fieldsHex: String, method: String, rssi: Double?, snr: Double?, t: Date)
         case state(String, t: Date)
 
         /// Delivery lifecycle event for an outbound message, keyed by its LXMF
@@ -887,7 +887,13 @@ public final class PythonBridge: @unchecked Sendable {
                 let title = pyStringFromDict(item, key: "title") ?? ""
                 let fieldsHex = pyStringFromDict(item, key: "fields_hex") ?? ""
                 let method = pyStringFromDict(item, key: "method") ?? ""
-                out.append(.inbound(sourceHash: h, messageHash: messageHash, content: c, title: title, fieldsHex: fieldsHex, method: method, t: t))
+                // Signal metrics captured at delivery time by rns_bridge.py.
+                // Absent (nil) when the receiving interface is unknown or the
+                // metric is unavailable — PyFloat_AsDouble accepts both the
+                // int rssi and the float snr.
+                let rssi = pyDoubleFromDict(item, key: "rssi")
+                let snr = pyDoubleFromDict(item, key: "snr")
+                out.append(.inbound(sourceHash: h, messageHash: messageHash, content: c, title: title, fieldsHex: fieldsHex, method: method, rssi: rssi, snr: snr, t: t))
             case "state":
                 let v = pyStringFromDict(item, key: "value") ?? "?"
                 out.append(.state(v, t: t))

--- a/Sources/RNSAPI/Protocols/RnsBackend.swift
+++ b/Sources/RNSAPI/Protocols/RnsBackend.swift
@@ -63,7 +63,10 @@ public enum BackendEvent: Equatable, Sendable {
     /// `fieldsPacked` is the inbound LXMF field map as MessagePack bytes (empty
     /// = no fields) — decode with `LxmfFieldCodec.unpack`. Carries telemetry /
     /// attachments / reactions / replies / icon / cease through the seam.
-    case inbound(sourceHash: String, messageHash: String, content: String, title: String, fieldsPacked: Data, method: LXDeliveryMethod?, t: Date)
+    /// `rssi` (dBm) and `snr` (dB) are the receiving interface's signal
+    /// metrics captured at delivery time by the backend (RNode: both, BLE:
+    /// RSSI only, other interfaces: nil) — nil when unavailable.
+    case inbound(sourceHash: String, messageHash: String, content: String, title: String, fieldsPacked: Data, method: LXDeliveryMethod?, rssi: Double?, snr: Double?, t: Date)
     case state(String, t: Date)
     /// Delivery lifecycle event for an outbound message. `method` is the
     /// effective transport used for this attempt and is independent of state.

--- a/Sources/RNSBackendPy/PythonRNSBackend.swift
+++ b/Sources/RNSBackendPy/PythonRNSBackend.swift
@@ -423,7 +423,7 @@ public final class PythonRNSBackend: RnsBackend, @unchecked Sendable {
         switch e {
         case let .announce(d, a, asp, pk, ifn, h, t):
             return .announce(destHash: d, appDataHex: a, aspect: asp, publicKeysHex: pk, interfaceName: ifn, hops: h, t: t)
-        case let .inbound(s, mh, c, ti, fh, method, t):
+        case let .inbound(s, mh, c, ti, fh, method, rssi, snr, t):
             // fieldsHex = MessagePack-packed LXMF field map (hex), extracted by
             // rns_bridge.py's delivery callback; decode to the neutral fieldsPacked.
             let deliveryMethod: LXDeliveryMethod?
@@ -434,7 +434,7 @@ public final class PythonRNSBackend: RnsBackend, @unchecked Sendable {
             case "paper": deliveryMethod = .paper
             default: deliveryMethod = nil
             }
-            return .inbound(sourceHash: s, messageHash: mh, content: c, title: ti, fieldsPacked: (try? fh.hexToData()) ?? Data(), method: deliveryMethod, t: t)
+            return .inbound(sourceHash: s, messageHash: mh, content: c, title: ti, fieldsPacked: (try? fh.hexToData()) ?? Data(), method: deliveryMethod, rssi: rssi, snr: snr, t: t)
         case let .state(s, t):
             return .state(s, t: t)
         case let .delivery(m, s, method, t):

--- a/Sources/RNSBackendSwift/SwiftRNSBackend.swift
+++ b/Sources/RNSBackendSwift/SwiftRNSBackend.swift
@@ -750,7 +750,11 @@ public final class SwiftRNSBackend: RnsBackend, @unchecked Sendable {
             let content = String(data: message.content, encoding: .utf8) ?? ""
             let title = String(data: message.title, encoding: .utf8) ?? ""
             let fieldsPacked = (message.fields?.isEmpty == false) ? LxmfFieldCodec.pack(message.fields!) : Data()
-            continuation.yield(.inbound(sourceHash: message.sourceHash.hexHash, messageHash: message.hash.hexHash, content: content, title: title, fieldsPacked: fieldsPacked, method: Self.mapDeliveryMethod(message.method), t: Date()))
+            // The Swift/NE backend persists inbound through its own LXMRouter
+            // (GRDB) and has no receiving-interface RSSI/SNR to attach — the
+            // signal metrics are a Python-backend concern (captured at delivery
+            // time in rns_bridge.py). Pass nil; the cards stay hidden.
+            continuation.yield(.inbound(sourceHash: message.sourceHash.hexHash, messageHash: message.hash.hexHash, content: content, title: title, fieldsPacked: fieldsPacked, method: Self.mapDeliveryMethod(message.method), rssi: nil, snr: nil, t: Date()))
         }
         func router(_ router: LXMFSwift.LXMRouter, didUpdateMessage message: LXMFSwift.LXMessage) {
             if message.state == .delivered {

--- a/Sources/SwiftBLEBridge/BleGattClient.swift
+++ b/Sources/SwiftBLEBridge/BleGattClient.swift
@@ -58,6 +58,10 @@ internal final class BleGattClient {
     /// completes. The bridge polls periodically post-connect.
     var rssi: Int?
 
+    /// When `rssi` was last sampled. nil until the first successful
+    /// `readRSSI()` lands. Used to reject stale samples at delivery time.
+    var rssiSampledAt: Date?
+
     /// Outbound fragments awaiting CoreBluetooth transmit-queue space.
     /// writeValue(.withoutResponse) silently drops once the per-peripheral
     /// queue is full (iOS 11+), so frames are queued here and drained as space

--- a/Sources/SwiftBLEBridge/BleNativeBindings.swift
+++ b/Sources/SwiftBLEBridge/BleNativeBindings.swift
@@ -184,6 +184,20 @@ public func columba_ble_get_peer_mtu(_ address: UnsafePointer<CChar>?) -> Int32 
     return Int32(SwiftBLEBridge.shared.getPeerMtu(address: addr) ?? 0)
 }
 
+/// Return the most recent RSSI (dBm) for a peer, or `Int32.min` as the
+/// "unknown" sentinel when no sample is available (null pointer, peer not
+/// connected, peripheral-role peer with no readable RSSI, or no sample yet).
+///
+/// A real RSSI is always a small negative dBm value (-30 … -120 in practice),
+/// so `Int32.min` can never be confused with a legitimate reading. The Python
+/// `IOSBLEDriver` maps the sentinel back to `None`.
+@_used
+@_cdecl("columba_ble_get_peer_rssi")
+public func columba_ble_get_peer_rssi(_ address: UnsafePointer<CChar>?) -> Int32 {
+    guard let addr = decodeCString(address) else { return Int32.min }
+    return SwiftBLEBridge.shared.getPeerRssi(address: addr).map(Int32.init) ?? Int32.min
+}
+
 // MARK: - Config
 
 @_used

--- a/Sources/SwiftBLEBridge/SwiftBLEBridge.swift
+++ b/Sources/SwiftBLEBridge/SwiftBLEBridge.swift
@@ -750,8 +750,16 @@ public final class SwiftBLEBridge: NSObject, @unchecked Sendable {
             // peripheral-role peers (no gattClients entry) have no readable
             // RSSI at all. Returning nil lets the UI omit the card rather
             // than persist and display a misleading value.
+            //
+            // Freshness guard: the poll task refreshes `client.rssi` every
+            // ~3s, but if every `readRSSI()` in a window fails or returns a
+            // sentinel the stored value goes unversioned and silently ages.
+            // A sample older than 2 poll intervals is no longer "current",
+            // so reject it.
+            let maxSampleAge: TimeInterval = 2 * rssiPollInterval
             if let client = gattClients[address], client.state == .established,
-               let rssi = client.rssi {
+               let rssi = client.rssi, let sampledAt = client.rssiSampledAt,
+               Date().timeIntervalSince(sampledAt) <= maxSampleAge {
                 return rssi
             }
             return nil
@@ -1282,6 +1290,7 @@ extension SwiftBLEBridge: CBPeripheralDelegate {
         // doesn't overwrite a good RSSI that getConnectionDetails() surfaces.
         guard value != 127, value != -127, value != 0 else { return }
         gattClients[address]?.rssi = value
+        gattClients[address]?.rssiSampledAt = Date()
     }
 }
 

--- a/Sources/SwiftBLEBridge/SwiftBLEBridge.swift
+++ b/Sources/SwiftBLEBridge/SwiftBLEBridge.swift
@@ -743,16 +743,18 @@ public final class SwiftBLEBridge: NSObject, @unchecked Sendable {
     }
     public func getPeerRssi(address: String) -> Int? {
         queue.sync {
-            // Prefer the fresh `readRSSI()` sample from an established
-            // central-side GATT client (the same value getConnectionDetails
-            // surfaces for the central role); fall back to the last scan-time
-            // discovery report. Peripheral-role peers have no RSSI — Core
-            // Bluetooth doesn't expose the central's RSSI to us — so they
-            // simply have no gattClients entry and resolve to nil.
-            if let client = gattClients[address] {
-                return client.rssi ?? lastDiscoveryReport[address]?.rssi
+            // Only report a FRESH `readRSSI()` sample from an established
+            // central-side GATT client. No discovery/scan-time fallback:
+            // `lastDiscoveryReport` holds the RSSI from the initial scan,
+            // which can be arbitrarily stale by delivery time, and
+            // peripheral-role peers (no gattClients entry) have no readable
+            // RSSI at all. Returning nil lets the UI omit the card rather
+            // than persist and display a misleading value.
+            if let client = gattClients[address], client.state == .established,
+               let rssi = client.rssi {
+                return rssi
             }
-            return lastDiscoveryReport[address]?.rssi
+            return nil
         }
     }
     public func getPeerRole(address: String) -> BleConnectionRole? {

--- a/Sources/SwiftBLEBridge/SwiftBLEBridge.swift
+++ b/Sources/SwiftBLEBridge/SwiftBLEBridge.swift
@@ -742,7 +742,18 @@ public final class SwiftBLEBridge: NSObject, @unchecked Sendable {
         }
     }
     public func getPeerRssi(address: String) -> Int? {
-        queue.sync { lastDiscoveryReport[address]?.rssi }
+        queue.sync {
+            // Prefer the fresh `readRSSI()` sample from an established
+            // central-side GATT client (the same value getConnectionDetails
+            // surfaces for the central role); fall back to the last scan-time
+            // discovery report. Peripheral-role peers have no RSSI — Core
+            // Bluetooth doesn't expose the central's RSSI to us — so they
+            // simply have no gattClients entry and resolve to nil.
+            if let client = gattClients[address] {
+                return client.rssi ?? lastDiscoveryReport[address]?.rssi
+            }
+            return lastDiscoveryReport[address]?.rssi
+        }
     }
     public func getPeerRole(address: String) -> BleConnectionRole? {
         queue.sync {

--- a/Tests/static/test_inbound_delivery_method.py
+++ b/Tests/static/test_inbound_delivery_method.py
@@ -40,6 +40,8 @@ class InboundDeliveryMethodTests(unittest.TestCase):
             and node.name in {
                 "_canonical_inbound_hash",
                 "_inbound_delivery_method_name",
+                "_receiving_interface",
+                "_signal_metrics",
                 "_delivery_callback",
             }
         }
@@ -47,6 +49,8 @@ class InboundDeliveryMethodTests(unittest.TestCase):
             {
                 "_canonical_inbound_hash",
                 "_inbound_delivery_method_name",
+                "_receiving_interface",
+                "_signal_metrics",
                 "_delivery_callback",
             },
             set(functions),
@@ -54,13 +58,20 @@ class InboundDeliveryMethodTests(unittest.TestCase):
         namespace = {
             "Any": Any,
             "LXMF": types.SimpleNamespace(LXMessage=FakeMessage),
-            "RNS": types.SimpleNamespace(LOG_ERROR=1, log=lambda *_args: None),
+            "RNS": types.SimpleNamespace(
+                LOG_ERROR=1,
+                LOG_DEBUG=2,
+                log=lambda *_args: None,
+                Transport=types.SimpleNamespace(path_table={}),
+            ),
             "_put": lambda kind, **payload: events.append((kind, payload)),
         }
         module = ast.Module(
             body=[
                 functions["_canonical_inbound_hash"],
                 functions["_inbound_delivery_method_name"],
+                functions["_receiving_interface"],
+                functions["_signal_metrics"],
                 functions["_delivery_callback"],
             ],
             type_ignores=[],

--- a/Tests/static/test_inbound_signal_metrics.py
+++ b/Tests/static/test_inbound_signal_metrics.py
@@ -1,0 +1,220 @@
+import ast
+import types
+import unittest
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[2]
+BRIDGE = ROOT / "app" / "rns_bridge.py"
+
+_REQUIRED_HELPERS = {
+    "_canonical_inbound_hash",
+    "_inbound_delivery_method_name",
+    "_receiving_interface",
+    "_signal_metrics",
+    "_delivery_callback",
+}
+
+
+class FakeMessage:
+    OPPORTUNISTIC = 0x01
+    DIRECT = 0x02
+    PROPAGATED = 0x03
+    PAPER = 0x04
+
+    def __init__(
+        self,
+        method: int = 0x01,
+        receiving_interface: Any = None,
+        source_hash: bytes = bytes.fromhex("11" * 16),
+    ):
+        self.method = method
+        self.fields = None
+        self.source_hash = source_hash
+        self.hash = bytes.fromhex("22" * 32)
+        self.message_id = self.hash
+        self.packed = None
+        if receiving_interface is not None:
+            self.receiving_interface = receiving_interface
+
+    def content_as_string(self) -> str:
+        return "received through relay"
+
+    def title_as_string(self) -> str:
+        return ""
+
+
+class RNodeLikeInterface:
+    """Mirrors IOSRNodeInterface: exposes get_rssi() + get_snr()."""
+
+    def __init__(self, rssi: int, snr: float):
+        self._rssi = rssi
+        self._snr = snr
+
+    def get_rssi(self) -> int:
+        return self._rssi
+
+    def get_snr(self) -> float:
+        return self._snr
+
+
+class BLEPeerInterface:
+    """Mirrors ble_reticulum.BLEPeerInterface: no get_rssi of its own, but
+    carries a parent_interface that does (the IOSBLEInterface)."""
+
+    def __init__(self, parent):
+        self.parent_interface = parent
+        self.peer_address = "AA:BB:CC:DD:EE:FF"
+
+
+class BLEParentInterface:
+    def __init__(self, rssi: int):
+        self._rssi = rssi
+
+    def get_rssi(self) -> int:
+        return self._rssi
+
+
+class TCPInterface:
+    """No signal-metric methods at all (like a TCP / Auto / Backbone iface)."""
+
+
+class RaisingRssiInterface:
+    def get_rssi(self) -> int:
+        raise RuntimeError("radio went away")
+
+    def get_snr(self) -> float:
+        return 3.5
+
+
+class InboundSignalMetricsTests(unittest.TestCase):
+    def _load(self, events, path_table=None, receiving_via_annotation=True):
+        tree = ast.parse(BRIDGE.read_text(encoding="utf-8"))
+        functions = {
+            node.name: node
+            for node in tree.body
+            if isinstance(node, ast.FunctionDef) and node.name in _REQUIRED_HELPERS
+        }
+        self.assertEqual(_REQUIRED_HELPERS, set(functions))
+        path_table = dict(path_table or {})
+        namespace = {
+            "Any": Any,
+            "LXMF": types.SimpleNamespace(LXMessage=FakeMessage),
+            "RNS": types.SimpleNamespace(
+                LOG_ERROR=1,
+                LOG_DEBUG=2,
+                log=lambda *_args: None,
+                Transport=types.SimpleNamespace(path_table=path_table),
+            ),
+            "_put": lambda kind, **payload: events.append((kind, payload)),
+        }
+        module = ast.Module(
+            body=[
+                functions["_canonical_inbound_hash"],
+                functions["_inbound_delivery_method_name"],
+                functions["_receiving_interface"],
+                functions["_signal_metrics"],
+                functions["_delivery_callback"],
+            ],
+            type_ignores=[],
+        )
+        exec(compile(module, str(BRIDGE), "exec"), namespace)
+        return namespace["_delivery_callback"]
+
+    def test_rnode_inbound_carries_rssi_and_snr(self):
+        events = []
+        callback = self._load(events)
+        iface = RNodeLikeInterface(rssi=-72, snr=6.25)
+        callback(FakeMessage(receiving_interface=iface))
+
+        self.assertEqual(1, len(events))
+        kind, payload = events[0]
+        self.assertEqual("inbound", kind)
+        self.assertEqual(-72, payload["rssi"])
+        self.assertAlmostEqual(6.25, payload["snr"])
+        # Existing keys are preserved verbatim alongside the new metrics.
+        self.assertEqual("22" * 32, payload["message_hash"])
+        self.assertEqual("11" * 16, payload["source_hash"])
+        self.assertEqual("opportunistic", payload["method"])
+        self.assertIn("fields_hex", payload)
+
+    def test_ble_peer_interface_resolves_rssi_via_parent(self):
+        events = []
+        callback = self._load(events)
+        # BLEPeerInterface has no get_rssi; the parent (IOSBLEInterface) does.
+        parent = BLEParentInterface(rssi=-80)
+        peer = BLEPeerInterface(parent)
+        callback(FakeMessage(receiving_interface=peer))
+
+        self.assertEqual(1, len(events))
+        _, payload = events[0]
+        self.assertEqual(-80, payload["rssi"])
+        # BLE has no SNR on any platform.
+        self.assertIsNone(payload["snr"])
+
+    def test_tcp_inbound_has_no_metrics_but_still_emits(self):
+        events = []
+        callback = self._load(events)
+        callback(FakeMessage(receiving_interface=TCPInterface()))
+
+        self.assertEqual(1, len(events))
+        kind, payload = events[0]
+        self.assertEqual("inbound", kind)
+        self.assertIsNone(payload["rssi"])
+        self.assertIsNone(payload["snr"])
+        self.assertEqual("22" * 32, payload["message_hash"])
+
+    def test_missing_receiving_interface_yields_none_metrics(self):
+        events = []
+        callback = self._load(events)
+        # No receiving_interface annotation and no path_table entry.
+        callback(FakeMessage())
+        self.assertEqual(1, len(events))
+        _, payload = events[0]
+        self.assertIsNone(payload["rssi"])
+        self.assertIsNone(payload["snr"])
+
+    def test_path_table_fallback_resolves_interface(self):
+        events = []
+        src = bytes.fromhex("33" * 16)
+        rnode = RNodeLikeInterface(rssi=-64, snr=10.0)
+        # path_table entry: index 5 is the receiving Interface object.
+        path_table = {src: [0, 0, 1, 0, None, rnode, None]}
+        callback = self._load(events, path_table=path_table)
+        # Message carries NO receiving_interface annotation, only a
+        # source_hash, so the callback must fall back to path_table[src][5].
+        callback(FakeMessage(source_hash=src))
+
+        self.assertEqual(1, len(events))
+        _, payload = events[0]
+        self.assertEqual(-64, payload["rssi"])
+        self.assertAlmostEqual(10.0, payload["snr"])
+
+    def test_rssi_getter_raising_falls_back_to_none_without_raising(self):
+        events = []
+        callback = self._load(events)
+        # get_rssi raises, get_snr still works. The exception must be swallowed
+        # (delivery must not wedge) and rssi must be None.
+        iface = RaisingRssiInterface()
+        callback(FakeMessage(receiving_interface=iface))
+
+        self.assertEqual(1, len(events))
+        _, payload = events[0]
+        self.assertIsNone(payload["rssi"])
+        self.assertAlmostEqual(3.5, payload["snr"])
+
+    def test_signal_metrics_none_interface_returns_none_pair(self):
+        # Direct unit check of the helper for the None-interface fast path.
+        tree = ast.parse(BRIDGE.read_text(encoding="utf-8"))
+        fn = next(
+            node for node in tree.body
+            if isinstance(node, ast.FunctionDef) and node.name == "_signal_metrics"
+        )
+        namespace = {"Any": Any, "RNS": types.SimpleNamespace(log=lambda *_a: None)}
+        exec(compile(ast.Module(body=[fn], type_ignores=[]), str(BRIDGE), "exec"), namespace)
+        self.assertEqual((None, None), namespace["_signal_metrics"](None))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tests/static/test_ios_ble_bridge_contract.py
+++ b/Tests/static/test_ios_ble_bridge_contract.py
@@ -149,6 +149,28 @@ class IOSBLEBridgeContracts(unittest.TestCase):
         self.assertIn("client.rssi", code)
         self.assertNotIn("lastDiscoveryReport", code)
 
+    def test_peer_rssi_rejects_stale_poll_samples(self) -> None:
+        # If readRSSI() keeps failing, client.rssi stays unversioned and
+        # silently ages. getPeerRssi must bound sample age (2 poll
+        # intervals) via rssiSampledAt, which didReadRSSI stamps on every
+        # accepted sample. Regression: Greptile P2 iteration 2 on PR #190
+        # ("Cached RSSI remains stale").
+        bridge = BRIDGE.read_text()
+        start = bridge.index("public func getPeerRssi(address: String)")
+        end = bridge.index("public func getPeerRole(address: String)")
+        body = bridge[start:end]
+        code = "\n".join(l.split("//", 1)[0] for l in body.splitlines())
+        self.assertIn("client.rssiSampledAt", code)
+        self.assertIn("2 * rssiPollInterval", code)
+        # Every accepted sample must be versioned at write time.
+        write = bridge.index("gattClients[address]?.rssi = value")
+        self.assertIn(
+            "gattClients[address]?.rssiSampledAt = Date()",
+            bridge[write:write + 200],
+        )
+        client = CLIENT.read_text()
+        self.assertIn("var rssiSampledAt: Date?", client)
+
     def test_stalled_central_handshake_times_out_and_releases_peer(self) -> None:
         source = BRIDGE.read_text()
         self.assertIn("private let connectionTimeout: TimeInterval = 30.0", source)

--- a/Tests/static/test_ios_ble_bridge_contract.py
+++ b/Tests/static/test_ios_ble_bridge_contract.py
@@ -114,15 +114,24 @@ class IOSBLEBridgeContracts(unittest.TestCase):
         self.assertIn("slot: .onMtuNegotiated", central_migration)
         self.assertIn("args: [address, client.mtu]", central_migration)
 
-    def test_python_can_query_native_peer_role_and_mtu(self) -> None:
+    def test_python_can_query_native_peer_role_mtu_and_rssi(self) -> None:
         bindings = BINDINGS.read_text()
         driver = DRIVER.read_text()
-        for symbol in ("columba_ble_get_peer_role", "columba_ble_get_peer_mtu"):
+        for symbol in (
+            "columba_ble_get_peer_role",
+            "columba_ble_get_peer_mtu",
+            "columba_ble_get_peer_rssi",
+        ):
             self.assertIn(f'@_cdecl("{symbol}")', bindings)
             self.assertIn(f'"{symbol}"', driver)
         self.assertIn("def get_peer_mtu(self, address: str)", driver)
         self.assertIn('return "central"', driver)
         self.assertIn('return "peripheral"', driver)
+        # The RSSI query must resolve the Int32.min "unknown" sentinel to
+        # None so the detail cards stay hidden when no sample is available.
+        self.assertIn("def get_peer_rssi(self, address: str)", driver)
+        self.assertIn("def get_last_receive_rssi(self)", driver)
+        self.assertIn("return rssi if rssi != _RSSI_UNKNOWN else None", driver)
 
     def test_stalled_central_handshake_times_out_and_releases_peer(self) -> None:
         source = BRIDGE.read_text()

--- a/Tests/static/test_ios_ble_bridge_contract.py
+++ b/Tests/static/test_ios_ble_bridge_contract.py
@@ -133,6 +133,22 @@ class IOSBLEBridgeContracts(unittest.TestCase):
         self.assertIn("def get_last_receive_rssi(self)", driver)
         self.assertIn("return rssi if rssi != _RSSI_UNKNOWN else None", driver)
 
+    def test_peer_rssi_never_falls_back_to_discovery_cache(self) -> None:
+        # getPeerRssi must report ONLY a fresh readRSSI() sample from an
+        # established central client. Falling back to lastDiscoveryReport
+        # (scan-time RSSI) would persist and display a stale value for
+        # peripheral-role or disconnected peers, which have no readable
+        # RSSI. Regression: Greptile P2 on PR #190 (stale discovery RSSI).
+        source = BRIDGE.read_text()
+        start = source.index("public func getPeerRssi(address: String)")
+        end = source.index("public func getPeerRole(address: String)")
+        body = source[start:end]
+        # Strip comment lines so the assertion checks the code, not prose.
+        code = "\n".join(l.split("//", 1)[0] for l in body.splitlines())
+        self.assertIn("client.state == .established", code)
+        self.assertIn("client.rssi", code)
+        self.assertNotIn("lastDiscoveryReport", code)
+
     def test_stalled_central_handshake_times_out_and_releases_peer(self) -> None:
         source = BRIDGE.read_text()
         self.assertIn("private let connectionTimeout: TimeInterval = 30.0", source)

--- a/Tests/static/test_no_message_content_in_logs.py
+++ b/Tests/static/test_no_message_content_in_logs.py
@@ -405,7 +405,7 @@ class NoMessageContentInLogsTests(unittest.TestCase):
         source = APPSERVICES.read_text(encoding="utf-8")
         case = re.search(
             r"case \.inbound\(let sourceHash, let messageHash, let content, let title, "
-            r"let fieldsPacked, let method, let t\):\n"
+            r"let fieldsPacked, let method, let rssi, let snr, let t\):\n"
             r"(?P<body>.*?)\n            guard let data = Data\(hexString: sourceHash\)",
             source,
             re.DOTALL,

--- a/Tests/static/test_reported_runtime_bugs.py
+++ b/Tests/static/test_reported_runtime_bugs.py
@@ -121,9 +121,9 @@ class ReportedRuntimeBugContracts(unittest.TestCase):
 
         py_backend = PY_BACKEND.read_text()
         self.assertIsNotNone(re.search(
-            r"case let \.inbound\(s, mh, c, ti, fh, method, t\):.*?"
+            r"case let \.inbound\(s, mh, c, ti, fh, method, rssi, snr, t\):.*?"
             r"\.inbound\(sourceHash: s, messageHash: mh, content: c.*?"
-            r"method: deliveryMethod",
+            r"method: deliveryMethod, rssi: rssi, snr: snr, t: t",
             py_backend,
             re.DOTALL,
         ))
@@ -133,7 +133,8 @@ class ReportedRuntimeBugContracts(unittest.TestCase):
             swift_backend,
             r"\.inbound\(sourceHash: message\.sourceHash\.hexHash, "
             r"messageHash: message\.hash\.hexHash, content:.*?"
-            r"method: Self\.mapDeliveryMethod\(message\.method\)",
+            r"method: Self\.mapDeliveryMethod\(message\.method\), "
+            r"rssi: nil, snr: nil, t: Date\(\)\)",
         )
         self.assertIn("case .paper: return .paper", swift_backend)
 
@@ -148,6 +149,9 @@ class ReportedRuntimeBugContracts(unittest.TestCase):
         persist_source = persist.group(0)
         self.assertIn("messageHashHex: String", persist_source)
         self.assertIn("method: LXDeliveryMethod?", persist_source)
+        self.assertIn("rssi: Double? = nil, snr: Double? = nil", persist_source)
+        self.assertIn("message.rssi = rssi", persist_source)
+        self.assertIn("message.snr = snr", persist_source)
         self.assertIn("Data(hexString: messageHashHex)", persist_source)
         self.assertIn("parsedHash.count == 32", persist_source)
         self.assertIn("Data([0x00]) + Data(SHA256.hash(data: seed))", persist_source)
@@ -167,9 +171,9 @@ class ReportedRuntimeBugContracts(unittest.TestCase):
         self.assertIn('self.deliveryMethod = "paper"', bubble)
         self.assertIsNotNone(re.search(
             r"case \.inbound\(let sourceHash, let messageHash, let content,"
-            r".*?let method, let t\):.*?"
+            r".*?let method, let rssi, let snr, let t\):.*?"
             r"persistInboundFromPython\(sourceHash: data, messageHashHex: messageHash,"
-            r".*?method: method, timestamp: t\)",
+            r".*?method: method, rssi: rssi, snr: snr, timestamp: t\)",
             app_services,
             re.DOTALL,
         ))

--- a/app/ble/IOSBLEDriver.py
+++ b/app/ble/IOSBLEDriver.py
@@ -97,6 +97,14 @@ _columba_ble_get_peer_role = _decl(
 _columba_ble_get_peer_mtu = _decl(
     "columba_ble_get_peer_mtu", [ctypes.c_char_p], ctypes.c_int32
 )
+# RSSI query returns a signed dBm value or `Int32.min` as the "unknown"
+# sentinel (see `columba_ble_get_peer_rssi` in BleNativeBindings.swift).
+_columba_ble_get_peer_rssi = _decl(
+    "columba_ble_get_peer_rssi", [ctypes.c_char_p], ctypes.c_int32
+)
+# `Int32.min` — the C-side "no RSSI available" sentinel. A real RSSI is always
+# a small negative dBm value, so it can never collide with this.
+_RSSI_UNKNOWN = -2**31
 _columba_ble_configure_power = _decl(
     "columba_ble_configure_power", [ctypes.c_char_p], ctypes.c_int32
 )
@@ -133,6 +141,12 @@ class IOSBLEDriver(BLEDriverInterface):
         # address) and to surface `on_address_changed` to BLEInterface.
         self._address_to_identity: dict[str, str] = {}
         self._identity_to_address: dict[str, str] = {}
+        # Address of the most recent peer that sent us data. Used by
+        # `get_last_receive_rssi()` so a delivery-time RSSI query (from the
+        # Python bridge's `_signal_metrics`) can be attributed to the peer
+        # that just delivered the message. Mirrors Android's
+        # `android_ble_driver._last_receive_address`. Cleared on stop().
+        self._last_receive_address: str | None = None
         self._lock = threading.Lock()
         # Power preset captured in `set_power_mode` — passed to Swift via
         # `configure_power` so the Settings/DiagLog status output reflects
@@ -211,6 +225,11 @@ class IOSBLEDriver(BLEDriverInterface):
                 RNS.log(f"IOSBLEDriver: on_device_disconnected raised: {e}", RNS.LOG_ERROR)
 
     def _raw_on_data_received(self, address: str, data: bytes) -> None:
+        # Track the last sender so a delivery-time RSSI query can be
+        # attributed to the peer that just delivered data (mirrors
+        # Android's `on_data_received`). Done before the callback check so a
+        # missing upstream slot doesn't leave the attribution stale.
+        self._last_receive_address = address
         if self.on_data_received is None:
             return
         try:
@@ -325,6 +344,7 @@ class IOSBLEDriver(BLEDriverInterface):
             self._address_to_identity.clear()
             self._identity_to_address.clear()
             self._connected_peers.clear()
+            self._last_receive_address = None
 
     def set_identity(self, identity_bytes: bytes) -> None:
         if _columba_ble_set_identity is None:
@@ -469,6 +489,37 @@ class IOSBLEDriver(BLEDriverInterface):
             return None
         mtu = int(_columba_ble_get_peer_mtu(address.encode("utf-8")))
         return mtu if mtu > 0 else None
+
+    def get_peer_rssi(self, address: str) -> Optional[int]:
+        """Most recent RSSI (dBm) for a peer, or None when unavailable.
+
+        The value is the latest `readRSSI()` sample from the established
+        central-side GATT client (falling back to the last scan-time discovery
+        report) — surfaced by `columba_ble_get_peer_rssi`. Returns None for
+        peripheral-role peers: Core Bluetooth does not expose the central's
+        RSSI to us. Best-effort — any failure resolves to None.
+        """
+        if _columba_ble_get_peer_rssi is None:
+            return None
+        try:
+            rssi = int(_columba_ble_get_peer_rssi(address.encode("utf-8")))
+        except Exception as e:  # noqa: BLE001 — metric failure must not raise
+            RNS.log(f"IOSBLEDriver: get_peer_rssi failed: {e}", RNS.LOG_DEBUG)
+            return None
+        return rssi if rssi != _RSSI_UNKNOWN else None
+
+    def get_last_receive_rssi(self) -> Optional[int]:
+        """RSSI (dBm) of the most recent peer that sent us data, or None.
+
+        Called at delivery time by the Python bridge's `_signal_metrics` so
+        the receiving-interface card can show the signal strength of the link
+        that just delivered a message. Mirrors Android's
+        `android_ble_driver.get_last_receive_rssi()`.
+        """
+        address = self._last_receive_address
+        if address is None:
+            return None
+        return self.get_peer_rssi(address)
 
     def request_identity_resync(self, address: str) -> bool:
         if _columba_ble_request_identity_resync is None:

--- a/app/ble/IOSBLEInterface.py
+++ b/app/ble/IOSBLEInterface.py
@@ -77,6 +77,31 @@ class IOSBLEInterface(BLEInterface):
 
         RNS.log(f"iOS BLE Interface '{self.name}' initialized", RNS.LOG_INFO)
 
+    def get_rssi(self):
+        """Get the RSSI of the most recently received message, in dBm.
+
+        Called at message-delivery time by the Python bridge's
+        `_signal_metrics` to extract a signal-strength metric for the
+        receiving-interface card. Mirrors Android's
+        `AndroidBLEInterface.get_rssi()` -> `driver.get_last_receive_rssi()`.
+
+        Returns:
+            RSSI in dBm (negative int), or None when unavailable.
+
+        Note:
+            iOS BLE does not provide per-packet RSSI like RNode hardware.
+            This returns the last known connection RSSI from the Swift
+            bridge, which is updated from `readRSSI()` polling on the
+            established central-side link (falling back to the last
+            scan-time discovery report). Returns None for peripheral-role
+            peers, for which Core Bluetooth exposes no RSSI — the
+            "dependent on BLE role" behavior called out in the issue.
+        """
+        driver = getattr(self, "driver", None)
+        if driver is None:
+            return None
+        return driver.get_last_receive_rssi()
+
 
 # Required by Reticulum's external-interface loader.
 interface_class = IOSBLEInterface

--- a/app/rns_bridge.py
+++ b/app/rns_bridge.py
@@ -446,6 +446,84 @@ def _inbound_delivery_method_name(message: Any) -> str:
     return ""
 
 
+def _receiving_interface(message: Any) -> Any | None:
+    """Resolve the `RNS.Interface` a message arrived on, best-effort.
+
+    Two sources in priority order (mirrors Columba Android's event_bridge):
+      1. The torlando-tech LXMF fork sets `message.receiving_interface` on
+         inbound opportunistic messages. Upstream LXMF leaves it off entirely,
+         so getattr-guard.
+      2. Fallback to `RNS.Transport.path_table[source_hash][5]` for
+         link-based (DIRECT) deliveries and any case where the LXMF annotation
+         didn't fire — every reachable destination has a path_table entry
+         whose index 5 is the receiving Interface object.
+
+    Returns `None` when neither source yields an interface; the caller treats
+    that as "no signal metrics available" and omits them from the event.
+    """
+    recv_iface = getattr(message, "receiving_interface", None)
+    if recv_iface is not None:
+        return recv_iface
+    source_hash_bytes = getattr(message, "source_hash", None)
+    if source_hash_bytes is None:
+        return None
+    try:
+        path_entry = RNS.Transport.path_table.get(source_hash_bytes)
+        if path_entry is not None and len(path_entry) > 5:
+            return path_entry[5]
+    except Exception as e:  # noqa: BLE001 — fallback is best-effort
+        RNS.log(f"rns_bridge: path_table fallback failed: {e}", RNS.LOG_DEBUG)
+    return None
+
+
+def _signal_metrics(interface_obj: Any) -> tuple[int | None, float | None]:
+    """Extract (rssi, snr) from a receiving `RNS.Interface` at delivery time.
+
+    Mirrors Columba Android's event_bridge `_signal_metrics` plus the legacy
+    `signal_quality.extract_signal_metrics` BLE peer-interface fallback:
+    RNode-class interfaces expose `get_rssi()` + `get_snr()`; TCP / Auto /
+    Backbone interfaces don't, so the result is `(None, None)` for those. BLE
+    peer sub-interfaces (`ble_reticulum.BLEPeerInterface`) don't expose
+    `get_rssi` themselves but carry a `parent_interface` that does, so we try
+    the object itself and then its parent. BLE has no SNR on any platform.
+
+    Best-effort: any attribute-access / call exception falls back to `None`,
+    because a signal-metrics failure must never wedge inbound message delivery.
+    The values are interface-wide "latest received" stats captured at delivery
+    time, not per-packet (same semantics as Android).
+    """
+    rssi = None
+    snr = None
+    if interface_obj is None:
+        return rssi, snr
+    candidates = [interface_obj]
+    parent = getattr(interface_obj, "parent_interface", None)
+    if parent is not None:
+        candidates.append(parent)
+    for candidate in candidates:
+        if rssi is None:
+            get_rssi = getattr(candidate, "get_rssi", None)
+            if callable(get_rssi):
+                try:
+                    v = get_rssi()
+                    if v is not None:
+                        rssi = int(v)
+                except Exception as e:  # noqa: BLE001
+                    RNS.log(f"rns_bridge: get_rssi failed: {e}", RNS.LOG_DEBUG)
+        if snr is None:
+            get_snr = getattr(candidate, "get_snr", None)
+            if callable(get_snr):
+                try:
+                    v = get_snr()
+                    if v is not None:
+                        snr = float(v)
+                except Exception as e:  # noqa: BLE001
+                    RNS.log(f"rns_bridge: get_snr failed: {e}", RNS.LOG_DEBUG)
+        if rssi is not None and snr is not None:
+            break
+    return rssi, snr
+
+
 def _delivery_callback(message: "LXMF.LXMessage") -> None:
     """Fires for every inbound LXMF message routed to our delivery destination."""
     try:
@@ -479,6 +557,14 @@ def _delivery_callback(message: "LXMF.LXMessage") -> None:
         # targeting; dropping the callback here would lose the whole message.
         RNS.log("Inbound LXMF message has no recoverable wire hash", RNS.LOG_ERROR)
     message_hash = canonical_hash.hex() if canonical_hash is not None else ""
+    # Signal metrics for the receiving interface (RNode: RSSI + SNR; BLE: RSSI
+    # only, and only for the central role that has an RSSI to report; TCP /
+    # Auto / propagated: none). Best-effort — a failure here must not lose the
+    # message, so both fall back to None when the interface is unknown or the
+    # metric is unavailable. Mirrors Columba Android's event_bridge delivery
+    # payload. `receiving_interface`/`receiving_hops` resolution lives in
+    # `_receiving_interface`; the metric extraction lives in `_signal_metrics`.
+    rssi, snr = _signal_metrics(_receiving_interface(message))
     _put(
         "inbound",
         source_hash=src,
@@ -487,6 +573,8 @@ def _delivery_callback(message: "LXMF.LXMessage") -> None:
         title=title,
         fields_hex=fields_hex,
         method=_inbound_delivery_method_name(message),
+        rssi=rssi,
+        snr=snr,
     )
 
 


### PR DESCRIPTION
## Summary

Wire the receiving-interface signal metrics the Python layer already
tracks into the iOS message-details screen, matching Android Columba
(issue #178). RSSI/SNR were persisted and rendered by existing UI cards
but were never populated, so the cards never appeared.

## Changes

- **`app/rns_bridge.py`** - the actual gap:
  - `_receiving_interface()`: resolves the `RNS.Interface` a message
    arrived on (LXMF `receiving_interface`/`receiving_hops` annotation
    first, `path_table[source_hash][5]` fallback for link-based/direct
    deliveries). Verified the pinned LXMF fork commit and RNS pin
    already carry the capture/path-table layout.
  - `_signal_metrics()`: best-effort `(rssi, snr)` extraction with the
    `BLEPeerInterface.parent_interface` fallback (ported from Android
    `event_bridge.py`); any failure yields `None` so delivery never
    wedges.
  - `_delivery_callback()` now emits `rssi`/`snr` in the inbound event.
- **BLE plumbing** (central-role only, matching the issue's role
  dependency - CoreBluetooth exposes RSSI for central-side connections):
  - `SwiftBLEBridge.getPeerRssi()` prefers a fresh `readRSSI()` sample
    from the established GATT client instead of the stale scan-time
    value.
  - New `columba_ble_get_peer_rssi` C export (`Int32.min` "unknown"
    sentinel) + linker export entry.
  - `IOSBLEDriver`: last-receive address tracking, `get_peer_rssi()`,
    `get_last_receive_rssi()`; `IOSBLEInterface.get_rssi()`.
- **Swift event seam**: `PythonBridge.Event.inbound` and
  `RNSAPI.BackendEvent.inbound` carry `rssi`/`snr`;
  `PythonRNSBackend` maps them through; `SwiftRNSBackend` passes nil
  (Model B / Network Extension has no Python runtime, so the cards stay
  hidden there); `AppServices.persistInboundFromPython` stores the
  values before `saveMessage` (existing `mapToGRDBMessage` carries them
  to the record and the existing `rssiCard`/`snrCard` render them).
- **`MessageDetailView`**: SNR card gains the -5 dB boundary to match
  Android's 5-tier `SignalQualityInfo`.

## Tests

- New `Tests/static/test_inbound_signal_metrics.py` (7 tests): RNode
  both-metrics, BLE parent-interface fallback, TCP no-metrics, missing
  interface, path_table fallback, raising getter, helper None-pair.
- Extended the BLE bridge contract and inbound-event contract static
  tests for the new export and event fields.
- Full static suite: 320 tests pass (1 pre-existing skip).

## Verification

- Built on the Mac mini (Debug, device destination) and installed
  in-place on the physical iPhone 14 via `xcrun devicectl` (no data
  wipe). App launched from the new container and Torlando confirmed the
  feature works on device (RSSI/SNR visible in message details for a
  received message).
- One compile fix landed during the device build:
  `rssi.map(String.init)` is ambiguous in Swift; replaced with an
  explicit interpolation closure (commit `4d578fa6`).

## Risk / rollback

- Display-only change to the inbound event path; metrics are best-effort
  and default to `None` (cards hidden) on any lookup failure, so a bad
  read cannot block message delivery or persistence.
- No schema change - `rssi`/`snr` GRDB columns already exist.
- Rollback: close PR; no data migration needed.