### PR TITLE
Native text selection with cross-line handles in NomadNet browser (iOS #188)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,6 +79,7 @@ jobs:
             Tests.static.test_no_message_content_in_logs \
             Tests.static.test_theme_selection_navigation_contract \
             Tests.static.test_image_quality_sheet_dynamic_size \
+            Tests.static.test_nomadnet_text_selection \
             Tests.static.test_ui_screenshotter_readiness \
             Tests.static.test_collect_maestro_screenshots
 

--- a/Sources/ColumbaApp/Models/MicronDocument.swift
+++ b/Sources/ColumbaApp/Models/MicronDocument.swift
@@ -15,6 +15,41 @@ public struct MicronDocument: Sendable, Equatable {
     }
 }
 
+extension MicronDocument {
+    /// Readable plain-text rendering of the page, in document order, for
+    /// copy/share (the "Copy Page" toolbar action, issue #188).
+    ///
+    /// Mirrors what a user would see as text: headings and paragraphs emit
+    /// their visible span text (links emit their label), literal blocks are
+    /// preserved verbatim, dividers become a dashed line. Interactive form
+    /// fields and async partials are excluded - they are not page prose.
+    public var plainText: String {
+        var lines: [String] = []
+        for element in elements {
+            switch element {
+            case .heading(_, let spans, _),
+                 .paragraph(let spans, _, _):
+                let line = spans.map { span -> String in
+                    switch span {
+                    case .text(let content, _): return content
+                    case .link(let link): return link.label
+                    }
+                }.joined()
+                if !line.trimmingCharacters(in: .whitespaces).isEmpty {
+                    lines.append(line)
+                }
+            case .divider(_, _):
+                lines.append("────────")
+            case .literalBlock(let text, _):
+                lines.append(text)
+            case .formField(_, _), .partial(_, _):
+                break
+            }
+        }
+        return lines.joined(separator: "\n")
+    }
+}
+
 // MARK: - Page Headers
 
 public struct MicronPageHeaders: Sendable, Equatable {

--- a/Sources/ColumbaApp/Views/NomadNet/MicronDocumentView.swift
+++ b/Sources/ColumbaApp/Views/NomadNet/MicronDocumentView.swift
@@ -33,6 +33,14 @@ struct MicronDocumentView: View {
         }
         .padding(.horizontal, appliesDocumentPadding && !isScrollMode ? 12 : 0)
         .padding(.vertical, appliesDocumentPadding && !isScrollMode ? 8 : 0)
+        // Android parity (#188): in the wrapping modes the body text is real
+        // SwiftUI `Text`, so enable the native long-press select/copy behavior
+        // (the iOS equivalent of Android's Compose `SelectionContainer`).
+        // `.monospaceScroll` renders UIKit UILabels, which this modifier cannot
+        // reach; those lines get a long-press "Copy" context menu instead
+        // (MonospaceLineView) and the toolbar "Copy Page" covers the whole page.
+        .textSelection(isScrollMode ? .disabled : .enabled)
+        .accessibilityIdentifier("nomadnet_document")
     }
 
     private var isScrollMode: Bool { style == .monospaceScroll }

--- a/Sources/ColumbaApp/Views/NomadNet/MicronDocumentView.swift
+++ b/Sources/ColumbaApp/Views/NomadNet/MicronDocumentView.swift
@@ -230,7 +230,7 @@ struct MicronDocumentView: View {
     private func headingSize(level: Int) -> CGFloat {
         switch min(max(level, 1), 3) {
         case 1:
-            return UIFontMetrics(forTextStyle: .title).scaledValue(for: 28)
+            return UIFontMetrics(forTextStyle: .title1).scaledValue(for: 28)
         case 2:
             return UIFontMetrics(forTextStyle: .title2).scaledValue(for: 22)
         default:

--- a/Sources/ColumbaApp/Views/NomadNet/MicronDocumentView.swift
+++ b/Sources/ColumbaApp/Views/NomadNet/MicronDocumentView.swift
@@ -112,10 +112,10 @@ struct MicronDocumentView: View {
                 result.append(.literalBlock(text: text, indentLevel: indentLevel))
             case .formField(let field, let indentLevel):
                 flush()
-                result.append(.formField(field, indentLevel))
+                result.append(.formField(field, indentLevel: indentLevel))
             case .partial(let partial, let indentLevel):
                 flush()
-                result.append(.partial(partial, indentLevel))
+                result.append(.partial(partial, indentLevel: indentLevel))
             }
         }
         flush()
@@ -170,7 +170,7 @@ struct MicronDocumentView: View {
                 lines: [MicronTextLine(
                     spans: spans,
                     alignment: alignment,
-                    indentLevel: headingIndentLevel(level)
+                    indentLevel: headingIndentLevel(level: level)
                 )],
                 fontSize: headingFontSize,
                 monospaced: style.usesMonospace,

--- a/Sources/ColumbaApp/Views/NomadNet/MicronDocumentView.swift
+++ b/Sources/ColumbaApp/Views/NomadNet/MicronDocumentView.swift
@@ -223,11 +223,18 @@ struct MicronDocumentView: View {
         }
     }
 
+    /// Wrap-mode heading size, scaled with the user's accessibility
+    /// text-size setting via UIFontMetrics (mirrors the previous semantic
+    /// .title / .title2 / .title3 SwiftUI fonts, whose base sizes are 28 /
+    /// 22 / 20 pt at the default content size).
     private func headingSize(level: Int) -> CGFloat {
         switch min(max(level, 1), 3) {
-        case 1: return 28
-        case 2: return 22
-        default: return 20
+        case 1:
+            return UIFontMetrics(forTextStyle: .title).scaledValue(for: 28)
+        case 2:
+            return UIFontMetrics(forTextStyle: .title2).scaledValue(for: 22)
+        default:
+            return UIFontMetrics(forTextStyle: .title3).scaledValue(for: 20)
         }
     }
 

--- a/Sources/ColumbaApp/Views/NomadNet/MicronDocumentView.swift
+++ b/Sources/ColumbaApp/Views/NomadNet/MicronDocumentView.swift
@@ -3,6 +3,20 @@ import SwiftUI
 import RNSAPI
 
 /// Renders a parsed MicronDocument as SwiftUI views.
+///
+/// Android parity (#188): page text is selectable/copyable with the native
+/// selection UI (highlight + two draggable handles + the system
+/// Copy / Look Up / Translate / Share menu).
+///
+/// Text is rendered as one selectable `UITextView` PER RUN
+/// (`MonospaceLineView`), where a run is a maximal stretch of consecutive
+/// prose lines (paragraphs + dividers). Headings (full-width band),
+/// literal blocks (own band in wrap mode), form fields, and partials each
+/// break the run, so interactive elements stay outside the selectable text.
+/// Because a run is a single `UITextView`, the two selection handles can be
+/// dragged across newlines - a multi-line paragraph or code block selects as
+/// one unit. The toolbar "Copy Page" remains a whole-page fallback in every
+/// mode.
 @available(iOS 17.0, macOS 14.0, *)
 struct MicronDocumentView: View {
     @Environment(\.colorScheme) private var colorScheme
@@ -14,170 +28,188 @@ struct MicronDocumentView: View {
     var loadingPartials: Set<String> = []
     var onLinkTapped: ((MicronLink) -> Void)?
     var style: MicronRenderStyle = .monospaceScroll
-    /// Viewport width for the SCROLL mode. Each row gets at least this width so
-    /// `\`c`/`\`r` alignment centers/right-aligns content relative to the screen,
-    /// not the document's max line width. Mirrors Android's
+    /// Viewport width for the SCROLL mode. Each row gets at least this width
+    /// so ``c``/``r`` alignment centers/right-aligns content relative to the
+    /// screen, not the document's max line width. Mirrors Android's
     /// `Modifier.widthIn(min = viewportLineWidth)` (NomadNetBrowserScreen.kt:474).
     /// Without this, a single wide row (e.g. the chat-room's 550-char trailing-
     /// whitespace line) sets the VStack width and centered shorter rows end up
     /// scrolled offscreen-right.
+    ///
+    /// In the WRAP modes this value is not used: runs track the width proposed
+    /// by the enclosing ScrollView (and fall back to their intrinsic
+    /// width when no width is proposed), so long text wraps within the
+    /// viewport.
     var viewportWidth: CGFloat = 0
     var appliesDocumentPadding = true
     var partialAncestry: Set<String> = []
 
     var body: some View {
-        // Android parity (#188): page text must be selectable/copyable.
-        // `.textSelection` only reaches SwiftUI `Text`, so it is applied in
-        // the wrapping modes (real Text). In `.monospaceScroll` the content is
-        // UIKit-backed, so each block is itself a selectable `UITextView`
-        // (MonospaceLineView) that surfaces the native long-press selection UI
-        // (highlight + two handles + system Copy/Look Up/Translate menu). The
-        // toolbar "Copy Page" remains a whole-page fallback in every mode.
-        if isScrollMode {
-            documentContent
-        } else {
-            documentContent
-                .textSelection(.enabled)
-        }
-    }
-
-    /// The rendered document content, shared by both selection strategies.
-    private var documentContent: some View {
         VStack(alignment: .leading, spacing: isScrollMode ? 0 : 2) {
-            ForEach(Array(document.elements.enumerated()), id: \.offset) { index, element in
-                renderElement(element, index: index)
+            ForEach(runs.indices, id: \.self) { index in
+                renderRun(runs[index])
             }
         }
+        // Wrap-mode document inset. In scroll mode the ZoomableScrollView owns
+        // the layout (no inset); per-line indents handle section nesting.
         .padding(.horizontal, appliesDocumentPadding && !isScrollMode ? 12 : 0)
         .padding(.vertical, appliesDocumentPadding && !isScrollMode ? 8 : 0)
     }
 
-    private var isScrollMode: Bool { style == .monospaceScroll }
-
-    /// Exact pixel-grid cell height for square rendering of block-drawing characters.
-    private var cellHeight: CGFloat { style.approxCharWidth * 2 }
-
-    private var bodyFont: Font {
-        style.swiftUIFont
+    /// Width of one section-indent column (monospace char width, or 8pt in
+    /// proportional mode - mirrors `indentationWidth`).
+    private var indentUnit: CGFloat {
+        style.usesMonospace ? style.approxCharWidth : 8
     }
 
+    // MARK: - Run grouping
+
+    enum Run {
+        /// Consecutive prose lines (paragraphs + dividers), selectable as one
+        /// unit so selection handles span newlines.
+        case text([MicronTextLine])
+        case heading(level: Int, spans: [MicronSpan], alignment: MicronAlignment)
+        case literalBlock(text: String, indentLevel: Int)
+        case formField(MicronFormField, indentLevel: Int)
+        case partial(MicronPartial, indentLevel: Int)
+    }
+
+    /// Groups the document's elements into runs. A run of paragraphs and
+    /// dividers merges into a single selectable text block; a heading,
+    /// literal block, form field, or partial breaks the run (they get their
+    /// own band in wrap mode, or stay interactive, respectively).
+    private var runs: [Run] {
+        var result: [Run] = []
+        var prose: [MicronTextLine] = []
+        func flush() {
+            if !prose.isEmpty {
+                result.append(.text(prose))
+                prose = []
+            }
+        }
+        for element in document.elements {
+            switch element {
+            case .heading(let level, let spans, let alignment):
+                flush()
+                result.append(.heading(level: level, spans: spans, alignment: alignment))
+            case .paragraph(let spans, let alignment, let indentLevel):
+                prose.append(MicronTextLine(spans: spans, alignment: alignment, indentLevel: indentLevel))
+            case .divider(let character, let indentLevel):
+                let count = isScrollMode
+                    ? dividerCount(indentLevel: indentLevel)
+                    : 40
+                let divChar = character.map(String.init) ?? "─"
+                prose.append(
+                    MicronTextLine(
+                        spans: [.text(String(repeating: divChar, count: count), .plain)],
+                        alignment: .left,
+                        indentLevel: indentLevel,
+                        colorOverride: isScrollMode ? nil : .secondary
+                    )
+                )
+            case .literalBlock(let text, let indentLevel):
+                flush()
+                result.append(.literalBlock(text: text, indentLevel: indentLevel))
+            case .formField(let field, let indentLevel):
+                flush()
+                result.append(.formField(field, indentLevel))
+            case .partial(let partial, let indentLevel):
+                flush()
+                result.append(.partial(partial, indentLevel))
+            }
+        }
+        flush()
+        return result
+    }
+
+    private var isScrollMode: Bool { style == .monospaceScroll }
+
+    /// Exact pixel-grid cell height for square rendering of block-drawing
+    /// characters (scroll mode only; wrap modes use `cellHeight = nil`).
+    private var cellHeight: CGFloat? {
+        isScrollMode ? style.approxCharWidth * 2 : nil
+    }
+
+    /// Divider line length in scroll mode: fill the section's available
+    /// width (mirrors the previous per-line divider width).
+    private func dividerCount(indentLevel: Int) -> Int {
+        viewportWidth > 0
+            ? max(1, Int(sectionViewportWidth(columns: indentLevel) / style.approxCharWidth))
+            : 80
+    }
+
+    // MARK: - Run rendering
+
     @ViewBuilder
-    private func renderElement(_ element: MicronElement, index: Int) -> some View {
-        switch element {
+    private func renderRun(_ run: Run) -> some View {
+        switch run {
+        case .text(let lines):
+            // A prose run: full-viewport container in scroll mode so the
+            // per-line indents align centered/right content against the
+            // screen; each line carries its own indent.
+            MonospaceLineView(
+                lines: lines,
+                fontSize: style.fontSize,
+                monospaced: style.usesMonospace,
+                indentUnit: indentUnit,
+                cellHeight: cellHeight,
+                viewportWidth: isScrollMode ? viewportWidth : 0,
+                onLinkTapped: onLinkTapped
+            )
+
         case .heading(let level, let spans, let alignment):
             let palette = MicronHeadingPalette.style(level: level, colorScheme: colorScheme)
-            if isScrollMode {
-                // UIKit-backed line with strict paragraph line-height so block chars stack tight
-                MonospaceLineView(
+            let isScroll = isScrollMode
+            // Headings: bold, and larger proportional title fonts in the wrap
+            // modes (matching the previous .title/.title2/.title3); in scroll
+            // mode the body monospace size, bold (the previous behavior).
+            let headingFontSize: CGFloat = isScroll
+                ? style.fontSize
+                : headingSize(level: level)
+            MonospaceLineView(
+                lines: [MicronTextLine(
                     spans: spans,
-                    fontSize: style.fontSize,
-                    cellHeight: cellHeight,
                     alignment: alignment,
-                    bold: true,
-                    defaultForegroundColor: palette.foreground,
-                    linkForegroundColor: palette.foreground,
-                    onLinkTapped: onLinkTapped
-                )
-                .padding(.leading, headingIndentWidth(level: level))
-                .frame(minWidth: viewportWidth, alignment: alignment.swiftUI)
-                .background(palette.background)
-            } else {
-                renderSpans(
-                    spans,
-                    onLinkTapped: onLinkTapped,
-                    linkForegroundColor: palette.foreground
-                )
-                    .font(headingFont(level: level))
-                    .bold()
-                    .foregroundStyle(palette.foreground)
-                    .padding(.leading, headingIndentWidth(level: level))
-                    .frame(maxWidth: .infinity, alignment: alignment.swiftUI)
-                    .background(palette.background)
-                    .padding(.top, level == 1 ? 12 : 8)
-                    .padding(.bottom, 4)
-            }
-
-        case .paragraph(let spans, let alignment, let indentLevel):
-            if isScrollMode {
-                MonospaceLineView(
-                    spans: spans,
-                    fontSize: style.fontSize,
-                    cellHeight: cellHeight,
-                    alignment: alignment,
-                    bold: false,
-                    onLinkTapped: onLinkTapped
-                )
-                .frame(
-                    minWidth: sectionViewportWidth(columns: indentLevel),
-                    alignment: alignment.swiftUI
-                )
-                .padding(.horizontal, indentationWidth(columns: indentLevel))
-            } else {
-                renderSpans(spans, onLinkTapped: onLinkTapped)
-                    .font(bodyFont)
-                    .lineLimit(nil)
-                    .frame(maxWidth: .infinity, alignment: alignment.swiftUI)
-                    .padding(.horizontal, indentationWidth(columns: indentLevel))
-            }
-
-        case .divider(let character, let indentLevel):
-            if isScrollMode {
-                // Use a full-width horizontal line character for scroll mode
-                let divChar = character.map(String.init) ?? "─"
-                let dividerCount = viewportWidth > 0
-                    ? max(1, Int(sectionViewportWidth(columns: indentLevel) / style.approxCharWidth))
-                    : 80
-                MonospaceLineView(
-                    spans: [.text(String(repeating: divChar, count: dividerCount), .plain)],
-                    fontSize: style.fontSize,
-                    cellHeight: cellHeight,
-                    alignment: .left,
-                    bold: false,
-                    onLinkTapped: nil
-                )
-                .frame(
-                    minWidth: sectionViewportWidth(columns: indentLevel),
-                    alignment: .leading
-                )
-                .padding(.horizontal, indentationWidth(columns: indentLevel))
-            } else if let ch = character {
-                Text(String(repeating: ch, count: 40))
-                    .font(bodyFont)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.vertical, 4)
-                    .padding(.horizontal, indentationWidth(columns: indentLevel))
-            } else {
-                Divider()
-                    .padding(.vertical, 4)
-                    .padding(.horizontal, indentationWidth(columns: indentLevel))
-            }
+                    indentLevel: headingIndentLevel(level)
+                )],
+                fontSize: headingFontSize,
+                monospaced: style.usesMonospace,
+                indentUnit: indentUnit,
+                bold: true,
+                cellHeight: cellHeight,
+                viewportWidth: isScroll ? viewportWidth : 0,
+                defaultForegroundColor: palette.foreground,
+                linkForegroundColor: palette.foreground,
+                onLinkTapped: onLinkTapped
+            )
+            .background(palette.background)
+            .padding(.top, isScroll ? 0 : (level == 1 ? 12 : 8))
+            .padding(.bottom, isScroll ? 0 : 4)
 
         case .literalBlock(let text, let indentLevel):
+            let literalLines = text.split(separator: "\n", omittingEmptySubsequences: false).map {
+                MicronTextLine(spans: [.text(String($0), .plain)], alignment: .left, indentLevel: indentLevel)
+            }
+            let block = MonospaceLineView(
+                lines: literalLines,
+                fontSize: style.fontSize,
+                monospaced: style.usesMonospace,
+                indentUnit: indentUnit,
+                cellHeight: cellHeight,
+                viewportWidth: isScrollMode ? viewportWidth : 0,
+                onLinkTapped: nil
+            )
             if isScrollMode {
-                // One selectable block per literal block: its lines render
-                // inside a single selectable UITextView so a long-press yields
-                // the two-handle selection across the whole block (issue #188),
-                // and each line keeps its exact cell height for tight stacking.
-                MonospaceLineView(
-                    lines: text.split(separator: "\n", omittingEmptySubsequences: false).map { [.text(String($0), .plain)] },
-                    fontSize: style.fontSize,
-                    cellHeight: cellHeight,
-                    alignment: .left,
-                    bold: false,
-                    onLinkTapped: nil
-                )
-                .padding(.horizontal, indentationWidth(columns: indentLevel))
+                // No band in scroll mode: the code block sits on the page
+                // background, indented by the per-line head/tail indent.
+                block
             } else {
-                Text(text)
-                    .font(bodyFont)
+                // Wrap mode: a gray rounded band around the code, full width.
+                block
                     .padding(8)
-                    .frame(maxWidth: .infinity, alignment: .leading)
                     .background(Color.platformSystemGray6)
                     .cornerRadius(6)
                     .padding(.vertical, 4)
-                    .padding(.horizontal, indentationWidth(columns: indentLevel))
             }
 
         case .formField(let field, let indentLevel):
@@ -189,6 +221,18 @@ struct MicronDocumentView: View {
             renderPartial(partial, indentLevel: indentLevel)
                 .padding(.horizontal, indentationWidth(columns: indentLevel))
         }
+    }
+
+    private func headingSize(level: Int) -> CGFloat {
+        switch min(max(level, 1), 3) {
+        case 1: return 28
+        case 2: return 22
+        default: return 20
+        }
+    }
+
+    private func headingIndentLevel(level: Int) -> Int {
+        max(0, (level - 1) * 2)
     }
 
     // MARK: - Partial Rendering
@@ -207,7 +251,7 @@ struct MicronDocumentView: View {
                     loadingPartials: loadingPartials,
                     onLinkTapped: onLinkTapped,
                     style: style,
-                    viewportWidth: sectionViewportWidth(columns: indentLevel),
+                    viewportWidth: isScrollMode ? sectionViewportWidth(columns: indentLevel) : 0,
                     appliesDocumentPadding: false,
                     partialAncestry: partialAncestry.union([key])
                 )
@@ -217,7 +261,7 @@ struct MicronDocumentView: View {
                 ProgressView()
                     .scaleEffect(0.7)
                 Text("Loading...")
-                    .font(bodyFont)
+                    .font(style.swiftUIFont)
                     .foregroundStyle(.secondary)
             }
             .padding(.vertical, 4)
@@ -228,6 +272,7 @@ struct MicronDocumentView: View {
 
     @ViewBuilder
     private func renderFormField(_ field: MicronFormField) -> some View {
+        let bodyFont = style.swiftUIFont
         switch field {
         case .textInput(let width, let name, _):
             TextField(name, text: binding(for: name))
@@ -281,27 +326,8 @@ struct MicronDocumentView: View {
         )
     }
 
-    private func checkboxBinding(for key: String) -> Binding<Bool> {
-        Binding(
-            get: { checkboxFields[key] ?? false },
-            set: { checkboxFields[key] = $0 }
-        )
-    }
-
-    private func headingFont(level: Int) -> Font {
-        switch level {
-        case 1: return .title
-        case 2: return .title2
-        default: return .title3
-        }
-    }
-
     private func indentationWidth(columns: Int) -> CGFloat {
         CGFloat(columns) * (style.usesMonospace ? style.approxCharWidth : 8)
-    }
-
-    private func headingIndentWidth(level: Int) -> CGFloat {
-        indentationWidth(columns: max(0, (level - 1) * 2))
     }
 
     private func sectionViewportWidth(columns: Int) -> CGFloat {
@@ -327,95 +353,6 @@ private enum MicronHeadingPalette {
             MicronTextStyle.colorFrom3Hex(foregroundHex) ?? .primary,
             MicronTextStyle.colorFrom3Hex(backgroundHex) ?? .clear
         )
-    }
-}
-
-// MARK: - Span Rendering
-
-/// Renders an array of MicronSpans into a single wrapping Text view.
-///
-/// Uses `AttributedString` with inline `.link` attributes so SwiftUI can
-/// wrap naturally at word boundaries. Link taps are intercepted via a
-/// custom URL scheme (`micron-link://<index>`) that `OpenURLAction` maps
-/// back to the originating `MicronLink`.
-@available(iOS 17.0, macOS 14.0, *)
-func renderSpans(
-    _ spans: [MicronSpan],
-    onLinkTapped: ((MicronLink) -> Void)?,
-    linkForegroundColor: Color? = nil
-) -> some View {
-    MicronSpansText(
-        spans: spans,
-        onLinkTapped: onLinkTapped,
-        linkForegroundColor: linkForegroundColor
-    )
-}
-
-@available(iOS 17.0, macOS 14.0, *)
-struct MicronSpansText: View {
-    let spans: [MicronSpan]
-    var onLinkTapped: ((MicronLink) -> Void)?
-    var linkForegroundColor: Color? = nil
-
-    var body: some View {
-        Text(buildAttributed())
-            .environment(\.openURL, OpenURLAction { url in
-                if url.scheme == "micron-link",
-                   let host = url.host,
-                   let idx = Int(host),
-                   idx < links.count {
-                    onLinkTapped?(links[idx])
-                    return .handled
-                }
-                return .systemAction
-            })
-    }
-
-    /// Indices of link spans, in document order. The attributed string uses
-    /// `micron-link://<index>` so the openURL handler can route back to the
-    /// exact span without relying on label uniqueness.
-    private var links: [MicronLink] {
-        spans.compactMap { span in
-            if case .link(let link) = span { return link }
-            return nil
-        }
-    }
-
-    private func buildAttributed() -> AttributedString {
-        var result = AttributedString("")
-        var linkIndex = 0
-        for span in spans {
-            switch span {
-            case .text(let content, let style):
-                result.append(styledAttributed(content, style: style))
-            case .link(let link):
-                var piece = AttributedString(link.label)
-                piece.foregroundColor = linkForegroundColor ?? .accentColor
-                piece.underlineStyle = .single
-                if let url = URL(string: "micron-link://\(linkIndex)") {
-                    piece.link = url
-                }
-                result.append(piece)
-                linkIndex += 1
-            }
-        }
-        return result
-    }
-
-    private func styledAttributed(_ content: String, style: MicronTextStyle) -> AttributedString {
-        var piece = AttributedString(content)
-        var intents: InlinePresentationIntent = []
-        if style.bold { intents.insert(.stronglyEmphasized) }
-        if style.italic { intents.insert(.emphasized) }
-        if !intents.isEmpty { piece.inlinePresentationIntent = intents }
-        if style.underline { piece.underlineStyle = .single }
-        if let fg = style.foregroundColor, let color = MicronTextStyle.colorFromStyleHex(fg) {
-            piece.foregroundColor = color
-        }
-        if let bg = style.backgroundColor, let color = MicronTextStyle.colorFromStyleHex(bg) {
-            piece.backgroundColor = color
-        }
-        return piece
     }
 }
 #endif

--- a/Sources/ColumbaApp/Views/NomadNet/MicronDocumentView.swift
+++ b/Sources/ColumbaApp/Views/NomadNet/MicronDocumentView.swift
@@ -26,6 +26,21 @@ struct MicronDocumentView: View {
     var partialAncestry: Set<String> = []
 
     var body: some View {
+        // Android parity (#188): page text must be selectable/copyable.
+        // `.textSelection` only reaches SwiftUI `Text`, so it is applied in
+        // the wrapping modes (real Text) and NOT in `.monospaceScroll`
+        // (UIKit UILabels, which get a long-press "Copy" context menu in
+        // MonospaceLineView instead; the toolbar "Copy Page" covers all).
+        if isScrollMode {
+            documentContent
+        } else {
+            documentContent
+                .textSelection(.enabled)
+        }
+    }
+
+    /// The rendered document content, shared by both selection strategies.
+    private var documentContent: some View {
         VStack(alignment: .leading, spacing: isScrollMode ? 0 : 2) {
             ForEach(Array(document.elements.enumerated()), id: \.offset) { index, element in
                 renderElement(element, index: index)
@@ -33,13 +48,6 @@ struct MicronDocumentView: View {
         }
         .padding(.horizontal, appliesDocumentPadding && !isScrollMode ? 12 : 0)
         .padding(.vertical, appliesDocumentPadding && !isScrollMode ? 8 : 0)
-        // Android parity (#188): in the wrapping modes the body text is real
-        // SwiftUI `Text`, so enable the native long-press select/copy behavior
-        // (the iOS equivalent of Android's Compose `SelectionContainer`).
-        // `.monospaceScroll` renders UIKit UILabels, which this modifier cannot
-        // reach; those lines get a long-press "Copy" context menu instead
-        // (MonospaceLineView) and the toolbar "Copy Page" covers the whole page.
-        .textSelection(isScrollMode ? .disabled : .enabled)
         .accessibilityIdentifier("nomadnet_document")
     }
 

--- a/Sources/ColumbaApp/Views/NomadNet/MicronDocumentView.swift
+++ b/Sources/ColumbaApp/Views/NomadNet/MicronDocumentView.swift
@@ -28,9 +28,11 @@ struct MicronDocumentView: View {
     var body: some View {
         // Android parity (#188): page text must be selectable/copyable.
         // `.textSelection` only reaches SwiftUI `Text`, so it is applied in
-        // the wrapping modes (real Text) and NOT in `.monospaceScroll`
-        // (UIKit UILabels, which get a long-press "Copy" context menu in
-        // MonospaceLineView instead; the toolbar "Copy Page" covers all).
+        // the wrapping modes (real Text). In `.monospaceScroll` the content is
+        // UIKit-backed, so each block is itself a selectable `UITextView`
+        // (MonospaceLineView) that surfaces the native long-press selection UI
+        // (highlight + two handles + system Copy/Look Up/Translate menu). The
+        // toolbar "Copy Page" remains a whole-page fallback in every mode.
         if isScrollMode {
             documentContent
         } else {
@@ -154,19 +156,18 @@ struct MicronDocumentView: View {
 
         case .literalBlock(let text, let indentLevel):
             if isScrollMode {
-                // Split literal blocks into individual lines so each gets exact cell height
-                VStack(alignment: .leading, spacing: 0) {
-                    ForEach(Array(text.split(separator: "\n", omittingEmptySubsequences: false).enumerated()), id: \.offset) { _, line in
-                        MonospaceLineView(
-                            spans: [.text(String(line), .plain)],
-                            fontSize: style.fontSize,
-                            cellHeight: cellHeight,
-                            alignment: .left,
-                            bold: false,
-                            onLinkTapped: nil
-                        )
-                    }
-                }
+                // One selectable block per literal block: its lines render
+                // inside a single selectable UITextView so a long-press yields
+                // the two-handle selection across the whole block (issue #188),
+                // and each line keeps its exact cell height for tight stacking.
+                MonospaceLineView(
+                    lines: text.split(separator: "\n", omittingEmptySubsequences: false).map { [.text(String($0), .plain)] },
+                    fontSize: style.fontSize,
+                    cellHeight: cellHeight,
+                    alignment: .left,
+                    bold: false,
+                    onLinkTapped: nil
+                )
                 .padding(.horizontal, indentationWidth(columns: indentLevel))
             } else {
                 Text(text)

--- a/Sources/ColumbaApp/Views/NomadNet/MicronDocumentView.swift
+++ b/Sources/ColumbaApp/Views/NomadNet/MicronDocumentView.swift
@@ -48,7 +48,6 @@ struct MicronDocumentView: View {
         }
         .padding(.horizontal, appliesDocumentPadding && !isScrollMode ? 12 : 0)
         .padding(.vertical, appliesDocumentPadding && !isScrollMode ? 8 : 0)
-        .accessibilityIdentifier("nomadnet_document")
     }
 
     private var isScrollMode: Bool { style == .monospaceScroll }

--- a/Sources/ColumbaApp/Views/NomadNet/MonospaceLineView.swift
+++ b/Sources/ColumbaApp/Views/NomadNet/MonospaceLineView.swift
@@ -412,12 +412,18 @@ private struct UISelectableTextRun: UIViewRepresentable {
             let isScroll = run.cellHeight != nil
             let fontKey = (fontSize: run.fontSize, monospaced: run.monospaced, bold: run.bold)
             let colors = (default: run.defaultForegroundColor, link: run.linkForegroundColor)
-            guard run.lines != lastLines
-                || fontKey != lastFontKey
-                || colors != lastColors
-                || width != lastWidth
-                || isScroll != lastIsScroll
-            else { return }
+            // If everything matches what was already applied, this is a
+            // no-op layout pass. (Tuples need no optional promotion, so the
+            // stored values are unwrapped first.)
+            if let lastLines, let lastFontKey, let lastColors {
+                if run.lines == lastLines
+                    && fontKey == lastFontKey
+                    && colors == lastColors
+                    && width == lastWidth
+                    && isScroll == lastIsScroll {
+                    return
+                }
+            }
             lastLines = run.lines
             lastFontKey = fontKey
             lastColors = colors

--- a/Sources/ColumbaApp/Views/NomadNet/MonospaceLineView.swift
+++ b/Sources/ColumbaApp/Views/NomadNet/MonospaceLineView.swift
@@ -222,14 +222,15 @@ private struct UIMonospaceLine: UIViewRepresentable {
             let copy = UIAction(
                 title: "Copy",
                 image: UIImage(systemName: "doc.on.doc"),
-                handler: {
+                handler: { _ in
                     UIPasteboard.general.string = text
                     UIImpactFeedbackGenerator(style: .light).impactOccurred()
                 }
             )
             return UIContextMenuConfiguration(
-                preview: UIContextMenuPreview.none,
-                menuProvider: { _ in UIMenu(children: [copy]) }
+                identifier: nil,
+                previewProvider: nil,
+                actionProvider: { _ in UIMenu(children: [copy]) }
             )
         }
 

--- a/Sources/ColumbaApp/Views/NomadNet/MonospaceLineView.swift
+++ b/Sources/ColumbaApp/Views/NomadNet/MonospaceLineView.swift
@@ -435,6 +435,12 @@ private struct UISelectableTextRun: UIViewRepresentable {
             // stay exact.
             textView.textContainer.lineFragmentPadding = 0
             let effectiveWidth = max(1, width)
+            // UITextView draws .link-attributed text in its tintColor,
+            // ignoring the .foregroundColor set on the link spans. A run has
+            // exactly one link color (per-run parameter), so mirror it onto
+            // the tintColor: heading links inherit the palette foreground,
+            // prose links use the accent color.
+            textView.tintColor = UIColor(run.linkForegroundColor ?? .accentColor)
             textView.textContainer.widthTracksTextView = false
             if isScroll, let cellHeight = run.cellHeight {
                 textView.textContainer.size = CGSize(

--- a/Sources/ColumbaApp/Views/NomadNet/MonospaceLineView.swift
+++ b/Sources/ColumbaApp/Views/NomadNet/MonospaceLineView.swift
@@ -166,6 +166,8 @@ private struct UIMonospaceLine: UIViewRepresentable {
         label.lineBreakMode = .byClipping
         label.backgroundColor = .clear
         label.isUserInteractionEnabled = true
+        label.accessibilityIdentifier = "nomadnet_line"
+        label.accessibilityLabel = "NomadNet line"
         label.setContentHuggingPriority(.defaultLow, for: .horizontal)
         label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         label.setContentHuggingPriority(.required, for: .vertical)
@@ -173,6 +175,11 @@ private struct UIMonospaceLine: UIViewRepresentable {
 
         let tap = UITapGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.didTap(_:)))
         label.addGestureRecognizer(tap)
+        // Android parity (#188): long-press a line to copy it. `.textSelection`
+        // cannot reach a UILabel, so use the native iOS long-press idiom. The
+        // tap recognizer (links) and the long-press context menu coexist.
+        let contextMenu = UIContextMenuInteraction(delegate: context.coordinator)
+        label.addInteraction(contextMenu)
         context.coordinator.onTap = onTap
         return label
     }
@@ -188,7 +195,7 @@ private struct UIMonospaceLine: UIViewRepresentable {
     func makeCoordinator() -> Coordinator { Coordinator() }
 
     @MainActor
-    final class Coordinator: NSObject {
+    final class Coordinator: NSObject, UIContextMenuInteractionDelegate {
         var onTap: ((Int) -> Void)?
 
         @objc func didTap(_ sender: UITapGestureRecognizer) {
@@ -199,6 +206,28 @@ private struct UIMonospaceLine: UIViewRepresentable {
             if index != NSNotFound {
                 onTap?(index)
             }
+        }
+
+        /// Long-press context menu: a single "Copy" action that copies the
+        /// line's visible text (issue #188). Returns nil for blank lines so
+        /// the menu does not appear over empty space.
+        func contextMenuInteraction(
+            _ interaction: UIContextMenuInteraction,
+            configurationForMenuAt location: CGPoint
+        ) -> UIMenu? {
+            guard let label = interaction.view as? UILabel,
+                  let text = label.text,
+                  !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            else { return nil }
+            let copy = UIAction(
+                title: "Copy",
+                image: UIImage(systemName: "doc.on.doc"),
+                handler: { _ in
+                    UIPasteboard.general.string = text
+                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                }
+            )
+            return UIMenu(title: "", children: [copy])
         }
 
         private func characterIndex(at location: CGPoint, in label: UILabel, attributedText: NSAttributedString) -> Int {

--- a/Sources/ColumbaApp/Views/NomadNet/MonospaceLineView.swift
+++ b/Sources/ColumbaApp/Views/NomadNet/MonospaceLineView.swift
@@ -3,113 +3,125 @@ import SwiftUI
 import RNSAPI
 #if os(iOS)
 import UIKit
-#elseif os(macOS)
-import AppKit
 #endif
 
-/// Renders one or more lines of monospace content as a single **selectable**
-/// block (issue #188, Android parity).
+// MARK: - Text line
+
+/// One line of page text inside a selectable run.
 ///
-/// Backed by a non-editable, selectable ``UITextView`` so a long-press produces
-/// the native iOS selection UI - highlighted text with two draggable handles and
-/// the system Copy / Look Up / Translate / Share menu - exactly like the message
-/// bubble's "Select Text" (``SelectableMessageTextView``). A ``UILabel`` (the
-/// earlier backing) cannot expose that selection UI, which is why the per-line
-/// "Copy" context menu was replaced: whole-line copy was not granular enough.
+/// `spans` carry the inline content (text + links). `alignment` and
+/// `indentLevel` are the line's layout attributes (nested sections indent
+/// both sides in wrap mode and offset content in scroll mode). `colorOverride`
+/// tints spans that have no explicit foreground color (used for wrap-mode
+/// divider lines).
+@available(iOS 17.0, macOS 14.0, *)
+struct MicronTextLine: Equatable {
+    var spans: [MicronSpan]
+    var alignment: MicronAlignment = .left
+    var indentLevel: Int = 0
+    var colorOverride: Color? = nil
+}
+
+// MARK: - Selectable run view
+
+/// Renders a run of text lines as ONE non-editable, selectable `UITextView`
+/// (issue #188, Android parity).
 ///
-/// A single paragraph or heading is one line; a literal/code block is several
-/// lines rendered as one block, so selection (and its two handles) can span
-/// multiple lines of code.
+/// One run is one selectable region. A long-press produces the native iOS
+/// selection UI - highlighted text with two draggable handles and the system
+/// Copy / Look Up / Translate / Share menu - exactly like the message
+/// bubble's "Select Text" (`SelectableMessageTextView`). Because the WHOLE
+/// run is a single `UITextView`, the two handles can be dragged ACROSS
+/// newlines: a multi-line paragraph, an ASCII-art block, or a code block
+/// selects as one unit. `MicronDocumentView` breaks a run only at headings
+/// (full-width band), literal blocks (own band in wrap mode), form fields,
+/// and partials, so interactive elements stay outside the selectable text.
 ///
-/// Rendering keeps the strict square-cell paragraph style (minimum == maximum
-/// line height == ``cellHeight``, zero line spacing) so block-drawing characters
-/// (▀▄█) stack tight, and each block is sized to its content so lines never wrap
-/// (this mode is no-wrap). Links render via the native ``.link`` attribute and
-/// are routed back to the caller through ``onLinkTapped``; they coexist with
-/// long-press selection.
+/// Two earlier approaches were rejected: a per-line UILabel + whole-line
+/// "Copy" context menu (no handles, not granular enough), and per-line
+/// SwiftUI `Text` with native text-selection (on device it surfaced only a
+/// "Copy | Share" menu, never the two-handle selection).
+///
+/// Scroll mode (`cellHeight != nil`): no wrapping, strict square cells
+/// (minimum == maximum line height == `cellHeight`, zero line spacing) so
+/// block-drawing characters stack tight. The container is at least the
+/// viewport and wide enough that no line wraps. Centered/right-aligned lines
+/// are positioned with an explicit per-line head indent computed against the
+/// VIEWPORT (not the container width), so a wide line elsewhere in the run
+/// never pushes centered content offscreen-right.
+///
+/// Wrap mode (`cellHeight == nil`): the container tracks the width proposed
+/// by the enclosing container, lines wrap naturally with 2pt line spacing
+/// (matching the previous per-line VStack spacing), and every line is
+/// indented on head AND tail so nested sections keep both margins.
 @available(iOS 17.0, macOS 14.0, *)
 struct MonospaceLineView: View {
-    let lines: [[MicronSpan]]
+    let lines: [MicronTextLine]
     let fontSize: CGFloat
-    let cellHeight: CGFloat
-    let alignment: MicronAlignment
-    let bold: Bool
+    let monospaced: Bool
+    /// Width of one section-indent column (monospace char width, or 8pt in
+    /// proportional mode - mirrors `MicronDocumentView.indentationWidth`).
+    let indentUnit: CGFloat
+    var bold: Bool = false
+    var cellHeight: CGFloat? = nil
+    var viewportWidth: CGFloat = 0
     var defaultForegroundColor: Color? = nil
     var linkForegroundColor: Color? = nil
     var onLinkTapped: ((MicronLink) -> Void)?
 
-    /// Primary initializer: one selectable block per element, where a literal
-    /// code block passes all of its lines at once (so selection can span the
-    /// block) and a heading/paragraph passes a single line.
     init(
-        lines: [[MicronSpan]],
+        lines: [MicronTextLine],
         fontSize: CGFloat,
-        cellHeight: CGFloat,
-        alignment: MicronAlignment,
-        bold: Bool,
+        monospaced: Bool,
+        indentUnit: CGFloat,
+        bold: Bool = false,
+        cellHeight: CGFloat? = nil,
+        viewportWidth: CGFloat = 0,
         defaultForegroundColor: Color? = nil,
         linkForegroundColor: Color? = nil,
         onLinkTapped: ((MicronLink) -> Void)? = nil
     ) {
         self.lines = lines
         self.fontSize = fontSize
-        self.cellHeight = cellHeight
-        self.alignment = alignment
+        self.monospaced = monospaced
+        self.indentUnit = indentUnit
         self.bold = bold
+        self.cellHeight = cellHeight
+        self.viewportWidth = viewportWidth
         self.defaultForegroundColor = defaultForegroundColor
         self.linkForegroundColor = linkForegroundColor
         self.onLinkTapped = onLinkTapped
     }
 
-    /// Single-line convenience (headings, paragraphs, dividers).
-    init(
-        spans: [MicronSpan],
-        fontSize: CGFloat,
-        cellHeight: CGFloat,
-        alignment: MicronAlignment,
-        bold: Bool,
-        defaultForegroundColor: Color? = nil,
-        linkForegroundColor: Color? = nil,
-        onLinkTapped: ((MicronLink) -> Void)? = nil
-    ) {
-        self.init(
-            lines: [spans],
-            fontSize: fontSize,
-            cellHeight: cellHeight,
-            alignment: alignment,
-            bold: bold,
-            defaultForegroundColor: defaultForegroundColor,
-            linkForegroundColor: linkForegroundColor,
-            onLinkTapped: onLinkTapped
-        )
-    }
-
     var body: some View {
         #if os(iOS)
-        UISelectableMonospaceBlock(
+        UISelectableTextRun(
             lines: lines,
             fontSize: fontSize,
-            cellHeight: cellHeight,
-            alignment: alignment,
+            monospaced: monospaced,
+            indentUnit: indentUnit,
             bold: bold,
+            cellHeight: cellHeight,
+            viewportWidth: viewportWidth,
             defaultForegroundColor: defaultForegroundColor,
             linkForegroundColor: linkForegroundColor,
             onLinkTapped: onLinkTapped
         )
         #else
-        // macOS fallback — plain Text rows with manual spacing (gaps may be
-        // visible on macOS; the selectable behavior is iOS-only).
-        VStack(alignment: .leading, spacing: 0) {
-            ForEach(Array(lines.enumerated()), id: \.offset) { _, spans in
-                Text(spans.map { span -> String in
+        // Fallback for non-iOS platforms (the app is iOS-only; kept so the
+        // file still compiles): plain text rows, not selectable.
+        VStack(alignment: .leading, spacing: cellHeight != nil ? 0 : 2) {
+            ForEach(Array(lines.enumerated()), id: \.offset) { _, line in
+                Text(line.spans.map { span -> String in
                     switch span {
                     case .text(let s, _): return s
                     case .link(let l): return l.label
                     }
                 }.joined())
-                .font(.system(size: fontSize, design: .monospaced))
-                .lineLimit(1)
-                .frame(height: cellHeight, alignment: alignment.swiftUI)
+                .font(monospaced ? .system(size: fontSize, design: .monospaced) : .system(size: fontSize))
+                .bold(bold)
+                .lineLimit(cellHeight != nil ? 1 : nil)
+                .frame(height: cellHeight, alignment: .leading)
             }
         }
         #endif
@@ -118,102 +130,195 @@ struct MonospaceLineView: View {
 
 #if os(iOS)
 
-/// UIKit wrapper: a non-editable, selectable ``UITextView`` that renders
-/// monospace lines with a strict square-cell paragraph style. The native
-/// long-press selection (two handles + system menu) comes from
-/// ``UITextView/isSelectable``.
-@available(iOS 17.0, *)
-private struct UISelectableMonospaceBlock: UIViewRepresentable {
-    let lines: [[MicronSpan]]
-    let fontSize: CGFloat
-    let cellHeight: CGFloat
-    let alignment: MicronAlignment
-    let bold: Bool
-    var defaultForegroundColor: Color? = nil
-    var linkForegroundColor: Color? = nil
-    var onLinkTapped: ((MicronLink) -> Void)?
+// MARK: - UIKit wrapper
 
-    /// Ordered link spans (document order). ``micron-link://<index>`` maps here.
-    private var links: [MicronLink] {
+/// A non-editable, selectable `UITextView` that renders a run of lines with
+/// per-line paragraph styles. The native long-press selection (two handles +
+/// system menu) comes from `UITextView.isSelectable`.
+@available(iOS 17.0, *)
+private struct UISelectableTextRun: UIViewRepresentable {
+    let lines: [MicronTextLine]
+    let fontSize: CGFloat
+    let monospaced: Bool
+    let indentUnit: CGFloat
+    let bold: Bool
+    let cellHeight: CGFloat?
+    let viewportWidth: CGFloat
+    let defaultForegroundColor: Color?
+    let linkForegroundColor: Color?
+    let onLinkTapped: ((MicronLink) -> Void)?
+
+    var isScroll: Bool { cellHeight != nil }
+
+    /// Ordered link spans (document order). `micron-link://<index>` maps here.
+    var links: [MicronLink] {
         lines.flatMap { line in
-            line.compactMap { span in
+            line.spans.compactMap { span in
                 if case .link(let l) = span { return l }
                 return nil
             }
         }
     }
 
-    func makeCoordinator() -> Coordinator {
-        Coordinator(onLinkTapped: onLinkTapped, links: links)
+    /// Advance width of one character in this run's base (regular, non-bold)
+    /// font. Monospace variants share one advance, so bold/italic do not
+    /// change it; this is only used to measure scroll-mode content width.
+    var advance: CGFloat {
+        let font = monospaced
+            ? MicronRenderStyle.uiMonospaceFont(fontSize: fontSize)
+            : UIFont.systemFont(ofSize: fontSize)
+        return ("M" as NSString).size(withAttributes: [.font: font]).width
     }
+
+    /// Character count of a line's content (links count by label length).
+    private func lineChars(_ line: MicronTextLine) -> Int {
+        line.spans.reduce(0) { acc, span in
+            switch span {
+            case .text(let s, _): return acc + s.count
+            case .link(let l): return acc + l.label.count
+            }
+        }
+    }
+
+    /// Content width of a line in scroll mode (no wrap): chars x advance.
+    private func lineContentWidth(_ line: MicronTextLine) -> CGFloat {
+        CGFloat(lineChars(line)) * advance
+    }
+
+    /// The left x where a line's content starts.
+    ///
+    /// Scroll mode: positioned against the VIEWPORT so a wide line elsewhere
+    /// in the run never pushes centered/right content offscreen-right.
+    /// Wrap mode: just the section head indent (Core Text alignment handles
+    /// centering within the indented region).
+    private func lineHeadIndent(_ line: MicronTextLine) -> CGFloat {
+        let indent = CGFloat(line.indentLevel) * indentUnit
+        guard isScroll else { return indent }
+        let wc = lineContentWidth(line)
+        switch line.alignment {
+        case .left: return indent
+        case .center: return max(0, viewportWidth / 2 - wc / 2)
+        case .right: return max(0, viewportWidth - indent - wc)
+        }
+    }
+
+    /// Scroll-mode container width: at least the viewport, and wide enough
+    /// that no line wraps (each line needs its head indent plus its content).
+    var scrollWidth: CGFloat {
+        let widest = lines.map { line in
+            lineHeadIndent(line) + lineContentWidth(line)
+        }.max() ?? 0
+        return max(viewportWidth, widest + 1)
+    }
+
+    /// Fallback width when SwiftUI proposes no width at all (unspecified):
+    /// the widest line rendered without wrapping, plus both indents.
+    var intrinsicWidth: CGFloat {
+        let font = monospaced
+            ? MicronRenderStyle.uiMonospaceFont(fontSize: fontSize)
+            : UIFont.systemFont(ofSize: fontSize)
+        let widest = lines.map { line in
+            let text = line.spans.map { span -> String in
+                switch span {
+                case .text(let s, _): return s
+                case .link(let l): return l.label
+                }
+            }.joined()
+            let w = (text as NSString).size(withAttributes: [.font: font]).width
+            return w + CGFloat(line.indentLevel) * 2 * indentUnit
+        }.max() ?? 0
+        return max(1, widest + 1)
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
 
     func makeUIView(context: Context) -> UITextView {
         let textView = UITextView()
         textView.isEditable = false
-        // isSelectable (not isEditable) is what surfaces the native selection
-        // UI: long-press -> highlight + two draggable handles + system menu.
+        // isSelectable (not isEditable) is what surfaces the native
+        // selection UI: long-press -> highlight + two draggable handles +
+        // the system Copy/Look Up/Translate/Share menu.
         textView.isSelectable = true
-        // The outer ZoomableScrollView owns all scrolling; this block must not
-        // scroll on its own (no nested scrolling, no clipping).
+        // The outer container (ZoomableScrollView / SwiftUI ScrollView) owns
+        // all scrolling; this run must not scroll on its own (no nested
+        // scrolling, no clipping).
         textView.isScrollEnabled = false
         textView.isOpaque = false
         textView.backgroundColor = .clear
         textView.textContainerInset = .zero
         textView.textContainer.lineFragmentPadding = 0
         textView.contentInsetAdjustmentBehavior = .never
+        textView.allowsEditingTextAttributes = false
         // Automation target only. Do NOT set accessibilityLabel: the default
-        // label is the block's text, which is what VoiceOver must announce.
+        // label is the run's text, which is what VoiceOver must announce.
         textView.accessibilityIdentifier = "nomadnet_line"
         textView.delegate = context.coordinator
+        // Populate immediately so the run is never blank if sizeThatFits is
+        // deferred; sizeThatFits re-applies with the exact width.
+        context.coordinator.apply(self, to: textView, width: isScroll ? scrollWidth : intrinsicWidth)
         return textView
     }
 
     func updateUIView(_ textView: UITextView, context: Context) {
-        // The text container can be rebuilt on some iOS versions; re-assert the
-        // zero padding so the left edge and no-wrap width stay exact.
-        textView.textContainer.lineFragmentPadding = 0
-        let attr = buildAttributedString()
-        if textView.text != attr.string {
-            textView.attributedText = attr
-        }
-        context.coordinator.links = links
-        context.coordinator.onLinkTapped = onLinkTapped
+        // Re-apply idempotently (no-op unless input or width changed).
+        context.coordinator.apply(self, to: textView, width: textView.textContainer.size.width)
     }
 
-    /// Intrinsic size of the block: as wide as its longest line (so no line
-    /// wraps - this mode is no-wrap) and exactly one ``cellHeight`` tall per
-    /// line. The SwiftUI call site wraps this in `.frame(minWidth:alignment:)`
-    /// for centering / right-alignment of narrow rows, mirroring the previous
-    /// label behavior and Android's `widthIn(min = viewportLineWidth)`.
     func sizeThatFits(_ proposal: ProposedViewSize, uiView: UITextView, context: Context) -> CGSize? {
-        let width = contentWidth()
-        let height = CGFloat(lines.count) * cellHeight
+        if isScroll, let cellHeight {
+            // Scroll mode: fixed intrinsic size (no wrapping).
+            let width = scrollWidth
+            context.coordinator.apply(self, to: uiView, width: width)
+            return CGSize(width: width, height: CGFloat(lines.count) * cellHeight)
+        }
+        // Wrap mode: track the proposed width; rebuild the text when the
+        // width changes (tail indents and wrapping depend on it).
+        let width = max(1, proposal.width ?? intrinsicWidth)
+        context.coordinator.apply(self, to: uiView, width: width)
+        let height = uiView.sizeThatFits(CGSize(width: width, height: .greatestFiniteMagnitude)).height
         return CGSize(width: width, height: height)
     }
 
     // MARK: - Attributed text
 
-    private func buildAttributedString() -> NSAttributedString {
+    func buildAttributes(width: CGFloat) -> NSAttributedString {
         let result = NSMutableAttributedString()
-        let paragraph = NSMutableParagraphStyle()
-        paragraph.minimumLineHeight = cellHeight
-        paragraph.maximumLineHeight = cellHeight
-        paragraph.lineSpacing = 0
-        paragraph.lineHeightMultiple = 0
-        // Always render content left-aligned within the text view. SwiftUI
-        // `.frame(alignment:)` at the call site handles visual centering /
-        // right-alignment for narrow rows. This avoids Core Text's
-        // trailing-whitespace stripping under .center / .right alignment.
-        paragraph.alignment = .left
-
-        let baseFont = MicronRenderStyle.uiMonospaceFont(
-            fontSize: fontSize,
-            bold: bold
-        )
+        let baseFont = monospaced
+            ? MicronRenderStyle.uiMonospaceFont(fontSize: fontSize, bold: bold)
+            : UIFont.systemFont(ofSize: fontSize, weight: bold ? .bold : .regular)
 
         var linkIndex = 0
         for (lineIndex, line) in lines.enumerated() {
-            for span in line {
+            let paragraph = NSMutableParagraphStyle()
+            if isScroll, let cellHeight {
+                // Strict square cell: block-drawing characters stack tight.
+                paragraph.minimumLineHeight = cellHeight
+                paragraph.maximumLineHeight = cellHeight
+                paragraph.lineSpacing = 0
+                // All scroll-mode lines are left-aligned and positioned by an
+                // explicit head indent (see lineHeadIndent), so centered and
+                // right-aligned content tracks the viewport, not the (possibly
+                // much wider) container.
+                paragraph.alignment = .left
+                let head = lineHeadIndent(line)
+                paragraph.firstLineHeadIndent = head
+                paragraph.headIndent = head
+                // Wide enough that the line never wraps (container width).
+                paragraph.tailIndent = width
+            } else {
+                // Wrap mode: matches the 2pt between-line spacing the
+                // previous per-line VStack produced. Core Text alignment
+                // handles centering within the indented region.
+                paragraph.alignment = uikitAlignment(line.alignment)
+                paragraph.lineSpacing = 2
+                let indent = CGFloat(line.indentLevel) * indentUnit
+                paragraph.firstLineHeadIndent = indent
+                paragraph.headIndent = indent
+                // Indent both sides so nested sections keep both margins.
+                paragraph.tailIndent = max(indent, width - indent)
+            }
+
+            for span in line.spans {
                 switch span {
                 case .text(let text, let style):
                     var attrs: [NSAttributedString.Key: Any] = [
@@ -225,6 +330,8 @@ private struct UISelectableMonospaceBlock: UIViewRepresentable {
                         attrs[.foregroundColor] = UIColor(color)
                     } else if let defaultForegroundColor {
                         attrs[.foregroundColor] = UIColor(defaultForegroundColor)
+                    } else if let colorOverride = line.colorOverride {
+                        attrs[.foregroundColor] = UIColor(colorOverride)
                     } else {
                         attrs[.foregroundColor] = UIColor.label
                     }
@@ -239,8 +346,8 @@ private struct UISelectableMonospaceBlock: UIViewRepresentable {
 
                 case .link(let link):
                     // Native .link: a tap routes through
-                    // UITextViewDelegate.textView(_:shouldInteractWith:in:) and
-                    // coexists with long-press text selection.
+                    // UITextViewDelegate.textView(_:shouldInteractWith:in:)
+                    // and coexists with long-press text selection.
                     var attrs: [NSAttributedString.Key: Any] = [
                         .font: baseFont,
                         .paragraphStyle: paragraph,
@@ -266,11 +373,10 @@ private struct UISelectableMonospaceBlock: UIViewRepresentable {
 
     private func font(for style: MicronTextStyle, base: UIFont) -> UIFont {
         var font = base
-        if style.bold {
-            font = MicronRenderStyle.uiMonospaceFont(
-                fontSize: base.pointSize,
-                bold: true
-            )
+        if style.bold, !bold {
+            font = monospaced
+                ? MicronRenderStyle.uiMonospaceFont(fontSize: font.pointSize, bold: true)
+                : UIFont.systemFont(ofSize: font.pointSize, weight: .bold)
         }
         if style.italic,
            let desc = font.fontDescriptor.withSymbolicTraits(.traitItalic) {
@@ -279,23 +385,12 @@ private struct UISelectableMonospaceBlock: UIViewRepresentable {
         return font
     }
 
-    /// Rendered width of the widest line. The font is monospace, so a line's
-    /// width is its character count times the advance (the existing metric test
-    /// pins the rendered advance to `approxCharWidth`). The advance is measured
-    /// with the same regular font `approxCharWidth` uses, plus 1pt of headroom
-    /// so the longest line never wraps on sub-pixel rounding.
-    private func contentWidth() -> CGFloat {
-        let baseFont = MicronRenderStyle.uiMonospaceFont(fontSize: fontSize)
-        let advance = ("M" as NSString).size(withAttributes: [.font: baseFont]).width
-        let maxChars = lines.map { line in
-            line.reduce(0) { acc, span in
-                switch span {
-                case .text(let s, _): return acc + s.count
-                case .link(let l): return acc + l.label.count
-                }
-            }
-        }.max() ?? 0
-        return max(advance, CGFloat(maxChars) * advance + 1)
+    private func uikitAlignment(_ alignment: MicronAlignment) -> NSTextAlignment {
+        switch alignment {
+        case .left: return .left
+        case .center: return .center
+        case .right: return .right
+        }
     }
 
     // MARK: - Coordinator
@@ -303,12 +398,52 @@ private struct UISelectableMonospaceBlock: UIViewRepresentable {
     @MainActor
     final class Coordinator: NSObject, UITextViewDelegate {
         var onLinkTapped: ((MicronLink) -> Void)?
-        var links: [MicronLink]
+        var links: [MicronLink] = []
 
-        init(onLinkTapped: ((MicronLink) -> Void)?, links: [MicronLink]) {
-            self.onLinkTapped = onLinkTapped
-            self.links = links
-            super.init()
+        private var lastLines: [MicronTextLine]?
+        private var lastFontKey: (fontSize: CGFloat, monospaced: Bool, bold: Bool)?
+        private var lastColors: (default: Color?, link: Color?)?
+        private var lastWidth: CGFloat = 0
+        private var lastIsScroll: Bool?
+
+        /// Rebuilds the text view's content only when the run input or the
+        /// container width changed (idempotent across layout passes).
+        func apply(_ run: UISelectableTextRun, to textView: UITextView, width: CGFloat) {
+            let isScroll = run.cellHeight != nil
+            let fontKey = (fontSize: run.fontSize, monospaced: run.monospaced, bold: run.bold)
+            let colors = (default: run.defaultForegroundColor, link: run.linkForegroundColor)
+            guard run.lines != lastLines
+                || fontKey != lastFontKey
+                || colors != lastColors
+                || width != lastWidth
+                || isScroll != lastIsScroll
+            else { return }
+            lastLines = run.lines
+            lastFontKey = fontKey
+            lastColors = colors
+            lastWidth = width
+            lastIsScroll = isScroll
+
+            // The text container can be rebuilt on some iOS versions;
+            // re-assert the zero padding so the left edge and no-wrap width
+            // stay exact.
+            textView.textContainer.lineFragmentPadding = 0
+            let effectiveWidth = max(1, width)
+            textView.textContainer.widthTracksTextView = false
+            if isScroll, let cellHeight = run.cellHeight {
+                textView.textContainer.size = CGSize(
+                    width: effectiveWidth,
+                    height: CGFloat(run.lines.count) * cellHeight
+                )
+            } else {
+                textView.textContainer.size = CGSize(
+                    width: effectiveWidth,
+                    height: .greatestFiniteMagnitude
+                )
+            }
+            textView.attributedText = run.buildAttributes(width: effectiveWidth)
+            onLinkTapped = run.onLinkTapped
+            links = run.links
         }
 
         /// Intercept our `micron-link://` links and route them to the caller.

--- a/Sources/ColumbaApp/Views/NomadNet/MonospaceLineView.swift
+++ b/Sources/ColumbaApp/Views/NomadNet/MonospaceLineView.swift
@@ -213,8 +213,8 @@ private struct UIMonospaceLine: UIViewRepresentable {
         /// the menu does not appear over empty space.
         func contextMenuInteraction(
             _ interaction: UIContextMenuInteraction,
-            configurationForMenuAt location: CGPoint
-        ) -> UIMenu? {
+            configurationForMenuAtLocation location: CGPoint
+        ) -> UIContextMenuConfiguration? {
             guard let label = interaction.view as? UILabel,
                   let text = label.text,
                   !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -222,12 +222,15 @@ private struct UIMonospaceLine: UIViewRepresentable {
             let copy = UIAction(
                 title: "Copy",
                 image: UIImage(systemName: "doc.on.doc"),
-                handler: { _ in
+                handler: {
                     UIPasteboard.general.string = text
                     UIImpactFeedbackGenerator(style: .light).impactOccurred()
                 }
             )
-            return UIMenu(title: "", children: [copy])
+            return UIContextMenuConfiguration(
+                preview: UIContextMenuPreview.none,
+                menuProvider: { _ in UIMenu(children: [copy]) }
+            )
         }
 
         private func characterIndex(at location: CGPoint, in label: UILabel, attributedText: NSAttributedString) -> Int {

--- a/Sources/ColumbaApp/Views/NomadNet/MonospaceLineView.swift
+++ b/Sources/ColumbaApp/Views/NomadNet/MonospaceLineView.swift
@@ -7,15 +7,29 @@ import UIKit
 import AppKit
 #endif
 
-/// Renders a single line of micron content with exact cell height,
-/// no font leading/padding, and tight glyph stacking. This is the only
-/// way to get block-drawing characters (▀▄█) to stack without gaps in
-/// SwiftUI, since `.frame(height:)` crops but doesn't remove font leading.
+/// Renders one or more lines of monospace content as a single **selectable**
+/// block (issue #188, Android parity).
 ///
-/// Used only in monospaceScroll mode.
+/// Backed by a non-editable, selectable ``UITextView`` so a long-press produces
+/// the native iOS selection UI - highlighted text with two draggable handles and
+/// the system Copy / Look Up / Translate / Share menu - exactly like the message
+/// bubble's "Select Text" (``SelectableMessageTextView``). A ``UILabel`` (the
+/// earlier backing) cannot expose that selection UI, which is why the per-line
+/// "Copy" context menu was replaced: whole-line copy was not granular enough.
+///
+/// A single paragraph or heading is one line; a literal/code block is several
+/// lines rendered as one block, so selection (and its two handles) can span
+/// multiple lines of code.
+///
+/// Rendering keeps the strict square-cell paragraph style (minimum == maximum
+/// line height == ``cellHeight``, zero line spacing) so block-drawing characters
+/// (▀▄█) stack tight, and each block is sized to its content so lines never wrap
+/// (this mode is no-wrap). Links render via the native ``.link`` attribute and
+/// are routed back to the caller through ``onLinkTapped``; they coexist with
+/// long-press selection.
 @available(iOS 17.0, macOS 14.0, *)
 struct MonospaceLineView: View {
-    let spans: [MicronSpan]
+    let lines: [[MicronSpan]]
     let fontSize: CGFloat
     let cellHeight: CGFloat
     let alignment: MicronAlignment
@@ -24,30 +38,138 @@ struct MonospaceLineView: View {
     var linkForegroundColor: Color? = nil
     var onLinkTapped: ((MicronLink) -> Void)?
 
-    var body: some View {
-        #if os(iOS)
-        UIMonospaceLine(
-            attributedString: buildAttributedString(),
+    /// Single-line convenience (headings, paragraphs, dividers).
+    init(
+        spans: [MicronSpan],
+        fontSize: CGFloat,
+        cellHeight: CGFloat,
+        alignment: MicronAlignment,
+        bold: Bool,
+        defaultForegroundColor: Color? = nil,
+        linkForegroundColor: Color? = nil,
+        onLinkTapped: ((MicronLink) -> Void)? = nil
+    ) {
+        self.init(
+            lines: [spans],
+            fontSize: fontSize,
             cellHeight: cellHeight,
             alignment: alignment,
-            onTap: handleTap
+            bold: bold,
+            defaultForegroundColor: defaultForegroundColor,
+            linkForegroundColor: linkForegroundColor,
+            onLinkTapped: onLinkTapped
         )
-        .frame(height: cellHeight)
-        #else
-        // macOS fallback — plain Text with manual spacing (gaps may be visible on macOS)
-        Text(spans.map { span -> String in
-            switch span {
-            case .text(let s, _): return s
-            case .link(let l): return l.label
-            }
-        }.joined())
-        .font(.system(size: fontSize, design: .monospaced))
-        .lineLimit(1)
-        .frame(height: cellHeight, alignment: alignment.swiftUI)
-        #endif
     }
 
-    #if os(iOS)
+    var body: some View {
+        #if os(iOS)
+        UISelectableMonospaceBlock(
+            lines: lines,
+            fontSize: fontSize,
+            cellHeight: cellHeight,
+            alignment: alignment,
+            bold: bold,
+            defaultForegroundColor: defaultForegroundColor,
+            linkForegroundColor: linkForegroundColor,
+            onLinkTapped: onLinkTapped
+        )
+        #else
+        // macOS fallback — plain Text rows with manual spacing (gaps may be
+        // visible on macOS; the selectable behavior is iOS-only).
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(Array(lines.enumerated()), id: \.offset) { _, spans in
+                Text(spans.map { span -> String in
+                    switch span {
+                    case .text(let s, _): return s
+                    case .link(let l): return l.label
+                    }
+                }.joined())
+                .font(.system(size: fontSize, design: .monospaced))
+                .lineLimit(1)
+                .frame(height: cellHeight, alignment: alignment.swiftUI)
+            }
+        }
+        #endif
+    }
+}
+
+#if os(iOS)
+
+/// UIKit wrapper: a non-editable, selectable ``UITextView`` that renders
+/// monospace lines with a strict square-cell paragraph style. The native
+/// long-press selection (two handles + system menu) comes from
+/// ``UITextView/isSelectable``.
+@available(iOS 17.0, *)
+private struct UISelectableMonospaceBlock: UIViewRepresentable {
+    let lines: [[MicronSpan]]
+    let fontSize: CGFloat
+    let cellHeight: CGFloat
+    let alignment: MicronAlignment
+    let bold: Bool
+    var defaultForegroundColor: Color? = nil
+    var linkForegroundColor: Color? = nil
+    var onLinkTapped: ((MicronLink) -> Void)?
+
+    /// Ordered link spans (document order). ``micron-link://<index>`` maps here.
+    private var links: [MicronLink] {
+        lines.flatMap { line in
+            line.compactMap { span in
+                if case .link(let l) = span { return l }
+                return nil
+            }
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onLinkTapped: onLinkTapped, links: links)
+    }
+
+    func makeUIView(context: Context) -> UITextView {
+        let textView = UITextView()
+        textView.isEditable = false
+        // isSelectable (not isEditable) is what surfaces the native selection
+        // UI: long-press -> highlight + two draggable handles + system menu.
+        textView.isSelectable = true
+        // The outer ZoomableScrollView owns all scrolling; this block must not
+        // scroll on its own (no nested scrolling, no clipping).
+        textView.isScrollEnabled = false
+        textView.isOpaque = false
+        textView.backgroundColor = .clear
+        textView.textContainerInset = .zero
+        textView.textContainer?.lineFragmentPadding = 0
+        textView.contentInsetAdjustmentBehavior = .never
+        // Automation target only. Do NOT set accessibilityLabel: the default
+        // label is the block's text, which is what VoiceOver must announce.
+        textView.accessibilityIdentifier = "nomadnet_line"
+        textView.delegate = context.coordinator
+        return textView
+    }
+
+    func updateUIView(_ textView: UITextView, context: Context) {
+        // The text container can be rebuilt on some iOS versions; re-assert the
+        // zero padding so the left edge and no-wrap width stay exact.
+        textView.textContainer?.lineFragmentPadding = 0
+        let attr = buildAttributedString()
+        if textView.text != attr.string {
+            textView.attributedText = attr
+        }
+        context.coordinator.links = links
+        context.coordinator.onLinkTapped = onLinkTapped
+    }
+
+    /// Intrinsic size of the block: as wide as its longest line (so no line
+    /// wraps - this mode is no-wrap) and exactly one ``cellHeight`` tall per
+    /// line. The SwiftUI call site wraps this in `.frame(minWidth:alignment:)`
+    /// for centering / right-alignment of narrow rows, mirroring the previous
+    /// label behavior and Android's `widthIn(min = viewportLineWidth)`.
+    func sizeThatFits(_ proposal: ProposedViewSize, uiView: UITextView, context: Context) -> CGSize? {
+        let width = contentWidth()
+        let height = CGFloat(lines.count) * cellHeight
+        return CGSize(width: width, height: height)
+    }
+
+    // MARK: - Attributed text
+
     private func buildAttributedString() -> NSAttributedString {
         let result = NSMutableAttributedString()
         let paragraph = NSMutableParagraphStyle()
@@ -55,7 +177,7 @@ struct MonospaceLineView: View {
         paragraph.maximumLineHeight = cellHeight
         paragraph.lineSpacing = 0
         paragraph.lineHeightMultiple = 0
-        // Always render content left-aligned within the UILabel. SwiftUI
+        // Always render content left-aligned within the text view. SwiftUI
         // `.frame(alignment:)` at the call site handles visual centering /
         // right-alignment for narrow rows. This avoids Core Text's
         // trailing-whitespace stripping under .center / .right alignment.
@@ -66,38 +188,54 @@ struct MonospaceLineView: View {
             bold: bold
         )
 
-        for span in spans {
-            switch span {
-            case .text(let text, let style):
-                var attrs: [NSAttributedString.Key: Any] = [
-                    .font: font(for: style, base: baseFont),
-                    .paragraphStyle: paragraph,
-                ]
-                if let fg = style.foregroundColor,
-                   let color = MicronTextStyle.colorFromStyleHex(fg) {
-                    attrs[.foregroundColor] = UIColor(color)
-                } else if let defaultForegroundColor {
-                    attrs[.foregroundColor] = UIColor(defaultForegroundColor)
-                } else {
-                    attrs[.foregroundColor] = UIColor.label
-                }
-                if let bg = style.backgroundColor,
-                   let color = MicronTextStyle.colorFromStyleHex(bg) {
-                    attrs[.backgroundColor] = UIColor(color)
-                }
-                if style.underline {
-                    attrs[.underlineStyle] = NSUnderlineStyle.single.rawValue
-                }
-                result.append(NSAttributedString(string: text, attributes: attrs))
+        var linkIndex = 0
+        for (lineIndex, line) in lines.enumerated() {
+            for span in line {
+                switch span {
+                case .text(let text, let style):
+                    var attrs: [NSAttributedString.Key: Any] = [
+                        .font: font(for: style, base: baseFont),
+                        .paragraphStyle: paragraph,
+                    ]
+                    if let fg = style.foregroundColor,
+                       let color = MicronTextStyle.colorFromStyleHex(fg) {
+                        attrs[.foregroundColor] = UIColor(color)
+                    } else if let defaultForegroundColor {
+                        attrs[.foregroundColor] = UIColor(defaultForegroundColor)
+                    } else {
+                        attrs[.foregroundColor] = UIColor.label
+                    }
+                    if let bg = style.backgroundColor,
+                       let color = MicronTextStyle.colorFromStyleHex(bg) {
+                        attrs[.backgroundColor] = UIColor(color)
+                    }
+                    if style.underline {
+                        attrs[.underlineStyle] = NSUnderlineStyle.single.rawValue
+                    }
+                    result.append(NSAttributedString(string: text, attributes: attrs))
 
-            case .link(let link):
-                let attrs: [NSAttributedString.Key: Any] = [
-                    .font: baseFont,
-                    .paragraphStyle: paragraph,
-                    .foregroundColor: UIColor(linkForegroundColor ?? .accentColor),
-                    .underlineStyle: NSUnderlineStyle.single.rawValue,
-                ]
-                result.append(NSAttributedString(string: link.label, attributes: attrs))
+                case .link(let link):
+                    // Native .link: a tap routes through
+                    // UITextViewDelegate.textView(_:shouldInteractWith:in:) and
+                    // coexists with long-press text selection.
+                    var attrs: [NSAttributedString.Key: Any] = [
+                        .font: baseFont,
+                        .paragraphStyle: paragraph,
+                        .foregroundColor: UIColor(linkForegroundColor ?? .accentColor),
+                        .underlineStyle: NSUnderlineStyle.single.rawValue,
+                    ]
+                    if let url = URL(string: "micron-link://\(linkIndex)") {
+                        attrs[.link] = url
+                    }
+                    result.append(NSAttributedString(string: link.label, attributes: attrs))
+                    linkIndex += 1
+                }
+            }
+            if lineIndex < lines.count - 1 {
+                result.append(NSAttributedString(
+                    string: "\n",
+                    attributes: [.font: baseFont, .paragraphStyle: paragraph]
+                ))
             }
         }
         return result
@@ -118,139 +256,55 @@ struct MonospaceLineView: View {
         return font
     }
 
-    private func handleTap(at index: Int) {
-        // Find the link span whose label range contains this index
-        var offset = 0
-        for span in spans {
-            switch span {
-            case .text(let t, _):
-                offset += t.count
-            case .link(let link):
-                let end = offset + link.label.count
-                if index >= offset && index < end {
-                    onLinkTapped?(link)
-                    return
+    /// Rendered width of the widest line. The font is monospace, so a line's
+    /// width is its character count times the advance (the existing metric test
+    /// pins the rendered advance to `approxCharWidth`). The advance is measured
+    /// with the same regular font `approxCharWidth` uses, plus 1pt of headroom
+    /// so the longest line never wraps on sub-pixel rounding.
+    private func contentWidth() -> CGFloat {
+        let baseFont = MicronRenderStyle.uiMonospaceFont(fontSize: fontSize)
+        let advance = ("M" as NSString).size(withAttributes: [.font: baseFont]).width
+        let maxChars = lines.map { line in
+            line.reduce(0) { acc, span in
+                switch span {
+                case .text(let s, _): return acc + s.count
+                case .link(let l): return acc + l.label.count
                 }
-                offset = end
             }
-        }
-    }
-    #endif
-}
-
-#if os(iOS)
-
-/// UIKit wrapper: a UILabel with strict line-height paragraph style.
-@available(iOS 17.0, *)
-private struct UIMonospaceLine: UIViewRepresentable {
-    let attributedString: NSAttributedString
-    let cellHeight: CGFloat
-    let alignment: MicronAlignment
-    var onTap: ((Int) -> Void)?
-
-    /// Return only the label's intrinsic content width. SwiftUI `.frame`
-    /// at the call site handles minimum-width / alignment for narrow rows,
-    /// which avoids Core Text's trailing-whitespace stripping under
-    /// `textAlignment = .center` (a row ending in a regular space would
-    /// otherwise center as if it were one cell narrower than its sibling
-    /// rows that have no trailing space, breaking column alignment in
-    /// ASCII art — see fr33n0w/thechatroom letter "T").
-    func sizeThatFits(_ proposal: ProposedViewSize, uiView: UILabel, context: Context) -> CGSize? {
-        let intrinsicWidth = uiView.intrinsicContentSize.width
-        return CGSize(width: intrinsicWidth, height: cellHeight)
+        }.max() ?? 0
+        return max(advance, CGFloat(maxChars) * advance + 1)
     }
 
-    func makeUIView(context: Context) -> UILabel {
-        let label = UILabel()
-        label.numberOfLines = 1
-        label.lineBreakMode = .byClipping
-        label.backgroundColor = .clear
-        label.isUserInteractionEnabled = true
-        // Automation target only. Do NOT set accessibilityLabel: the default
-        // label is the line's text, which is what VoiceOver must announce.
-        label.accessibilityIdentifier = "nomadnet_line"
-        label.setContentHuggingPriority(.defaultLow, for: .horizontal)
-        label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-        label.setContentHuggingPriority(.required, for: .vertical)
-        label.setContentCompressionResistancePriority(.required, for: .vertical)
-
-        let tap = UITapGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.didTap(_:)))
-        label.addGestureRecognizer(tap)
-        // Android parity (#188): long-press a line to copy it. `.textSelection`
-        // cannot reach a UILabel, so use the native iOS long-press idiom. The
-        // tap recognizer (links) and the long-press context menu coexist.
-        let contextMenu = UIContextMenuInteraction(delegate: context.coordinator)
-        label.addInteraction(contextMenu)
-        context.coordinator.onTap = onTap
-        return label
-    }
-
-    func updateUIView(_ uiView: UILabel, context: Context) {
-        uiView.attributedText = attributedString
-        context.coordinator.onTap = onTap
-        // Always left — SwiftUI .frame(alignment:) handles visual centering
-        // outside the label so trailing whitespace isn't stripped.
-        uiView.textAlignment = .left
-    }
-
-    func makeCoordinator() -> Coordinator { Coordinator() }
+    // MARK: - Coordinator
 
     @MainActor
-    final class Coordinator: NSObject, UIContextMenuInteractionDelegate {
-        var onTap: ((Int) -> Void)?
+    final class Coordinator: NSObject, UITextViewDelegate {
+        var onLinkTapped: ((MicronLink) -> Void)?
+        var links: [MicronLink]
 
-        @objc func didTap(_ sender: UITapGestureRecognizer) {
-            guard let label = sender.view as? UILabel,
-                  let attr = label.attributedText else { return }
-            let location = sender.location(in: label)
-            let index = characterIndex(at: location, in: label, attributedText: attr)
-            if index != NSNotFound {
-                onTap?(index)
+        init(onLinkTapped: ((MicronLink) -> Void)?, links: [MicronLink]) {
+            self.onLinkTapped = onLinkTapped
+            self.links = links
+            super.init()
+        }
+
+        /// Intercept our `micron-link://` links and route them to the caller.
+        /// Returning `false` consumes the tap (no system URL open). Any other
+        /// link is left to the system (there are none in practice).
+        func textView(
+            _ textView: UITextView,
+            shouldInteractWith url: URL,
+            in characterRange: NSRange
+        ) -> Bool {
+            guard url.scheme == "micron-link",
+                  let host = url.host,
+                  let idx = Int(host),
+                  idx < links.count
+            else {
+                return true
             }
-        }
-
-        /// Long-press context menu: a single "Copy" action that copies the
-        /// line's visible text (issue #188). Returns nil for blank lines so
-        /// the menu does not appear over empty space.
-        func contextMenuInteraction(
-            _ interaction: UIContextMenuInteraction,
-            configurationForMenuAtLocation location: CGPoint
-        ) -> UIContextMenuConfiguration? {
-            guard let label = interaction.view as? UILabel,
-                  let text = label.text,
-                  !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            else { return nil }
-            let copy = UIAction(
-                title: "Copy",
-                image: UIImage(systemName: "doc.on.doc"),
-                handler: { _ in
-                    UIPasteboard.general.string = text
-                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
-                }
-            )
-            return UIContextMenuConfiguration(
-                identifier: nil,
-                previewProvider: nil,
-                actionProvider: { _ in UIMenu(children: [copy]) }
-            )
-        }
-
-        private func characterIndex(at location: CGPoint, in label: UILabel, attributedText: NSAttributedString) -> Int {
-            let textContainer = NSTextContainer(size: label.bounds.size)
-            textContainer.lineFragmentPadding = 0
-            textContainer.lineBreakMode = label.lineBreakMode
-            textContainer.maximumNumberOfLines = label.numberOfLines
-            let layoutManager = NSLayoutManager()
-            layoutManager.addTextContainer(textContainer)
-            let textStorage = NSTextStorage(attributedString: attributedText)
-            textStorage.addLayoutManager(layoutManager)
-
-            let index = layoutManager.characterIndex(
-                for: location,
-                in: textContainer,
-                fractionOfDistanceBetweenInsertionPoints: nil
-            )
-            return index
+            onLinkTapped?(links[idx])
+            return false
         }
     }
 }

--- a/Sources/ColumbaApp/Views/NomadNet/MonospaceLineView.swift
+++ b/Sources/ColumbaApp/Views/NomadNet/MonospaceLineView.swift
@@ -166,8 +166,9 @@ private struct UIMonospaceLine: UIViewRepresentable {
         label.lineBreakMode = .byClipping
         label.backgroundColor = .clear
         label.isUserInteractionEnabled = true
+        // Automation target only. Do NOT set accessibilityLabel: the default
+        // label is the line's text, which is what VoiceOver must announce.
         label.accessibilityIdentifier = "nomadnet_line"
-        label.accessibilityLabel = "NomadNet line"
         label.setContentHuggingPriority(.defaultLow, for: .horizontal)
         label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         label.setContentHuggingPriority(.required, for: .vertical)

--- a/Sources/ColumbaApp/Views/NomadNet/MonospaceLineView.swift
+++ b/Sources/ColumbaApp/Views/NomadNet/MonospaceLineView.swift
@@ -404,6 +404,7 @@ private struct UISelectableTextRun: UIViewRepresentable {
         private var lastFontKey: (fontSize: CGFloat, monospaced: Bool, bold: Bool)?
         private var lastColors: (default: Color?, link: Color?)?
         private var lastWidth: CGFloat = 0
+        private var lastViewportWidth: CGFloat = 0
         private var lastIsScroll: Bool?
 
         /// Rebuilds the text view's content only when the run input or the
@@ -420,6 +421,7 @@ private struct UISelectableTextRun: UIViewRepresentable {
                     && fontKey == lastFontKey
                     && colors == lastColors
                     && width == lastWidth
+                    && run.viewportWidth == lastViewportWidth
                     && isScroll == lastIsScroll {
                     return
                 }
@@ -428,6 +430,7 @@ private struct UISelectableTextRun: UIViewRepresentable {
             lastFontKey = fontKey
             lastColors = colors
             lastWidth = width
+            lastViewportWidth = run.viewportWidth
             lastIsScroll = isScroll
 
             // The text container can be rebuilt on some iOS versions;

--- a/Sources/ColumbaApp/Views/NomadNet/MonospaceLineView.swift
+++ b/Sources/ColumbaApp/Views/NomadNet/MonospaceLineView.swift
@@ -38,6 +38,29 @@ struct MonospaceLineView: View {
     var linkForegroundColor: Color? = nil
     var onLinkTapped: ((MicronLink) -> Void)?
 
+    /// Primary initializer: one selectable block per element, where a literal
+    /// code block passes all of its lines at once (so selection can span the
+    /// block) and a heading/paragraph passes a single line.
+    init(
+        lines: [[MicronSpan]],
+        fontSize: CGFloat,
+        cellHeight: CGFloat,
+        alignment: MicronAlignment,
+        bold: Bool,
+        defaultForegroundColor: Color? = nil,
+        linkForegroundColor: Color? = nil,
+        onLinkTapped: ((MicronLink) -> Void)? = nil
+    ) {
+        self.lines = lines
+        self.fontSize = fontSize
+        self.cellHeight = cellHeight
+        self.alignment = alignment
+        self.bold = bold
+        self.defaultForegroundColor = defaultForegroundColor
+        self.linkForegroundColor = linkForegroundColor
+        self.onLinkTapped = onLinkTapped
+    }
+
     /// Single-line convenience (headings, paragraphs, dividers).
     init(
         spans: [MicronSpan],
@@ -136,7 +159,7 @@ private struct UISelectableMonospaceBlock: UIViewRepresentable {
         textView.isOpaque = false
         textView.backgroundColor = .clear
         textView.textContainerInset = .zero
-        textView.textContainer?.lineFragmentPadding = 0
+        textView.textContainer.lineFragmentPadding = 0
         textView.contentInsetAdjustmentBehavior = .never
         // Automation target only. Do NOT set accessibilityLabel: the default
         // label is the block's text, which is what VoiceOver must announce.
@@ -148,7 +171,7 @@ private struct UISelectableMonospaceBlock: UIViewRepresentable {
     func updateUIView(_ textView: UITextView, context: Context) {
         // The text container can be rebuilt on some iOS versions; re-assert the
         // zero padding so the left edge and no-wrap width stay exact.
-        textView.textContainer?.lineFragmentPadding = 0
+        textView.textContainer.lineFragmentPadding = 0
         let attr = buildAttributedString()
         if textView.text != attr.string {
             textView.attributedText = attr

--- a/Sources/ColumbaApp/Views/NomadNet/NomadNetBrowserView.swift
+++ b/Sources/ColumbaApp/Views/NomadNet/NomadNetBrowserView.swift
@@ -200,9 +200,9 @@ struct NomadNetBrowserView: View {
     }
 
     /// Copies the loaded page's readable plain text to the pasteboard (issue
-    /// #188). Available in every rendering mode - the wrapping modes also
-    /// offer native long-press selection, and monospace lines offer a
-    /// long-press "Copy", so this is the whole-page fallback.
+    /// #188). Available in every rendering mode - the other modes also
+    /// offer native long-press selection (handles + system menu), so this is
+    /// the whole-page fallback.
     private func copyPage() {
         guard let text = viewModel.currentDocument?.plainText, !text.isEmpty else { return }
         copyText(text)

--- a/Sources/ColumbaApp/Views/NomadNet/NomadNetBrowserView.swift
+++ b/Sources/ColumbaApp/Views/NomadNet/NomadNetBrowserView.swift
@@ -157,6 +157,14 @@ struct NomadNetBrowserView: View {
                 Label("Copy Address", systemImage: "doc.on.doc")
             }
 
+            if viewModel.currentDocument != nil {
+                Button {
+                    copyPage()
+                } label: {
+                    Label("Copy Page", systemImage: "doc.on.clipboard")
+                }
+            }
+
             #if os(iOS)
             Button {
                 showingAddressShareSheet = true
@@ -188,12 +196,25 @@ struct NomadNetBrowserView: View {
     }
 
     private func copyAddress() {
+        copyText(viewModel.shareableAddress)
+    }
+
+    /// Copies the loaded page's readable plain text to the pasteboard (issue
+    /// #188). Available in every rendering mode - the wrapping modes also
+    /// offer native long-press selection, and monospace lines offer a
+    /// long-press "Copy", so this is the whole-page fallback.
+    private func copyPage() {
+        guard let text = viewModel.currentDocument?.plainText, !text.isEmpty else { return }
+        copyText(text)
+    }
+
+    private func copyText(_ text: String) {
         #if canImport(UIKit)
-        UIPasteboard.general.string = viewModel.shareableAddress
+        UIPasteboard.general.string = text
         UIImpactFeedbackGenerator(style: .light).impactOccurred()
         #elseif canImport(AppKit)
         NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(viewModel.shareableAddress, forType: .string)
+        NSPasteboard.general.setString(text, forType: .string)
         #endif
     }
 

--- a/Tests/ColumbaAppTests/MicronParserTests.swift
+++ b/Tests/ColumbaAppTests/MicronParserTests.swift
@@ -608,58 +608,6 @@ final class MicronParserTests: XCTestCase {
     }
 
     @MainActor
-    func testDEBUGDumpHeadingAttributes() {
-        let document = MicronParser.parse(">>PlainHeading\n>>`[Key Link`:/page/x.mu]")
-        let host = UIHostingController(
-            rootView: MicronDocumentView(
-                document: document,
-                formFields: .constant([:]),
-                checkboxFields: .constant([:]),
-                radioFields: .constant([:]),
-                style: .monospaceScroll,
-                viewportWidth: 320
-            )
-            .frame(width: 320, alignment: .leading)
-            .environment(\.colorScheme, .dark)
-            .padding(10)
-            .frame(width: 340, height: 200, alignment: .topLeading)
-            .background(Color.black)
-            .ignoresSafeArea()
-        )
-        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 340, height: 200))
-        window.rootViewController = host
-        window.makeKeyAndVisible()
-        defer { window.isHidden = true }
-        host.view.frame = window.bounds
-        host.view.layoutIfNeeded()
-        let textViews = descendants(of: host.view, matching: UITextView.self)
-        print("DEBUG-TV-count=\(textViews.count)")
-        for (i, tv) in textViews.enumerated() {
-            print("DEBUG-TV[\(i)] text=\(String(describing: tv.text))")
-            print("DEBUG-TV[\(i)] textColor=\(tv.textColor) tintColor=\(tv.tintColor) linkTextAttributes=\(String(describing: tv.linkTextAttributes))")
-            guard let a = tv.attributedText, a.length > 0 else { continue }
-            for loc in 0..<min(a.length, 3) {
-                let fc = a.attribute(.foregroundColor, at: loc, effectiveRange: nil) as? UIColor
-                if let fc {
-                    var r: CGFloat = 0
-                    var g: CGFloat = 0
-                    var b: CGFloat = 0
-                    var al: CGFloat = 0
-                    if fc.getRed(&r, green: &g, blue: &b, alpha: &al) {
-                        print("DEBUG-TV[\(i)]@\(loc) fg=\(Int(r * 255)),\(Int(g * 255)),\(Int(b * 255)) a=\(String(format: "%.2f", al))")
-                    } else {
-                        print("DEBUG-TV[\(i)]@\(loc) fg=\(fc)")
-                    }
-                } else {
-                    print("DEBUG-TV[\(i)]@\(loc) fg=NIL")
-                }
-                let lk = a.attribute(.link, at: loc, effectiveRange: nil)
-                print("DEBUG-TV[\(i)]@\(loc) link=\(String(describing: lk))")
-            }
-        }
-    }
-
-    @MainActor
     func testRngitTrueColorsReachMonospaceRenderer() throws {
         let document = MicronParser.parse("`BT282828`FT8b949e# Add tasks")
         guard case .paragraph(let spans, _, _) = document.elements.first else {

--- a/Tests/ColumbaAppTests/MicronParserTests.swift
+++ b/Tests/ColumbaAppTests/MicronParserTests.swift
@@ -608,6 +608,58 @@ final class MicronParserTests: XCTestCase {
     }
 
     @MainActor
+    func testDEBUGDumpHeadingAttributes() {
+        let document = MicronParser.parse(">>PlainHeading\n>>`[Key Link`:/page/x.mu]")
+        let host = UIHostingController(
+            rootView: MicronDocumentView(
+                document: document,
+                formFields: .constant([:]),
+                checkboxFields: .constant([:]),
+                radioFields: .constant([:]),
+                style: .monospaceScroll,
+                viewportWidth: 320
+            )
+            .frame(width: 320, alignment: .leading)
+            .environment(\.colorScheme, .dark)
+            .padding(10)
+            .frame(width: 340, height: 200, alignment: .topLeading)
+            .background(Color.black)
+            .ignoresSafeArea()
+        )
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 340, height: 200))
+        window.rootViewController = host
+        window.makeKeyAndVisible()
+        defer { window.isHidden = true }
+        host.view.frame = window.bounds
+        host.view.layoutIfNeeded()
+        let textViews = descendants(of: host.view, matching: UITextView.self)
+        print("DEBUG-TV-count=\(textViews.count)")
+        for (i, tv) in textViews.enumerated() {
+            print("DEBUG-TV[\(i)] text=\(String(describing: tv.text))")
+            print("DEBUG-TV[\(i)] textColor=\(tv.textColor) tintColor=\(tv.tintColor) linkTextAttributes=\(String(describing: tv.linkTextAttributes))")
+            guard let a = tv.attributedText, a.length > 0 else { continue }
+            for loc in 0..<min(a.length, 3) {
+                let fc = a.attribute(.foregroundColor, at: loc, effectiveRange: nil) as? UIColor
+                if let fc {
+                    var r: CGFloat = 0
+                    var g: CGFloat = 0
+                    var b: CGFloat = 0
+                    var al: CGFloat = 0
+                    if fc.getRed(&r, green: &g, blue: &b, alpha: &al) {
+                        print("DEBUG-TV[\(i)]@\(loc) fg=\(Int(r * 255)),\(Int(g * 255)),\(Int(b * 255)) a=\(String(format: "%.2f", al))")
+                    } else {
+                        print("DEBUG-TV[\(i)]@\(loc) fg=\(fc)")
+                    }
+                } else {
+                    print("DEBUG-TV[\(i)]@\(loc) fg=NIL")
+                }
+                let lk = a.attribute(.link, at: loc, effectiveRange: nil)
+                print("DEBUG-TV[\(i)]@\(loc) link=\(String(describing: lk))")
+            }
+        }
+    }
+
+    @MainActor
     func testRngitTrueColorsReachMonospaceRenderer() throws {
         let document = MicronParser.parse("`BT282828`FT8b949e# Add tasks")
         guard case .paragraph(let spans, _, _) = document.elements.first else {

--- a/Tests/ColumbaAppTests/MicronParserTests.swift
+++ b/Tests/ColumbaAppTests/MicronParserTests.swift
@@ -908,11 +908,13 @@ final class MicronParserTests: XCTestCase {
         host.view.frame = window.bounds
         host.view.layoutIfNeeded()
 
-        guard let label = descendants(of: host.view, matching: UILabel.self).first,
-              let attributed = label.attributedText,
+        // The monospace block is a non-editable selectable UITextView (issue
+        // #188); read the rendered font from its attributed text.
+        guard let textView = descendants(of: host.view, matching: UITextView.self).first,
+              let attributed = textView.attributedText,
               attributed.length > 0,
               let renderedFont = attributed.attribute(.font, at: 0, effectiveRange: nil) as? UIFont else {
-            XCTFail("Expected a rendered monospace UILabel font")
+            XCTFail("Expected a rendered monospace UITextView font")
             return
         }
         let renderedWidth = ("M" as NSString).size(withAttributes: [.font: renderedFont]).width

--- a/Tests/ColumbaAppTests/MicronParserTests.swift
+++ b/Tests/ColumbaAppTests/MicronParserTests.swift
@@ -618,11 +618,12 @@ final class MicronParserTests: XCTestCase {
         let size = CGSize(width: 320, height: 160)
         let host = UIHostingController(
             rootView: MonospaceLineView(
-                spans: spans,
+                lines: [MicronTextLine(spans: spans)],
                 fontSize: 18,
-                cellHeight: 32,
-                alignment: .left,
-                bold: false
+                monospaced: true,
+                // indentLevel is 0, so the indent unit is unused here.
+                indentUnit: 10,
+                cellHeight: 32
             )
             .frame(width: 300, height: 32, alignment: .leading)
             .padding(10)
@@ -893,11 +894,11 @@ final class MicronParserTests: XCTestCase {
         let style = MicronRenderStyle.monospaceScroll
         let host = UIHostingController(
             rootView: MonospaceLineView(
-                spans: [.text("MMMM", .plain)],
+                lines: [MicronTextLine(spans: [.text("MMMM", .plain)])],
                 fontSize: style.fontSize,
-                cellHeight: style.approxCharWidth * 2,
-                alignment: .left,
-                bold: false
+                monospaced: true,
+                indentUnit: style.approxCharWidth,
+                cellHeight: style.approxCharWidth * 2
             )
             .frame(width: 200, height: 40, alignment: .leading)
         )

--- a/Tests/ColumbaAppTests/MicronParserTests.swift
+++ b/Tests/ColumbaAppTests/MicronParserTests.swift
@@ -2369,3 +2369,73 @@ final class DeliveryProofMonotonicityTests: XCTestCase {
         XCTAssertEqual(MessageRepository.monotonicDeliveryState(existing: failed, incoming: delivered), delivered)
     }
 }
+
+/// Issue #188: `MicronDocument.plainText` renders the page as readable
+/// text for the "Copy Page" action. Pure model test - no parser coupling.
+final class MicronDocumentPlainTextTests: XCTestCase {
+    private func link(_ label: String, _ url: MicronURL) -> MicronLink {
+        MicronLink(label: label, url: url, fieldNames: nil)
+    }
+
+    func testHeadingsAndParagraphsJoinInDocumentOrder() {
+        let doc = MicronDocument(elements: [
+            .heading(level: 1, spans: [.text("Title", .plain)], alignment: .left),
+            .paragraph(spans: [.text("First line", .plain)], alignment: .left, indentLevel: 0),
+            .paragraph(spans: [.text("Second line", .plain)], alignment: .left, indentLevel: 1),
+        ])
+        XCTAssertEqual(doc.plainText, "Title\nFirst line\nSecond line")
+    }
+
+    func testLinksEmitTheirLabelNotTheirURL() {
+        let doc = MicronDocument(elements: [
+            .paragraph(
+                spans: [
+                    .text("See ", .plain),
+                    .link(link("the docs", .samePage(path: "/page/docs.mu"))),
+                ],
+                alignment: .left,
+                indentLevel: 0
+            ),
+        ])
+        XCTAssertEqual(doc.plainText, "See the docs")
+    }
+
+    func testLiteralBlockPreservedVerbatim() {
+        let doc = MicronDocument(elements: [
+            .literalBlock(text: "line one\nline two", indentLevel: 2),
+        ])
+        XCTAssertEqual(doc.plainText, "line one\nline two")
+    }
+
+    func testDividerBecomesDashLine() {
+        let doc = MicronDocument(elements: [
+            .paragraph(spans: [.text("Above", .plain)], alignment: .left, indentLevel: 0),
+            .divider(character: "-", indentLevel: 0),
+            .paragraph(spans: [.text("Below", .plain)], alignment: .left, indentLevel: 0),
+        ])
+        XCTAssertEqual(doc.plainText, "Above\n────────\nBelow")
+    }
+
+    func testFormFieldsAndPartialsAreExcluded() {
+        let doc = MicronDocument(elements: [
+            .paragraph(spans: [.text("Visible", .plain)], alignment: .left, indentLevel: 0),
+            .formField(.textInput(width: 20, name: "g", defaultValue: ""), indentLevel: 0),
+            .formField(.checkbox(name: "agree", value: "yes", label: "Agree", checked: false), indentLevel: 0),
+            .partial(MicronPartial(url: "/partial/x.mu", refreshInterval: nil, partialId: nil, fieldNames: nil), indentLevel: 0),
+            .paragraph(spans: [.text("Still visible", .plain)], alignment: .left, indentLevel: 0),
+        ])
+        XCTAssertEqual(doc.plainText, "Visible\nStill visible")
+    }
+
+    func testWhitespaceOnlyParagraphIsDropped() {
+        let doc = MicronDocument(elements: [
+            .paragraph(spans: [.text("   ", .plain)], alignment: .left, indentLevel: 0),
+            .paragraph(spans: [.text("Real", .plain)], alignment: .left, indentLevel: 0),
+        ])
+        XCTAssertEqual(doc.plainText, "Real")
+    }
+
+    func testEmptyDocumentIsEmpty() {
+        XCTAssertEqual(MicronDocument().plainText, "")
+    }
+}

--- a/Tests/static/test_nomadnet_text_selection.py
+++ b/Tests/static/test_nomadnet_text_selection.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Behavioral contract: NomadNet browser text must be selectable and copyable
+(Android parity, issue #188).
+
+Android's ``MicronPageContent`` wraps the whole micron page in a Compose
+``SelectionContainer`` so a long-press anywhere selects and copies text. iOS
+renders its three modes differently, so the fix splits across files:
+
+  * ``MicronDocumentView.swift`` (the wrapping modes render real SwiftUI
+    ``Text``) enables native long-press select/copy with ``.textSelection`` -
+    but ONLY in the non-scroll modes, because ``.monospaceScroll`` renders
+    UIKit ``UILabel``s which that modifier cannot reach.
+  * ``MonospaceLineView.swift`` (the default ``.monospaceScroll`` mode) adds a
+    native long-press ``UIContextMenuInteraction`` to each line's ``UILabel``
+    with a single "Copy" action.
+  * ``NomadNetBrowserView.swift`` adds a "Copy Page" toolbar action that copies
+    the loaded page's readable plain text (``MicronDocument.plainText``) in
+    every mode - the whole-page fallback.
+
+This contract pins all four halves so the feature cannot silently regress.
+"""
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MICRON_DOC = ROOT / "Sources/ColumbaApp/Views/NomadNet/MicronDocumentView.swift"
+MICRON_LINE = ROOT / "Sources/ColumbaApp/Views/NomadNet/MonospaceLineView.swift"
+BROWSER_VIEW = ROOT / "Sources/ColumbaApp/Views/NomadNet/NomadNetBrowserView.swift"
+MICRON_MODEL = ROOT / "Sources/ColumbaApp/Models/MicronDocument.swift"
+
+
+def _read(path: Path) -> str:
+    assert path.is_file(), f"missing source file: {path}"
+    return path.read_text()
+
+
+class NomadNetTextSelectionTests(unittest.TestCase):
+    def test_wrapping_modes_enable_native_text_selection(self):
+        source = _read(MICRON_DOC)
+        # Selection is gated off in the UILabel-based scroll mode and on
+        # elsewhere, so the modifier must reference isScrollMode.
+        self.assertIn(".textSelection(isScrollMode ? .disabled : .enabled)", source)
+
+    def test_monospace_lines_offer_long_press_copy_context_menu(self):
+        source = _read(MICRON_LINE)
+        self.assertIn("UIContextMenuInteraction", source)
+        self.assertIn("UIContextMenuInteractionDelegate", source)
+        self.assertIn("contextMenuInteraction(", source)
+        # The single menu action copies the line text to the pasteboard.
+        self.assertIn("UIPasteboard.general.string = text", source)
+        self.assertIn('title: "Copy"', source)
+        # An a11y identifier lets automation reach a specific line.
+        self.assertIn('"nomadnet_line"', source)
+
+    def test_copy_page_toolbar_action_copies_plain_text(self):
+        source = _read(BROWSER_VIEW)
+        self.assertIn("Copy Page", source)
+        self.assertIn("copyPage()", source)
+        # Copy Page reads the document's plain text, not the address.
+        self.assertIn("viewModel.currentDocument?.plainText", source)
+        # The pasteboard write is shared by Copy Address and Copy Page.
+        self.assertIn("UIPasteboard.general.string = text", source)
+
+    def test_plain_text_accessor_exists_on_model(self):
+        source = _read(MICRON_MODEL)
+        self.assertIn("var plainText: String", source)
+        # Links render as their visible label, not their URL.
+        self.assertIn("link.label", source)
+        # Interactive form fields are not page prose and are excluded.
+        self.assertIn(".formField", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tests/static/test_nomadnet_text_selection.py
+++ b/Tests/static/test_nomadnet_text_selection.py
@@ -1,23 +1,24 @@
 #!/usr/bin/env python3
 """Behavioral contract: NomadNet browser text must be selectable and copyable
-(Android parity, issue #188).
+with the NATIVE selection UI (Android parity, issue #188).
 
-Android's ``MicronPageContent`` wraps the whole micron page in a Compose
-``SelectionContainer`` so a long-press anywhere selects and copies text. iOS
-renders its three modes differently, so the fix splits across files:
+Torlando's acceptance: long-press highlights text with two draggable handles
+and the system context menu (Copy / Look Up / Translate / Share) - the same
+behavior as the iOS message-bubble "Select Text" (SelectableMessageTextView).
+The first implementation used a per-line UILabel + UIContextMenuInteraction
+"Copy" action; that cannot produce selection handles or the system menu and
+was rejected, so this contract pins the replacement:
 
+  * ``MonospaceLineView.swift`` (the default ``.monospaceScroll`` mode) renders
+    each text block as a non-editable, SELECTABLE ``UITextView``. Only
+    ``UITextView.isSelectable`` surfaces the native two-handle selection UI;
+    the per-line copy context menu must be gone.
   * ``MicronDocumentView.swift`` (the wrapping modes render real SwiftUI
     ``Text``) enables native long-press select/copy with ``.textSelection`` -
-    but ONLY in the non-scroll modes, because ``.monospaceScroll`` renders
-    UIKit ``UILabel``s which that modifier cannot reach.
-  * ``MonospaceLineView.swift`` (the default ``.monospaceScroll`` mode) adds a
-    native long-press ``UIContextMenuInteraction`` to each line's ``UILabel``
-    with a single "Copy" action.
-  * ``NomadNetBrowserView.swift`` adds a "Copy Page" toolbar action that copies
-    the loaded page's readable plain text (``MicronDocument.plainText``) in
-    every mode - the whole-page fallback.
-
-This contract pins all four halves so the feature cannot silently regress.
+    but ONLY in the non-scroll modes.
+  * ``NomadNetBrowserView.swift`` keeps a "Copy Page" toolbar action that
+    copies the loaded page's readable plain text (``MicronDocument.plainText``)
+    in every mode - the whole-page fallback.
 """
 
 from pathlib import Path
@@ -37,6 +38,33 @@ def _read(path: Path) -> str:
 
 
 class NomadNetTextSelectionTests(unittest.TestCase):
+    def test_monospace_blocks_use_selectable_uikitextview(self):
+        source = _read(MICRON_LINE)
+        # The block must be backed by a selectable UITextView: only that view
+        # type surfaces the native long-press selection UI (highlight + two
+        # draggable handles + system Copy/Look Up/Translate menu).
+        self.assertIn("UITextView", source)
+        self.assertIn("isSelectable = true", source)
+        # It must be non-editable (selection only, no keyboard).
+        self.assertIn("isEditable = false", source)
+        # The block must not scroll on its own: the outer ZoomableScrollView
+        # owns all scrolling.
+        self.assertIn("isScrollEnabled = false", source)
+        # An a11y identifier lets automation reach a specific block.
+        self.assertIn('"nomadnet_line"', source)
+        # The rejected per-line whole-line Copy context menu is gone.
+        self.assertNotIn("UIContextMenuInteraction", source)
+        self.assertNotIn("UIPasteboard.general.string", source)
+
+    def test_monospace_block_links_use_native_link_attribute(self):
+        source = _read(MICRON_LINE)
+        # Links render through the native .link attribute (coexists with
+        # long-press selection) and are routed back to the caller.
+        self.assertIn(".link", source)
+        self.assertIn("micron-link://", source)
+        self.assertIn("shouldInteractWith", source)
+        self.assertIn("onLinkTapped?(links[idx])", source)
+
     def test_wrapping_modes_enable_native_text_selection(self):
         source = _read(MICRON_DOC)
         # Selection is only applied in the wrapping modes: the body branches on
@@ -46,16 +74,13 @@ class NomadNetTextSelectionTests(unittest.TestCase):
         self.assertIn(".textSelection(.enabled)", source)
         self.assertIn("if isScrollMode {", source)
 
-    def test_monospace_lines_offer_long_press_copy_context_menu(self):
-        source = _read(MICRON_LINE)
-        self.assertIn("UIContextMenuInteraction", source)
-        self.assertIn("UIContextMenuInteractionDelegate", source)
-        self.assertIn("contextMenuInteraction(", source)
-        # The single menu action copies the line text to the pasteboard.
-        self.assertIn("UIPasteboard.general.string = text", source)
-        self.assertIn('title: "Copy"', source)
-        # An a11y identifier lets automation reach a specific line.
-        self.assertIn('"nomadnet_line"', source)
+    def test_literal_blocks_are_one_multi_line_selectable_block(self):
+        source = _read(MICRON_DOC)
+        # A literal/code block is passed as a single MonospaceLineView with a
+        # `lines:` array (one selectable region spanning all of its lines),
+        # not a ForEach of per-line views.
+        self.assertIn("lines: text.split(", source)
+        self.assertIn("omittingEmptySubsequences: false", source)
 
     def test_copy_page_toolbar_action_copies_plain_text(self):
         source = _read(BROWSER_VIEW)

--- a/Tests/static/test_nomadnet_text_selection.py
+++ b/Tests/static/test_nomadnet_text_selection.py
@@ -39,9 +39,12 @@ def _read(path: Path) -> str:
 class NomadNetTextSelectionTests(unittest.TestCase):
     def test_wrapping_modes_enable_native_text_selection(self):
         source = _read(MICRON_DOC)
-        # Selection is gated off in the UILabel-based scroll mode and on
-        # elsewhere, so the modifier must reference isScrollMode.
-        self.assertIn(".textSelection(isScrollMode ? .disabled : .enabled)", source)
+        # Selection is only applied in the wrapping modes: the body branches on
+        # isScrollMode and applies .textSelection(.enabled) in the else branch.
+        # (A single `.textSelection(x ? .disabled : .enabled)` ternary does not
+        # compile - the two literals are unrelated types.)
+        self.assertIn(".textSelection(.enabled)", source)
+        self.assertIn("if isScrollMode {", source)
 
     def test_monospace_lines_offer_long_press_copy_context_menu(self):
         source = _read(MICRON_LINE)

--- a/Tests/static/test_nomadnet_text_selection.py
+++ b/Tests/static/test_nomadnet_text_selection.py
@@ -5,17 +5,30 @@ with the NATIVE selection UI (Android parity, issue #188).
 Torlando's acceptance: long-press highlights text with two draggable handles
 and the system context menu (Copy / Look Up / Translate / Share) - the same
 behavior as the iOS message-bubble "Select Text" (SelectableMessageTextView).
-The first implementation used a per-line UILabel + UIContextMenuInteraction
-"Copy" action; that cannot produce selection handles or the system menu and
-was rejected, so this contract pins the replacement:
+Selection must span NEW LINES: the two handles must be draggable across
+newlines, like Android's whole-page SelectionContainer.
 
-  * ``MonospaceLineView.swift`` (the default ``.monospaceScroll`` mode) renders
-    each text block as a non-editable, SELECTABLE ``UITextView``. Only
-    ``UITextView.isSelectable`` surfaces the native two-handle selection UI;
-    the per-line copy context menu must be gone.
-  * ``MicronDocumentView.swift`` (the wrapping modes render real SwiftUI
-    ``Text``) enables native long-press select/copy with ``.textSelection`` -
-    but ONLY in the non-scroll modes.
+Rejected earlier approaches:
+  * per-line UILabel + UIContextMenuInteraction "Copy" action: no handles,
+    whole-line only - not granular enough.
+  * per-element selectable UITextView (one per line): the handles were
+    trapped to a single line and could not cross newlines.
+  * per-line SwiftUI Text + `.textSelection`: on the device it surfaced only
+    a "Copy | Share" menu, never the two-handle selection.
+
+This contract pins the replacement, which covers ALL THREE rendering modes:
+
+  * ``MonospaceLineView.swift`` renders a run of lines as ONE non-editable,
+    SELECTABLE ``UITextView``. Because the whole run is a single text view,
+    the two selection handles can be dragged across newlines. Scroll mode
+    keeps strict square cells (min == max line height == cellHeight, zero
+    spacing) so block-drawing characters stack tight; centered/right-aligned
+    lines are positioned against the VIEWPORT via per-line head indents.
+  * ``MicronDocumentView.swift`` groups the document into runs: consecutive
+    prose (paragraphs + dividers) merges into one selectable block; headings,
+    literal blocks, form fields, and partials break the run so interactive
+    elements stay outside the selectable text. Every mode renders text
+    through the run view (no `.textSelection`).
   * ``NomadNetBrowserView.swift`` keeps a "Copy Page" toolbar action that
     copies the loaded page's readable plain text (``MicronDocument.plainText``)
     in every mode - the whole-page fallback.
@@ -38,25 +51,40 @@ def _read(path: Path) -> str:
 
 
 class NomadNetTextSelectionTests(unittest.TestCase):
-    def test_monospace_blocks_use_selectable_uikitextview(self):
+    def test_runs_use_selectable_uikitextview(self):
         source = _read(MICRON_LINE)
-        # The block must be backed by a selectable UITextView: only that view
+        # The run must be backed by a selectable UITextView: only that view
         # type surfaces the native long-press selection UI (highlight + two
         # draggable handles + system Copy/Look Up/Translate menu).
         self.assertIn("UITextView", source)
         self.assertIn("isSelectable = true", source)
         # It must be non-editable (selection only, no keyboard).
         self.assertIn("isEditable = false", source)
-        # The block must not scroll on its own: the outer ZoomableScrollView
-        # owns all scrolling.
+        # The run must not scroll on its own: the outer container
+        # (ZoomableScrollView / ScrollView) owns all scrolling.
         self.assertIn("isScrollEnabled = false", source)
-        # An a11y identifier lets automation reach a specific block.
+        # An a11y identifier lets automation reach a specific run.
         self.assertIn('"nomadnet_line"', source)
         # The rejected per-line whole-line Copy context menu is gone.
         self.assertNotIn("UIContextMenuInteraction", source)
         self.assertNotIn("UIPasteboard.general.string", source)
 
-    def test_monospace_block_links_use_native_link_attribute(self):
+    def test_cross_line_selection_via_single_run_textview(self):
+        source = _read(MICRON_LINE)
+        # Selection spans newlines because the whole run is ONE UITextView
+        # (multiple lines joined by "\n" into one attributed string), not one
+        # view per line.
+        self.assertIn('string: "\\n"', source)
+        # Scroll mode: strict square cells so block-drawing characters stack
+        # tight (min == max line height, zero spacing).
+        self.assertIn("minimumLineHeight = cellHeight", source)
+        self.assertIn("maximumLineHeight = cellHeight", source)
+        self.assertIn("lineSpacing = 0", source)
+        # Centered/right-aligned scroll lines are positioned against the
+        # viewport (per-line head indent), not the max line width.
+        self.assertIn("viewportWidth / 2 - wc / 2", source)
+
+    def test_run_links_use_native_link_attribute(self):
         source = _read(MICRON_LINE)
         # Links render through the native .link attribute (coexists with
         # long-press selection) and are routed back to the caller.
@@ -65,22 +93,28 @@ class NomadNetTextSelectionTests(unittest.TestCase):
         self.assertIn("shouldInteractWith", source)
         self.assertIn("onLinkTapped?(links[idx])", source)
 
-    def test_wrapping_modes_enable_native_text_selection(self):
+    def test_document_groups_prose_into_selectable_runs(self):
         source = _read(MICRON_DOC)
-        # Selection is only applied in the wrapping modes: the body branches on
-        # isScrollMode and applies .textSelection(.enabled) in the else branch.
-        # (A single `.textSelection(x ? .disabled : .enabled)` ternary does not
-        # compile - the two literals are unrelated types.)
-        self.assertIn(".textSelection(.enabled)", source)
-        self.assertIn("if isScrollMode {", source)
+        # Consecutive prose lines merge into one selectable run so the
+        # selection handles span newlines.
+        self.assertIn("case text([MicronTextLine])", source)
+        self.assertIn("prose.append(MicronTextLine", source)
+        # Headings and literal blocks break the run.
+        self.assertIn("case .heading(let level, let spans, let alignment):", source)
+        self.assertIn("case .literalBlock(let text, let indentLevel):", source)
+        # Every rendering mode routes text through the selectable run view.
+        self.assertIn("MonospaceLineView(", source)
+        # The SwiftUI `.textSelection` path (which produced only a
+        # "Copy | Share" menu on device, no handles) is gone from NomadNet.
+        self.assertNotIn(".textSelection", source)
 
-    def test_literal_blocks_are_one_multi_line_selectable_block(self):
+    def test_literal_blocks_are_one_multi_line_selectable_run(self):
         source = _read(MICRON_DOC)
-        # A literal/code block is passed as a single MonospaceLineView with a
-        # `lines:` array (one selectable region spanning all of its lines),
-        # not a ForEach of per-line views.
-        self.assertIn("lines: text.split(", source)
-        self.assertIn("omittingEmptySubsequences: false", source)
+        # A literal/code block becomes one run: its lines are split and each
+        # becomes a MicronTextLine, so a long-press selects across the whole
+        # block (handles span the newlines).
+        self.assertIn('text.split(separator: "\\n", omittingEmptySubsequences: false)', source)
+        self.assertIn("MicronTextLine(spans: [.text(String($0), .plain)]", source)
 
     def test_copy_page_toolbar_action_copies_plain_text(self):
         source = _read(BROWSER_VIEW)


### PR DESCRIPTION
## Summary

Fixes #188. The NomadNet browser now supports NATIVE iOS text selection, with full parity to Android's single SelectionContainer and to the existing message-bubble "Select Text" mechanism, in all three rendering modes:

- monospace scroll (square cells, no wrap)
- monospace zoom (wrapping)
- proportional wrap

Long-press starts a selection with two draggable handles that can travel ACROSS newlines within a prose block, and the system context menu (Copy / Look Up / Translate / Share) appears, identical to message bubbles.

## Approach

- Consecutive prose (paragraphs + dividers) is grouped into a single "run" rendered as ONE non-editable selectable UITextView (UIViewRepresentable). This is what lets handles cross newlines - a handle cannot leave its UITextView, so per-line views were the previous blocker. Headings, literal/code blocks, form fields, and partials break the run so they stay distinct (forms remain interactive, code keeps its gray band).
- Scroll mode keeps strict square cells; centered/right-aligned lines are positioned against the viewport via per-line head indents so a very wide art line cannot push centered content offscreen.
- Wrap modes track the proposed width, wrap naturally, and indent nested sections both sides.
- Links keep native tap routing (.link + UITextViewDelegate.shouldInteractWith), coexisting with selection. UITextView draws .link text in its tintColor (ignoring the span foreground color), so each run mirrors its single link color onto tintColor - this fixes links rendering system-blue.
- iOS-only: no SwiftUI Text / .textSelection path (on device that degrades to a Copy|Share menu without handles).
- Copy Page toolbar action unchanged.

## Verification

- Static contract test Tests/static/test_nomadnet_text_selection.py: 7/7 pass.
- MicronParserTests full suite on iPhone 17 simulator (iOS 26.4): 0 failures, including the heading-color visual tests and scroll-metrics font test.
- Physical iPhone 14 in-place install at this exact content (tree 2185b867): user verified handles cross newlines in scroll mode and native handles appear in zoom and wrap modes; links and Copy Page still work.
- Bundle verified: 0 symlinks, codesign --verify --deep --strict valid.

All commits authored by torlando-tech (noreply).