### PR TITLE
Fix LXMF announce missing display name on app startup

### DIFF
--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -1514,7 +1514,9 @@ public final class AppServices {
         // each start, so it is intentionally not cached.)
         self.pythonStartIdentity = identity
         // Single source of the startup display name (see the method docs above).
-        let displayName = await SettingsRepository().getDisplayName()
+        // resolveDisplayName() applies the "Anonymous Peer" fallback so a
+        // missing/empty preference can never produce a nameless startup announce.
+        let displayName = await SettingsRepository().resolveDisplayName()
 
         // Model B (Track C3): when `BackendPreference.modelB` is on,
         // `BackendFactory.make` returns the thin-client `ProxyRnsBackend`, which
@@ -5041,7 +5043,7 @@ public final class AppServices {
             return
         }
         DiagLog.log("[AUTO_ANNOUNCE] triggered")
-        let displayName = await SettingsRepository().getDisplayName()
+        let displayName = await SettingsRepository().resolveDisplayName()
         do {
             try await sendAllAnnounces(displayName: displayName)
             lastAutoAnnounce = Date()

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -1316,6 +1316,14 @@ public final class AppServices {
         self.propagationManager = propManager
         await propManager.loadPreferences()
 
+        // Resolve the configured display name BEFORE booting the backend. The
+        // Python bridge registers the LXMF delivery identity with this name, and
+        // the startup announce (plus the delayed 2/5/15/30s re-announces) emit it
+        // verbatim. Previously this was "", which registered an empty display_name
+        // and made the initial announces announce with NO name — peers saw a bare
+        // destination hash until a later manual/auto announce overwrote it. That is
+        // the "LXMF destination announced without a display name" bug.
+        let announceDisplayName = await SettingsRepository().getDisplayName()
         try await InitializationLifecycleActivation.run(
             readiness: {
                 // The Compat-layer LXMRouter / Transport are stubs; real network
@@ -1325,7 +1333,7 @@ public final class AppServices {
                     identityHashHex: newIdentity.hexHash,
                     router: newRouter,
                     interfaces: InterfaceRepository().getEnabledInterfaces(),
-                    displayName: ""
+                    displayName: announceDisplayName
                 )
             },
             activate: {
@@ -3278,6 +3286,11 @@ public final class AppServices {
         #endif
 
         // Start the backend, then activate initialization-owned manager tasks.
+        // Resolve the configured display name first so the startup announce
+        // carries it (see the equivalent comment in the other initializeUnlocked
+        // path — an empty name here is what made the destination announce
+        // without a display name).
+        let announceDisplayName = await SettingsRepository().getDisplayName()
         try await InitializationLifecycleActivation.run(
             readiness: {
                 try await self.startPythonBackend(
@@ -3285,7 +3298,7 @@ public final class AppServices {
                     identityHashHex: identityHash,
                     router: newRouter,
                     interfaces: InterfaceRepository().getEnabledInterfaces(),
-                    displayName: ""
+                    displayName: announceDisplayName
                 )
             },
             activate: {

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -622,10 +622,6 @@ public final class AppServices {
     /// interfaces, without making AppServices re-derive it.
     private var pythonStartIdentity: Identity?
 
-    /// Display name passed to the Python backend on start. Cached for
-    /// the restart path (same reason as pythonStartIdentity).
-    private var pythonStartDisplayName: String = ""
-
     /// The interface entities currently live in the Python RNS stack, keyed by
     /// entity id. Seeded when the backend starts and updated incrementally by
     /// `applyInterfaceChanges()` as interfaces are hot-added / hot-removed.
@@ -1316,14 +1312,9 @@ public final class AppServices {
         self.propagationManager = propManager
         await propManager.loadPreferences()
 
-        // Resolve the configured display name BEFORE booting the backend. The
-        // Python bridge registers the LXMF delivery identity with this name, and
-        // the startup announce (plus the delayed 2/5/15/30s re-announces) emit it
-        // verbatim. Previously this was "", which registered an empty display_name
-        // and made the initial announces announce with NO name — peers saw a bare
-        // destination hash until a later manual/auto announce overwrote it. That is
-        // the "LXMF destination announced without a display name" bug.
-        let announceDisplayName = await SettingsRepository().getDisplayName()
+        // Start the backend. startPythonBackend resolves the configured
+        // display name itself (see its docs) so the startup announce carries
+        // it - resolving it here too would duplicate the single source.
         try await InitializationLifecycleActivation.run(
             readiness: {
                 // The Compat-layer LXMRouter / Transport are stubs; real network
@@ -1332,8 +1323,7 @@ public final class AppServices {
                     identity: newIdentity,
                     identityHashHex: newIdentity.hexHash,
                     router: newRouter,
-                    interfaces: InterfaceRepository().getEnabledInterfaces(),
-                    displayName: announceDisplayName
+                    interfaces: InterfaceRepository().getEnabledInterfaces()
                 )
             },
             activate: {
@@ -1496,22 +1486,35 @@ public final class AppServices {
     }
     #endif
 
+    /// Start the embedded Python RNS backend.
+    ///
+    /// Single source for the startup display name. Resolves the configured name
+    /// here (via `SettingsRepository`) rather than in the two `initializeUnlocked`
+    /// callers, so there is exactly one place that feeds the name to
+    /// `register_delivery_identity`. The Python bridge registers the LXMF delivery
+    /// identity with this name, and the startup announce (plus the delayed
+    /// 2/5/15/30s re-announces) emit it verbatim. Previously the name was "", which
+    /// registered an empty display_name and made the initial announces go out with
+    /// NO name - peers saw a bare destination hash until a later manual/auto
+    /// announce overwrote it. That was the "LXMF destination announced without a
+    /// display name" bug.
     private func startPythonBackend(
         identity: Identity,
         identityHashHex: String,
         router: LXMRouter,
-        interfaces: [InterfaceEntity],
-        displayName: String
+        interfaces: [InterfaceEntity]
     ) async throws {
         DiagLog.log("[RNS] backend start entered with \(interfaces.count) interfaces")
         if backend != nil {
             DiagLog.log("[RNS] already started")
             return
         }
-        // Cache the start args so restartPythonBackend() can re-invoke
-        // this method after the user applies interface changes.
+        // Cache the start identity so restartPythonBackend() can confirm the
+        // backend was started. (The display name is re-resolved from settings at
+        // each start, so it is intentionally not cached.)
         self.pythonStartIdentity = identity
-        self.pythonStartDisplayName = displayName
+        // Single source of the startup display name (see the method docs above).
+        let displayName = await SettingsRepository().getDisplayName()
 
         // Model B (Track C3): when `BackendPreference.modelB` is on,
         // `BackendFactory.make` returns the thin-client `ProxyRnsBackend`, which
@@ -3286,19 +3289,16 @@ public final class AppServices {
         #endif
 
         // Start the backend, then activate initialization-owned manager tasks.
-        // Resolve the configured display name first so the startup announce
-        // carries it (see the equivalent comment in the other initializeUnlocked
-        // path — an empty name here is what made the destination announce
-        // without a display name).
-        let announceDisplayName = await SettingsRepository().getDisplayName()
+        // startPythonBackend resolves the configured display name itself so the
+        // startup announce carries it (see its docs); an empty name here was what
+        // made the destination announce without a display name.
         try await InitializationLifecycleActivation.run(
             readiness: {
                 try await self.startPythonBackend(
                     identity: identity,
                     identityHashHex: identityHash,
                     router: newRouter,
-                    interfaces: InterfaceRepository().getEnabledInterfaces(),
-                    displayName: announceDisplayName
+                    interfaces: InterfaceRepository().getEnabledInterfaces()
                 )
             },
             activate: {

--- a/Sources/ColumbaApp/Services/AutoAnnounceManager.swift
+++ b/Sources/ColumbaApp/Services/AutoAnnounceManager.swift
@@ -134,7 +134,7 @@ public final class AutoAnnounceManager {
             // Perform the announce
             guard let services = appServices else { return }
 
-            let displayName = await SettingsRepository().getDisplayName()
+            let displayName = await SettingsRepository().resolveDisplayName()
             do {
                 try await services.sendAllAnnounces(displayName: displayName)
                 logger.info("Auto-announce sent successfully")

--- a/Sources/ColumbaApp/Services/IdentityManager.swift
+++ b/Sources/ColumbaApp/Services/IdentityManager.swift
@@ -268,7 +268,8 @@ actor IdentityManager {
         let destHash = Destination.hash(identity: oldIdentity, appName: "lxmf", aspects: ["delivery"])
         let destHashHex = destHash.map { String(format: "%02x", $0) }.joined()
 
-        // Load display name from settings
+        // Load display name from settings (getDisplayName trims, so a
+        // whitespace-only value is treated as unset).
         let displayName = await settingsRepository.getDisplayName()
 
         // Rename lxmf.db to lxmf_{hash}.db
@@ -288,7 +289,7 @@ actor IdentityManager {
         let now = Date().timeIntervalSince1970
         let local = LocalIdentity(
             identityHash: hash,
-            displayName: displayName.isEmpty ? "Anonymous Peer" : displayName,
+            displayName: displayName.isEmpty ? SettingsRepository.defaultDisplayName : displayName,
             destinationHash: destHashHex,
             createdAt: now,
             lastUsedAt: now,

--- a/Sources/ColumbaApp/Services/IdentityManager.swift
+++ b/Sources/ColumbaApp/Services/IdentityManager.swift
@@ -191,9 +191,11 @@ actor IdentityManager {
     /// Rename an identity.
     func renameIdentity(_ hash: String, newName: String) {
         guard let idx = identities.firstIndex(where: { $0.identityHash == hash }) else { return }
-        identities[idx].displayName = newName
+        // Normalize at the write boundary so LocalIdentity.displayName matches
+        // what the settings repo persists/announces (trimmed, non-divergent).
+        identities[idx].displayName = newName.trimmingCharacters(in: .whitespacesAndNewlines)
         saveIdentities()
-        logger.info("Renamed identity \(hash) to '\(newName)'")
+        logger.info("Renamed identity \(hash) to '\(identities[idx].displayName)'")
     }
 
     // MARK: - Delete

--- a/Sources/ColumbaApp/Services/IdentityManager.swift
+++ b/Sources/ColumbaApp/Services/IdentityManager.swift
@@ -107,6 +107,15 @@ actor IdentityManager {
     /// Merge storage first to preserve records written by an older importer or another
     /// actor instance, then persist the union without replacing restored identities.
     func importIdentityRecord(_ local: LocalIdentity) throws {
+        // Normalize the imported display name at the write boundary so the
+        // stored record matches the settings-repo read boundary (trimmed).
+        // Otherwise a whitespace-padded name in a backup would display locally
+        // as "  Bob  " while peers are announced "Bob".
+        var local = local
+        let trimmed = local.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed != local.displayName {
+            local.displayName = trimmed
+        }
         let previous = identities
         var merged = Self.loadIdentities()
         for existing in identities where !merged.contains(where: { $0.identityHash == existing.identityHash }) {
@@ -193,9 +202,10 @@ actor IdentityManager {
         guard let idx = identities.firstIndex(where: { $0.identityHash == hash }) else { return }
         // Normalize at the write boundary so LocalIdentity.displayName matches
         // what the settings repo persists/announces (trimmed, non-divergent).
-        identities[idx].displayName = newName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmed = newName.trimmingCharacters(in: .whitespacesAndNewlines)
+        identities[idx].displayName = trimmed
         saveIdentities()
-        logger.info("Renamed identity \(hash) to '\(identities[idx].displayName)'")
+        logger.info("Renamed identity \(hash) to '\(trimmed)'")
     }
 
     // MARK: - Delete

--- a/Sources/ColumbaApp/Services/IdentityManager.swift
+++ b/Sources/ColumbaApp/Services/IdentityManager.swift
@@ -67,7 +67,7 @@ actor IdentityManager {
         let now = Date().timeIntervalSince1970
         let local = LocalIdentity(
             identityHash: identityHash,
-            displayName: displayName,
+            displayName: SettingsRepository.resolvedDisplayName(displayName),
             destinationHash: destHashHex,
             createdAt: now,
             lastUsedAt: now,
@@ -200,10 +200,14 @@ actor IdentityManager {
         guard let idx = identities.firstIndex(where: { $0.identityHash == hash }) else { return }
         // Normalize at the write boundary so LocalIdentity.displayName matches
         // what the settings repo persists/announces (trimmed, non-divergent).
-        let trimmed = newName.trimmingCharacters(in: .whitespacesAndNewlines)
-        identities[idx].displayName = trimmed
+        // Uses the shared trim-or-`defaultDisplayName` contract so a blank or
+        // whitespace-only rename resolves to "Anonymous Peer" instead of
+        // persisting an empty name that the identity list and "Active:" label
+        // would render inconsistently with the announced name.
+        let resolved = SettingsRepository.resolvedDisplayName(newName)
+        identities[idx].displayName = resolved
         saveIdentities()
-        logger.info("Renamed identity \(hash) to '\(trimmed)'")
+        logger.info("Renamed identity \(hash) to '\(resolved)'")
     }
 
     // MARK: - Delete
@@ -279,8 +283,10 @@ actor IdentityManager {
         let destHashHex = destHash.map { String(format: "%02x", $0) }.joined()
 
         // Load display name from settings (getDisplayName trims, so a
-        // whitespace-only value is treated as unset).
-        let displayName = await settingsRepository.getDisplayName()
+        // whitespace-only value is treated as unset). Resolve through the
+        // shared trim-or-`defaultDisplayName` contract so the migrated
+        // identity's stored name matches what announce would broadcast.
+        let displayName = await settingsRepository.resolveDisplayName()
 
         // Rename lxmf.db to lxmf_{hash}.db
         let columbaDir = Self.columbaDirectory

--- a/Sources/ColumbaApp/Services/IdentityManager.swift
+++ b/Sources/ColumbaApp/Services/IdentityManager.swift
@@ -107,15 +107,13 @@ actor IdentityManager {
     /// Merge storage first to preserve records written by an older importer or another
     /// actor instance, then persist the union without replacing restored identities.
     func importIdentityRecord(_ local: LocalIdentity) throws {
-        // Normalize the imported display name at the write boundary so the
-        // stored record matches the settings-repo read boundary (trimmed).
-        // Otherwise a whitespace-padded name in a backup would display locally
-        // as "  Bob  " while peers are announced "Bob".
+        // Validate the imported display name through the same
+        // trim-or-default rule the announce resolver uses. A backup may carry
+        // a whitespace-padded or whitespace-only name; normalizing it here
+        // keeps the local record, the persisted settings copy, and the peer
+        // announce identical after the identity is activated.
         var local = local
-        let trimmed = local.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed != local.displayName {
-            local.displayName = trimmed
-        }
+        local.displayName = SettingsRepository.resolvedDisplayName(local.displayName)
         let previous = identities
         var merged = Self.loadIdentities()
         for existing in identities where !merged.contains(where: { $0.identityHash == existing.identityHash }) {

--- a/Sources/ColumbaApp/Services/SettingsRepository.swift
+++ b/Sources/ColumbaApp/Services/SettingsRepository.swift
@@ -108,22 +108,25 @@ public actor SettingsRepository {
     /// This name is broadcast to the network when announcing,
     /// allowing other users to identify this device.
     ///
-    /// - Returns: Display name, or empty string if not set
+    /// Single normalization point for the stored display name: trims surrounding
+    /// whitespace so every read path (local presentation, identity-page announce,
+    /// migration export, and the announce triggers) sees the same value rather
+    /// than diverging between a trimmed announce name and a raw stored one.
+    ///
+    /// - Returns: Display name trimmed of surrounding whitespace, or empty string if not set
     public func getDisplayName() -> String {
-        defaults.string(forKey: Keys.displayName) ?? ""
+        (defaults.string(forKey: Keys.displayName) ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    /// The display name to broadcast on announce, applying the default fallback.
+    /// The display name to broadcast on announce, guaranteed non-empty.
     ///
-    /// Returns the configured name trimmed of surrounding whitespace, or
-    /// `defaultDisplayName` when none is set (or only whitespace). This is the
-    /// single point that guarantees the startup / auto / manual announce paths
-    /// never emit a nameless LXMF announce - an empty `getDisplayName()` value
-    /// forwarded to `register_delivery_identity` is exactly the
-    /// "announced without a display name" bug.
+    /// Applies the `defaultDisplayName` fallback to the already-normalized
+    /// `getDisplayName()` so no announce path (startup / auto / manual /
+    /// Contacts) can emit a nameless LXMF announce. This is the single point
+    /// that closes the "announced without a display name" bug.
     public func resolveDisplayName() -> String {
-        let name = (defaults.string(forKey: Keys.displayName) ?? "")
-            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let name = getDisplayName()
         return name.isEmpty ? Self.defaultDisplayName : name
     }
 

--- a/Sources/ColumbaApp/Services/SettingsRepository.swift
+++ b/Sources/ColumbaApp/Services/SettingsRepository.swift
@@ -119,6 +119,16 @@ public actor SettingsRepository {
             .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    /// Normalize a display name: trim surrounding whitespace and substitute the
+    /// default for an empty result. Single source of the normalization contract
+    /// shared by the announce resolver (`resolveDisplayName`) and the
+    /// identity-import boundary, so both paths apply the identical
+    /// trim-or-`defaultDisplayName` rule.
+    static func resolvedDisplayName(_ raw: String) -> String {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? defaultDisplayName : trimmed
+    }
+
     /// The display name to broadcast on announce, guaranteed non-empty.
     ///
     /// Applies the `defaultDisplayName` fallback to the already-normalized
@@ -126,8 +136,7 @@ public actor SettingsRepository {
     /// Contacts) can emit a nameless LXMF announce. This is the single point
     /// that closes the "announced without a display name" bug.
     public func resolveDisplayName() -> String {
-        let name = getDisplayName()
-        return name.isEmpty ? Self.defaultDisplayName : name
+        Self.resolvedDisplayName(getDisplayName())
     }
 
     /// Set the display name for announces.

--- a/Sources/ColumbaApp/Services/SettingsRepository.swift
+++ b/Sources/ColumbaApp/Services/SettingsRepository.swift
@@ -142,11 +142,16 @@ public actor SettingsRepository {
     /// Set the display name for announces.
     ///
     /// - Parameter name: Display name to broadcast when announcing. Stored
-    ///   trimmed of surrounding whitespace so the write boundary matches the
-    ///   read boundary (`getDisplayName`) and no caller can persist a
-    ///   name whose stored and normalized forms differ.
+    ///   through the shared trim-or-`defaultDisplayName` contract
+    ///   (`resolvedDisplayName`) so the stored value is never empty: clearing
+    ///   the field (or saving only whitespace) persists "Anonymous Peer"
+    ///   rather than an empty string. This makes the persisted display name
+    ///   match what `resolveDisplayName()` announces, so every local surface
+    ///   that reads the name (identity page, settings "Active:" label,
+    ///   identity-management list) agrees with the network instead of
+    ///   diverging on a blank entry.
     public func setDisplayName(_ name: String) {
-        defaults.set(name.trimmingCharacters(in: .whitespacesAndNewlines), forKey: Keys.displayName)
+        defaults.set(Self.resolvedDisplayName(name), forKey: Keys.displayName)
     }
 
     // MARK: - Delivery & Propagation

--- a/Sources/ColumbaApp/Services/SettingsRepository.swift
+++ b/Sources/ColumbaApp/Services/SettingsRepository.swift
@@ -132,9 +132,12 @@ public actor SettingsRepository {
 
     /// Set the display name for announces.
     ///
-    /// - Parameter name: Display name to broadcast when announcing
+    /// - Parameter name: Display name to broadcast when announcing. Stored
+    ///   trimmed of surrounding whitespace so the write boundary matches the
+    ///   read boundary (`getDisplayName`) and no caller can persist a
+    ///   name whose stored and normalized forms differ.
     public func setDisplayName(_ name: String) {
-        defaults.set(name, forKey: Keys.displayName)
+        defaults.set(name.trimmingCharacters(in: .whitespacesAndNewlines), forKey: Keys.displayName)
     }
 
     // MARK: - Delivery & Propagation

--- a/Sources/ColumbaApp/Services/SettingsRepository.swift
+++ b/Sources/ColumbaApp/Services/SettingsRepository.swift
@@ -97,6 +97,12 @@ public actor SettingsRepository {
 
     // MARK: - Display Name
 
+    /// The display name shown to peers when the user has not set one.
+    /// Single source of truth for the "Anonymous Peer" default; previously this
+    /// literal was duplicated across IdentityManager, OnboardingViewModel, and
+    /// the startup path with slightly different empty-guards.
+    public static let defaultDisplayName = "Anonymous Peer"
+
     /// Get the display name for announces.
     ///
     /// This name is broadcast to the network when announcing,
@@ -105,6 +111,20 @@ public actor SettingsRepository {
     /// - Returns: Display name, or empty string if not set
     public func getDisplayName() -> String {
         defaults.string(forKey: Keys.displayName) ?? ""
+    }
+
+    /// The display name to broadcast on announce, applying the default fallback.
+    ///
+    /// Returns the configured name trimmed of surrounding whitespace, or
+    /// `defaultDisplayName` when none is set (or only whitespace). This is the
+    /// single point that guarantees the startup / auto / manual announce paths
+    /// never emit a nameless LXMF announce - an empty `getDisplayName()` value
+    /// forwarded to `register_delivery_identity` is exactly the
+    /// "announced without a display name" bug.
+    public func resolveDisplayName() -> String {
+        let name = (defaults.string(forKey: Keys.displayName) ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return name.isEmpty ? Self.defaultDisplayName : name
     }
 
     /// Set the display name for announces.

--- a/Sources/ColumbaApp/ViewModels/ContactsViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/ContactsViewModel.swift
@@ -954,7 +954,7 @@ public final class ContactsViewModel {
         isAnnouncing = true
 
         do {
-            let displayName = await SettingsRepository().getDisplayName()
+            let displayName = await SettingsRepository().resolveDisplayName()
             try await appServices.sendAllAnnounces(displayName: displayName)
             announceFeedback.show()
         } catch {

--- a/Sources/ColumbaApp/ViewModels/OnboardingViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/OnboardingViewModel.swift
@@ -102,9 +102,8 @@ final class OnboardingViewModel {
     // MARK: - Computed
 
     var effectiveDisplayName: String {
-        displayName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            ? "Anonymous Peer"
-            : displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmed = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? SettingsRepository.defaultDisplayName : trimmed
     }
 
     var selectedInterfaceNames: String {
@@ -250,7 +249,7 @@ final class OnboardingViewModel {
         try beginSaving()
         defer { isSaving = false }
 
-        let requestedName = createdIdentity?.displayName ?? "Anonymous Peer"
+        let requestedName = createdIdentity?.displayName ?? SettingsRepository.defaultDisplayName
         let local = try await createOrResumeIdentity(
             displayName: requestedName,
             identityManager: identityManager

--- a/Sources/ColumbaApp/ViewModels/SettingsViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/SettingsViewModel.swift
@@ -645,7 +645,11 @@ public final class SettingsViewModel {
         announceSuccess = false
 
         do {
-            try await appServices.sendAllAnnounces(displayName: identity.displayName)
+            // Announce through the shared resolver so the name matches the
+            // startup/Contacts/auto paths (normalized, non-empty) and reflects
+            // the saved value rather than a live unsent TextField edit.
+            let displayName = await settingsRepository.resolveDisplayName()
+            try await appServices.sendAllAnnounces(displayName: displayName)
             announceSuccess = true
             recordAnnounceTime()
             // Clear success after a delay
@@ -670,7 +674,11 @@ public final class SettingsViewModel {
         manualAnnounceError = nil
 
         do {
-            try await appServices.sendAllAnnounces(displayName: identity.displayName)
+            // Shared resolver: same normalized, non-empty name as every other
+            // announce trigger. Reading the saved value (not the live
+            // TextField) means an unsent edit can't be broadcast to peers.
+            let displayName = await settingsRepository.resolveDisplayName()
+            try await appServices.sendAllAnnounces(displayName: displayName)
             manualAnnounceSuccess = true
             recordAnnounceTime()
             Task {

--- a/Sources/ColumbaApp/ViewModels/SettingsViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/SettingsViewModel.swift
@@ -372,7 +372,8 @@ public final class SettingsViewModel {
         // is a secondary copy that can get out of sync (e.g. app group migration).
         let repoName = identity.displayName
         if let mgr = identityManager, let active = await mgr.getActiveIdentity() {
-            let idName = active.displayName
+            let rawIdName = active.displayName
+            let idName = rawIdName.trimmingCharacters(in: .whitespacesAndNewlines)
             let resolvedName: String
             if !idName.isEmpty && idName != SettingsRepository.defaultDisplayName {
                 resolvedName = idName
@@ -382,10 +383,11 @@ public final class SettingsViewModel {
                 await mgr.renameIdentity(active.identityHash, newName: repoName)
             } else {
                 // Both the active LocalIdentity and the settings repo hold no
-                // usable name (e.g. legacy data predating the never-empty
-                // invariant). Resolve to the shared default so the "Active:"
-                // label, identity page, and announced name all agree instead
-                // of the local state rendering blank.
+                // usable name: either genuinely empty or legacy whitespace-only
+                // data predating the never-empty invariant. Resolve to the
+                // shared default so the "Active:" label, identity page, and
+                // announced name all agree instead of the local state rendering
+                // blank.
                 resolvedName = SettingsRepository.defaultDisplayName
             }
             activeIdentityName = resolvedName
@@ -395,7 +397,7 @@ public final class SettingsViewModel {
                 savedDisplayName = resolvedName
                 await settingsRepository.setDisplayName(resolvedName)
             }
-            if idName != resolvedName {
+            if rawIdName != resolvedName {
                 await mgr.renameIdentity(active.identityHash, newName: resolvedName)
             }
         }

--- a/Sources/ColumbaApp/ViewModels/SettingsViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/SettingsViewModel.swift
@@ -38,9 +38,6 @@ public struct IdentityInfo: Equatable {
     /// Custom icon image data if set.
     public var customIconData: Data?
 
-    /// Default display name when none set.
-    public static let defaultDisplayName = "Unknown Peer"
-
     /// QR code string in Android Columba-compatible format.
     /// Format: `lxma://<destination_hash_hex>:<public_key_hex>`
     public var qrCodeString: String {
@@ -48,6 +45,16 @@ public struct IdentityInfo: Equatable {
             return destinationHash
         }
         return "lxma://\(destinationHash):\(publicKeyHex)"
+    }
+
+    /// The name that is actually broadcast to peers (trimmed, non-empty).
+    ///
+    /// Uses the shared trim-or-default contract
+    /// (`SettingsRepository.resolvedDisplayName`), so the identity page always
+    /// shows what announce and the LXMF announce wire actually carry - no
+    /// "Not set" / "Anonymous Peer" local-vs-network mismatch.
+    public var resolvedDisplayName: String {
+        SettingsRepository.resolvedDisplayName(displayName)
     }
 
     public init(

--- a/Sources/ColumbaApp/ViewModels/SettingsViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/SettingsViewModel.swift
@@ -623,22 +623,30 @@ public final class SettingsViewModel {
     /// Save the current display name.
     @MainActor
     public func saveDisplayName() async {
-        savedDisplayName = identity.displayName
-        await settingsRepository.setDisplayName(identity.displayName)
+        // Normalize the live value to exactly what is persisted (trimmed) so
+        // the TextField and "Active:" label match the saved and announced name
+        // immediately, not after a reload.
+        let name = identity.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        identity.displayName = name
+        savedDisplayName = name
+        await settingsRepository.setDisplayName(name)
         // Keep LocalIdentity.displayName in sync so the "Active:" label stays current.
         if let mgr = identityManager, let active = await mgr.getActiveIdentity() {
-            await mgr.renameIdentity(active.identityHash, newName: identity.displayName)
+            await mgr.renameIdentity(active.identityHash, newName: name)
         }
-        activeIdentityName = identity.displayName
+        activeIdentityName = name
         saveSettings()
     }
 
     /// Send announce to the network (from Identity page).
     @MainActor
     public func sendAnnounce() async {
-        // Save display name first
-        await settingsRepository.setDisplayName(identity.displayName)
-        savedDisplayName = identity.displayName
+        // Save display name first. Normalize the live value to match what is
+        // persisted so the displayed name matches the announced name.
+        let name = identity.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        identity.displayName = name
+        await settingsRepository.setDisplayName(name)
+        savedDisplayName = name
 
         isAnnouncing = true
         announceError = nil

--- a/Sources/ColumbaApp/ViewModels/SettingsViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/SettingsViewModel.swift
@@ -381,7 +381,12 @@ public final class SettingsViewModel {
                 // Repair LocalIdentity so it stays in sync.
                 await mgr.renameIdentity(active.identityHash, newName: repoName)
             } else {
-                resolvedName = idName
+                // Both the active LocalIdentity and the settings repo hold no
+                // usable name (e.g. legacy data predating the never-empty
+                // invariant). Resolve to the shared default so the "Active:"
+                // label, identity page, and announced name all agree instead
+                // of the local state rendering blank.
+                resolvedName = SettingsRepository.defaultDisplayName
             }
             activeIdentityName = resolvedName
             // Keep both sources in sync
@@ -389,6 +394,9 @@ public final class SettingsViewModel {
                 identity.displayName = resolvedName
                 savedDisplayName = resolvedName
                 await settingsRepository.setDisplayName(resolvedName)
+            }
+            if idName != resolvedName {
+                await mgr.renameIdentity(active.identityHash, newName: resolvedName)
             }
         }
 
@@ -630,10 +638,13 @@ public final class SettingsViewModel {
     /// Save the current display name.
     @MainActor
     public func saveDisplayName() async {
-        // Normalize the live value to exactly what is persisted (trimmed) so
-        // the TextField and "Active:" label match the saved and announced name
-        // immediately, not after a reload.
-        let name = identity.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Resolve through the shared trim-or-`defaultDisplayName` contract so
+        // the value persisted and the live state both use the identical,
+        // never-empty name. Clearing the field (or saving only whitespace)
+        // resolves to "Anonymous Peer", so settings, the active LocalIdentity,
+        // the "Active:" label, and the announced name all agree instead of the
+        // local state holding a blank entry.
+        let name = SettingsRepository.resolvedDisplayName(identity.displayName)
         identity.displayName = name
         savedDisplayName = name
         await settingsRepository.setDisplayName(name)
@@ -648,12 +659,16 @@ public final class SettingsViewModel {
     /// Send announce to the network (from Identity page).
     @MainActor
     public func sendAnnounce() async {
-        // Save display name first. Normalize the live value to match what is
-        // persisted so the displayed name matches the announced name.
-        let name = identity.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Save display name first. Resolve through the shared trim-or-`defaultDisplayName`
+        // contract so the value persisted and the live state both use the identical,
+        // never-empty name: clearing the field resolves to "Anonymous Peer" rather
+        // than persisting a blank entry that the "Active:" label and identity list
+        // would render inconsistently with the announced name.
+        let name = SettingsRepository.resolvedDisplayName(identity.displayName)
         identity.displayName = name
         await settingsRepository.setDisplayName(name)
         savedDisplayName = name
+        activeIdentityName = name
 
         isAnnouncing = true
         announceError = nil

--- a/Sources/ColumbaApp/ViewModels/SettingsViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/SettingsViewModel.swift
@@ -367,7 +367,7 @@ public final class SettingsViewModel {
         if let mgr = identityManager, let active = await mgr.getActiveIdentity() {
             let idName = active.displayName
             let resolvedName: String
-            if !idName.isEmpty && idName != "Anonymous Peer" {
+            if !idName.isEmpty && idName != SettingsRepository.defaultDisplayName {
                 resolvedName = idName
             } else if !repoName.isEmpty {
                 resolvedName = repoName

--- a/Sources/ColumbaApp/Views/Settings/MyIdentityView.swift
+++ b/Sources/ColumbaApp/Views/Settings/MyIdentityView.swift
@@ -75,7 +75,7 @@ struct MyIdentityView: View {
         .fullScreenCover(isPresented: $showQRFullScreen) {
             QRCodeFullScreenView(
                 qrCodeString: viewModel.identity.qrCodeString,
-                displayName: viewModel.identity.displayName
+                displayName: viewModel.identity.resolvedDisplayName
             )
         }
         .sheet(isPresented: $showShareSheet) {
@@ -114,17 +114,19 @@ struct MyIdentityView: View {
                 .font(.caption)
                 .foregroundStyle(Theme.textSecondary)
 
-            // Current identity info
+            // Current identity info. Show the *resolved* name - what announce
+            // actually broadcasts - so this label can never diverge from what
+            // peers receive (an empty custom name announces as the default).
             HStack {
                 Text("Current:")
                     .font(.subheadline)
                     .foregroundStyle(Theme.textSecondary)
-                Text(viewModel.identity.displayName.isEmpty ? "Not set" : viewModel.identity.displayName)
+                Text(viewModel.identity.resolvedDisplayName)
                     .font(.subheadline)
                     .foregroundStyle(Theme.accentColor)
             }
 
-            Text("Default: \(IdentityInfo.defaultDisplayName)")
+            Text("Default: \(SettingsRepository.defaultDisplayName)")
                 .font(.caption)
                 .foregroundStyle(Theme.textSecondary)
 


### PR DESCRIPTION
## Summary

The LXMF delivery destination was registered with an empty display name at backend
startup, so every startup announce (and the delayed 2/5/15/30s re-announces) went
out nameless. Peers saw a bare destination hash until a later manual/auto announce
(Settings button, Contacts button, auto-announce timer) re-sent the configured name.
That is why the destination was "sometimes announced without a display name".

## Changes

1. **Bug fix** (28df16b4): the two `initializeUnlocked()` paths in `AppServices.swift`
   booted the Python RNS backend with a hardcoded `displayName: ""`. The name now
   comes from `SettingsRepository().getDisplayName()` (onboarding always persists a
   non-empty name, defaulting to "Anonymous Peer", before the backend can start).
2. **DRY refactor** (d236b729): the display-name resolution is moved into
   `startPythonBackend`, the single point both init lifecycles reach. The two call
   sites no longer resolve the name themselves, and the write-only
   `pythonStartDisplayName` cache is removed (`restartPythonBackend` only rewrites
   the RNS config and prompts a relaunch; it never re-invokes `startPythonBackend`,
   so the cached value was never read). The name is now resolved in exactly one
   place, so the two init paths cannot drift, and a future backend restart would
   re-resolve the current name from settings.

## Verification

- Wire-format proof through the app's exact code path
  (`rns_bridge.start()` -> `register_delivery_identity` -> startup announce
  app_data, decoded via `LXMF.display_name_from_app_data` the way a peer decodes it):
  - buggy init: app_data `92c400c0` = msgpack `[b'', None]` -> peer decodes `''` ->
    falls back to the raw destination hash (the reported bug)
  - fixed init: app_data `92c40e416e6f6e6f6e796d6f75732050656572c0` =
    `['Anonymous Peer', None]` -> peer shows the name
- Build on the final head: `xcodebuild build` BUILD_EXIT=0, `ColumbaApp.app`
  produced (Mac mini, iPhone 17 simulator destination, iOS 26.4).
- Static contract suite: 329 tests OK (1 skipped), including the
  `startPythonBackend`-grepping contracts (Model B VPN isolation, background
  refresh wiring).
- No dangling references to the removed `pythonStartDisplayName` symbol;
  `backend.start` still receives the resolved name.

## Scope note

Both commits are in-scope: the fix and the single-sourcing refactor touch the same
startup path, and the refactor is what makes the fix maintainable.