### PR TITLE
iOS: Ogg/Opus voice message interop, real amplitude waveform, and playback fixes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,7 +81,8 @@ jobs:
             Tests.static.test_image_quality_sheet_dynamic_size \
             Tests.static.test_nomadnet_text_selection \
             Tests.static.test_ui_screenshotter_readiness \
-            Tests.static.test_collect_maestro_screenshots
+            Tests.static.test_collect_maestro_screenshots \
+            Tests.static.test_voice_messages
 
       # Verify a standalone production-layout app before xcodebuild test embeds
       # ColumbaAppTests.xctest under PlugIns in its hosted test copy.

--- a/Columba.xcodeproj/project.pbxproj
+++ b/Columba.xcodeproj/project.pbxproj
@@ -252,6 +252,7 @@
 		VMPLT02 /* VoiceMessagePlayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = VMPLT01 /* VoiceMessagePlayerTests.swift */; };
 		C2RFT02 /* Codec2RawFileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2RFT01 /* Codec2RawFileTests.swift */; };
 		OGFWR02 /* OggOpusFileWriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OGFWR01 /* OggOpusFileWriterTests.swift */; };
+		OGINB02 /* OggOpusInboundNormalizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OGINB01 /* OggOpusInboundNormalizerTests.swift */; };
 		OGGR002 /* OggOpusGranuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OGGR001 /* OggOpusGranuleTests.swift */; };
 		VMFT002 /* VoiceMessageFormatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = VMFT001 /* VoiceMessageFormatTests.swift */; };
 		AMOD002 /* AudioModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AMOD001 /* AudioModeTests.swift */; };
@@ -386,6 +387,8 @@
 		VBMD0 /* OggOpusGranule.swift in Sources */ = {isa = PBXBuildFile; fileRef = V0CD0 /* OggOpusGranule.swift */; };
 		VBSE0 /* OggOpusMetadataReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = V0CE0 /* OggOpusMetadataReader.swift */; };
 		VBME0 /* OggOpusMetadataReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = V0CE0 /* OggOpusMetadataReader.swift */; };
+		VBSN0 /* OggOpusInboundNormalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = V0CN0 /* OggOpusInboundNormalizer.swift */; };
+		VBMN0 /* OggOpusInboundNormalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = V0CN0 /* OggOpusInboundNormalizer.swift */; };
 		VBSF0 /* VoiceDraftRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = V0CF0 /* VoiceDraftRow.swift */; };
 		VBMF0 /* VoiceDraftRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = V0CF0 /* VoiceDraftRow.swift */; };
 		VBSJ0 /* VoiceMessageBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = V0CJ0 /* VoiceMessageBubble.swift */; };
@@ -506,6 +509,7 @@
 		VMPLT01 /* VoiceMessagePlayerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VoiceMessagePlayerTests.swift; sourceTree = "<group>"; };
 		C2RFT01 /* Codec2RawFileTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Codec2RawFileTests.swift; sourceTree = "<group>"; };
 		OGFWR01 /* OggOpusFileWriterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OggOpusFileWriterTests.swift; sourceTree = "<group>"; };
+		OGINB01 /* OggOpusInboundNormalizerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OggOpusInboundNormalizerTests.swift; sourceTree = "<group>"; };
 		OGGR001 /* OggOpusGranuleTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OggOpusGranuleTests.swift; sourceTree = "<group>"; };
 		VMFT001 /* VoiceMessageFormatTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VoiceMessageFormatTests.swift; sourceTree = "<group>"; };
 		AMOD001 /* AudioModeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudioModeTests.swift; sourceTree = "<group>"; };
@@ -666,6 +670,7 @@
 		V0CC0 /* OggOpusFileWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OggOpusFileWriter.swift; sourceTree = "<group>"; };
 		V0CD0 /* OggOpusGranule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OggOpusGranule.swift; sourceTree = "<group>"; };
 		V0CE0 /* OggOpusMetadataReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OggOpusMetadataReader.swift; sourceTree = "<group>"; };
+		V0CN0 /* OggOpusInboundNormalizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OggOpusInboundNormalizer.swift; sourceTree = "<group>"; };
 		V0CF0 /* VoiceDraftRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceDraftRow.swift; sourceTree = "<group>"; };
 		V0CJ0 /* VoiceMessageBubble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceMessageBubble.swift; sourceTree = "<group>"; };
 		V0CK0 /* VoiceMessageFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceMessageFormat.swift; sourceTree = "<group>"; };
@@ -1126,6 +1131,7 @@
 				VMPLT01 /* VoiceMessagePlayerTests.swift */,
 				C2RFT01 /* Codec2RawFileTests.swift */,
 				OGFWR01 /* OggOpusFileWriterTests.swift */,
+				OGINB01 /* OggOpusInboundNormalizerTests.swift */,
 				OGGR001 /* OggOpusGranuleTests.swift */,
 				VMFT001 /* VoiceMessageFormatTests.swift */,
 				AMOD001 /* AudioModeTests.swift */,
@@ -1235,6 +1241,7 @@
 				V0CC0 /* OggOpusFileWriter.swift */,
 				V0CD0 /* OggOpusGranule.swift */,
 				V0CE0 /* OggOpusMetadataReader.swift */,
+			V0CN0 /* OggOpusInboundNormalizer.swift */,
 				V0CF0 /* VoiceDraftRow.swift */,
 				V0CJ0 /* VoiceMessageBubble.swift */,
 				V0CK0 /* VoiceMessageFormat.swift */,
@@ -1531,6 +1538,7 @@
 				VBMC0 /* OggOpusFileWriter.swift in Sources */,
 				VBMD0 /* OggOpusGranule.swift in Sources */,
 				VBME0 /* OggOpusMetadataReader.swift in Sources */,
+				VBMN0 /* OggOpusInboundNormalizer.swift in Sources */,
 				VBMF0 /* VoiceDraftRow.swift in Sources */,
 				VBMJ0 /* VoiceMessageBubble.swift in Sources */,
 				VBMK0 /* VoiceMessageFormat.swift in Sources */,
@@ -1730,6 +1738,7 @@
 				VBSC0 /* OggOpusFileWriter.swift in Sources */,
 				VBSD0 /* OggOpusGranule.swift in Sources */,
 				VBSE0 /* OggOpusMetadataReader.swift in Sources */,
+				VBSN0 /* OggOpusInboundNormalizer.swift in Sources */,
 				VBSF0 /* VoiceDraftRow.swift in Sources */,
 				VBSJ0 /* VoiceMessageBubble.swift in Sources */,
 				VBSK0 /* VoiceMessageFormat.swift in Sources */,
@@ -1874,6 +1883,7 @@
 				VMPLT02 /* VoiceMessagePlayerTests.swift in Sources */,
 				C2RFT02 /* Codec2RawFileTests.swift in Sources */,
 				OGFWR02 /* OggOpusFileWriterTests.swift in Sources */,
+				OGINB02 /* OggOpusInboundNormalizerTests.swift in Sources */,
 				OGGR002 /* OggOpusGranuleTests.swift in Sources */,
 				VMFT002 /* VoiceMessageFormatTests.swift in Sources */,
 				AMOD002 /* AudioModeTests.swift in Sources */,

--- a/Columba.xcodeproj/project.pbxproj
+++ b/Columba.xcodeproj/project.pbxproj
@@ -253,6 +253,7 @@
 		C2RFT02 /* Codec2RawFileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2RFT01 /* Codec2RawFileTests.swift */; };
 		OGFWR02 /* OggOpusFileWriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OGFWR01 /* OggOpusFileWriterTests.swift */; };
 		OGINB02 /* OggOpusInboundNormalizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OGINB01 /* OggOpusInboundNormalizerTests.swift */; };
+		OGWFT2 /* OggOpusWaveformTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OGWFT1 /* OggOpusWaveformTests.swift */; };
 		OGGR002 /* OggOpusGranuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OGGR001 /* OggOpusGranuleTests.swift */; };
 		VMFT002 /* VoiceMessageFormatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = VMFT001 /* VoiceMessageFormatTests.swift */; };
 		AMOD002 /* AudioModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AMOD001 /* AudioModeTests.swift */; };
@@ -389,6 +390,8 @@
 		VBME0 /* OggOpusMetadataReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = V0CE0 /* OggOpusMetadataReader.swift */; };
 		VBSN0 /* OggOpusInboundNormalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = V0CN0 /* OggOpusInboundNormalizer.swift */; };
 		VBMN0 /* OggOpusInboundNormalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = V0CN0 /* OggOpusInboundNormalizer.swift */; };
+		VBSW0 /* OggOpusWaveform.swift in Sources */ = {isa = PBXBuildFile; fileRef = V0CW0 /* OggOpusWaveform.swift */; };
+		VBMW0 /* OggOpusWaveform.swift in Sources */ = {isa = PBXBuildFile; fileRef = V0CW0 /* OggOpusWaveform.swift */; };
 		VBSF0 /* VoiceDraftRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = V0CF0 /* VoiceDraftRow.swift */; };
 		VBMF0 /* VoiceDraftRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = V0CF0 /* VoiceDraftRow.swift */; };
 		VBSJ0 /* VoiceMessageBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = V0CJ0 /* VoiceMessageBubble.swift */; };
@@ -510,6 +513,7 @@
 		C2RFT01 /* Codec2RawFileTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Codec2RawFileTests.swift; sourceTree = "<group>"; };
 		OGFWR01 /* OggOpusFileWriterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OggOpusFileWriterTests.swift; sourceTree = "<group>"; };
 		OGINB01 /* OggOpusInboundNormalizerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OggOpusInboundNormalizerTests.swift; sourceTree = "<group>"; };
+		OGWFT1 /* OggOpusWaveformTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OggOpusWaveformTests.swift; sourceTree = "<group>"; };
 		OGGR001 /* OggOpusGranuleTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OggOpusGranuleTests.swift; sourceTree = "<group>"; };
 		VMFT001 /* VoiceMessageFormatTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VoiceMessageFormatTests.swift; sourceTree = "<group>"; };
 		AMOD001 /* AudioModeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudioModeTests.swift; sourceTree = "<group>"; };
@@ -671,6 +675,7 @@
 		V0CD0 /* OggOpusGranule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OggOpusGranule.swift; sourceTree = "<group>"; };
 		V0CE0 /* OggOpusMetadataReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OggOpusMetadataReader.swift; sourceTree = "<group>"; };
 		V0CN0 /* OggOpusInboundNormalizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OggOpusInboundNormalizer.swift; sourceTree = "<group>"; };
+		V0CW0 /* OggOpusWaveform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OggOpusWaveform.swift; sourceTree = "<group>"; };
 		V0CF0 /* VoiceDraftRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceDraftRow.swift; sourceTree = "<group>"; };
 		V0CJ0 /* VoiceMessageBubble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceMessageBubble.swift; sourceTree = "<group>"; };
 		V0CK0 /* VoiceMessageFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceMessageFormat.swift; sourceTree = "<group>"; };
@@ -1132,6 +1137,7 @@
 				C2RFT01 /* Codec2RawFileTests.swift */,
 				OGFWR01 /* OggOpusFileWriterTests.swift */,
 				OGINB01 /* OggOpusInboundNormalizerTests.swift */,
+				OGWFT1 /* OggOpusWaveformTests.swift */,
 				OGGR001 /* OggOpusGranuleTests.swift */,
 				VMFT001 /* VoiceMessageFormatTests.swift */,
 				AMOD001 /* AudioModeTests.swift */,
@@ -1242,6 +1248,7 @@
 				V0CD0 /* OggOpusGranule.swift */,
 				V0CE0 /* OggOpusMetadataReader.swift */,
 			V0CN0 /* OggOpusInboundNormalizer.swift */,
+			V0CW0 /* OggOpusWaveform.swift */,
 				V0CF0 /* VoiceDraftRow.swift */,
 				V0CJ0 /* VoiceMessageBubble.swift */,
 				V0CK0 /* VoiceMessageFormat.swift */,
@@ -1539,6 +1546,7 @@
 				VBMD0 /* OggOpusGranule.swift in Sources */,
 				VBME0 /* OggOpusMetadataReader.swift in Sources */,
 				VBMN0 /* OggOpusInboundNormalizer.swift in Sources */,
+				VBMW0 /* OggOpusWaveform.swift in Sources */,
 				VBMF0 /* VoiceDraftRow.swift in Sources */,
 				VBMJ0 /* VoiceMessageBubble.swift in Sources */,
 				VBMK0 /* VoiceMessageFormat.swift in Sources */,
@@ -1739,6 +1747,7 @@
 				VBSD0 /* OggOpusGranule.swift in Sources */,
 				VBSE0 /* OggOpusMetadataReader.swift in Sources */,
 				VBSN0 /* OggOpusInboundNormalizer.swift in Sources */,
+				VBSW0 /* OggOpusWaveform.swift in Sources */,
 				VBSF0 /* VoiceDraftRow.swift in Sources */,
 				VBSJ0 /* VoiceMessageBubble.swift in Sources */,
 				VBSK0 /* VoiceMessageFormat.swift in Sources */,
@@ -1884,6 +1893,7 @@
 				C2RFT02 /* Codec2RawFileTests.swift in Sources */,
 				OGFWR02 /* OggOpusFileWriterTests.swift in Sources */,
 				OGINB02 /* OggOpusInboundNormalizerTests.swift in Sources */,
+				OGWFT2 /* OggOpusWaveformTests.swift in Sources */,
 				OGGR002 /* OggOpusGranuleTests.swift in Sources */,
 				VMFT002 /* VoiceMessageFormatTests.swift in Sources */,
 				AMOD002 /* AudioModeTests.swift in Sources */,

--- a/Columba.xcodeproj/project.pbxproj
+++ b/Columba.xcodeproj/project.pbxproj
@@ -247,6 +247,15 @@
 		9566DCEF56FEFC97BAAA47BA /* MessageFormattedTimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC4EF2D71A3D88C71D5BEDAD /* MessageFormattedTimeTests.swift */; };
 		A1B2C3D4E5F60718293A4B5E /* MessageBubbleLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718293A4B5D /* MessageBubbleLayoutTests.swift */; };
 		APVT002 /* MessageAttachmentPreviewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = APVT001 /* MessageAttachmentPreviewTests.swift */; };
+		MAFLD02 /* MessageAudioFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = MAFLD01 /* MessageAudioFieldTests.swift */; };
+		VMRCD02 /* VoiceMessageRecorderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = VMRCD01 /* VoiceMessageRecorderTests.swift */; };
+		VMPLT02 /* VoiceMessagePlayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = VMPLT01 /* VoiceMessagePlayerTests.swift */; };
+		C2RFT02 /* Codec2RawFileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2RFT01 /* Codec2RawFileTests.swift */; };
+		OGFWR02 /* OggOpusFileWriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OGFWR01 /* OggOpusFileWriterTests.swift */; };
+		OGGR002 /* OggOpusGranuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OGGR001 /* OggOpusGranuleTests.swift */; };
+		VMFT002 /* VoiceMessageFormatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = VMFT001 /* VoiceMessageFormatTests.swift */; };
+		AMOD002 /* AudioModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AMOD001 /* AudioModeTests.swift */; };
+		VTSU002 /* VoiceTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = VTSU001 /* VoiceTestSupport.swift */; };
 		9673457897893BF9DE512A0F /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F006 /* SettingsViewModel.swift */; };
 		973B4BBFD50C0935D1525F8E /* NomadNetBrowserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F081 /* NomadNetBrowserView.swift */; };
 		97FCC1B1FF91DD6EF2706B04 /* LoRaPresets.swift in Sources */ = {isa = PBXBuildFile; fileRef = F045 /* LoRaPresets.swift */; };
@@ -367,6 +376,30 @@
 		RMLT003 /* RuntimeActivityMonitorLeaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = RMLT001 /* RuntimeActivityMonitorLeaseTests.swift */; };
 		TMP002 /* ThemeManagerPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = TMP001 /* ThemeManagerPersistenceTests.swift */; };
 		T003 /* MicronParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FT03 /* MicronParserTests.swift */; };
+		VBSA0 /* AudioMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = V0CA0 /* AudioMode.swift */; };
+		VBMA0 /* AudioMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = V0CA0 /* AudioMode.swift */; };
+		VBSB0 /* Codec2RawFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = V0CB0 /* Codec2RawFile.swift */; };
+		VBMB0 /* Codec2RawFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = V0CB0 /* Codec2RawFile.swift */; };
+		VBSC0 /* OggOpusFileWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = V0CC0 /* OggOpusFileWriter.swift */; };
+		VBMC0 /* OggOpusFileWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = V0CC0 /* OggOpusFileWriter.swift */; };
+		VBSD0 /* OggOpusGranule.swift in Sources */ = {isa = PBXBuildFile; fileRef = V0CD0 /* OggOpusGranule.swift */; };
+		VBMD0 /* OggOpusGranule.swift in Sources */ = {isa = PBXBuildFile; fileRef = V0CD0 /* OggOpusGranule.swift */; };
+		VBSE0 /* OggOpusMetadataReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = V0CE0 /* OggOpusMetadataReader.swift */; };
+		VBME0 /* OggOpusMetadataReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = V0CE0 /* OggOpusMetadataReader.swift */; };
+		VBSF0 /* VoiceDraftRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = V0CF0 /* VoiceDraftRow.swift */; };
+		VBMF0 /* VoiceDraftRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = V0CF0 /* VoiceDraftRow.swift */; };
+		VBSJ0 /* VoiceMessageBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = V0CJ0 /* VoiceMessageBubble.swift */; };
+		VBMJ0 /* VoiceMessageBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = V0CJ0 /* VoiceMessageBubble.swift */; };
+		VBSK0 /* VoiceMessageFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = V0CK0 /* VoiceMessageFormat.swift */; };
+		VBMK0 /* VoiceMessageFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = V0CK0 /* VoiceMessageFormat.swift */; };
+		VBSL0 /* VoiceMessagePlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = V0CL0 /* VoiceMessagePlayer.swift */; };
+		VBML0 /* VoiceMessagePlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = V0CL0 /* VoiceMessagePlayer.swift */; };
+		VBSM0 /* VoiceMessageRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = V0CM0 /* VoiceMessageRecorder.swift */; };
+		VBMM0 /* VoiceMessageRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = V0CM0 /* VoiceMessageRecorder.swift */; };
+		VBSP0 /* VoiceQualityPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = V0CP0 /* VoiceQualityPickerSheet.swift */; };
+		VBMP0 /* VoiceQualityPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = V0CP0 /* VoiceQualityPickerSheet.swift */; };
+		VBSR0 /* VoiceWaveformBars.swift in Sources */ = {isa = PBXBuildFile; fileRef = V0CR0 /* VoiceWaveformBars.swift */; };
+		VBMR0 /* VoiceWaveformBars.swift in Sources */ = {isa = PBXBuildFile; fileRef = V0CR0 /* VoiceWaveformBars.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -468,6 +501,15 @@
 		BC4EF2D71A3D88C71D5BEDAD /* MessageFormattedTimeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MessageFormattedTimeTests.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60718293A4B5D /* MessageBubbleLayoutTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MessageBubbleLayoutTests.swift; sourceTree = "<group>"; };
 		APVT001 /* MessageAttachmentPreviewTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MessageAttachmentPreviewTests.swift; sourceTree = "<group>"; };
+		MAFLD01 /* MessageAudioFieldTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MessageAudioFieldTests.swift; sourceTree = "<group>"; };
+		VMRCD01 /* VoiceMessageRecorderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VoiceMessageRecorderTests.swift; sourceTree = "<group>"; };
+		VMPLT01 /* VoiceMessagePlayerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VoiceMessagePlayerTests.swift; sourceTree = "<group>"; };
+		C2RFT01 /* Codec2RawFileTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Codec2RawFileTests.swift; sourceTree = "<group>"; };
+		OGFWR01 /* OggOpusFileWriterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OggOpusFileWriterTests.swift; sourceTree = "<group>"; };
+		OGGR001 /* OggOpusGranuleTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OggOpusGranuleTests.swift; sourceTree = "<group>"; };
+		VMFT001 /* VoiceMessageFormatTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VoiceMessageFormatTests.swift; sourceTree = "<group>"; };
+		AMOD001 /* AudioModeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudioModeTests.swift; sourceTree = "<group>"; };
+		VTSU001 /* VoiceTestSupport.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VoiceTestSupport.swift; sourceTree = "<group>"; };
 		BF48C97880B30682DC35613C /* CeaseTelemetry.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CeaseTelemetry.swift; sourceTree = "<group>"; };
 		BGTF /* BackgroundTransportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundTransportView.swift; sourceTree = "<group>"; };
 		BKF002 /* BackendFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendFactory.swift; sourceTree = "<group>"; };
@@ -619,6 +661,18 @@
 		TMP001 /* ThemeManagerPersistenceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThemeManagerPersistenceTests.swift; sourceTree = "<group>"; };
 		SRB002 /* SwiftRNSBackend.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SwiftRNSBackend.swift; path = Sources/RNSBackendSwift/SwiftRNSBackend.swift; sourceTree = SOURCE_ROOT; };
 		TPROD /* ColumbaAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ColumbaAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		V0CA0 /* AudioMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioMode.swift; sourceTree = "<group>"; };
+		V0CB0 /* Codec2RawFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Codec2RawFile.swift; sourceTree = "<group>"; };
+		V0CC0 /* OggOpusFileWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OggOpusFileWriter.swift; sourceTree = "<group>"; };
+		V0CD0 /* OggOpusGranule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OggOpusGranule.swift; sourceTree = "<group>"; };
+		V0CE0 /* OggOpusMetadataReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OggOpusMetadataReader.swift; sourceTree = "<group>"; };
+		V0CF0 /* VoiceDraftRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceDraftRow.swift; sourceTree = "<group>"; };
+		V0CJ0 /* VoiceMessageBubble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceMessageBubble.swift; sourceTree = "<group>"; };
+		V0CK0 /* VoiceMessageFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceMessageFormat.swift; sourceTree = "<group>"; };
+		V0CL0 /* VoiceMessagePlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceMessagePlayer.swift; sourceTree = "<group>"; };
+		V0CM0 /* VoiceMessageRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceMessageRecorder.swift; sourceTree = "<group>"; };
+		V0CP0 /* VoiceQualityPickerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceQualityPickerSheet.swift; sourceTree = "<group>"; };
+		V0CR0 /* VoiceWaveformBars.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceWaveformBars.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1067,6 +1121,15 @@
 				RFT001 /* RuntimeFlavorTests.swift */,
 				RMLT001 /* RuntimeActivityMonitorLeaseTests.swift */,
 				TMP001 /* ThemeManagerPersistenceTests.swift */,
+				MAFLD01 /* MessageAudioFieldTests.swift */,
+				VMRCD01 /* VoiceMessageRecorderTests.swift */,
+				VMPLT01 /* VoiceMessagePlayerTests.swift */,
+				C2RFT01 /* Codec2RawFileTests.swift */,
+				OGFWR01 /* OggOpusFileWriterTests.swift */,
+				OGGR001 /* OggOpusGranuleTests.swift */,
+				VMFT001 /* VoiceMessageFormatTests.swift */,
+				AMOD001 /* AudioModeTests.swift */,
+				VTSU001 /* VoiceTestSupport.swift */,
 			);
 			path = Tests/ColumbaAppTests;
 			sourceTree = "<group>";
@@ -1158,9 +1221,29 @@
 				GVIEWS /* Views */,
 				GSVC /* Services */,
 				GRES /* Resources */,
+				GVOC /* Voice */,
 				9A4EC6E91C9E0CAAD134372D /* Python */,
 			);
 			path = Sources/ColumbaApp;
+			sourceTree = "<group>";
+		};
+		GVOC /* Voice */ = {
+			isa = PBXGroup;
+			children = (
+				V0CA0 /* AudioMode.swift */,
+				V0CB0 /* Codec2RawFile.swift */,
+				V0CC0 /* OggOpusFileWriter.swift */,
+				V0CD0 /* OggOpusGranule.swift */,
+				V0CE0 /* OggOpusMetadataReader.swift */,
+				V0CF0 /* VoiceDraftRow.swift */,
+				V0CJ0 /* VoiceMessageBubble.swift */,
+				V0CK0 /* VoiceMessageFormat.swift */,
+				V0CL0 /* VoiceMessagePlayer.swift */,
+				V0CM0 /* VoiceMessageRecorder.swift */,
+				V0CP0 /* VoiceQualityPickerSheet.swift */,
+				V0CR0 /* VoiceWaveformBars.swift */,
+			);
+			path = Voice;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1443,6 +1526,18 @@
 				MDB002 /* MessageBody.swift in Sources */,
 				D93546FFCB0106CF3F68B2C5 /* MessageDetailView.swift in Sources */,
 				D709D8EDF36F85DEB5AABEC4 /* MessageInputBar.swift in Sources */,
+				VBMA0 /* AudioMode.swift in Sources */,
+				VBMB0 /* Codec2RawFile.swift in Sources */,
+				VBMC0 /* OggOpusFileWriter.swift in Sources */,
+				VBMD0 /* OggOpusGranule.swift in Sources */,
+				VBME0 /* OggOpusMetadataReader.swift in Sources */,
+				VBMF0 /* VoiceDraftRow.swift in Sources */,
+				VBMJ0 /* VoiceMessageBubble.swift in Sources */,
+				VBMK0 /* VoiceMessageFormat.swift in Sources */,
+				VBML0 /* VoiceMessagePlayer.swift in Sources */,
+				VBMM0 /* VoiceMessageRecorder.swift in Sources */,
+				VBMP0 /* VoiceQualityPickerSheet.swift in Sources */,
+				VBMR0 /* VoiceWaveformBars.swift in Sources */,
 				A48DAD459DFDFDC94AC92B5A /* SettingsView.swift in Sources */,
 				31F207DBD45E2CA682A3F830 /* MyIdentityView.swift in Sources */,
 				22C0D4CEA5878FC810F04D1A /* ExpandableSettingsCard.swift in Sources */,
@@ -1630,6 +1725,18 @@
 				MDB001 /* MessageBody.swift in Sources */,
 				073 /* MessageDetailView.swift in Sources */,
 				015 /* MessageInputBar.swift in Sources */,
+				VBSA0 /* AudioMode.swift in Sources */,
+				VBSB0 /* Codec2RawFile.swift in Sources */,
+				VBSC0 /* OggOpusFileWriter.swift in Sources */,
+				VBSD0 /* OggOpusGranule.swift in Sources */,
+				VBSE0 /* OggOpusMetadataReader.swift in Sources */,
+				VBSF0 /* VoiceDraftRow.swift in Sources */,
+				VBSJ0 /* VoiceMessageBubble.swift in Sources */,
+				VBSK0 /* VoiceMessageFormat.swift in Sources */,
+				VBSL0 /* VoiceMessagePlayer.swift in Sources */,
+				VBSM0 /* VoiceMessageRecorder.swift in Sources */,
+				VBSP0 /* VoiceQualityPickerSheet.swift in Sources */,
+				VBSR0 /* VoiceWaveformBars.swift in Sources */,
 				016 /* SettingsView.swift in Sources */,
 				017 /* MyIdentityView.swift in Sources */,
 				018 /* ExpandableSettingsCard.swift in Sources */,
@@ -1762,6 +1869,15 @@
 				RFT002 /* RuntimeFlavorTests.swift in Sources */,
 				RMLT002 /* RuntimeActivityMonitorLeaseTests.swift in Sources */,
 				TMP002 /* ThemeManagerPersistenceTests.swift in Sources */,
+				MAFLD02 /* MessageAudioFieldTests.swift in Sources */,
+				VMRCD02 /* VoiceMessageRecorderTests.swift in Sources */,
+				VMPLT02 /* VoiceMessagePlayerTests.swift in Sources */,
+				C2RFT02 /* Codec2RawFileTests.swift in Sources */,
+				OGFWR02 /* OggOpusFileWriterTests.swift in Sources */,
+				OGGR002 /* OggOpusGranuleTests.swift in Sources */,
+				VMFT002 /* VoiceMessageFormatTests.swift in Sources */,
+				AMOD002 /* AudioModeTests.swift in Sources */,
+				VTSU002 /* VoiceTestSupport.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/ColumbaApp/App/ColumbaApp.swift
+++ b/Sources/ColumbaApp/App/ColumbaApp.swift
@@ -421,10 +421,12 @@ struct ColumbaApp: App {
                     let imageFormat = q("image_format") ?? ""
                     let fileHex = q("file_hex") ?? ""
                     let fileName = q("file_name") ?? ""
+                    let audioMode = q("audio_mode") ?? ""
+                    let audioHex = q("audio_hex") ?? ""
                     // NO-PII: never log message content — diag.log and the
                     // unified log are readable by anyone with the device.
                     logger.info("test-send to=\(to, privacy: .public) len=\(content.utf8.count, privacy: .public)")
-                    DiagLog.log("[TEST-SEND] to=\(to.prefix(8)) method=\(method.isEmpty ? "opportunistic" : method) len=\(content.utf8.count) image=\(imageHex.isEmpty ? 0 : imageHex.count/2)B(\(imageFormat)) file=\(fileHex.isEmpty ? 0 : fileHex.count/2)B(\(fileName))")
+                    DiagLog.log("[TEST-SEND] to=\(to.prefix(8)) method=\(method.isEmpty ? "opportunistic" : method) len=\(content.utf8.count) image=\(imageHex.isEmpty ? 0 : imageHex.count/2)B(\(imageFormat)) file=\(fileHex.isEmpty ? 0 : fileHex.count/2)B(\(fileName)) audio=\(audioHex.isEmpty ? 0 : audioHex.count/2)B(mode=\(audioMode))")
                     NotificationCenter.default.post(
                         name: Notification.Name("ColumbaTestSend"),
                         object: nil,
@@ -436,6 +438,8 @@ struct ColumbaApp: App {
                             "image_format": imageFormat,
                             "file_hex": fileHex,
                             "file_name": fileName,
+                            "audio_mode": audioMode,
+                            "audio_hex": audioHex,
                         ]
                     )
                     return

--- a/Sources/ColumbaApp/Resources/Localizable.xcstrings
+++ b/Sources/ColumbaApp/Resources/Localizable.xcstrings
@@ -1481,6 +1481,416 @@
     },
     "Google Maps": {
       "comment": "Name of the Google Maps option in the directions chooser."
+    },
+    "Select Voice Message Quality": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select Voice Message Quality"
+          }
+        }
+      }
+    },
+    "Choose the recording format and bandwidth": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose the recording format and bandwidth"
+          }
+        }
+      }
+    },
+    "Record": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Record"
+          }
+        }
+      }
+    },
+    "Codec2 1200": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codec2 1200"
+          }
+        }
+      }
+    },
+    "Very low bandwidth voice": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Very low bandwidth voice"
+          }
+        }
+      }
+    },
+    "Codec2 2400": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codec2 2400"
+          }
+        }
+      }
+    },
+    "Low bandwidth voice": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Low bandwidth voice"
+          }
+        }
+      }
+    },
+    "Codec2 3200": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codec2 3200"
+          }
+        }
+      }
+    },
+    "Clearer speech at low bandwidth": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clearer speech at low bandwidth"
+          }
+        }
+      }
+    },
+    "Medium Quality": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Medium Quality"
+          }
+        }
+      }
+    },
+    "Opus 8 kbps mono - good balance of quality and bandwidth": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opus 8 kbps mono - good balance of quality and bandwidth"
+          }
+        }
+      }
+    },
+    "High Quality": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "High Quality"
+          }
+        }
+      }
+    },
+    "Opus 16 kbps mono - higher fidelity audio": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opus 16 kbps mono - higher fidelity audio"
+          }
+        }
+      }
+    },
+    "Maximum Quality": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maximum Quality"
+          }
+        }
+      }
+    },
+    "Opus 32 kbps stereo - best audio, requires more bandwidth": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opus 32 kbps stereo - best audio, requires more bandwidth"
+          }
+        }
+      }
+    },
+    "Voice": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voice"
+          }
+        }
+      }
+    },
+    "Record a voice message": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Record a voice message"
+          }
+        }
+      }
+    },
+    "Voice message": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voice message"
+          }
+        }
+      }
+    },
+    "Start recording": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start recording"
+          }
+        }
+      }
+    },
+    "Stop recording": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stop recording"
+          }
+        }
+      }
+    },
+    "Cancel recording": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel recording"
+          }
+        }
+      }
+    },
+    "Remove recording": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove recording"
+          }
+        }
+      }
+    },
+    "Microphone permission is required to record a voice message.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Microphone permission is required to record a voice message."
+          }
+        }
+      }
+    },
+    "Voice messages are not supported on this device.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voice messages are not supported on this device."
+          }
+        }
+      }
+    },
+    "Recording": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recording"
+          }
+        }
+      }
+    },
+    "Finalizing": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finalizing"
+          }
+        }
+      }
+    },
+    "Selected voice message": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selected voice message"
+          }
+        }
+      }
+    },
+    "Recording error: %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recording error: %@"
+          }
+        }
+      }
+    },
+    "Ready to record a voice message": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ready to record a voice message"
+          }
+        }
+      }
+    },
+    "Grant microphone access": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grant microphone access"
+          }
+        }
+      }
+    },
+    "Microphone access is disabled. Enable it in app settings.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Microphone access is disabled. Enable it in app settings."
+          }
+        }
+      }
+    },
+    "Open settings": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open settings"
+          }
+        }
+      }
+    },
+    "Voice recording is unavailable during a call.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voice recording is unavailable during a call."
+          }
+        }
+      }
+    },
+    "Play voice message": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Play voice message"
+          }
+        }
+      }
+    },
+    "Pause voice message": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pause voice message"
+          }
+        }
+      }
+    },
+    "Loading voice message": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading voice message"
+          }
+        }
+      }
+    },
+    "Voice message unavailable": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voice message unavailable"
+          }
+        }
+      }
+    },
+    "Unsupported voice message": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unsupported voice message"
+          }
+        }
+      }
+    },
+    "%@ of %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ of %@"
+          }
+        }
+      }
+    },
+    "Unable to play voice message": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to play voice message"
+          }
+        }
+      }
+    },
+    "Voice message recording produced no audio.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voice message recording produced no audio."
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -1775,6 +1775,7 @@ public final class AppServices {
                         imageData: imageData,
                         imageFormat: imageFormat.isEmpty ? nil : imageFormat,
                         fileAttachments: fileAttachments,
+                        audioAttachment: nil,
                         iconAppearance: nil,
                         replyToMessageHashHex: nil,
                         replyQuotedContent: nil,

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -1741,6 +1741,8 @@ public final class AppServices {
             let imageFormat = (note.userInfo?["image_format"] as? String) ?? ""
             let fileHex = (note.userInfo?["file_hex"] as? String) ?? ""
             let fileName = (note.userInfo?["file_name"] as? String) ?? ""
+            let audioModeStr = (note.userInfo?["audio_mode"] as? String) ?? ""
+            let audioHex = (note.userInfo?["audio_hex"] as? String) ?? ""
             // Resolve delivery method. `direct`/`propagated` ride a Link or
             // a propagation node, respectively; everything else (including
             // empty) goes opportunistic — matches LXDeliveryMethod's three
@@ -1762,6 +1764,17 @@ public final class AppServices {
             } else {
                 fileAttachments = nil
             }
+            // FIELD_AUDIO (0x07) = [mode_int, bytes]. Accepts the mode as a
+            // hex ("0x10") or decimal ("16") string; the payload is hex. Bad
+            // input drops the field (loud in the inbound tap), never crashes.
+            let audioAttachment: RnsAudio?
+            if !audioHex.isEmpty,
+               let mode = Int(audioModeStr.isEmpty ? "0" : audioModeStr.replacingOccurrences(of: "0x", with: ""), radix: audioModeStr.lowercased().hasPrefix("0x") ? 16 : 10),
+               let data = try? audioHex.hexToData() {
+                audioAttachment = RnsAudio(mode: mode, bytes: data)
+            } else {
+                audioAttachment = nil
+            }
             Task { @MainActor in
                 guard let backend = self.backend else {
                     DiagLog.log("[TEST-SEND] no backend")
@@ -1775,7 +1788,7 @@ public final class AppServices {
                         imageData: imageData,
                         imageFormat: imageFormat.isEmpty ? nil : imageFormat,
                         fileAttachments: fileAttachments,
-                        audioAttachment: nil,
+                        audioAttachment: audioAttachment,
                         iconAppearance: nil,
                         replyToMessageHashHex: nil,
                         replyQuotedContent: nil,

--- a/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
@@ -27,6 +27,7 @@ public final class MessagingViewModel {
         let imageData: Data?
         let imageFormat: String?
         let fileAttachments: [RnsFileAttachment]?
+        let audioAttachment: RnsAudio?
         let iconAppearance: IconAppearance?
         let replyToMessageHashHex: String?
         let replyQuotedContent: String?
@@ -788,6 +789,7 @@ public final class MessagingViewModel {
             imageData: request.imageData,
             imageFormat: request.imageFormat,
             fileAttachments: request.fileAttachments,
+            audioAttachment: request.audioAttachment,
             iconAppearance: request.iconAppearance,
             replyToMessageHashHex: request.replyToMessageHashHex,
             replyQuotedContent: request.replyQuotedContent,
@@ -838,12 +840,15 @@ public final class MessagingViewModel {
         imageData: Data?,
         imageFormat: String?,
         attachments: [(name: String, data: Data)]?,
+        audioAttachment: AudioAttachment? = nil,
         replyToId: String? = nil,
         localRetryHash: Data? = nil,
         replacedStorageHash: Data? = nil
     ) async -> Bool {
         let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedText.isEmpty || imageData != nil || (attachments != nil && !attachments!.isEmpty) else {
+        guard !trimmedText.isEmpty || imageData != nil
+              || (attachments != nil && !attachments!.isEmpty)
+              || audioAttachment != nil else {
             return false
         }
 
@@ -886,6 +891,14 @@ public final class MessagingViewModel {
         // Add file attachments field (FIELD_FILE_ATTACHMENTS = 0x05): [[name, data], ...]
         if let attachments, !attachments.isEmpty {
             fields[LXMessage.FIELD_FILE_ATTACHMENTS] = attachments.map { [$0.name, $0.data] as [Any] } as [Any]
+        }
+
+        // Add audio field (FIELD_AUDIO = 0x07): [mode_int, bytes]. Written to
+        // the LOCAL field map so it persists in packedLxmf and survives a
+        // reload / retry rehydration; the SAME attachment is also passed as a
+        // typed param to the wire send below (see OutboundSendRequest).
+        if let audioAttachment {
+            fields[LXMessage.FIELD_AUDIO] = audioAttachment.fieldValue
         }
 
         // Add reply reference (FIELD_APP_DATA = 0x10)
@@ -944,6 +957,7 @@ public final class MessagingViewModel {
             imageData: imageData,
             imageFormat: imageFormat,
             attachments: attachments?.map { FileAttachment(name: $0.name, data: $0.data) },
+            audioAttachment: audioAttachment,
             replyToId: replyToId,
             replyToPreview: replyPreview,
             storageHash: localRetryHash,
@@ -980,6 +994,7 @@ public final class MessagingViewModel {
                     fileAttachments: attachments?.map {
                         RnsFileAttachment(name: $0.name, data: $0.data)
                     },
+                    audioAttachment: audioAttachment.map { RnsAudio(mode: Int($0.mode.rawValue), bytes: $0.bytes) },
                     iconAppearance: icon,
                     replyToMessageHashHex: replyToId,
                     replyQuotedContent: replyPreview,
@@ -1069,6 +1084,7 @@ public final class MessagingViewModel {
                             fileAttachments: attachments?.map {
                                 RnsFileAttachment(name: $0.name, data: $0.data)
                             },
+                            audioAttachment: audioAttachment.map { RnsAudio(mode: Int($0.mode.rawValue), bytes: $0.bytes) },
                             iconAppearance: icon,
                             replyToMessageHashHex: replyToId,
                             replyQuotedContent: replyPreview,
@@ -1172,6 +1188,7 @@ public final class MessagingViewModel {
                             imageData: imageData,
                             imageFormat: imageFormat,
                             attachments: attachments?.map { FileAttachment(name: $0.name, data: $0.data) },
+                            audioAttachment: audioAttachment,
                             replyToId: replyToId,
                             replyToPreview: replyPreview
                         )
@@ -1237,6 +1254,7 @@ public final class MessagingViewModel {
                 imageData: failedMessage.imageData,
                 imageFormat: failedMessage.imageFormat,
                 attachments: failedMessage.attachments?.map { (name: $0.name, data: $0.data) },
+                audioAttachment: failedMessage.audioAttachment,
                 replyToId: failedMessage.replyToId
             )
             return
@@ -1261,6 +1279,7 @@ public final class MessagingViewModel {
             imageData: failedMessage.imageData,
             imageFormat: failedMessage.imageFormat,
             attachments: failedMessage.attachments?.map { (name: $0.name, data: $0.data) },
+            audioAttachment: failedMessage.audioAttachment,
             replyToId: failedMessage.replyToId,
             localRetryHash: retryHash,
             replacedStorageHash: storedHash

--- a/Sources/ColumbaApp/Views/Messaging/MessageBubble.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageBubble.swift
@@ -43,6 +43,10 @@ struct MessageBubble: View {
     var onOpenFileAttachment: ((Int) -> Void)?
     /// Callback for opening delivery details from a failed status indicator.
     var onShowDeliveryFailure: (() -> Void)?
+    /// Shared voice player for field-7 audio messages (one per conversation
+    /// screen, so a single voice message plays at a time). nil means the
+    /// bubble cannot offer playback (audio is rendered as unavailable).
+    var voicePlayer: VoiceMessagePlayer? = nil
 
     // MARK: - Theme (delegates to Theme/ThemeManager)
 
@@ -79,6 +83,18 @@ struct MessageBubble: View {
                                 .padding(.vertical, 4)
                         }
                         .buttonStyle(.plain)
+                    }
+
+                    // Voice message (field 7). Rendered above the text, with
+                    // its own play/waveform/progress surface.
+                    if message.audioAttachment != nil {
+                        if let voicePlayer {
+                            VoiceMessageBubble(message: message, player: voicePlayer)
+                        } else {
+                            // No player wired (e.g. a preview): show the
+                            // non-playable attachment so the bubble is not blank.
+                            VoiceMessageBubbleUnavailable()
+                        }
                     }
 
                     // Inline image
@@ -338,6 +354,7 @@ public struct Message: Identifiable, Equatable {
     public var imageData: Data?
     public var imageFormat: String?
     public var attachments: [FileAttachment]?
+    public var audioAttachment: AudioAttachment?
 
     // Metadata for message details
     public var deliveryMethod: String?
@@ -375,7 +392,18 @@ public struct Message: Identifiable, Equatable {
 
     /// True if message has no visible content (telemetry-only messages).
     public var isEmpty: Bool {
-        content.isEmpty && imageData == nil && (attachments == nil || attachments!.isEmpty)
+        content.isEmpty && imageData == nil
+            && (attachments == nil || attachments!.isEmpty)
+            && audioAttachment == nil
+    }
+
+    /// Decode `FIELD_AUDIO` (0x07) `[mode, bytes]` from a field map, lenient
+    /// on the integer type of the mode element. Returns nil when the field is
+    /// absent or malformed; a `.custom` (unsupported) mode still yields an
+    /// attachment the UI renders as a non-playable bubble.
+    static func audioAttachment(from fields: [UInt8: Any]?) -> AudioAttachment? {
+        guard let fields else { return nil }
+        return AudioAttachment.fromWireValue(fields[LXMessage.FIELD_AUDIO])
     }
 
     /// Create a new message.
@@ -389,6 +417,7 @@ public struct Message: Identifiable, Equatable {
         imageData: Data? = nil,
         imageFormat: String? = nil,
         attachments: [FileAttachment]? = nil,
+        audioAttachment: AudioAttachment? = nil,
         replyToId: String? = nil,
         replyToPreview: String? = nil,
         reactions: [ReactionDisplay] = [],
@@ -404,6 +433,7 @@ public struct Message: Identifiable, Equatable {
         self.imageData = imageData
         self.imageFormat = imageFormat
         self.attachments = attachments
+        self.audioAttachment = audioAttachment
         self.replyToId = replyToId
         self.replyToPreview = replyToPreview
         self.reactions = reactions
@@ -467,6 +497,10 @@ public struct Message: Identifiable, Equatable {
             }
             if !atts.isEmpty { self.attachments = atts }
         }
+
+        // Extract audio field (0x07): [mode_int, bytes]. Lenient `[Int, Data]`
+        // acceptance; an unsupported mode still yields a (non-playable) bubble.
+        self.audioAttachment = Self.audioAttachment(from: lxMessage.fields)
 
         // Extract reply_to from FIELD_APP_DATA (0x10)
         if let appData = lxMessage.fields?[LXMessage.FIELD_APP_DATA] as? [String: Any],
@@ -610,6 +644,8 @@ public struct Message: Identifiable, Equatable {
                 }
                 if !atts.isEmpty { self.attachments = atts }
             }
+            // FIELD_AUDIO (0x07) = [mode_int, bytes]
+            self.audioAttachment = Self.audioAttachment(from: fields)
 
             // Fallback: extract reply_to from packed fields if DB column was nil
             if self.replyToId == nil,

--- a/Sources/ColumbaApp/Views/Messaging/MessageInputBar.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageInputBar.swift
@@ -181,6 +181,21 @@ struct MessageInputBar: View {
     var onSend: () -> Void
     var onImagePicker: () -> Void
     var onAttachment: () -> Void
+    /// Mic tap: opens the voice quality picker and, on confirm, starts
+    /// recording. nil hides the button (callers that don't support voice).
+    var onVoiceRecord: (() -> Void)? = nil
+    /// The composer's voice recorder. Non-nil while the voice panel is open
+    /// (after the quality picker confirms, until closed/removed/sent); nil
+    /// hides the draft row and the mic button is the entry point.
+    var voiceRecorder: VoiceMessageRecorder? = nil
+    /// The shared voice player for the draft-row preview playback.
+    var voicePlayer: VoiceMessagePlayer? = nil
+    /// Start recording with the chosen profile (from the panel's Start row).
+    var onVoiceStartRecording: ((VoiceMessageFormat) -> Void)? = nil
+    /// Remove the selected draft recording.
+    var onVoiceRemoveDraft: (() -> Void)? = nil
+    /// Close the voice panel (return to the normal composer).
+    var onVoiceClosePanel: (() -> Void)? = nil
 
     @AppStorage(ComposerKeyboardPreference.key)
     private var sendsOnReturn = ComposerKeyboardPreference.defaultValue
@@ -193,6 +208,17 @@ struct MessageInputBar: View {
         !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         || attachedImage != nil
         || !attachedFiles.isEmpty
+        || voiceDraftAudio != nil
+    }
+
+    /// The finalized, unsent voice recording (if any). nil while idle /
+    /// recording / finalizing, so Send stays disabled until a draft exists.
+    private var voiceDraftAudio: AudioAttachment? {
+        guard let voiceRecorder else { return nil }
+        if case .completed(let recording) = voiceRecorder.state {
+            return recording.audio
+        }
+        return nil
     }
 
     // MARK: - Body
@@ -269,6 +295,23 @@ struct MessageInputBar: View {
                 }
             }
 
+            // Voice draft row (ready / recording / finalizing / selected).
+            // Only present while the voice panel is open (the recorder is
+            // passed through); when the panel is closed, nil hides it and
+            // the mic button (in the action row) is the entry point.
+            if let voiceRecorder, let voicePlayer {
+                VoiceDraftRow(
+                    recorder: voiceRecorder,
+                    player: voicePlayer,
+                    onStart: { format in onVoiceStartRecording?(format) },
+                    onRemove: { onVoiceRemoveDraft?() },
+                    onClose: { onVoiceClosePanel?() }
+                )
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .transition(.opacity.combined(with: .move(edge: .bottom)))
+            }
+
             HStack(alignment: .bottom, spacing: 12) {
                 // Text field container
                 HStack(alignment: .bottom, spacing: 8) {
@@ -284,6 +327,20 @@ struct MessageInputBar: View {
 
                 // Action buttons
                 HStack(spacing: 12) {
+                    // Voice message (mic) button — opens the quality picker and
+                    // records a voice message. Hidden for callers that don't
+                    // support voice (onVoiceRecord == nil).
+                    if onVoiceRecord != nil {
+                        Button(action: { onVoiceRecord?() }) {
+                            Image(systemName: "mic")
+                                .font(.system(size: 20))
+                                .foregroundStyle(Theme.textSecondary)
+                        }
+                        .buttonStyle(ScaleButtonStyle())
+                        .accessibilityIdentifier("voice_message_button")
+                        .accessibilityLabel(String(localized: "Record a voice message"))
+                    }
+
                     // Image picker button
                     Button(action: onImagePicker) {
                         Image(systemName: "photo")

--- a/Sources/ColumbaApp/Views/Messaging/MessageTimelineView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageTimelineView.swift
@@ -86,6 +86,8 @@ struct MessageTimelineView: UIViewControllerRepresentable {
     let onOpenLink: (MessageLinkTarget) -> Void
     let onOpenImage: (Message) -> Void
     let onOpenFileAttachment: (Message, Int) -> Void
+    /// Shared voice player for field-7 audio messages in the timeline.
+    let voicePlayer: VoiceMessagePlayer?
 
     func makeUIViewController(context: Context) -> MessageTimelineViewController {
         let controller = MessageTimelineViewController()
@@ -96,6 +98,7 @@ struct MessageTimelineView: UIViewControllerRepresentable {
         controller.onLongPress = onLongPress
         controller.onShowDeliveryFailure = onShowDeliveryFailure
         controller.onOpenLink = onOpenLink
+        controller.voicePlayer = voicePlayer
         controller.setReactionMode(messageID: reactionModeMessageID)
         applyAttachmentCallbacks(to: controller)
         return controller
@@ -108,6 +111,7 @@ struct MessageTimelineView: UIViewControllerRepresentable {
         controller.onLongPress = onLongPress
         controller.onShowDeliveryFailure = onShowDeliveryFailure
         controller.onOpenLink = onOpenLink
+        controller.voicePlayer = voicePlayer
         controller.setReactionMode(messageID: reactionModeMessageID)
         applyAttachmentCallbacks(to: controller)
         controller.update(
@@ -135,6 +139,7 @@ final class MessageTimelineViewController: UIViewController, UICollectionViewDat
     var onOpenLink: ((MessageLinkTarget) -> Void)?
     var onOpenImage: ((Message) -> Void)?
     var onOpenFileAttachment: ((Message, Int) -> Void)?
+    var voicePlayer: VoiceMessagePlayer?
 
     private var messages: [Message] = []
     private var conversationID: String?
@@ -344,7 +349,8 @@ final class MessageTimelineViewController: UIViewController, UICollectionViewDat
                     },
                     onShowDeliveryFailure: { [weak self] in
                         self?.routeDeliveryFailure(messageID: message.id)
-                    }
+                    },
+                    voicePlayer: voicePlayer
                 )
             }
         }

--- a/Sources/ColumbaApp/Views/Messaging/MessageTimelineView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageTimelineView.swift
@@ -87,7 +87,8 @@ struct MessageTimelineView: UIViewControllerRepresentable {
     let onOpenImage: (Message) -> Void
     let onOpenFileAttachment: (Message, Int) -> Void
     /// Shared voice player for field-7 audio messages in the timeline.
-    let voicePlayer: VoiceMessagePlayer?
+    /// nil = voice-unavailable fallback (rendered non-playable).
+    let voicePlayer: VoiceMessagePlayer? = nil
 
     func makeUIViewController(context: Context) -> MessageTimelineViewController {
         let controller = MessageTimelineViewController()

--- a/Sources/ColumbaApp/Views/Messaging/MessageTimelineView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessageTimelineView.swift
@@ -88,7 +88,7 @@ struct MessageTimelineView: UIViewControllerRepresentable {
     let onOpenFileAttachment: (Message, Int) -> Void
     /// Shared voice player for field-7 audio messages in the timeline.
     /// nil = voice-unavailable fallback (rendered non-playable).
-    let voicePlayer: VoiceMessagePlayer? = nil
+    let voicePlayer: VoiceMessagePlayer?
 
     func makeUIViewController(context: Context) -> MessageTimelineViewController {
         let controller = MessageTimelineViewController()

--- a/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
@@ -794,6 +794,12 @@ struct MessagingView: View {
             flushDraft(for: .navigation)
             NotificationService.activeConversationThreadId = nil
             exitAttachmentInteractionState()
+            // Stop playback and release the audio session we may have taken
+            // for it: the view's player is per-conversation, so leaving while
+            // a voice message plays would otherwise strand the shared
+            // AVAudioSession active (other apps' interrupted audio couldn't
+            // resume). stopCurrent is a no-op when nothing is playing.
+            voicePlayer.stopCurrent()
         }
         .onChange(of: scenePhase) { oldPhase, newPhase in
             guard oldPhase == .active, newPhase != .active else { return }

--- a/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
@@ -955,7 +955,7 @@ struct MessagingView: View {
     private func openVoicePanel(format: VoiceMessageFormat) {
         selectedVoiceFormat = format
         voicePanelOpen = true
-        if AVAudioSession.sharedInstance().recordPermission() == .granted {
+        if AVAudioSession.sharedInstance().recordPermission == .granted {
             startVoiceRecording(format: format)
         }
     }

--- a/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
+++ b/Sources/ColumbaApp/Views/Messaging/MessagingView.swift
@@ -224,6 +224,24 @@ struct MessagingView: View {
     @State private var showQualityPicker = false
     @State private var pendingRawImage: UIImage?
     @State private var selectedImagePreset: SettingsViewModel.ImageQualityPreset = .high
+    // MARK: - Voice message state (issue #168)
+    /// Shared player for the timeline's field-7 audio bubbles (one per
+    /// conversation screen, so a single voice message plays at a time).
+    @State private var voicePlayer = VoiceMessagePlayer()
+    /// The composer's recorder (in-memory; a recording is a temp file until
+    /// sent, then the payload is in the message's field-7 attachment).
+    @State private var voiceRecorder = VoiceMessageRecorder()
+    /// The finalized, unsent voice recording (kept alongside the recorder so
+    /// `sendMessage` can capture it before the recorder is reset).
+    @State private var pendingVoice: AudioAttachment?
+    /// True while the voice quality picker is presented.
+    @State private var showVoiceQualityPicker = false
+    /// The profile selected in the voice quality picker (default = Medium).
+    @State private var selectedVoiceFormat: VoiceMessageFormat = .defaultFormat
+    /// True while the composer voice panel (VoiceDraftRow) is open: from the
+    /// quality picker's confirm until the recording is sent, removed, or the
+    /// panel is closed (mirrors Android's `showVoiceControls`).
+    @State private var voicePanelOpen = false
     @State private var isNearBottom = true
     /// One-shot flag so the post-load scroll-to-bottom only fires the
     /// first time messages populate. Subsequent message arrivals use
@@ -294,7 +312,8 @@ struct MessagingView: View {
                     },
                     onOpenLink: openMessageLink,
                     onOpenImage: openImageAttachment,
-                    onOpenFileAttachment: openFileAttachment
+                    onOpenFileAttachment: openFileAttachment,
+                    voicePlayer: voicePlayer
                 )
                 .safeAreaInset(edge: .bottom, spacing: 0) {
                     MessageInputBar(
@@ -305,7 +324,13 @@ struct MessagingView: View {
                         onDismissReply: { withAnimation(.easeInOut(duration: 0.25)) { vm.replyToMessage = nil } },
                         onSend: sendMessage,
                         onImagePicker: { showPhotoPicker = true },
-                        onAttachment: { showFilePicker = true }
+                        onAttachment: { showFilePicker = true },
+                        onVoiceRecord: { showVoiceQualityPicker = true },
+                        voiceRecorder: voicePanelOpen ? voiceRecorder : nil,
+                        voicePlayer: voicePlayer,
+                        onVoiceStartRecording: { format in startVoiceRecording(format: format) },
+                        onVoiceRemoveDraft: { voiceRecorder.removeSelected(); voicePanelOpen = false },
+                        onVoiceClosePanel: { voiceRecorder.cancel(); voicePanelOpen = false }
                     )
                     .photosPicker(isPresented: $showPhotoPicker, selection: $selectedPhotoItem, matching: .images)
                     .onChange(of: selectedPhotoItem) { _, newItem in
@@ -404,7 +429,8 @@ struct MessagingView: View {
                                         onOpenImage: { openImageAttachment(message) },
                                         onOpenFileAttachment: { index in
                                             openFileAttachment(message, index: index)
-                                        }
+                                        },
+                                        voicePlayer: voicePlayer
                                     )
                                 }
                                 .id(message.id)
@@ -454,7 +480,13 @@ struct MessagingView: View {
                             onDismissReply: { withAnimation(.easeInOut(duration: 0.25)) { vm.replyToMessage = nil } },
                             onSend: sendMessage,
                             onImagePicker: { showPhotoPicker = true },
-                            onAttachment: { showFilePicker = true }
+                            onAttachment: { showFilePicker = true },
+                            onVoiceRecord: { showVoiceQualityPicker = true },
+                            voiceRecorder: voicePanelOpen ? voiceRecorder : nil,
+                            voicePlayer: voicePlayer,
+                            onVoiceStartRecording: { format in startVoiceRecording(format: format) },
+                            onVoiceRemoveDraft: { voiceRecorder.removeSelected(); voicePanelOpen = false },
+                            onVoiceClosePanel: { voiceRecorder.cancel(); voicePanelOpen = false }
                         )
                         .photosPicker(isPresented: $showPhotoPicker, selection: $selectedPhotoItem, matching: .images)
                         .onChange(of: selectedPhotoItem) { _, newItem in
@@ -632,6 +664,25 @@ struct MessagingView: View {
             // closures makes it fail with "unable to type-check in
             // reasonable time". Kept out of the body for that reason.
             imageQualityPickerSheet
+        }
+        // Voice message quality picker (issue #168). Confirm starts recording
+        // with the chosen profile; the recorder's draft row then shows above
+        // the composer.
+        .sheet(isPresented: $showVoiceQualityPicker) {
+            voiceQualityPickerSheet
+        }
+        // Keep `pendingVoice` in sync with the recorder's finalized draft so
+        // `sendMessage` can capture it (and clear it) without re-reading the
+        // recorder's observable state mid-send. Returning to `.idle` (cancel,
+        // remove, teardown) also closes the panel, mirroring Android's
+        // `showVoiceControls = false` on every cancel/close path.
+        .onChange(of: voiceRecorder.state) { _, newState in
+            if case .completed(let recording) = newState {
+                pendingVoice = recording.audio
+            } else if case .idle = newState {
+                pendingVoice = nil
+                voicePanelOpen = false
+            }
         }
         // Codec picker → place the voice call. The active/outgoing call UI
         // (VoiceCallScreen) is presented app-root in MainTabView off
@@ -872,6 +923,57 @@ struct MessagingView: View {
         .presentationDragIndicator(.visible)
     }
 
+    // Voice-quality bottom sheet height, scaled by Dynamic Type (same pattern
+    // as the image-quality sheet, issue #181).
+    @ScaledMetric(relativeTo: .body) private var voiceQualitySheetHeight: CGFloat = 360
+
+    // Voice-quality bottom sheet (issue #168). Confirm closes the picker and
+    // starts the recorder with the chosen profile; the recorder's draft row
+    // then appears above the composer. Start failures surface in the recorder
+    // state (the draft row shows the error).
+    private var voiceQualityPickerSheet: some View {
+        VoiceQualityPickerSheet(
+            sheetHeight: voiceQualitySheetHeight,
+            selectedFormat: $selectedVoiceFormat,
+            onConfirm: { format in
+                showVoiceQualityPicker = false
+                openVoicePanel(format: format)
+            },
+            onCancel: {
+                showVoiceQualityPicker = false
+            }
+        )
+        .presentationDetents([.height(voiceQualitySheetHeight)])
+        .presentationDragIndicator(.visible)
+    }
+
+    /// The quality picker's confirm (Android `QualitySelectionDialog.onConfirm`):
+    /// remember the format, open the voice panel, and start recording when the
+    /// microphone is already permitted. Otherwise the panel shows its
+    /// permission row and Start is a no-op until the user grants access (the
+    /// recorder's `.failed` + "not supported" surfaces any device limitation).
+    private func openVoicePanel(format: VoiceMessageFormat) {
+        selectedVoiceFormat = format
+        voicePanelOpen = true
+        if AVAudioSession.sharedInstance().recordPermission() == .granted {
+            startVoiceRecording(format: format)
+        }
+    }
+
+    /// Start recording a voice message with the chosen profile. A capture or
+    /// permission failure is reflected in `voiceRecorder` state (the panel's
+    /// ready row shows the error; `lastFailureWasUnsupported` shows the
+    /// dedicated unsupported row).
+    private func startVoiceRecording(format: VoiceMessageFormat) {
+        do {
+            _ = try voiceRecorder.start(format: format)
+        } catch {
+            // `start` already set the recorder's `.failed` state +
+            // `errorMessage`; nothing else to do (the panel surfaces it).
+            logger.info("Voice recording start failed: \(error.localizedDescription)")
+        }
+    }
+
     @State private var isSyncing = false
 
     #if os(iOS)
@@ -1105,6 +1207,9 @@ struct MessagingView: View {
         let text = messageText.trimmingCharacters(in: .whitespacesAndNewlines)
         let image = attachedImage
         let files = attachedFiles
+        // Voice draft (if a recording is finalized and selected in the
+        // composer). Captured now so the recorder reset below doesn't race it.
+        let voice = pendingVoice
         let replyTarget = viewModel?.replyToMessage
         let replyToId: String? = {
             guard let target = replyTarget,
@@ -1113,7 +1218,7 @@ struct MessagingView: View {
             return hash.map { String(format: "%02x", $0) }.joined()
         }()
 
-        guard !text.isEmpty || image != nil || !files.isEmpty else { return }
+        guard !text.isEmpty || image != nil || !files.isEmpty || voice != nil else { return }
 
         if let composerLifecycle {
             composerLifecycle.clearForSend {
@@ -1125,6 +1230,10 @@ struct MessagingView: View {
         }
         attachedImage = nil
         attachedFiles = []
+        // Clear the draft (also clears the recorder's selected recording and
+        // its temp file via removeSelected()).
+        pendingVoice = nil
+        voiceRecorder.removeSelected()
         withAnimation(.easeInOut(duration: 0.25)) {
             viewModel?.replyToMessage = nil
         }
@@ -1150,6 +1259,7 @@ struct MessagingView: View {
                 imageData: imageData,
                 imageFormat: imageFormat,
                 attachments: fileAttachments,
+                audioAttachment: voice,
                 replyToId: replyToId
             )
         }

--- a/Sources/ColumbaApp/Voice/AudioMode.swift
+++ b/Sources/ColumbaApp/Voice/AudioMode.swift
@@ -1,0 +1,168 @@
+//
+//  AudioMode.swift
+//  ColumbaApp
+//
+//  The canonical audio-mode values used in LXMF `FIELD_AUDIO` (0x07) =
+//  `[mode, bytes]`. These mirror the wire constants in RNSAPI's
+//  `LxmfFields.AM_*` (which match upstream LXMF and Android), and add the
+//  mapping between that WIRE numbering and the LXST `Codec2Mode` header-byte
+//  numbering, which are DIFFERENT schemes and must never be conflated.
+//
+
+import Foundation
+import RNSAPI
+import LXSTSwift
+
+/// A canonical LXMF `FIELD_AUDIO` mode.
+///
+/// The raw value is the on-wire integer (see `LxmfFields.AM_*`). Codec2 modes
+/// carry their bitrate so the two numbering schemes (wire mode vs LXST
+/// `Codec2Mode` header byte) can be reconciled by bitrate rather than raw
+/// value:
+///
+///   | mode             | wire | Codec2Mode header |
+///   | ---------------- | ---- | ----------------- |
+///   | codec2 700C      | 0x03 | 0x00              |
+///   | codec2 1200      | 0x04 | 0x01              |
+///   | codec2 1300      | 0x05 | 0x02              |
+///   | codec2 1400      | 0x06 | 0x03              |
+///   | codec2 1600      | 0x07 | 0x04              |
+///   | codec2 2400      | 0x08 | 0x05              |
+///   | codec2 3200      | 0x09 | 0x06              |
+///   | opus (ogg)       | 0x10 | -                 |
+///   | custom           | 0xFF | -                 |
+public enum AudioMode: UInt8, Equatable, Hashable, Sendable {
+    case codec2_450PWB = 0x01
+    case codec2_450 = 0x02
+    case codec2_700C = 0x03
+    case codec2_1200 = 0x04
+    case codec2_1300 = 0x05
+    case codec2_1400 = 0x06
+    case codec2_1600 = 0x07
+    case codec2_2400 = 0x08
+    case codec2_3200 = 0x09
+    case opusOgg = 0x10
+    case custom = 0xFF
+
+    /// True for every Codec2 mode (the payload is a raw Codec2 frame
+    /// concatenation, not an Ogg file).
+    public var isCodec2: Bool {
+        switch self {
+        case .codec2_450PWB, .codec2_450, .codec2_700C, .codec2_1200,
+             .codec2_1300, .codec2_1400, .codec2_1600, .codec2_2400,
+             .codec2_3200:
+            return true
+        case .opusOgg, .custom:
+            return false
+        }
+    }
+
+    /// The Codec2 bitrate (bps) for Codec2 modes, else nil.
+    public var codec2Bitrate: Int? {
+        switch self {
+        case .codec2_450PWB: return 450
+        case .codec2_450: return 450
+        case .codec2_700C: return 700
+        case .codec2_1200: return 1200
+        case .codec2_1300: return 1300
+        case .codec2_1400: return 1400
+        case .codec2_1600: return 1600
+        case .codec2_2400: return 2400
+        case .codec2_3200: return 3200
+        case .opusOgg, .custom: return nil
+        }
+    }
+
+    /// The LXST `Codec2Mode` (header-byte numbering) this wire mode maps to,
+    /// resolved by bitrate. nil for non-Codec2 modes and for Codec2 rates
+    /// LXST does not implement (450/450PWB are not in LXST `Codec2Mode`).
+    public var codec2Mode: Codec2Mode? {
+        switch self {
+        case .codec2_700C: return .codec2_700C
+        case .codec2_1200: return .codec2_1200
+        case .codec2_1300: return .codec2_1300
+        case .codec2_1400: return .codec2_1400
+        case .codec2_1600: return .codec2_1600
+        case .codec2_2400: return .codec2_2400
+        case .codec2_3200: return .codec2_3200
+        case .opusOgg, .custom, .codec2_450PWB, .codec2_450: return nil
+        }
+    }
+
+    /// The single-byte Codec2 header value (LXST `Codec2Mode.rawValue`) that
+    /// must PREFIX the raw frames when decoding, and that LXST `encode`
+    /// prepends and we strip when writing. nil for non-Codec2 modes.
+    public var codec2HeaderByte: UInt8? { codec2Mode?.rawValue }
+
+    /// Build an `AudioMode` from an on-wire integer, accepting any canonical
+    /// value. Unknown / non-canonical bytes map to `.custom` so a message with
+    /// an unrecognized mode still renders (as non-playable) instead of being
+    /// dropped.
+    public init?(wireValue: Int) {
+        guard let raw = UInt8(exactly: UInt64(wireValue & 0xFF)) else { return nil }
+        // Accept only canonical values; anything else is `.custom`.
+        switch raw {
+        case 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x10, 0xFF:
+            self = AudioMode(rawValue: raw)!
+        default:
+            self = .custom
+        }
+    }
+}
+
+/// A stored voice-message attachment, decoded from `FIELD_AUDIO`
+/// (`[mode, bytes]`) or produced by the recorder before send.
+///
+/// The payload encoding is dictated by `mode`:
+///   - Codec2 modes: raw concatenation of complete Codec2 frames (NO header
+///     byte; the mode is known from `mode`, not from a header byte).
+///   - `.opusOgg`: a valid Ogg/Opus file (the `bytes` ARE the `.ogg`).
+public struct AudioAttachment: Equatable, Sendable {
+    public let mode: AudioMode
+    public let bytes: Data
+    /// Decoded duration in milliseconds (best-effort; nil if not yet computed).
+    public var durationMs: Int?
+    public var sizeBytes: Int
+
+    public init(mode: AudioMode, bytes: Data, durationMs: Int? = nil) {
+        self.mode = mode
+        self.bytes = bytes
+        self.durationMs = durationMs
+        self.sizeBytes = bytes.count
+    }
+
+    /// Decoded duration in seconds (best-effort; 0 when not yet computed).
+    public var durationSeconds: Double {
+        guard let ms = durationMs, ms > 0 else { return 0 }
+        return Double(ms) / 1000.0
+    }
+
+    /// The `FIELD_AUDIO` wire value: `[mode, bytes]`.
+    public var fieldValue: [Any] { [mode.rawValue, bytes] }
+
+    /// Extract an `AudioAttachment` from a decoded `FIELD_AUDIO` value
+    /// (`[Int, Data]`). Accepts the canonical array form leniently: the mode
+    /// may arrive as any signed/unsigned integer and the payload must be
+    /// `Data`. Returns nil when the shape is not recognized (the caller then
+    /// renders a non-playable "unsupported voice message" bubble).
+    public static func fromWireValue(_ value: Any?) -> AudioAttachment? {
+        guard let arr = value as? [Any], arr.count >= 2 else { return nil }
+        // The mode is the first element; accept it as any integer type.
+        let modeValue: Int
+        switch arr[0] {
+        case let i as Int: modeValue = i
+        case let i as Int8: modeValue = Int(i)
+        case let i as Int16: modeValue = Int(i)
+        case let i as Int32: modeValue = Int(i)
+        case let i as Int64: modeValue = Int(i)
+        case let u as UInt8: modeValue = Int(u)
+        case let u as UInt16: modeValue = Int(u)
+        case let u as UInt32: modeValue = Int(u)
+        case let u as UInt64: modeValue = Int(u)
+        default: return nil
+        }
+        guard let mode = AudioMode(wireValue: modeValue) else { return nil }
+        guard let data = arr[1] as? Data else { return nil }
+        return AudioAttachment(mode: mode, bytes: data)
+    }
+}

--- a/Sources/ColumbaApp/Voice/Codec2RawFile.swift
+++ b/Sources/ColumbaApp/Voice/Codec2RawFile.swift
@@ -1,0 +1,175 @@
+//
+//  Codec2RawFile.swift
+//  ColumbaApp
+//
+//  Codec2 voice-message file codec. The on-disk / on-wire Codec2 payload is a
+//  RAW concatenation of complete Codec2 frames — NO telephone profile/mode
+//  header byte and NO Ogg wrap (the mode is carried in the `FIELD_AUDIO`
+//  `[mode, bytes]` tuple, not in the payload). This matches Android Columba's
+//  `Codec2VoiceRecorderBackend`, which writes each frame's bytes straight to
+//  the `.c2` file with no header, and Python LXST / Sideband, which decode the
+//  raw frames given the mode.
+//
+//  LXSTSwift's `Codec2Codec.encode` PREPENDS a mode-header byte and
+//  `decode` EXPECTS one — so we strip the header byte on write and prefix it
+//  (the `AudioMode.codec2HeaderByte` = `Codec2Mode.rawValue`, a DIFFERENT
+//  numbering from the wire mode) on decode. The header byte is never stored in
+//  the file or sent on the wire.
+//
+
+import Foundation
+import LXSTSwift
+
+/// Decoded Codec2 PCM (8 kHz mono int16).
+public struct DecodedCodec2 {
+    public let samples: [Int16]
+    public let sampleRateHz: Int
+    public var durationMs: Int { (samples.count * 1_000) / sampleRateHz }
+}
+
+public enum Codec2FileError: Error, Equatable {
+    case incompleteFrame          // payload is not a whole number of frames
+    case noFrames                 // payload is empty
+    case exceedsDecodeCeiling     // would exceed the 5-minute decoded-sample ceiling
+    case emptyPcm
+}
+
+public enum Codec2RawFile {
+
+    /// Codec2 fixed input/output rate (all modes).
+    public static let sampleRate = 8_000
+    /// 5-minute decoded-sample ceiling (matches Android's `MAX_DECODED_SAMPLES`
+    /// = INPUT_RATE * 60 * 5). Checked in WIDE arithmetic before allocating the
+    /// decoded buffer, so a small hostile payload cannot expand into unbounded
+    /// decoded memory.
+    public static let maxDecodedSamples: Int = sampleRate * 60 * 5
+
+    // MARK: - Encode (for the recorder)
+
+    /// Encode one full Codec2 frame of PCM and return its RAW frame bytes
+    /// (the leading mode-header byte that LXSTSwift prepends is stripped).
+    ///
+    /// - Parameters:
+    ///   - pcm: exactly `samplesPerFrame` mono int16 samples at 8 kHz.
+    ///   - codec: the `Codec2Codec` for the selected mode.
+    @discardableResult
+    public static func encodeFrame(
+        pcm: [Int16],
+        codec: Codec2Codec
+    ) throws -> Data {
+        guard !pcm.isEmpty else { throw Codec2FileError.emptyPcm }
+        let encoded = try codec.encode(pcm)
+        // Strip the leading mode-header byte LXSTSwift prepends.
+        return encoded.count > 1 ? Data(encoded.dropFirst()) : Data()
+    }
+
+    /// Encode a whole PCM buffer to the raw frame concatenation (header byte
+    /// stripped). Equivalent to encoding frame-by-frame and concatenating, but
+    /// a single call into LXSTSwift.
+    public static func encodeAll(
+        pcm: [Int16],
+        codec: Codec2Codec
+    ) throws -> Data {
+        guard !pcm.isEmpty else { throw Codec2FileError.emptyPcm }
+        let encoded = try codec.encode(pcm)
+        return encoded.count > 1 ? Data(encoded.dropFirst()) : Data()
+    }
+
+    // MARK: - Decode (for playback / metadata)
+
+    /// Decode a raw Codec2 frame concatenation back to 8 kHz mono PCM.
+    ///
+    /// The mode (from `AudioMode`) supplies the header byte that LXSTSwift's
+    /// decoder expects as the first byte; the header is prefixed here and never
+    /// present in the file/wire payload. Enforces the 5-minute decoded ceiling
+    /// before allocating.
+    public static func decode(
+        _ bytes: Data,
+        mode: AudioMode,
+        codec: Codec2Codec
+    ) throws -> DecodedCodec2 {
+        guard bytes.count > 0 else { throw Codec2FileError.noFrames }
+        guard let c2 = mode.codec2Mode else { throw Codec2FileError.noFrames } // not a Codec2 mode
+        guard let header = mode.codec2HeaderByte else { throw Codec2FileError.noFrames }
+        let geometry = geometry(for: c2)
+        guard geometry.bytesPerFrame > 0 else { throw Codec2FileError.incompleteFrame }
+        let frameCount = bytes.count / geometry.bytesPerFrame
+        guard frameCount > 0 else { throw Codec2FileError.incompleteFrame }
+        guard bytes.count % geometry.bytesPerFrame == 0 else { throw Codec2FileError.incompleteFrame }
+        // Wide-arithmetic ceiling check BEFORE allocating the output buffer.
+        let sampleCount = Int64(frameCount) * Int64(geometry.samplesPerFrame)
+        guard sampleCount <= Int64(maxDecodedSamples) else {
+            throw Codec2FileError.exceedsDecodeCeiling
+        }
+        let framed = Data([header]) + bytes
+        let samples = try codec.decode(framed)
+        return DecodedCodec2(samples: samples, sampleRateHz: sampleRate)
+    }
+
+    /// Convenience decode that constructs the codec from the mode (for the
+    /// playback / waveform / metadata paths, which only know the `AudioMode`).
+    @discardableResult
+    public static func decodePayload(
+        _ bytes: Data,
+        mode: AudioMode
+    ) throws -> DecodedCodec2 {
+        guard let c2 = mode.codec2Mode else { throw Codec2FileError.noFrames }
+        let codec = try Codec2Codec(mode: c2)
+        return try decode(bytes, mode: mode, codec: codec)
+    }
+
+    // MARK: - WAV bridge (for AVAudioPlayer)
+
+    /// Write decoded 8 kHz mono PCM16 to a WAV file (RIFF/WAVE). `AVAudioPlayer`
+    /// plays WAV; it cannot play raw Codec2 frames.
+    @discardableResult
+    public static func writeWave(_ decoded: DecodedCodec2, to url: URL) throws -> URL {
+        let sampleRate = decoded.sampleRateHz
+        let pcm = decoded.samples
+        let pcmByteCount = pcm.count * 2
+        var wav = Data(capacity: 44 + pcmByteCount)
+        wav.append(contentsOf: Array("RIFF".utf8))
+        wav.append(contentsOf: withLE32(36 + pcmByteCount))
+        wav.append(contentsOf: Array("WAVE".utf8))
+        wav.append(contentsOf: Array("fmt ".utf8))
+        wav.append(contentsOf: withLE32(16))     // fmt chunk size
+        wav.append(contentsOf: withLE16(1))      // PCM format
+        wav.append(contentsOf: withLE16(1))      // mono
+        wav.append(contentsOf: withLE32(sampleRate))
+        wav.append(contentsOf: withLE32(sampleRate * 2)) // byte rate
+        wav.append(contentsOf: withLE16(2))      // block align
+        wav.append(contentsOf: withLE16(16))     // bits per sample
+        wav.append(contentsOf: Array("data".utf8))
+        wav.append(contentsOf: withLE32(pcmByteCount))
+        for s in pcm {
+            wav.append(UInt8(s & 0xFF))
+            wav.append(UInt8((s >> 8) & 0xFF))
+        }
+        try wav.write(to: url)
+        return url
+    }
+
+    // MARK: - Codec geometry (static; LXSTSwift keeps samplesPerFrame/bytesPerFrame
+    // private, so we use the authoritative libcodec2 table. `bytesPerFrame` is
+    // self-consistent as bitrate × samplesPerFrame / 8000.)
+
+    /// (samplesPerFrame, bytesPerFrame) per Codec2 mode.
+    public static func geometry(for mode: Codec2Mode) -> (samplesPerFrame: Int, bytesPerFrame: Int) {
+        switch mode {
+        case .codec2_700C:  return (160, 14)
+        case .codec2_1200:  return (240, 36)
+        case .codec2_1300:  return (240, 39)
+        case .codec2_1400:  return (240, 42)
+        case .codec2_1600:  return (240, 48)
+        case .codec2_2400:  return (320, 96)
+        case .codec2_3200:  return (320, 128)
+        }
+    }
+
+    // MARK: - Endianness
+
+    private static func withLE16(_ v: Int) -> [UInt8] { [UInt8(v & 0xFF), UInt8((v >> 8) & 0xFF)] }
+    private static func withLE32(_ v: Int) -> [UInt8] {
+        [UInt8(v & 0xFF), UInt8((v >> 8) & 0xFF), UInt8((v >> 16) & 0xFF), UInt8((v >> 24) & 0xFF)]
+    }
+}

--- a/Sources/ColumbaApp/Voice/Codec2RawFile.swift
+++ b/Sources/ColumbaApp/Voice/Codec2RawFile.swift
@@ -89,9 +89,10 @@ public enum Codec2RawFile {
         codec: Codec2Codec
     ) throws -> DecodedCodec2 {
         guard bytes.count > 0 else { throw Codec2FileError.noFrames }
-        guard let c2 = mode.codec2Mode else { throw Codec2FileError.noFrames } // not a Codec2 mode
-        guard let header = mode.codec2HeaderByte else { throw Codec2FileError.noFrames }
-        let geometry = geometry(for: c2)
+        guard mode.codec2Mode != nil, let header = mode.codec2HeaderByte else {
+            throw Codec2FileError.noFrames // not a Codec2 mode
+        }
+        let geometry = geometry(of: codec)
         guard geometry.bytesPerFrame > 0 else { throw Codec2FileError.incompleteFrame }
         let frameCount = bytes.count / geometry.bytesPerFrame
         guard frameCount > 0 else { throw Codec2FileError.incompleteFrame }
@@ -149,21 +150,72 @@ public enum Codec2RawFile {
         return url
     }
 
-    // MARK: - Codec geometry (static; LXSTSwift keeps samplesPerFrame/bytesPerFrame
-    // private, so we use the authoritative libcodec2 table. `bytesPerFrame` is
-    // self-consistent as bitrate × samplesPerFrame / 8000.)
+    // MARK: - Codec geometry (derived from the LIVE codec)
+    //
+    // Android reads samplesPerFrame/bytesPerFrame straight from the native
+    // handle (NativeCodec2.getSamplesPerFrame/getFrameBytes). LXSTSwift reads
+    // the same live values at init but keeps them `private`, and it is a remote
+    // SPM dependency we do not fork. So we DERIVE the geometry from the codec
+    // itself: samplesPerFrame is the smallest PCM length that encodes to one
+    // frame (encode() throws below that), and bytesPerFrame is that one frame's
+    // byte count (minus the prepended mode-header byte). Result is cached per
+    // mode (keyed by the mode header byte). This guarantees the geometry always
+    // matches what the linked libcodec2 actually produces - no hardcoded table
+    // to drift. (An earlier hardcoded table computed bytesPerFrame in BITS,
+    // which was 8x too large and broke every Codec2 encode/decode assertion.)
 
-    /// (samplesPerFrame, bytesPerFrame) per Codec2 mode.
+    private static let geoLock = NSLock()
+    private static var geoCache: [UInt8: (samplesPerFrame: Int, bytesPerFrame: Int)] = [:]
+
+    /// Geometry for a codec already in the requested mode (preferred: avoids
+    /// building a second codec instance).
+    public static func geometry(of codec: Codec2Codec) -> (samplesPerFrame: Int, bytesPerFrame: Int) {
+        let key = codec.modeHeader
+        geoLock.lock()
+        if let cached = geoCache[key] { geoLock.unlock(); return cached }
+        geoLock.unlock()
+        let derived = probeGeometry(codec)
+        geoLock.lock(); geoCache[key] = derived; geoLock.unlock()
+        return derived
+    }
+
+    /// Geometry for a mode (convenience: builds a codec, then derives).
     public static func geometry(for mode: Codec2Mode) -> (samplesPerFrame: Int, bytesPerFrame: Int) {
-        switch mode {
-        case .codec2_700C:  return (160, 14)
-        case .codec2_1200:  return (240, 36)
-        case .codec2_1300:  return (240, 39)
-        case .codec2_1400:  return (240, 42)
-        case .codec2_1600:  return (240, 48)
-        case .codec2_2400:  return (320, 96)
-        case .codec2_3200:  return (320, 128)
+        let key = UInt8(mode.rawValue)
+        geoLock.lock()
+        if let cached = geoCache[key] { geoLock.unlock(); return cached }
+        geoLock.unlock()
+        guard let codec = try? Codec2Codec(mode: mode) else {
+            return (0, 0) // fail closed: callers guard bytesPerFrame > 0
         }
+        let derived = probeGeometry(codec)
+        geoLock.lock(); geoCache[key] = derived; geoLock.unlock()
+        return derived
+    }
+
+    /// Find (samplesPerFrame, bytesPerFrame) by probing the live codec.
+    /// `encode(N)` throws exactly when N < samplesPerFrame (fewer than one
+    /// frame), so binary-searching the success boundary yields samplesPerFrame.
+    /// Then encode exactly that many samples and measure the frame's byte count
+    /// (minus the leading mode-header byte LXSTSwift prepends).
+    private static func probeGeometry(_ codec: Codec2Codec) -> (samplesPerFrame: Int, bytesPerFrame: Int) {
+        guard (try? codec.encode(probePCM(4096))) != nil else { return (0, 0) }
+        var lo = 1, hi = 4096
+        while lo < hi {
+            let mid = (lo + hi) / 2
+            if (try? codec.encode(probePCM(mid))) != nil { hi = mid } else { lo = mid + 1 }
+        }
+        let spf = lo
+        guard let full = try? codec.encode(probePCM(spf)), full.count > 1 else { return (0, 0) }
+        return (spf, full.count - 1) // drop the leading mode-header byte
+    }
+
+    /// Deterministic probe PCM (content is irrelevant; encode only cares about
+    /// the sample count relative to samplesPerFrame).
+    private static func probePCM(_ n: Int) -> [Int16] {
+        var a = [Int16](repeating: 0, count: n)
+        for i in 0..<n { a[i] = Int16((i * 37) % 2000 - 1000) }
+        return a
     }
 
     // MARK: - Endianness

--- a/Sources/ColumbaApp/Voice/OggOpusFileWriter.swift
+++ b/Sources/ColumbaApp/Voice/OggOpusFileWriter.swift
@@ -161,7 +161,7 @@ public final class OggOpusFileWriter {
     private func appendPage(payload: [UInt8], lacing: [UInt8], granule: UInt64, bos: Bool) throws {
         guard lacing.count >= 1, lacing.count <= 255 else { throw OggOpusFileError("lacing-range") }
         var header = [UInt8](repeating: 0, count: OggOpusGranule.oggHeaderSize)
-        header[0..<4] = OggOpusGranule.capturePattern
+        header.replaceSubrange(0..<4, with: OggOpusGranule.capturePattern)
         header[4] = 0x02                       // version
         header[5] = bos ? 0x02 : 0x00          // flags: 0x02 = begin of stream
         for i in 0..<8 { header[6 + i] = UInt8((granule >> (i * 8)) & 0xFF) }
@@ -207,8 +207,10 @@ public final class OggOpusFileWriter {
             throw error
         }
         do {
+            var resulting: URL?
             try FileManager.default.replaceItem(at: url, withItemAt: tmp,
-                                                backingItemURL: nil, options: [])
+                                                backupItemName: nil,
+                                                resultingItemURL: &resulting)
         } catch {
             // Fall back to a plain replace if the filesystem refuses.
             try? FileManager.default.removeItem(at: url)

--- a/Sources/ColumbaApp/Voice/OggOpusFileWriter.swift
+++ b/Sources/ColumbaApp/Voice/OggOpusFileWriter.swift
@@ -1,0 +1,220 @@
+//
+//  OggOpusFileWriter.swift
+//  ColumbaApp
+//
+//  Minimal Ogg/Opus muxer for stored voice messages. iOS has no system
+//  "record to Ogg/Opus" API, so Columba owns the container writer here.
+//
+//  The container is kept deliberately small: an OpusHead (identification) page,
+//  an OpusTags (comment) page, then audio pages carrying 60 ms Opus frames. A
+//  single Opus packet may span several pages (a 60 ms frame at ≥16 kbps can
+//  exceed one page's 255-byte payload limit); the packet's FINAL page carries
+//  the granule, its continuation pages carry -1.
+//
+//  INTEROP (the load-bearing part): every packet's granule is the CUMULATIVE
+//  END-OF-PACKET 48 kHz sample count, computed with the pure
+//  `OggOpusGranule.packetSamples48k`. This is precisely the layout Android's
+//  `OggOpusAndroidTimestampNormalizer` rewrites MediaRecorder output into, so
+//  the normalizer is a NO-OP on our output — the condition that makes the file
+//  playable by Sideband's LXST/libopusfile path. (MediaRecorder emitted
+//  packet-START granules starting at 0 that libopusfile rejects with
+//  OP_EBADTIMESTAMP; we emit end-of-packet directly, so we are Sideband-
+//  compatible on the first build. A unit test asserts the no-op property.)
+//
+//  `preSkip` is the encoder delay (48 kHz samples) recorded into OpusHead. A
+//  decoder discards that many leading samples. It is passed in by the recorder
+//  (derived from the libopus VOIP encoder's `OPUS_GET_LOOKAHEAD`, see
+//  `OggOpusWriter.preSkipForProfile`) and is a quality detail, not an interop
+//  one (granules are what drive the Sideband path).
+//
+
+import Foundation
+
+public struct OggOpusFileError: Error, Equatable {
+    public let code: String
+    public init(_ code: String) { self.code = code }
+}
+
+/// Builds an Ogg/Opus file byte stream from 60 ms Opus packets.
+///
+/// Pure: `appendPacket`/`finish` produce bytes; no I/O or AVFoundation here
+/// (the static `publishToDisk` helper is the only file-touching method).
+public final class OggOpusFileWriter {
+
+    public let channels: Int
+    /// Encoder delay (48 kHz samples) recorded into the OpusHead pre-skip field.
+    public let preSkip: Int
+    private let serial: UInt32
+    private var bytes: [UInt8] = []
+    private var pageSequence: Int32 = 0
+    /// Cumulative 48 kHz sample position = end of the last packet written.
+    private var cumulativeSamples: UInt64 = 0
+    private var packetsWritten = 0
+    private var finalGranule: UInt64 = 0
+
+    /// 8 MiB ceiling (matches the Android normalizer's `MAX_FILE_SIZE_BYTES`
+    /// and the playback metadata cap). Enforced in `finish` / `publishToDisk`.
+    public static let maxFileBytes = 8 * 1024 * 1024
+
+    /// The libopus VOIP encoder's `OPUS_GET_LOOKAHEAD` for the three Columba
+    /// Opus profiles. Derived from the vendored opus source
+    /// (`opus_encoder.c:2835-2845`): for `OPUS_APPLICATION_VOIP` the lookahead
+    /// is `Fs/400 + delay_compensation`, and `delay_compensation = Fs/250`
+    /// (`opus_encoder.c:282`), i.e. `Fs/100`. Hence 24 000/100 = 240 and
+    /// 48 000/100 = 480. (A `RESTRICTED_LOWDELAY` app would be `Fs/400`, but
+    /// Columba always uses the VOIP application.)
+    public static func preSkipForProfile(sampleRate: Int) -> Int {
+        max(1, sampleRate / 100)
+    }
+
+    public init(channels: Int, preSkip: Int, serial: UInt32? = nil) {
+        self.channels = channels
+        self.preSkip = preSkip
+        self.serial = serial ?? UInt32.random(in: 1...UInt32.max)
+        // All stored properties are now initialized; emit the two header pages
+        // (OpusHead on page 0 with the begin-of-stream flag, then OpusTags).
+        try? self.writeHeaderPages()
+    }
+
+    // MARK: - Header packets
+
+    /// Opus identification header (19 bytes): "OpusHead", version 1, channels,
+    /// pre-skip (16-bit LE), input sample rate (48 000, 32-bit LE), gain (0),
+    /// mapping family (0).
+    private func opusHead() -> [UInt8] {
+        var h = Array("OpusHead".utf8)
+        h.append(0x01)                       // version
+        h.append(UInt8(channels))            // channel count
+        h.append(UInt8(preSkip & 0xFF))      // pre-skip low byte (LE)
+        h.append(UInt8((preSkip >> 8) & 0xFF))
+        h.append(contentsOf: withLE32(48_000))
+        h.append(contentsOf: withLE16(0))    // output gain
+        h.append(0x00)                       // mapping family
+        return h
+    }
+
+    /// Opus comment header: "OpusTags", vendor-length (0), comment-count (0).
+    private func opusTags() -> [UInt8] {
+        var t = Array("OpusTags".utf8)
+        t.append(contentsOf: withLE32(0))
+        t.append(contentsOf: withLE32(0))
+        return t
+    }
+
+    // MARK: - Append
+
+    /// Append one 60 ms Opus packet on its OWN page, carrying the cumulative
+    /// end-of-packet granule. One packet per page is the exact layout Android's
+    /// Ogg normalizer rewrites to (and verifies: `packetCount == 1 &&
+    /// packetSize == payloadSize`), so our output is a normalizer no-op.
+    ///
+    /// A single Ogg page can hold up to 255 lacing values (255 × 255 = 65 025
+    /// bytes), which is far larger than any 60 ms Columba packet (≤ 240 bytes at
+    /// the 32 kbps ceiling), so no packet ever spans pages.
+    public func appendPacket(_ packet: [UInt8]) throws {
+        guard !packet.isEmpty else { throw OggOpusFileError("empty-packet") }
+        guard packet.count <= 255 * 255 else { throw OggOpusFileError("packet-too-large") }
+        let samples = try OggOpusGranule.packetSamples48k(packet)
+        cumulativeSamples += UInt64(samples)
+        packetsWritten += 1
+
+        // Split the packet into ≤255-byte lacing segments. A value of 255 means
+        // "full segment, continues"; the final segment (<255) terminates the
+        // packet. For a packet <255 bytes this is a single [count] lacing value.
+        var lacing: [UInt8] = []
+        var remaining = packet.count
+        while remaining >= 255 { lacing.append(255); remaining -= 255 }
+        lacing.append(UInt8(remaining))
+
+        try appendPage(payload: packet, lacing: lacing,
+                       granule: cumulativeSamples, bos: pageSequence == 0)
+    }
+
+    /// Finalize the stream. `bytes` is the complete Ogg/Opus file. Enforces the
+    /// size ceiling. (No trailing EOS page is required for libopusfile /
+    /// AVAudioPlayer.)
+    @discardableResult
+    public func finish() throws -> [UInt8] {
+        guard packetsWritten >= 1 else { throw OggOpusFileError("no-audio") }
+        finalGranule = cumulativeSamples
+        guard bytes.count <= OggOpusFileWriter.maxFileBytes else {
+            throw OggOpusFileError("size-limit")
+        }
+        return bytes
+    }
+
+    public var completedBytes: [UInt8] { bytes }
+    public var finalGranuleValue: UInt64 { finalGranule }
+    public var packets: Int { packetsWritten }
+
+    // MARK: - Page emission
+
+    /// Emit the OpusHead and OpusTags pages (granule -1) at the start of the
+    /// stream, before any audio page.
+    private func writeHeaderPages() throws {
+        try appendPage(payload: opusHead(), lacing: [UInt8(opusHead().count)],
+                       granule: OggOpusGranule.granuleUndefined, bos: true)
+        try appendPage(payload: opusTags(), lacing: [UInt8(opusTags().count)],
+                       granule: OggOpusGranule.granuleUndefined, bos: false)
+    }
+
+    private func appendPage(payload: [UInt8], lacing: [UInt8], granule: UInt64, bos: Bool) throws {
+        guard lacing.count >= 1, lacing.count <= 255 else { throw OggOpusFileError("lacing-range") }
+        var header = [UInt8](repeating: 0, count: OggOpusGranule.oggHeaderSize)
+        header[0..<4] = OggOpusGranule.capturePattern
+        header[4] = 0x02                       // version
+        header[5] = bos ? 0x02 : 0x00          // flags: 0x02 = begin of stream
+        for i in 0..<8 { header[6 + i] = UInt8((granule >> (i * 8)) & 0xFF) }
+        for i in 0..<4 { header[14 + i] = UInt8((serial >> (i * 8)) & 0xFF) }
+        for i in 0..<4 { header[18 + i] = UInt8((UInt32(pageSequence) >> (i * 8)) & 0xFF) }
+        header[26] = UInt8(lacing.count)
+
+        var page = header
+        page.append(contentsOf: lacing)
+        page.append(contentsOf: payload)
+
+        let crc = OggOpusGranule.oggChecksum(page, 0, page.count, zeroStoredChecksum: true)
+        for i in 0..<4 {
+            page[OggOpusGranule.checksumOffset + i] = UInt8((crc >> (i * 8)) & 0xFF)
+        }
+        bytes.append(contentsOf: page)
+        pageSequence += 1
+    }
+
+    private func withLE16(_ v: Int) -> [UInt8] { [UInt8(v & 0xFF), UInt8((v >> 8) & 0xFF)] }
+    private func withLE32(_ v: Int) -> [UInt8] {
+        [UInt8(v & 0xFF), UInt8((v >> 8) & 0xFF), UInt8((v >> 16) & 0xFF), UInt8((v >> 24) & 0xFF)]
+    }
+
+    // MARK: - Atomic, size-bounded publish (Android PR #1098 discipline)
+
+    /// Write `data` to `url` atomically: validate the size bound, write to a
+    /// temp file in the same directory, `synchronize`, replace the destination
+    /// (atomic where supported, plain replace otherwise), then best-effort
+    /// `synchronize` the directory. Never leaves a half-written file at `url`.
+    @discardableResult
+    public static func publishToDisk(_ data: Data, to url: URL) throws -> URL {
+        guard (1...OggOpusFileWriter.maxFileBytes).contains(data.count) else {
+            throw OggOpusFileError("size-limit")
+        }
+        let dir = url.deletingLastPathComponent()
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let tmp = dir.appendingPathComponent(".\u{200B}\(url.lastPathComponent).\(UUID().uuidString).tmp")
+        do {
+            try data.write(to: tmp, options: .atomic)
+        } catch {
+            try? FileManager.default.removeItem(at: tmp)
+            throw error
+        }
+        do {
+            try FileManager.default.replaceItem(at: url, withItemAt: tmp,
+                                                backingItemURL: nil, options: [])
+        } catch {
+            // Fall back to a plain replace if the filesystem refuses.
+            try? FileManager.default.removeItem(at: url)
+            try FileManager.default.moveItem(at: tmp, to: url)
+        }
+        try? FileManager.default.removeItem(at: tmp)
+        return url
+    }
+}

--- a/Sources/ColumbaApp/Voice/OggOpusFileWriter.swift
+++ b/Sources/ColumbaApp/Voice/OggOpusFileWriter.swift
@@ -162,7 +162,14 @@ public final class OggOpusFileWriter {
         guard lacing.count >= 1, lacing.count <= 255 else { throw OggOpusFileError("lacing-range") }
         var header = [UInt8](repeating: 0, count: OggOpusGranule.oggHeaderSize)
         header.replaceSubrange(0..<4, with: OggOpusGranule.capturePattern)
-        header[4] = 0x02                       // version
+        // OggS page-header version is ALWAYS 0 (the spec's only defined value).
+        // The begin-of-stream flag belongs in byte 5, not here. Writing 2 (an
+        // earlier bug) made every page reject in strict Ogg parsers - notably
+        // Sideband's libopusfile ("Invalid header page") and ffmpeg ("Invalid
+        // Ogg vers!"). iOS's own AVAudioPlayer is lenient about this byte, so
+        // the bug was invisible to our own player but broke every other
+        // receiver of our outbound Ogg. See OggOpusFileWriterTests.
+        header[4] = 0x00                       // version (OggS spec: 0)
         header[5] = bos ? 0x02 : 0x00          // flags: 0x02 = begin of stream
         for i in 0..<8 { header[6 + i] = UInt8((granule >> (i * 8)) & 0xFF) }
         for i in 0..<4 { header[14 + i] = UInt8((serial >> (i * 8)) & 0xFF) }

--- a/Sources/ColumbaApp/Voice/OggOpusFileWriter.swift
+++ b/Sources/ColumbaApp/Voice/OggOpusFileWriter.swift
@@ -207,7 +207,7 @@ public final class OggOpusFileWriter {
             throw error
         }
         do {
-            var resulting: URL?
+            var resulting: NSURL?
             try FileManager.default.replaceItem(at: url, withItemAt: tmp,
                                                 backupItemName: nil,
                                                 resultingItemURL: &resulting)

--- a/Sources/ColumbaApp/Voice/OggOpusGranule.swift
+++ b/Sources/ColumbaApp/Voice/OggOpusGranule.swift
@@ -1,0 +1,151 @@
+//
+//  OggOpusGranule.swift
+//  ColumbaApp
+//
+//  Pure Ogg/Opus page-granule arithmetic. The per-packet 48 kHz sample count
+//  (`packetSamples48k`) is ported bit-for-bit from Android Columba's
+//  `OggOpusAndroidTimestampNormalizer.opusPacketSamples` — the post-rollout
+//  Sideband-interop fix (PR #1098). The iOS Ogg writer (OggOpusFileWriter)
+//  emits granule positions computed with THIS exact function, so the writer's
+//  output is a no-op for the normalizer — which is precisely the condition
+//  that makes the file playable by Sideband's LXST/libopusfile path (the
+//  normalizer's output is the Sideband-proven layout). A unit test asserts the
+//  no-op property (see OggOpusFileWriterTests) and would catch any regression
+//  to packet-start granules before it ships.
+//
+//  This file is pure (no AVFoundation / no I/O) so the granule math is unit-
+//  testable on the host and in CI without an audio device.
+//
+
+import Foundation
+
+public enum OggOpusWriterError: Error, Equatable {
+    case emptyPacket
+    case truncatedMultiFrame
+    case invalidFrameCount
+    case invalidPacketDuration
+    case sizeLimitExceeded
+    case malformed
+}
+
+/// Pure Ogg/Opus granule + checksum math (shared by the writer and the
+/// validator test). No I/O, no AVFoundation.
+public enum OggOpusGranule {
+
+    /// Opus internal sample rate. Granule positions are ALWAYS in 48 kHz
+    /// samples (Ogg/Opus container invariant), regardless of the profile's
+    /// nominal input rate.
+    public static let sampleRate = 48_000
+
+    /// Ogg page header size in bytes.
+    public static let oggHeaderSize = 27
+    /// Offset of the 4-byte CRC within an Ogg page header.
+    public static let checksumOffset = 22
+    /// "OggS" capture pattern.
+    public static let capturePattern: [UInt8] = [0x4F, 0x67, 0x67, 0x53]
+
+    /// Number of 48 kHz samples represented by one Opus packet, decoded from
+    /// its TOC byte. Ported verbatim from Android's `opusPacketSamples`.
+    public static func packetSamples48k(_ packet: [UInt8]) throws -> Int {
+        guard let tocByte = packet.first else { throw OggOpusWriterError.emptyPacket }
+        let toc = Int(tocByte)
+
+        let frames: Int
+        switch toc & 0x03 {
+        case 0:      frames = 1
+        case 1, 2:   frames = 2
+        default:     // 3 -> N+1 encoded in the next byte
+            guard packet.count >= 2 else { throw OggOpusWriterError.truncatedMultiFrame }
+            frames = Int(packet[1] & 0x3F)
+        }
+        guard (1...48).contains(frames) else { throw OggOpusWriterError.invalidFrameCount }
+
+        let samplesPerFrame: Int
+        if toc & 0x80 != 0 {
+            // 48 kHz code (2.5/5/10/20 ms)
+            samplesPerFrame = (sampleRate << ((toc >> 3) & 0x03)) / 400
+        } else if toc & 0x60 == 0x60 {
+            // 20 ms fixed
+            samplesPerFrame = (toc & 0x08 != 0) ? sampleRate / 50 : sampleRate / 100
+        } else {
+            // code (5/10/20/60 ms)
+            let size = (toc >> 3) & 0x03
+            samplesPerFrame = (size == 3) ? sampleRate * 60 / 1_000 : (sampleRate << size) / 100
+        }
+
+        let total = frames * samplesPerFrame
+        // Bound a single packet's duration (120 ms ceiling) so a hostile or
+        // corrupt TOC cannot drive an unbounded granule / decode allocation.
+        let cap = sampleRate * 120 / 1_000
+        guard total >= 1, total <= cap else { throw OggOpusWriterError.invalidPacketDuration }
+        return total
+    }
+
+    // MARK: - Ogg CRC-32 (libogg-compatible, ported from the normalizer)
+
+    /// Ogg's CRC-32 lookup table (poly 0x04c11db7, init 0, no reflection, no
+    /// final XOR) — identical to libogg and to the Android normalizer's
+    /// `CRC_LOOKUP`.
+    public static let crcTable: [UInt32] = {
+        (0..<256).map { index -> UInt32 in
+            var value = UInt32(index) << 24
+            for _ in 0..<8 {
+                value = (value & 0x8000_0000) != 0 ? ((value << 1) ^ 0x04C1_1DB7) : (value << 1)
+            }
+            return value
+        }
+    }()
+
+    /// Compute the Ogg page CRC over `bytes[start..<end]`. When
+    /// `zeroStoredChecksum` is true the 4-byte stored-checksum field
+    /// (`start + checksumOffset ..< start + checksumOffset + 4`) is treated as
+    /// zero, as required to verify / (re)compute a page's own CRC.
+    public static func oggChecksum(
+        _ bytes: [UInt8],
+        _ start: Int,
+        _ end: Int,
+        zeroStoredChecksum: Bool = false
+    ) -> UInt32 {
+        var checksum: UInt32 = 0
+        var index = start
+        while index < end {
+            let inChecksumField = zeroStoredChecksum
+                && index >= start + checksumOffset
+                && index < start + checksumOffset + 4
+            let value = inChecksumField ? 0 : UInt32(bytes[index])
+            checksum = (checksum << 8) ^ crcTable[Int(((checksum >> 24) ^ value) & 0xFF)]
+            index += 1
+        }
+        return checksum
+    }
+
+    // MARK: - Little-endian helpers
+
+    public static func readIntLE(_ b: [UInt8], _ offset: Int) -> Int32 {
+        Int32(bitPattern: UInt32(b[offset])
+            | UInt32(b[offset + 1]) << 8
+            | UInt32(b[offset + 2]) << 16
+            | UInt32(b[offset + 3]) << 24)
+    }
+
+    public static func readUInt64LE(_ b: [UInt8], _ offset: Int) -> UInt64 {
+        var v: UInt64 = 0
+        for i in 0..<8 { v |= UInt64(b[offset + i]) << (i * 8) }
+        return v
+    }
+
+    /// The granule position is an INT64 in the Ogg page; libopusfile reads it
+    /// signed. -1 (0xFFFFFFFFFFFFFFFF) marks a header page with no granule.
+    public static var granuleUndefined: UInt64 { UInt64.max }
+
+    public static func writeIntLE(_ value: Int32, into b: inout [UInt8], _ offset: Int) {
+        b[offset]     = UInt8(value & 0xFF)
+        b[offset + 1] = UInt8((value >> 8) & 0xFF)
+        b[offset + 2] = UInt8((value >> 16) & 0xFF)
+        b[offset + 3] = UInt8((value >> 24) & 0xFF)
+    }
+
+    public static func writeUInt64LE(_ value: UInt64, into b: inout [UInt8], _ offset: Int) {
+        for i in 0..<8 { b[offset + i] = UInt8((value >> (i * 8)) & 0xFF) }
+    }
+}

--- a/Sources/ColumbaApp/Voice/OggOpusInboundNormalizer.swift
+++ b/Sources/ColumbaApp/Voice/OggOpusInboundNormalizer.swift
@@ -138,6 +138,11 @@ public enum OggOpusInboundNormalizer {
 
             if data[off + 4] != 0 { anyNonZeroVersionPage = true }
             let seg = Int(data[off + 26])
+            // The lacing table is attacker-controlled in size: validate that
+            // all `seg` entries exist before reading any of them (a page that
+            // declares more segments than remaining header bytes is
+            // malformed, not a reason to trap).
+            guard off + 27 + seg <= data.count else { throw NormalizeError.malformedPage }
             var payloadSize = 0
             for i in 0..<seg { payloadSize += Int(data[off + 27 + i]) }
             let payloadStart = off + 27 + seg

--- a/Sources/ColumbaApp/Voice/OggOpusInboundNormalizer.swift
+++ b/Sources/ColumbaApp/Voice/OggOpusInboundNormalizer.swift
@@ -1,0 +1,223 @@
+//
+//  OggOpusInboundNormalizer.swift
+//  ColumbaApp
+//
+//  Inbound Ogg/Opus normalization for stored voice messages.
+//
+//  WHY THIS EXISTS (the physical evidence, 2026-09-01):
+//
+//  iOS's AVAudioPlayer plays one-packet-per-page Ogg/Opus but REFUSES streams
+//  that pack many packets into one page. Verified byte-for-byte on the
+//  physical iPhone (and reproduced exactly by a local AVAudioPlayer harness):
+//
+//    - Android Columba "Medium Quality" (1 packet/page, 20 ms frames,
+//      cumulative granules, version=0)            -> PLAYS
+//    - iOS Columba's own recording (1 packet/page, version=0)     -> PLAYS
+//    - Sideband "High-quality voice" / PyOgg (up to ~103 packets
+//      packed per page, version=0)                -> "Voice message
+//      unavailable" (AVAudioPlayer.play() never reaches isPlaying)
+//
+//  The Sideband file is NOT malformed: libopusfile (Sideband's own decoder)
+//  and ffmpeg both decode it to the same sample count. It is a layout the
+//  iOS playback stack does not accept. The fix is to re-mux the inbound
+//  payload into the one-packet-per-page / cumulative-granule / version=0
+//  layout that iOS plays (and that Sideband/libopusfile also accept) before
+//  handing it to AVAudioPlayer. This is the defensive inbound pass that
+//  VoiceMessagePlayer's header comment anticipated.
+//
+//  The re-mux is a pure re-containerization: Opus packets are copied
+//  verbatim (no re-encode), so the decoded audio is bit-identical. Granules
+//  are recomputed as cumulative end-of-packet 48 kHz sample counts with the
+//  SAME arithmetic the outbound writer uses (OggOpusGranule.packetSamples48k),
+//  so the result is also a no-op for Android's normalizer.
+//
+//  When is a re-mux needed? Only when the stream deviates from the
+//  one-packet-per-page / cumulative-granule / version=0 layout: a page
+//  carrying more than one packet, a packet that spans a page boundary, or a
+//  non-zero page version byte. Streams already in the good layout (our own
+//  outbound, Android's, ffmpeg at typical settings) pass through UNCHANGED
+//  (returned as the same bytes) - so the common path costs a single page
+//  walk, not a full re-mux.
+//
+
+import Foundation
+
+/// Inbound Ogg/Opus re-muxer: converts non-canonical-layout streams into the
+/// one-packet-per-page / cumulative-granule / version=0 layout that iOS's
+/// AVAudioPlayer plays. Pure (no I/O, no AVFoundation) so it is unit-testable
+/// on the host. See the file header for the physical evidence.
+public enum OggOpusInboundNormalizer {
+
+    /// Size ceiling (matches the writer + metadata reader: 8 MiB).
+    public static let maxFileBytes = 8 * 1024 * 1024
+
+    /// Maximum pages we will walk / emit (guards a hostile stream).
+    private static let maxPages = 65_536
+
+    public struct NormalizationResult {
+        /// The bytes to play. Identical to the input when no re-mux was needed.
+        public let bytes: [UInt8]
+        /// True when the stream was re-muxed (layout changed), false when the
+        /// input already used the one-packet-per-page layout.
+        public let remuxed: Bool
+    }
+
+    public enum NormalizeError: Error, Equatable {
+        case empty
+        case notOgg
+        case missingOpusHead
+        case noAudioPackets
+        case malformedPage
+        case sizeLimitExceeded
+    }
+
+    /// Normalize an inbound Ogg/Opus payload for playback. Returns the input
+    /// unchanged when it is already one-packet-per-page / version=0; re-muxes
+    /// when any page carries more than one packet, a packet spans a page
+    /// boundary, or a page carries a non-zero version byte. Throws when the
+    /// bytes are not a decodable Ogg/Opus stream (the caller then surfaces
+    /// the existing unplayable error, unchanged).
+    public static func normalize(_ input: [UInt8]) throws -> NormalizationResult {
+        guard !input.isEmpty else { throw NormalizeError.empty }
+        guard input.count <= maxFileBytes else { throw NormalizeError.sizeLimitExceeded }
+        let parsed = try parseStream(input)
+        guard let head = parsed.head else { throw NormalizeError.missingOpusHead }
+        guard !parsed.audioPackets.isEmpty else { throw NormalizeError.noAudioPackets }
+
+        // Fast path: already one-packet-per-page, no spanning, version 0.
+        let needsRemux = parsed.anyMultiPacketPage
+            || parsed.anyPacketSpansPages
+            || parsed.anyNonZeroVersionPage
+        guard needsRemux else {
+            return NormalizationResult(bytes: input, remuxed: false)
+        }
+
+        // Re-mux: reuse the outbound writer's page emission (version=0, CRC,
+        // lacing, cumulative granules) so the output is guaranteed to be the
+        // exact layout the writer produces - the one AVAudioPlayer plays.
+        let remuxed = try remux(head: head, tags: parsed.tags, packets: parsed.audioPackets)
+        return NormalizationResult(bytes: remuxed, remuxed: true)
+    }
+
+    // MARK: - Parse
+
+    private struct Stream {
+        let head: [UInt8]?
+        let tags: [UInt8]?
+        let audioPackets: [[UInt8]]
+        let anyMultiPacketPage: Bool
+        let anyPacketSpansPages: Bool
+        let anyNonZeroVersionPage: Bool
+    }
+
+    /// Walk the page sequence and reassemble Opus packets across page
+    /// boundaries. Packet reassembly is the canonical Ogg rule: accumulate
+    /// lacing segments into a buffer and flush it as a complete packet the
+    /// first time a lacing value is < 255 (a 255 means the packet continues
+    /// into the next segment/page). This is layout-independent, so it works
+    /// for one-packet-per-page, many-packets-per-page, and spanning streams.
+    private static func parseStream(_ data: [UInt8]) throws -> Stream {
+        var head: [UInt8]?
+        var tags: [UInt8]?
+        var audioPackets: [[UInt8]] = []
+        var anyMultiPacketPage = false
+        var anyPacketSpansPages = false
+        var anyNonZeroVersionPage = false
+        var off = 0
+        var pageCount = 0
+        // Bytes of the in-progress packet (empty when no packet is open).
+        var carryover = [UInt8]()
+
+        while off < data.count {
+            guard off + 27 <= data.count,
+                  data[off] == 0x4F, data[off + 1] == 0x67,
+                  data[off + 2] == 0x67, data[off + 3] == 0x53
+            else { throw NormalizeError.malformedPage }
+            pageCount += 1
+            guard pageCount <= maxPages else { throw NormalizeError.sizeLimitExceeded }
+
+            if data[off + 4] != 0 { anyNonZeroVersionPage = true }
+            let seg = Int(data[off + 26])
+            var payloadSize = 0
+            for i in 0..<seg { payloadSize += Int(data[off + 27 + i]) }
+            let payloadStart = off + 27 + seg
+            let end = payloadStart + payloadSize
+            guard end <= data.count else { throw NormalizeError.malformedPage }
+
+            // Split this page's payload into complete packets by walking its
+            // lacing table. A page that completes >= 2 packets is a
+            // multi-packet page (the layout AVAudioPlayer rejects).
+            var flushedThisPage = 0
+            var pos = payloadStart
+            for i in 0..<seg {
+                let l = Int(data[off + 27 + i])
+                carryover.append(contentsOf: data[pos..<(pos + l)])
+                pos += l
+                if l < 255 {
+                    guard !carryover.isEmpty else { throw NormalizeError.malformedPage }
+                    classify(carryover, head: &head, tags: &tags, audio: &audioPackets)
+                    carryover.removeAll(keepingCapacity: true)
+                    flushedThisPage += 1
+                }
+            }
+            if flushedThisPage > 1 { anyMultiPacketPage = true }
+            // A non-empty carryover after this page's last segment means the
+            // in-progress packet's final segment was 255 (the packet
+            // continues into the next page) - one more layout AVAudioPlayer
+            // rejects. (This subsumes the page's continuation flag, which by
+            // the Ogg spec is set exactly when a page's last lacing is 255.)
+            if !carryover.isEmpty && end < data.count {
+                anyPacketSpansPages = true
+            }
+
+            off = end
+        }
+
+        if !carryover.isEmpty {
+            // Stream ended with a packet still open -> truncated.
+            throw NormalizeError.malformedPage
+        }
+        return Stream(head: head, tags: tags, audioPackets: audioPackets,
+                      anyMultiPacketPage: anyMultiPacketPage,
+                      anyPacketSpansPages: anyPacketSpansPages,
+                      anyNonZeroVersionPage: anyNonZeroVersionPage)
+    }
+
+    private static func classify(_ packet: [UInt8],
+                                 head: inout [UInt8]?,
+                                 tags: inout [UInt8]?,
+                                 audio: inout [[UInt8]]) {
+        let prefix8 = Array(packet.prefix(8))
+        if head == nil && prefix8 == Array("OpusHead".utf8) {
+            head = packet
+        } else if tags == nil && prefix8 == Array("OpusTags".utf8) {
+            tags = packet
+        } else {
+            audio.append(packet)
+        }
+    }
+
+    // MARK: - Re-mux
+
+    /// Emit OpusHead + OpusTags (fresh, canonical), then one Opus packet per
+    /// page with cumulative end-of-packet granules and version=0, using the
+    /// outbound writer so the page layout is identical to what iOS records.
+    /// `OggOpusFileWriter.appendPacket` re-validates each packet's TOC and
+    /// throws on an invalid one, so a hostile payload cannot produce a
+    /// decodable-but-corrupt re-mux.
+    private static func remux(head: [UInt8], tags: [UInt8]?, packets: [[UInt8]]) throws -> [UInt8] {
+        // Channels (OpusHead byte 9) and pre-skip (bytes 10-11, LE) carried
+        // over from the source header so the re-muxed file decodes to the
+        // same sample count with the same encoder-delay trim.
+        guard head.count >= 19 else { throw NormalizeError.missingOpusHead }
+        let channels = max(1, Int(head[9]))
+        let preSkip = Int(head[10]) | (Int(head[11]) << 8)
+
+        // Deterministic serial so the output is stable (and test-assertable).
+        let writer = OggOpusFileWriter(channels: channels, preSkip: preSkip, serial: 0xC010BA)
+        for packet in packets {
+            try writer.appendPacket(packet)
+        }
+        return try writer.finish()
+    }
+}

--- a/Sources/ColumbaApp/Voice/OggOpusInboundNormalizer.swift
+++ b/Sources/ColumbaApp/Voice/OggOpusInboundNormalizer.swift
@@ -197,6 +197,48 @@ public enum OggOpusInboundNormalizer {
         }
     }
 
+    // MARK: - Waveform (real amplitude for the bubble)
+
+    /// Pure bucketing + Android's exact display curve, over the per-frame
+    /// mono-folded energy of a decoded stream. Ported from Android
+    /// `PcmWaveformAccumulator.levels()`: each bar is the bucket RMS, then
+    /// `MIN_LEVEL(0.12) + (1 - 0.12) * (rms / peak)^0.7`, clamped to
+    /// `[0.12, 1.0]`. `preSkip` (encoder delay, 48 kHz samples) is trimmed so
+    /// the bars align with audible content. Pure (no codec / no I/O) so it is
+    /// unit-testable with synthetic energy; the AVAudioFile decode that feeds
+    /// it lives in `OggOpusWaveform`.
+    public static func peaksFromEnergy(
+        _ energyPerFrame: [Double], preSkip: Int, bars: Int
+    ) -> [Float] {
+        let minLevel = 0.12
+        let total = energyPerFrame.count
+        guard total > 0, bars >= 1 else { return [] }
+        // Index the usable (post-delay) portion of the timeline.
+        let skip = min(max(0, preSkip), total)
+        let usable = total - skip
+        guard usable > 0 else { return Array(repeating: Float(minLevel), count: bars) }
+
+        var bucketEnergy = [Double](repeating: 0, count: bars)
+        var bucketCount = [Int](repeating: 0, count: bars)
+        for i in skip..<total {
+            let usableIndex = i - skip
+            let bucket = min(bars - 1, (usableIndex * bars) / usable)
+            bucketEnergy[bucket] += energyPerFrame[i]
+            bucketCount[bucket] += 1
+        }
+        var rms = [Double](repeating: 0, count: bars)
+        for b in 0..<bars where bucketCount[b] > 0 {
+            rms[b] = sqrt(bucketEnergy[b] / Double(bucketCount[b]))
+        }
+        let peak = rms.max() ?? 0
+        guard peak > 0 else { return Array(repeating: Float(minLevel), count: bars) }
+        return rms.map { value in
+            guard value > 0 else { return Float(minLevel) }
+            let normalized = pow(value / peak, 0.7)
+            return Float(minLevel + (1 - minLevel) * normalized)
+        }
+    }
+
     // MARK: - Re-mux
 
     /// Emit OpusHead + OpusTags (fresh, canonical), then one Opus packet per

--- a/Sources/ColumbaApp/Voice/OggOpusMetadataReader.swift
+++ b/Sources/ColumbaApp/Voice/OggOpusMetadataReader.swift
@@ -1,0 +1,95 @@
+//
+//  OggOpusMetadataReader.swift
+//  ColumbaApp
+//
+//  Reads the duration (and, on request, a bounded PCM-decoded waveform) from
+//  finalized Ogg/Opus bytes. Ported from Android Columba's
+//  `OggOpusMetadata.kt`: duration comes from the final Ogg granule minus the
+//  OpusHead pre-skip, in 48 kHz samples. Parsing is fail-closed at every
+//  structural boundary, and the file is size-capped (8 MiB) so a small hostile
+//  payload cannot expand into unbounded work. No AVFoundation / no I/O here.
+//
+
+import Foundation
+
+public struct OggOpusMetadata {
+    public let durationMs: Int
+    /// Pre-skip (48 kHz samples) read from the OpusHead.
+    public let preSkip: Int
+    /// The final audio-page granule position (48 kHz samples).
+    public let finalGranule: Int
+}
+
+public enum OggOpusMetadataReader {
+
+    private static let sampleRate = 48_000
+    private static let maxPages = 65_536
+    private static let maxFileBytes = 8 * 1024 * 1024
+    private static let headerSize = 27
+
+    /// Read duration (and pre-skip) from Ogg/Opus bytes. Returns nil when the
+    /// bytes are not a valid Ogg/Opus stream (fail-closed).
+    public static func read(_ bytes: [UInt8]) -> OggOpusMetadata? {
+        let data = bytes
+        guard !data.isEmpty, data.count <= maxFileBytes else { return nil }
+        var offset = 0
+        var pageCount = 0
+        var preSkip: Int? = nil
+        var finalGranule: Int64 = -1
+
+        while offset < data.count && pageCount < maxPages {
+            guard offset + headerSize <= data.count, matchesAscii(data, offset, "OggS") else { return nil }
+            let segmentCount = Int(data[offset + 26])
+            let segmentTableStart = offset + headerSize
+            let payloadStart = segmentTableStart + segmentCount
+            guard payloadStart <= data.count else { return nil }
+
+            var payloadSize = 0
+            for index in 0..<segmentCount {
+                payloadSize += Int(data[segmentTableStart + index])
+            }
+            let pageEnd = payloadStart + payloadSize
+            guard pageEnd <= data.count else { return nil }
+
+            let granule = Int64(bitPattern: readUInt64LE(data, offset + 6))
+            if granule >= 0 { finalGranule = granule }
+
+            // OpusHead lives in the first page's payload (12+ bytes).
+            if payloadSize >= 12, matchesAscii(data, payloadStart, "OpusHead") {
+                preSkip = Int(data[payloadStart + 10]) | (Int(data[payloadStart + 11]) << 8)
+            }
+
+            offset = pageEnd
+            pageCount += 1
+        }
+
+        guard let parsedPreSkip = preSkip, finalGranule > 0 else { return nil }
+        let playableSamples = finalGranule - Int64(parsedPreSkip)
+        guard playableSamples > 0 else { return nil }
+        let durationMs = ((playableSamples * 1_000) / Int64(sampleRate)).clamped(to: 1...Int.max)
+        return OggOpusMetadata(durationMs: Int(durationMs),
+                               preSkip: parsedPreSkip,
+                               finalGranule: Int(finalGranule))
+    }
+
+    // MARK: - helpers
+
+    private static func matchesAscii(_ b: [UInt8], _ offset: Int, _ value: String) -> Bool {
+        let chars = Array(value.utf8)
+        guard offset >= 0, offset + chars.count <= b.count else { return false }
+        for i in 0..<chars.count where b[offset + i] != chars[i] { return false }
+        return true
+    }
+
+    private static func readUInt64LE(_ b: [UInt8], _ offset: Int) -> UInt64 {
+        var v: UInt64 = 0
+        for i in 0..<8 { v |= UInt64(b[offset + i]) << (i * 8) }
+        return v
+    }
+}
+
+extension Int64 {
+    func clamped(to range: ClosedRange<Int64>) -> Int64 {
+        min(max(self, range.lowerBound), range.upperBound)
+    }
+}

--- a/Sources/ColumbaApp/Voice/OggOpusMetadataReader.swift
+++ b/Sources/ColumbaApp/Voice/OggOpusMetadataReader.swift
@@ -66,7 +66,7 @@ public enum OggOpusMetadataReader {
         guard let parsedPreSkip = preSkip, finalGranule > 0 else { return nil }
         let playableSamples = finalGranule - Int64(parsedPreSkip)
         guard playableSamples > 0 else { return nil }
-        let durationMs = ((playableSamples * 1_000) / Int64(sampleRate)).clamped(to: 1...Int.max)
+        let durationMs = ((playableSamples * 1_000) / Int64(sampleRate)).clamped(to: 1...Int64.max)
         return OggOpusMetadata(durationMs: Int(durationMs),
                                preSkip: parsedPreSkip,
                                finalGranule: Int(finalGranule))
@@ -90,6 +90,6 @@ public enum OggOpusMetadataReader {
 
 extension Int64 {
     func clamped(to range: ClosedRange<Int64>) -> Int64 {
-        min(max(self, range.lowerBound), range.upperBound)
+        Swift.min(Swift.max(self, range.lowerBound), range.upperBound)
     }
 }

--- a/Sources/ColumbaApp/Voice/OggOpusWaveform.swift
+++ b/Sources/ColumbaApp/Voice/OggOpusWaveform.swift
@@ -1,0 +1,110 @@
+//
+//  OggOpusWaveform.swift
+//  ColumbaApp
+//
+//  Real-amplitude waveform for Ogg/Opus voice messages (Android parity).
+//
+//  The bubble's peak bars used to be a flat 0.5 fill for every Ogg message
+//  ("decoding the full file for peaks is heavy") - a row of identical short
+//  bars. Android decodes the file to PCM and shows a real RMS-per-bucket
+//  waveform; this is the iOS equivalent, using AVFoundation's file decoder
+//  (AVAudioFile) - the same family of decode as Android's MediaExtractor +
+//  MediaCodec, and a decoder that reads these files directly (verified
+//  against real artifacts incl. the Sideband HQ file that AVAudioPlayer's
+//  render path rejects). No raw opus C dependency is needed.
+//
+//  Layering (kept apart for testability):
+//   - `OggOpusInboundNormalizer.peaksFromEnergy` - PURE bucketing + Android's
+//     exact display curve. Unit-tested in CI with synthetic energy (no codec,
+//     no I/O, no AVFoundation - so it does not depend on the simulator's
+//     Ogg support, which is unreliable).
+//   - `peaks(fromBytes:decodeEnergy:)` - PURE orchestration that wires the
+//     pre-skip from the metadata parse to `peaksFromEnergy`, with an injected
+//     decode. Unit-tested in CI with a synthetic decode closure.
+//   - `realWaveform(from:)` - PRODUCTION glue that provides the AVAudioFile
+//     decode. Runs on-device (load-bearing); a decode failure is non-fatal and
+//     the caller keeps the neutral fallback, so audio still plays.
+//
+
+import AVFoundation
+import Foundation
+
+/// Decodes Ogg/Opus audio and turns it into the bubble's peak array.
+enum OggOpusWaveform {
+    /// Bar count matching `VoiceWaveformBars`'s 40-bar geometry.
+    static let bars = 40
+
+    /// Pure orchestration: read the pre-skip from the Ogg metadata, run the
+    /// injected decode to get per-frame mono energy, and return the normalized
+    /// peak array. Returns nil when the injected decode fails or yields no
+    /// frames (caller keeps the neutral fallback). `decodeEnergy` is injected
+    /// so CI can exercise the curve with synthetic data (the simulator's
+    /// AVFoundation is unreliable for Ogg); production uses `realWaveform`.
+    static func peaks(
+        fromBytes bytes: Data,
+        decodeEnergy: (Data) throws -> [Double]
+    ) -> [Float]? {
+        let preSkip = OggOpusMetadataReader.read([UInt8](bytes))?.preSkip ?? 0
+        guard let energy = try? decodeEnergy(bytes), !energy.isEmpty else { return nil }
+        return OggOpusInboundNormalizer.peaksFromEnergy(energy, preSkip: preSkip, bars: bars)
+    }
+
+    /// Production waveform: decode `bytes` (an in-memory Ogg/Opus file) with
+    /// AVFoundation and compute the normalized peak array. Synchronous and
+    /// CPU-bound - the player calls this from `prepare` (voice messages are
+    /// short; decode is tens of ms). Returns nil on any decode failure, a
+    /// file that carries no audio, or a stream that decodes to silence.
+    static func realWaveform(from bytes: Data) -> [Float]? {
+        peaks(fromBytes: bytes, decodeEnergy: decodeEnergyViaAVAudioFile)
+    }
+
+    /// AVAudioFile decode: write the bytes to a temp `.ogg`, decode to mono
+    /// PCM, and return per-sample squared energy (channel-folded, linear
+    /// float in ~[0,1]). Throws if AVFoundation cannot open/decode the file
+    /// or yields no frames.
+    private static func decodeEnergyViaAVAudioFile(_ bytes: Data) throws -> [Double] {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("columba-waveform", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent("waveform-\(UUID().uuidString).ogg")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try bytes.write(to: url)
+
+        let file = try AVAudioFile(forReading: url)
+        let format = file.processingFormat
+        let total = AVAudioFrameCount(file.length)
+        guard total > 0,
+              let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: total)
+        else { throw OggWaveformError.noAudio }
+        try file.read(into: buffer)
+
+        let n = Int(buffer.frameLength)
+        guard n > 0, let channelPtr = buffer.floatChannelData else {
+            throw OggWaveformError.noAudio
+        }
+        let channelCount = Int(buffer.format.channelCount)
+        guard channelCount >= 1 else { throw OggWaveformError.noAudio }
+        let ch0 = channelPtr[0]
+
+        // Mono-fold: mean of the channels, then squared (energy). Mono voice
+        // files fold to themselves.
+        var energy = [Double](repeating: 0, count: n)
+        if channelCount >= 2 {
+            let ch1 = channelPtr[1]
+            for i in 0..<n {
+                let m = (Double(ch0[i]) + Double(ch1[i])) * 0.5
+                energy[i] = m * m
+            }
+        } else {
+            for i in 0..<n {
+                let m = Double(ch0[i])
+                energy[i] = m * m
+            }
+        }
+        return energy
+    }
+}
+
+enum OggWaveformError: Error {
+    case noAudio
+}

--- a/Sources/ColumbaApp/Voice/VoiceDraftRow.swift
+++ b/Sources/ColumbaApp/Voice/VoiceDraftRow.swift
@@ -51,7 +51,7 @@ public struct VoiceDraftRow: View {
     // MARK: - Permission (app-level, mirrors Android's ContextCompat check)
 
     private var micPermission: AVAudioSession.RecordPermission {
-        AVAudioSession.sharedInstance().recordPermission()
+        AVAudioSession.sharedInstance().recordPermission
     }
 
     private var hasPermission: Bool { micPermission == .granted }
@@ -270,7 +270,7 @@ public struct VoiceDraftRow: View {
                     .foregroundStyle(Theme.textPrimary)
                     .accessibilityIdentifier("voice_panel_ready")
                 if let errorText {
-                    Text(String(localized: "Recording error: %@", errorText))
+                    Text(String(format: String(localized: "Recording error: %@"), errorText))
                         .font(.caption)
                         .foregroundStyle(Color.red)
                         .lineLimit(2)
@@ -389,7 +389,7 @@ public struct VoiceDraftRow: View {
     private func progressText(_ currentMs: Int, _ totalMs: Int) -> String {
         let current = formatElapsed(currentMs)
         let total = totalMs > 0 ? formatElapsed(totalMs) : "--:--"
-        return String(localized: "%@ of %@", current, total)
+        return String(format: String(localized: "%@ of %@"), current, total)
     }
 }
 

--- a/Sources/ColumbaApp/Voice/VoiceDraftRow.swift
+++ b/Sources/ColumbaApp/Voice/VoiceDraftRow.swift
@@ -342,7 +342,7 @@ public struct VoiceDraftRow: View {
                 Button(action: {
                     player.stopCurrent()
                     onRemove()
-                }) label: {
+                }) {
                     Image(systemName: "xmark.circle.fill")
                         .font(.system(size: 22))
                         .foregroundStyle(Theme.textSecondary)

--- a/Sources/ColumbaApp/Voice/VoiceDraftRow.swift
+++ b/Sources/ColumbaApp/Voice/VoiceDraftRow.swift
@@ -1,0 +1,405 @@
+//
+//  VoiceDraftRow.swift
+//  ColumbaApp
+//
+//  The composer's voice-message panel, shown above the text input while the
+//  user is recording, finalizing, or has a recorded-but-unsent draft. Ports
+//  Android Columba's `VoiceMessagePanel` (`VoiceMessageComponents.kt`, the
+//  `attachment_voice_panel_*` strings) state-for-state:
+//
+//   - not supported:   "Voice messages are not supported on this device." + Close.
+//   - blocked by call: "Voice recording is unavailable during a call." + Close.
+//   - no permission:   permission-needed (or permanently-denied) text +
+//                      "Grant microphone access" / "Open settings" + Close.
+//   - ready:           mic + "Ready to record a voice message" (+ the last
+//                      error, if any) + filled Start + Close. The panel's idle
+//                      state; on Android the panel is open after the quality
+//                      dialog confirms and Start begins recording with the
+//                      chosen format.
+//   - recording:       red dot + "Recording" + elapsed, Cancel (trash icon),
+//                      filled Stop.
+//   - finalizing:      spinner + "Finalizing" + Close.
+//   - selected:        draft preview (play toggle, waveform, "X of Y", remove,
+//                      Close) - Android's `VoiceDraftPreview`.
+//
+//  The panel is a single compact, bottom-anchored surface, matching Android's
+//  layout. Exact user-facing text comes from `Localizable.xcstrings`
+//  (Section 3 of the voice-messages parity plan); the static contract test
+//  asserts the literal values.
+//
+
+import SwiftUI
+import RNSAPI
+import AVFoundation
+
+/// The voice composer panel. Driven by a `VoiceMessageRecorder`'s observable
+/// state plus the mic-permission and call-active inputs the recorder does not
+/// model (those are app-level, checked here exactly as Android checks them in
+/// `MessagingScreen`).
+@available(iOS 17.0, *)
+public struct VoiceDraftRow: View {
+    let recorder: VoiceMessageRecorder
+    let player: VoiceMessagePlayer
+    /// True while a voice call is active (blocks recording, as on Android).
+    var isCallActive: Bool = false
+    var onStart: (VoiceMessageFormat) -> Void
+    var onRemove: () -> Void
+    var onClose: () -> Void
+
+    @State private var permissionBump = 0
+
+    // MARK: - Permission (app-level, mirrors Android's ContextCompat check)
+
+    private var micPermission: AVAudioSession.RecordPermission {
+        AVAudioSession.sharedInstance().recordPermission()
+    }
+
+    private var hasPermission: Bool { micPermission == .granted }
+
+    private var permissionPermanentlyDenied: Bool { micPermission == .denied }
+
+    public init(
+        recorder: VoiceMessageRecorder,
+        player: VoiceMessagePlayer,
+        isCallActive: Bool = false,
+        onStart: @escaping (VoiceMessageFormat) -> Void,
+        onRemove: @escaping () -> Void,
+        onClose: @escaping () -> Void
+    ) {
+        self.recorder = recorder
+        self.player = player
+        self.isCallActive = isCallActive
+        self.onStart = onStart
+        self.onRemove = onRemove
+        self.onClose = onClose
+    }
+
+    // MARK: - Body
+
+    public var body: some View {
+        Group {
+            if case .completed(let recording) = recorder.state {
+                previewPanel(recording)
+            } else {
+                switch recorder.state {
+                case .recording(let elapsedMs):
+                    recordingPanel(elapsedMs: elapsedMs)
+                case .finalizing:
+                    finalizingPanel
+                default:
+                    // idle / failed: the "ready" row (+ the last error, if any).
+                    readyPanel
+                }
+            }
+        }
+        // Re-evaluate the permission-based rows after a permission request
+        // resolves (the audio session does not publish the change itself).
+        .id(permissionBump)
+    }
+
+    // MARK: - Recording
+
+    private func recordingPanel(elapsedMs: Int) -> some View {
+        HStack(spacing: 12) {
+            Button(action: { recorder.cancel() }) {
+                Image(systemName: "trash")
+                    .font(.system(size: 18))
+                    .foregroundStyle(Color.red)
+                    .frame(width: 34, height: 34)
+            }
+            .accessibilityLabel(String(localized: "Cancel recording"))
+            .accessibilityIdentifier("voice_panel_cancel")
+
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 8) {
+                    Circle()
+                        .fill(Color.red)
+                        .frame(width: 8, height: 8)
+                    Text(String(localized: "Recording"))
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(Color.red)
+                        .accessibilityIdentifier("voice_panel_recording")
+                }
+                Text(formatElapsed(elapsedMs))
+                    .font(.title3.weight(.semibold).monospacedDigit())
+                    .foregroundStyle(Theme.textPrimary)
+                    .accessibilityLabel("Recording elapsed time")
+                    .accessibilityIdentifier("voice_panel_elapsed")
+            }
+            .accessibilityElement(children: .combine)
+
+            Spacer()
+
+            Button(action: { recorder.stop() }) {
+                Image(systemName: "stop.fill")
+                    .font(.system(size: 14))
+                    .foregroundStyle(.white)
+                    .frame(width: 40, height: 40)
+                    .background(Theme.accentColor, in: Circle())
+            }
+            .accessibilityLabel(String(localized: "Stop recording"))
+            .accessibilityIdentifier("voice_panel_stop")
+        }
+        .panelSurface()
+    }
+
+    // MARK: - Finalizing
+
+    private var finalizingPanel: some View {
+        HStack(spacing: 12) {
+            ProgressView()
+                .tint(Theme.accentColor)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(String(localized: "Finalizing"))
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(Theme.textPrimary)
+                    .accessibilityIdentifier("voice_panel_finalizing")
+                Text("--:--")
+                    .font(.title3.weight(.semibold).monospacedDigit())
+                    .foregroundStyle(Theme.textPrimary)
+            }
+            Spacer()
+            closeButton
+        }
+        .panelSurface()
+    }
+
+    // MARK: - Ready / unsupported / call / permission
+
+    @ViewBuilder
+    private var readyPanel: some View {
+        let errorText = recorder.errorMessage
+        if recorder.lastFailureWasUnsupported {
+            unsupportedRow
+        } else if isCallActive {
+            callActiveRow
+        } else if !hasPermission {
+            permissionRow
+        } else {
+            readyRow(errorText: errorText)
+        }
+    }
+
+    private var unsupportedRow: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "mic")
+                .font(.system(size: 20))
+                .foregroundStyle(Theme.textSecondary)
+                .accessibilityHidden(true)
+            Text(String(localized: "Voice messages are not supported on this device."))
+                .font(.subheadline)
+                .foregroundStyle(Theme.textSecondary)
+                .accessibilityIdentifier("voice_panel_unsupported")
+            Spacer()
+            closeButton
+        }
+        .panelSurface()
+    }
+
+    private var callActiveRow: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "mic.slash")
+                .font(.system(size: 20))
+                .foregroundStyle(Theme.textSecondary)
+                .accessibilityHidden(true)
+            Text(String(localized: "Voice recording is unavailable during a call."))
+                .font(.subheadline)
+                .foregroundStyle(Theme.textSecondary)
+                .accessibilityIdentifier("voice_panel_call_active")
+            Spacer()
+            closeButton
+        }
+        .panelSurface()
+    }
+
+    private var permissionRow: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "mic")
+                .font(.system(size: 20))
+                .foregroundStyle(Theme.accentColor)
+                .accessibilityHidden(true)
+            if permissionPermanentlyDenied {
+                Text(String(localized: "Microphone access is disabled. Enable it in app settings."))
+                    .font(.subheadline)
+                    .foregroundStyle(Theme.textPrimary)
+                    .lineLimit(2)
+                    .accessibilityIdentifier("voice_panel_permission_settings")
+            } else {
+                Text(String(localized: "Microphone permission is required to record a voice message."))
+                    .font(.subheadline)
+                    .foregroundStyle(Theme.textPrimary)
+                    .lineLimit(2)
+                    .accessibilityIdentifier("voice_panel_permission_needed")
+            }
+            Spacer()
+            Button {
+                if permissionPermanentlyDenied {
+                    openAppSettings()
+                } else {
+                    Task {
+                        // Awaits the user's response to the system prompt
+                        // before returning (iOS 17+ API).
+                        _ = await AVAudioApplication.requestRecordPermission()
+                        // The session does not publish permission changes;
+                        // change the panel's id so the whole row re-evaluates
+                        // `hasPermission` with the fresh value.
+                        permissionBump &+= 1
+                    }
+                }
+            } label: {
+                Text(permissionPermanentlyDenied
+                     ? String(localized: "Open settings")
+                     : String(localized: "Grant microphone access"))
+                    .font(.subheadline.weight(.medium))
+            }
+            .accessibilityIdentifier("voice_panel_request_permission")
+            closeButton
+        }
+        .panelSurface()
+    }
+
+    private func readyRow(errorText: String?) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: "mic")
+                .font(.system(size: 20))
+                .foregroundStyle(Theme.accentColor)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(String(localized: "Ready to record a voice message"))
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(Theme.textPrimary)
+                    .accessibilityIdentifier("voice_panel_ready")
+                if let errorText {
+                    Text(String(localized: "Recording error: %@", errorText))
+                        .font(.caption)
+                        .foregroundStyle(Color.red)
+                        .lineLimit(2)
+                        .accessibilityIdentifier("voice_panel_error")
+                }
+            }
+            Spacer()
+            Button {
+                onStart(recorder.selectedFormat ?? .defaultFormat)
+            } label: {
+                Image(systemName: "mic.fill")
+                    .font(.system(size: 14))
+                    .foregroundStyle(.white)
+                    .frame(width: 40, height: 40)
+                    .background(Theme.accentColor, in: Circle())
+            }
+            .accessibilityLabel(String(localized: "Start recording"))
+            .accessibilityIdentifier("voice_panel_start")
+            closeButton
+        }
+        .panelSurface()
+    }
+
+    // MARK: - Selected draft preview
+
+    private func previewPanel(_ recording: VoiceRecording) -> some View {
+        let attachment = recording.audio
+        let key = recording.url.path
+        let state = player.state(for: key)
+        let duration = state.durationMs > 0
+            ? state.durationMs
+            : (recording.durationMs > 0 ? recording.durationMs : Int(attachment.durationSeconds * 1000))
+        let progress: CGFloat = duration > 0 ? CGFloat(state.positionMs) / CGFloat(duration) : 0
+        let waveform = player.waveform(for: key) ?? VoiceWaveform.placeholder()
+        let isPlaying = state.status == .playing
+
+        return VStack(alignment: .leading, spacing: 6) {
+            Text(String(localized: "Voice message"))
+                .font(.caption)
+                .foregroundStyle(Theme.textSecondary)
+                .accessibilityIdentifier("voice_panel_title")
+            HStack(spacing: 12) {
+                Button {
+                    player.prepare(key: key, attachment: attachment)
+                    player.togglePlay(key: key, attachment: attachment)
+                } label: {
+                    Image(systemName: isPlaying ? "pause.circle.fill" : "play.circle.fill")
+                        .font(.system(size: 30))
+                        .foregroundStyle(Theme.accentColor)
+                }
+                .accessibilityLabel(
+                    isPlaying
+                        ? String(localized: "Pause voice message")
+                        : String(localized: "Play voice message")
+                )
+                .accessibilityIdentifier("voice_panel_play")
+
+                VoiceWaveformBars(peaks: waveform, progress: progress)
+                    .accessibilityHidden(true)
+
+                Text(progressText(state.positionMs, duration))
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(Theme.textSecondary)
+                    .accessibilityLabel("Playback progress")
+                    .accessibilityIdentifier("voice_panel_progress")
+
+                Spacer()
+
+                Button(action: {
+                    player.stopCurrent()
+                    onRemove()
+                }) label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 22))
+                        .foregroundStyle(Theme.textSecondary)
+                }
+                .accessibilityLabel(String(localized: "Remove recording"))
+                .accessibilityIdentifier("voice_panel_remove")
+            }
+        }
+        .panelSurface()
+        .onDisappear {
+            // Leaving the panel must not keep a preview playing.
+            player.stopCurrent()
+        }
+    }
+
+    // MARK: - Shared pieces
+
+    private var closeButton: some View {
+        Button(action: onClose) {
+            Image(systemName: "xmark")
+                .font(.system(size: 18, weight: .medium))
+                .foregroundStyle(Theme.textSecondary)
+                .frame(width: 34, height: 34)
+        }
+        .accessibilityLabel("Close")
+        .accessibilityIdentifier("voice_panel_close")
+    }
+
+    // MARK: - Actions
+
+    private func openAppSettings() {
+        if let url = URL(string: UIApplication.openSettingsURLString) {
+            UIApplication.shared.open(url)
+        }
+    }
+
+    // MARK: - Formatting
+
+    private func formatElapsed(_ ms: Int) -> String {
+        let totalSeconds = max(0, ms / 1000)
+        return String(format: "%d:%02d", totalSeconds / 60, totalSeconds % 60)
+    }
+
+    private func progressText(_ currentMs: Int, _ totalMs: Int) -> String {
+        let current = formatElapsed(currentMs)
+        let total = totalMs > 0 ? formatElapsed(totalMs) : "--:--"
+        return String(localized: "%@ of %@", current, total)
+    }
+}
+
+private extension View {
+    /// The shared panel surface (background + rounded corners).
+    func panelSurface() -> some View {
+        self
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .background(Theme.backgroundTertiary)
+            .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+    }
+}

--- a/Sources/ColumbaApp/Voice/VoiceDraftRow.swift
+++ b/Sources/ColumbaApp/Voice/VoiceDraftRow.swift
@@ -330,6 +330,11 @@ public struct VoiceDraftRow: View {
 
                 VoiceWaveformBars(peaks: waveform, progress: progress)
                     .accessibilityHidden(true)
+                    // The draft panel also has a Spacer() pinning the remove
+                    // button to the trailing edge; cap the (now-flexible)
+                    // waveform so it and the Spacer share the row instead of
+                    // the waveform grabbing it all.
+                    .frame(maxWidth: 200)
 
                 Text(progressText(state.positionMs, duration))
                     .font(.caption.monospacedDigit())

--- a/Sources/ColumbaApp/Voice/VoiceDraftRow.swift
+++ b/Sources/ColumbaApp/Voice/VoiceDraftRow.swift
@@ -352,6 +352,9 @@ public struct VoiceDraftRow: View {
             }
         }
         .panelSurface()
+        // Compute the draft waveform when the preview panel appears (same
+        // single-flighted path as the bubbles).
+        .onAppear { player.prepare(key: key, attachment: attachment) }
         .onDisappear {
             // Leaving the panel must not keep a preview playing.
             player.stopCurrent()

--- a/Sources/ColumbaApp/Voice/VoiceMessageBubble.swift
+++ b/Sources/ColumbaApp/Voice/VoiceMessageBubble.swift
@@ -126,6 +126,11 @@ public struct VoiceMessageBubble: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(isFromMe ? Color.clear : Theme.backgroundTertiary)
         .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+        // Android computes the waveform (and duration) when the bubble
+        // appears, not only on play tap. The decode is single-flighted +
+        // cached in the player, so repeated onAppear calls (scroll
+        // recycles) are no-ops after the first.
+        .onAppear { player.prepare(key: key, attachment: attachment) }
     }
 
     // MARK: - Unsupported / unavailable (Android: the error branches)

--- a/Sources/ColumbaApp/Voice/VoiceMessageBubble.swift
+++ b/Sources/ColumbaApp/Voice/VoiceMessageBubble.swift
@@ -37,6 +37,22 @@ public struct VoiceMessageBubble: View {
 
     private var key: String { message.id }
 
+    /// Stable, harness-computable tag for the message content (FNV-1a 32-bit,
+    /// lowercase hex). The conversation accumulates one voice bubble per
+    /// inbound note, so every per-bubble a11y identifier is
+    /// `<base>_<tag>`: the interop harness (Python) computes the identical
+    /// tag from the content it sent and targets THAT bubble instead of the
+    /// first matching id. (SwiftUI applies the LAST accessibilityIdentifier
+    /// on a view, so these are single identifiers, not base+tag pairs.)
+    private var contentTag: String {
+        var h: UInt32 = 0x811C9DC5
+        for b in message.content.utf8 {
+            h ^= UInt32(b)
+            h = h &* 0x01000193
+        }
+        return String(format: "%08x", h)
+    }
+
     public var body: some View {
         if let attachment = message.audioAttachment {
             // `.custom` (an unrecognized wire mode) is non-playable: map it to
@@ -68,13 +84,13 @@ public struct VoiceMessageBubble: View {
             Text(String(localized: "Voice message"))
                 .font(.subheadline.weight(.medium))
                 .foregroundStyle(Theme.textSecondary)
-                .accessibilityIdentifier("voice_bubble_title")
+                .accessibilityIdentifier("voice_bubble_title_\(contentTag)")
 
             if state.status == .loading {
                 Text(String(localized: "Loading voice message"))
                     .font(.caption)
                     .foregroundStyle(Theme.textSecondary)
-                    .accessibilityIdentifier("voice_bubble_loading")
+                    .accessibilityIdentifier("voice_bubble_loading_\(contentTag)")
             } else if let err = state.errorMessage {
                 stateView(errorMessage: err)
             } else {
@@ -92,7 +108,7 @@ public struct VoiceMessageBubble: View {
                             ? String(localized: "Pause voice message")
                             : String(localized: "Play voice message")
                     )
-                    .accessibilityIdentifier("voice_bubble_play")
+                    .accessibilityIdentifier("voice_bubble_play_\(contentTag)")
 
                     VoiceWaveformBars(peaks: waveform, progress: progressFraction)
                         .accessibilityHidden(true)
@@ -101,7 +117,7 @@ public struct VoiceMessageBubble: View {
                         .font(.caption.monospacedDigit())
                         .foregroundStyle(Theme.textSecondary)
                         .accessibilityLabel("Playback progress")
-                        .accessibilityIdentifier("voice_bubble_progress")
+                        .accessibilityIdentifier("voice_bubble_progress_\(contentTag)")
                 }
             }
         }
@@ -126,8 +142,8 @@ public struct VoiceMessageBubble: View {
         .lineLimit(2)
         .accessibilityIdentifier(
             errorMessage == "unsupported"
-                ? "voice_bubble_unsupported"
-                : "voice_bubble_unavailable"
+                ? "voice_bubble_unsupported_\(contentTag)"
+                : "voice_bubble_unavailable_\(contentTag)"
         )
     }
 

--- a/Sources/ColumbaApp/Voice/VoiceMessageBubble.swift
+++ b/Sources/ColumbaApp/Voice/VoiceMessageBubble.swift
@@ -141,7 +141,7 @@ public struct VoiceMessageBubble: View {
     private func progressText(_ currentMs: Int, _ totalMs: Int) -> String {
         let current = formatTime(currentMs)
         let total = totalMs > 0 ? formatTime(totalMs) : "--:--"
-        return String(localized: "%@ of %@", current, total)
+        return String(format: String(localized: "%@ of %@"), current, total)
     }
 }
 

--- a/Sources/ColumbaApp/Voice/VoiceMessageBubble.swift
+++ b/Sources/ColumbaApp/Voice/VoiceMessageBubble.swift
@@ -1,0 +1,169 @@
+//
+//  VoiceMessageBubble.swift
+//  ColumbaApp
+//
+//  The timeline rendering of a received/sent voice message (field 7). Ports
+//  Android Columba's `VoiceMessageBubble` (`VoiceMessageComponents.kt`, the
+//  `message_voice_*` strings) state-for-state:
+//
+//     title "Voice message"
+//     when:
+//       loading                  -> "Loading voice message"
+//       error == "unsupported"   -> "Unsupported voice message"
+//       error != null            -> "Voice message unavailable"
+//       else                     -> play/pause + waveform + "X of Y"
+//
+//  Playback is driven by a `VoiceMessagePlayer` (shared across the timeline,
+//  one per conversation screen). A message's player key is its message id, so
+//  at most one voice message plays at a time (the player cancels the prior
+//  when a new one starts).
+//
+
+import SwiftUI
+import RNSAPI
+
+/// The voice-message bubble shown in the chat timeline for a message that has
+/// a field-7 `AudioAttachment`.
+public struct VoiceMessageBubble: View {
+    let message: Message
+    let isFromMe: Bool
+    let player: VoiceMessagePlayer
+
+    public init(message: Message, player: VoiceMessagePlayer) {
+        self.message = message
+        self.isFromMe = message.isFromMe
+        self.player = player
+    }
+
+    private var key: String { message.id }
+
+    public var body: some View {
+        if let attachment = message.audioAttachment {
+            // `.custom` (an unrecognized wire mode) is non-playable: map it to
+            // the player's "unsupported" error state, exactly as Android maps
+            // a missing player (`VoiceMessagePlayerState(error = "unsupported")`).
+            if attachment.mode == .custom {
+                stateView(errorMessage: "unsupported")
+            } else {
+                playableRow(attachment)
+            }
+        }
+    }
+
+    // MARK: - Playable row (Android: the else branch)
+
+    @ViewBuilder
+    private func playableRow(_ attachment: AudioAttachment) -> some View {
+        let state = player.state(for: key)
+        let duration = state.durationMs > 0
+            ? state.durationMs
+            : (attachment.durationMs ?? Int(attachment.durationSeconds * 1000))
+        let progressFraction: CGFloat = duration > 0
+            ? CGFloat(state.positionMs) / CGFloat(duration)
+            : 0
+        let waveform = player.waveform(for: key) ?? VoiceWaveform.placeholder()
+        let isPlaying = state.status == .playing
+
+        VStack(alignment: .leading, spacing: 6) {
+            Text(String(localized: "Voice message"))
+                .font(.subheadline.weight(.medium))
+                .foregroundStyle(Theme.textSecondary)
+                .accessibilityIdentifier("voice_bubble_title")
+
+            if state.status == .loading {
+                Text(String(localized: "Loading voice message"))
+                    .font(.caption)
+                    .foregroundStyle(Theme.textSecondary)
+                    .accessibilityIdentifier("voice_bubble_loading")
+            } else if let err = state.errorMessage {
+                stateView(errorMessage: err)
+            } else {
+                HStack(spacing: 12) {
+                    Button {
+                        player.prepare(key: key, attachment: attachment)
+                        player.togglePlay(key: key, attachment: attachment)
+                    } label: {
+                        Image(systemName: isPlaying ? "pause.circle.fill" : "play.circle.fill")
+                            .font(.system(size: 30))
+                            .foregroundStyle(Theme.accentColor)
+                    }
+                    .accessibilityLabel(
+                        isPlaying
+                            ? String(localized: "Pause voice message")
+                            : String(localized: "Play voice message")
+                    )
+                    .accessibilityIdentifier("voice_bubble_play")
+
+                    VoiceWaveformBars(peaks: waveform, progress: progressFraction)
+                        .accessibilityHidden(true)
+
+                    Text(progressText(state.positionMs, duration))
+                        .font(.caption.monospacedDigit())
+                        .foregroundStyle(Theme.textSecondary)
+                        .accessibilityLabel("Playback progress")
+                        .accessibilityIdentifier("voice_bubble_progress")
+                }
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(isFromMe ? Color.clear : Theme.backgroundTertiary)
+        .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+    }
+
+    // MARK: - Unsupported / unavailable (Android: the error branches)
+
+    @ViewBuilder
+    private func stateView(errorMessage: String?) -> some View {
+        Text(
+            errorMessage == "unsupported"
+                ? String(localized: "Unsupported voice message")
+                : String(localized: "Voice message unavailable")
+        )
+        .font(.caption)
+        .foregroundStyle(Theme.textSecondary)
+        .lineLimit(2)
+        .accessibilityIdentifier(
+            errorMessage == "unsupported"
+                ? "voice_bubble_unsupported"
+                : "voice_bubble_unavailable"
+        )
+    }
+
+    // MARK: - Formatting
+
+    private func formatTime(_ ms: Int) -> String {
+        let totalSeconds = max(0, ms / 1000)
+        return String(format: "%d:%02d", totalSeconds / 60, totalSeconds % 60)
+    }
+
+    private func progressText(_ currentMs: Int, _ totalMs: Int) -> String {
+        let current = formatTime(currentMs)
+        let total = totalMs > 0 ? formatTime(totalMs) : "--:--"
+        return String(localized: "%@ of %@", current, total)
+    }
+}
+
+/// A non-playable voice-attachment indicator, used when a bubble has a field-7
+/// attachment but no player is wired (e.g. a preview context).
+public struct VoiceMessageBubbleUnavailable: View {
+    public init() {}
+
+    public var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "mic")
+                .font(.system(size: 16))
+                .foregroundStyle(Theme.textSecondary)
+                .accessibilityHidden(true)
+            Text(String(localized: "Voice message unavailable"))
+                .font(.subheadline)
+                .foregroundStyle(Theme.textSecondary)
+                .accessibilityIdentifier("voice_bubble_unavailable")
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
+        .background(Theme.backgroundTertiary)
+        .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+    }
+}

--- a/Sources/ColumbaApp/Voice/VoiceMessageFormat.swift
+++ b/Sources/ColumbaApp/Voice/VoiceMessageFormat.swift
@@ -1,0 +1,119 @@
+//
+//  VoiceMessageFormat.swift
+//  ColumbaApp
+//
+//  The six voice-message quality profiles, ported 1:1 from Android Columba's
+//  `VoiceMessageFormat.kt` (the post-alignment table from PR #1098 - three
+//  Codec2 + three Opus, "Medium Quality" as the default/recommended). The
+//  display names and descriptions are localized; the EXACT English text must
+//  match Android's `values/strings.xml` (enforced by
+//  Tests/static/test_voice_messages.py).
+//
+//  NOTE: this is the VOICE-MESSAGE table, distinct from the voice-CALL
+//  `CodecProfileInfo` (which has a different option set and link-probe-based
+//  recommendation). Do not conflate them.
+//
+
+import Foundation
+import SwiftUI
+import RNSAPI
+import LXSTSwift
+
+/// A voice-message recording quality profile.
+public enum VoiceMessageFormat: Int, CaseIterable, Identifiable, Sendable {
+    case codec2_1200
+    case codec2_2400
+    case codec2_3200
+    case opusMedium
+    case opusHigh
+    case opusMaximum
+
+    public var id: Int { rawValue }
+
+    /// The on-wire `FIELD_AUDIO` mode integer.
+    public var wireMode: UInt8 {
+        switch self {
+        case .codec2_1200: return LxmfFields.AM_CODEC2_1200
+        case .codec2_2400: return LxmfFields.AM_CODEC2_2400
+        case .codec2_3200: return LxmfFields.AM_CODEC2_3200
+        case .opusMedium, .opusHigh, .opusMaximum: return LxmfFields.AM_OPUS_OGG
+        }
+    }
+
+    public var isCodec2: Bool {
+        switch self {
+        case .codec2_1200, .codec2_2400, .codec2_3200: return true
+        case .opusMedium, .opusHigh, .opusMaximum: return false
+        }
+    }
+
+    /// The `AudioMode` carried in the `FIELD_AUDIO` wire field.
+    public var audioMode: AudioMode { AudioMode(wireValue: Int(wireMode))! }
+
+    /// The LXST `Codec2Mode` for Codec2 profiles (nil for Opus).
+    public var codec2Mode: Codec2Mode? {
+        switch self {
+        case .codec2_1200: return .codec2_1200
+        case .codec2_2400: return .codec2_2400
+        case .codec2_3200: return .codec2_3200
+        case .opusMedium, .opusHigh, .opusMaximum: return nil
+        }
+    }
+
+    /// The LXST `OpusProfile` for Opus profiles (nil for Codec2).
+    /// Maps exactly to Android's `RecordingConfig` sample-rate/channel/bitrate
+    /// table: medium 24k/mono/8k, high 48k/mono/16k, maximum 48k/stereo/32k.
+    public var opusProfile: OpusProfile? {
+        switch self {
+        case .opusMedium: return .voiceMedium
+        case .opusHigh: return .voiceHigh
+        case .opusMaximum: return .voiceMax
+        case .codec2_1200, .codec2_2400, .codec2_3200: return nil
+        }
+    }
+
+    public var displayName: LocalizedStringResource {
+        switch self {
+        case .codec2_1200: return LocalizedStringResource("Codec2 1200")
+        case .codec2_2400: return LocalizedStringResource("Codec2 2400")
+        case .codec2_3200: return LocalizedStringResource("Codec2 3200")
+        case .opusMedium: return LocalizedStringResource("Medium Quality")
+        case .opusHigh: return LocalizedStringResource("High Quality")
+        case .opusMaximum: return LocalizedStringResource("Maximum Quality")
+        }
+    }
+
+    public var description: LocalizedStringResource {
+        switch self {
+        case .codec2_1200: return LocalizedStringResource("Very low bandwidth voice")
+        case .codec2_2400: return LocalizedStringResource("Low bandwidth voice")
+        case .codec2_3200: return LocalizedStringResource("Clearer speech at low bandwidth")
+        case .opusMedium: return LocalizedStringResource("Opus 8 kbps mono - good balance of quality and bandwidth")
+        case .opusHigh: return LocalizedStringResource("Opus 16 kbps mono - higher fidelity audio")
+        case .opusMaximum: return LocalizedStringResource("Opus 32 kbps stereo - best audio, requires more bandwidth")
+        }
+    }
+
+    /// Whether this profile is the recommended default (Medium Quality).
+    public var isRecommended: Bool { self == Self.defaultFormat }
+
+    public static let defaultFormat: VoiceMessageFormat = .opusMedium
+
+    /// The outbound options shown in the quality picker, in display order
+    /// (Codec2 1200 → Maximum Quality).
+    public static let outboundOptions: [VoiceMessageFormat] = Array(Self.allCases)
+
+    /// Resolve a profile from an on-wire `FIELD_AUDIO` mode. Codec2 maps
+    /// 1:1; all Opus modes map to the profile whose rate/channels match is not
+    /// recoverable from the wire mode alone (Opus does not encode its bitrate
+    /// in the mode), so an inbound Opus message has no canonical profile -
+    /// return nil and let playback use the mode only.
+    public static func fromWireMode(_ wireMode: UInt8) -> VoiceMessageFormat? {
+        switch wireMode {
+        case LxmfFields.AM_CODEC2_1200: return .codec2_1200
+        case LxmfFields.AM_CODEC2_2400: return .codec2_2400
+        case LxmfFields.AM_CODEC2_3200: return .codec2_3200
+        default: return nil
+        }
+    }
+}

--- a/Sources/ColumbaApp/Voice/VoiceMessagePlayer.swift
+++ b/Sources/ColumbaApp/Voice/VoiceMessagePlayer.swift
@@ -150,6 +150,28 @@ public final class VoiceMessagePlayer {
         DiagLog.log("[VOICE-PLAY] start key=\(key.prefix(8)) mode=0x\(String(format: "%02x", attachment.mode.rawValue)) bytes=\(attachment.bytes.count)")
         let url = try renderToTempFile(attachment)
         tempFiles.append(url)
+
+        // The audio session must be in a PLAYBACK state before play(): the
+        // voice recorder sets it to .playAndRecord and deactivates it, and a
+        // .playAndRecord session (a) is silenced by the mute switch and
+        // (b) can default toward the earpiece - so AVAudioPlayer reports
+        // isPlaying=true but is inaudible. .playback routes to the speaker
+        // (or connected headphones) and ignores the mute switch. Guard
+        // against an active call (mode .voiceChat, set by CallKitManager):
+        // reconfiguring the category there would drop the mic and break the
+        // call, so leave the session alone in that case (playing a voice
+        // message mid-call is a rare edge case).
+        let session = AVAudioSession.sharedInstance()
+        if session.mode != .voiceChat {
+            do {
+                try session.setCategory(.playback, mode: .default, options: [])
+                try session.setActive(true, options: [])
+            } catch {
+                DiagLog.log("[VOICE-PLAY] session setup failed: \(error.localizedDescription)")
+            }
+        }
+        logSessionState(context: "pre-play")
+
         let filePlayer = try AVAudioPlayer(contentsOf: url)
         filePlayer.numberOfLoops = 0
         filePlayer.volume = 1.0
@@ -174,6 +196,7 @@ public final class VoiceMessagePlayer {
             DiagLog.log("[VOICE-PLAY] UNPLAYABLE url=\(url.lastPathComponent)")
             throw PlayerError.unplayable
         }
+        logSessionState(context: "playing")
         player = filePlayer
         var st = states[key] ?? PlaybackState()
         st.status = .playing
@@ -181,6 +204,15 @@ public final class VoiceMessagePlayer {
         states[key] = st
         DiagLog.log("[VOICE-PLAY] PLAYING durationMs=\(st.durationMs)")
         startProgressPolling()
+    }
+
+    /// Privacy-safe audio-session snapshot (category/route/volume only, no PII)
+    /// for diagnosing audible-playback issues on the WiFi-only device.
+    private func logSessionState(context: String) {
+        let s = AVAudioSession.sharedInstance()
+        let route = s.currentRoute
+        let outputs = route.outputs.map { "type=\($0.portType.rawValue)" }.joined(separator: ",")
+        DiagLog.log("[VOICE-SESSION] \(context) category=\(s.category.rawValue) mode=\(s.mode.rawValue) vol=\(String(format: "%.2f", s.outputVolume)) route=[\(outputs)]")
     }
 
     private func startProgressPolling() {

--- a/Sources/ColumbaApp/Voice/VoiceMessagePlayer.swift
+++ b/Sources/ColumbaApp/Voice/VoiceMessagePlayer.swift
@@ -48,7 +48,9 @@ public final class VoiceMessagePlayer {
     @ObservationIgnored private var currentKey: String?
     @ObservationIgnored private var player: AVAudioPlayer?
     @ObservationIgnored private var progressTask: Task<Void, Never>?
+    @ObservationIgnored private var waveformInFlight: [String: Task<Void, Never>] = [:]
     @ObservationIgnored private var tempFiles: [URL] = []
+    @ObservationIgnored private var isTornDown = false
     @ObservationIgnored private let maxCacheEntries = 128
 
     public init() {}
@@ -69,6 +71,8 @@ public final class VoiceMessagePlayer {
     // MARK: - Control
 
     /// Load metadata/waveform for a message's attachment without playing.
+    /// Safe to call repeatedly (onAppear + play tap): waveform computation is
+    /// single-flighted per key and cached, so repeated calls are no-ops.
     public func prepare(key: String, attachment: AudioAttachment) {
         var st = states[key] ?? PlaybackState()
         if st.status == .idle || st.status == .error {
@@ -77,9 +81,7 @@ public final class VoiceMessagePlayer {
             st.positionMs = 0
             states[key] = st
         }
-        if waveform(for: key) == nil, let peaks = resolveWaveform(attachment) {
-            cacheWaveform(key, peaks)
-        }
+        prepareWaveform(key: key, attachment: attachment)
     }
 
     /// Play a message. Replaces any in-flight playback.
@@ -92,9 +94,7 @@ public final class VoiceMessagePlayer {
         st.positionMs = 0
         st.durationMs = resolveDurationMs(attachment)
         states[key] = st
-        if waveform(for: key) == nil, let peaks = resolveWaveform(attachment) {
-            cacheWaveform(key, peaks)
-        }
+        prepareWaveform(key: key, attachment: attachment)
         Task { [weak self] in
             do {
                 try await self?.startPlayback(key: key, attachment: attachment)
@@ -247,20 +247,60 @@ public final class VoiceMessagePlayer {
         return attachment.durationMs ?? 0
     }
 
-    private func resolveWaveform(_ attachment: AudioAttachment) -> [Float]? {
-        let bars = 40
-        guard attachment.mode.isCodec2 else {
-            // Ogg: decoding the full file for peaks is heavy; use a neutral
-            // filled waveform (never block playback on it).
-            return Array(repeating: 0.5, count: bars)
+    /// Compute (or reuse the cached) waveform for a message.
+    ///
+    /// - Codec2: the payload is a small raw-frame concatenation; decode
+    ///   synchronously so the peaks are cached before the first play (the
+    ///   Codec2 decode is a few ms at most).
+    /// - Ogg/Opus: decoding the full file for peaks is heavier and uses
+    ///   AVFoundation's file decoder (reliable on device; on the simulator it
+    ///   may legitimately fail - that's fine). Compute on a background task,
+    ///   single-flighted per key (Android's `prepareMetadata` does the same);
+    ///   until it lands - or if it fails - the views render the neutral
+    ///   placeholder via `waveform(for:) ?? VoiceWaveform.placeholder()`.
+    ///   Playback never waits on it.
+    private func prepareWaveform(key: String, attachment: AudioAttachment) {
+        if waveform(for: key) != nil { return }
+        if attachment.mode.isCodec2 {
+            guard let peaks = codec2Peaks(attachment) else { return }
+            cacheWaveform(key, peaks)
+            return
         }
+        guard waveformInFlight[key] == nil else { return }
+        let bytes = attachment.bytes
+        let task = Task { [weak self] in
+            // Decode + bucket off the main actor; publish the peaks (if any)
+            // back on the main actor.
+            let peaks = await Task.detached(priority: .utility) {
+                OggOpusWaveform.realWaveform(from: bytes)
+            }.value
+            self?.cacheWaveformIfCurrent(key: key, peaks: peaks)
+        }
+        waveformInFlight[key] = task
+    }
+
+    /// Cache decoded Ogg peaks and clear the in-flight slot (called from the
+    /// prepareWaveform task, on the main actor). A nil decode result is a
+    /// non-fatal fail-open: the slot is still cleared and the views keep the
+    /// neutral placeholder.
+    private func cacheWaveformIfCurrent(key: String, peaks: [Float]?) {
+        waveformInFlight[key] = nil
+        if let peaks {
+            cacheWaveform(key, peaks)
+        }
+    }
+
+    /// Synchronous Codec2 peaks (pure decode + peak-max, as before).
+    private func codec2Peaks(_ attachment: AudioAttachment) -> [Float]? {
+        let bars = OggOpusWaveform.bars
         guard let decoded = try? Codec2RawFile.decodePayload(attachment.bytes, mode: attachment.mode) else {
-            return Array(repeating: 0.5, count: bars)
+            return nil
         }
         return peaks(from: decoded.samples, bars: bars)
     }
 
     private func cacheWaveform(_ key: String, _ peaks: [Float]) {
+        guard !isTornDown else { return }
         if waveforms.count >= maxCacheEntries {
             // Drop the oldest inserted key (FIFO approximation).
             if let oldest = waveforms.keys.first { waveforms[oldest] = nil }
@@ -289,10 +329,15 @@ public final class VoiceMessagePlayer {
 
     public func tearDown() {
         stopCurrent()
+        // Cancel any in-flight waveform decodes so a late result cannot
+        // repopulate the (about-to-be-cleared) cache.
+        for (_, task) in waveformInFlight { task.cancel() }
+        waveformInFlight.removeAll()
         for url in tempFiles { try? FileManager.default.removeItem(at: url) }
         tempFiles.removeAll()
         states.removeAll()
         waveforms.removeAll()
+        isTornDown = true
     }
 
     private enum PlayerError: Error { case unplayable }

--- a/Sources/ColumbaApp/Voice/VoiceMessagePlayer.swift
+++ b/Sources/ColumbaApp/Voice/VoiceMessagePlayer.swift
@@ -99,6 +99,7 @@ public final class VoiceMessagePlayer {
             do {
                 try await self?.startPlayback(key: key, attachment: attachment)
             } catch {
+                DiagLog.log("[VOICE-PLAY] ERROR key=\(key.prefix(8)) \(error.localizedDescription)")
                 self?.markError(key, error.localizedDescription)
             }
         }
@@ -146,10 +147,14 @@ public final class VoiceMessagePlayer {
     // MARK: - Playback start (off the main-actor hot path)
 
     private func startPlayback(key: String, attachment: AudioAttachment) async throws {
+        DiagLog.log("[VOICE-PLAY] start key=\(key.prefix(8)) mode=0x\(String(format: "%02x", attachment.mode.rawValue)) bytes=\(attachment.bytes.count)")
         let url = try renderToTempFile(attachment)
         tempFiles.append(url)
         let filePlayer = try AVAudioPlayer(contentsOf: url)
-        guard filePlayer.prepareToPlay() else {
+        let ready = filePlayer.prepareToPlay()
+        DiagLog.log("[VOICE-PLAY] prepareToPlay=\(ready) duration=\(filePlayer.duration)")
+        guard ready else {
+            DiagLog.log("[VOICE-PLAY] UNPLAYABLE url=\(url.lastPathComponent)")
             throw PlayerError.unplayable
         }
         filePlayer.numberOfLoops = 0
@@ -160,6 +165,7 @@ public final class VoiceMessagePlayer {
         st.status = .playing
         if st.durationMs == 0 { st.durationMs = Int((filePlayer.duration * 1_000).rounded()) }
         states[key] = st
+        DiagLog.log("[VOICE-PLAY] PLAYING durationMs=\(st.durationMs)")
         startProgressPolling()
     }
 

--- a/Sources/ColumbaApp/Voice/VoiceMessagePlayer.swift
+++ b/Sources/ColumbaApp/Voice/VoiceMessagePlayer.swift
@@ -151,16 +151,31 @@ public final class VoiceMessagePlayer {
         let url = try renderToTempFile(attachment)
         tempFiles.append(url)
         let filePlayer = try AVAudioPlayer(contentsOf: url)
-        let ready = filePlayer.prepareToPlay()
-        DiagLog.log("[VOICE-PLAY] prepareToPlay=\(ready) duration=\(filePlayer.duration)")
-        guard ready else {
+        filePlayer.numberOfLoops = 0
+        filePlayer.volume = 1.0
+        // prepareToPlay() is NOT a reliable gate for Ogg/Opus: AVFoundation's
+        // format reader returns false for streaming formats even when play()
+        // works (it still reads duration correctly, as seen in diag). Gate on
+        // the actual play() result (isPlaying) instead, with a brief poll for
+        // the first decode buffer.
+        _ = filePlayer.prepareToPlay()
+        filePlayer.play()
+        var playing = filePlayer.isPlaying
+        if !playing {
+            // First buffer may not be decoded synchronously for a streaming
+            // format; give it a short, bounded window before declaring defeat.
+            for _ in 0..<10 {
+                try? await Task.sleep(nanoseconds: 100_000_000)
+                if filePlayer.isPlaying { playing = true; break }
+            }
+        }
+        let playErr = filePlayer.error
+        DiagLog.log("[VOICE-PLAY] isPlaying=\(playing) duration=\(filePlayer.duration) error=\(String(describing: playErr))")
+        guard playing else {
             DiagLog.log("[VOICE-PLAY] UNPLAYABLE url=\(url.lastPathComponent)")
             throw PlayerError.unplayable
         }
-        filePlayer.numberOfLoops = 0
-        filePlayer.volume = 1.0
         player = filePlayer
-        filePlayer.play()
         var st = states[key] ?? PlaybackState()
         st.status = .playing
         if st.durationMs == 0 { st.durationMs = Int((filePlayer.duration * 1_000).rounded()) }

--- a/Sources/ColumbaApp/Voice/VoiceMessagePlayer.swift
+++ b/Sources/ColumbaApp/Voice/VoiceMessagePlayer.swift
@@ -169,8 +169,7 @@ public final class VoiceMessagePlayer {
                 if filePlayer.isPlaying { playing = true; break }
             }
         }
-        let playErr = filePlayer.error
-        DiagLog.log("[VOICE-PLAY] isPlaying=\(playing) duration=\(filePlayer.duration) error=\(String(describing: playErr))")
+        DiagLog.log("[VOICE-PLAY] isPlaying=\(playing) duration=\(filePlayer.duration)")
         guard playing else {
             DiagLog.log("[VOICE-PLAY] UNPLAYABLE url=\(url.lastPathComponent)")
             throw PlayerError.unplayable

--- a/Sources/ColumbaApp/Voice/VoiceMessagePlayer.swift
+++ b/Sources/ColumbaApp/Voice/VoiceMessagePlayer.swift
@@ -51,6 +51,10 @@ public final class VoiceMessagePlayer {
     @ObservationIgnored private var waveformInFlight: [String: Task<Void, Never>] = [:]
     @ObservationIgnored private var tempFiles: [URL] = []
     @ObservationIgnored private var isTornDown = false
+    /// True from the moment we activated the shared `AVAudioSession` for
+    /// playback until we deactivate it. We release only a session we own:
+    /// deactivating the recorder's or a call's session would clobber it.
+    @ObservationIgnored private var ownsPlaybackSession = false
     @ObservationIgnored private let maxCacheEntries = 128
 
     public init() {}
@@ -142,6 +146,23 @@ public final class VoiceMessagePlayer {
             states[key] = st
         }
         currentKey = nil
+        releasePlaybackSession()
+    }
+
+    /// Release the shared audio session we activated for playback, if we own
+    /// it. `notifyOthersOnDeactivation` lets audio interrupted from other
+    /// apps resume. Deactivating the recorder's or a live call's session
+    /// would clobber it, so we release only what we took - and `stopCurrent`
+    /// runs before `startPlayback` re-activates, so consecutive plays are
+    /// unaffected.
+    private func releasePlaybackSession() {
+        guard ownsPlaybackSession else { return }
+        ownsPlaybackSession = false
+        do {
+            try AVAudioSession.sharedInstance().setActive(false, options: [.notifyOthersOnDeactivation])
+        } catch {
+            DiagLog.log("[VOICE-PLAY] session release failed: \(error.localizedDescription)")
+        }
     }
 
     // MARK: - Playback start (off the main-actor hot path)
@@ -166,6 +187,10 @@ public final class VoiceMessagePlayer {
             do {
                 try session.setCategory(.playback, mode: .default, options: [])
                 try session.setActive(true, options: [])
+                // We made the shared session ours: release it when playback
+                // ends (stopCurrent / tearDown) so interrupted audio from
+                // other apps can resume and we hold no idle ownership.
+                ownsPlaybackSession = true
             } catch {
                 DiagLog.log("[VOICE-PLAY] session setup failed: \(error.localizedDescription)")
             }

--- a/Sources/ColumbaApp/Voice/VoiceMessagePlayer.swift
+++ b/Sources/ColumbaApp/Voice/VoiceMessagePlayer.swift
@@ -222,9 +222,15 @@ public final class VoiceMessagePlayer {
             try Codec2RawFile.writeWave(decoded, to: wav)
             return wav
         }
-        // Ogg/Opus: AVFoundation plays .ogg directly.
+        // Ogg/Opus: AVFoundation plays .ogg directly - EXCEPT it rejects the
+        // multi-packet-per-page layout that Sideband's PyOgg emits (see
+        // OggOpusInboundNormalizer). Normalize first; if the bytes are not a
+        // decodable Ogg stream at all, fall back to the raw bytes so the
+        // existing unplayable path still applies (never worse than before).
+        let raw = [UInt8](attachment.bytes)
+        let normalized = (try? OggOpusInboundNormalizer.normalize(raw))?.bytes
         let ogg = dir.appendingPathComponent("voice_\(UUID().uuidString).ogg")
-        try attachment.bytes.write(to: ogg)
+        try Data(normalized ?? raw).write(to: ogg)
         return ogg
     }
 

--- a/Sources/ColumbaApp/Voice/VoiceMessagePlayer.swift
+++ b/Sources/ColumbaApp/Voice/VoiceMessagePlayer.swift
@@ -1,0 +1,273 @@
+//
+//  VoiceMessagePlayer.swift
+//  ColumbaApp
+//
+//  Plays back a voice message `AudioAttachment`. Ported from Android
+//  Columba's `VoiceMessagePlayer`:
+//
+//   - Codec2 -> decode the raw-frame payload to 8 kHz mono PCM, write a temp
+//     `.wav` (PCM16), play with `AVAudioPlayer`.
+//   - Ogg/Opus -> write the bytes to a temp `.ogg` and play with
+//     `AVAudioPlayer` (AVFoundation plays Ogg/Opus natively on iOS 16+). If
+//     live interop testing shows an external Ogg (Sideband) fails to play on
+//     this path, an inbound granule-normalization pass is added here before
+//     play (defensive; Android's normalizer was outbound-only).
+//
+//  A single shared instance plays one message at a time (like Android's
+//  MediaPlayer singleton). Per-message state (idle / loading / playing /
+//  paused / progress / duration / error) is published on the main actor;
+//  progress is polled at ~250 ms. Duration + waveform metadata is cached and
+//  bounded (128 entries).
+//
+
+import Foundation
+import Observation
+import AVFoundation
+import LXSTSwift
+
+@available(iOS 17.0, *)
+@Observable
+@MainActor
+public final class VoiceMessagePlayer {
+
+    public struct PlaybackState: Equatable {
+        public enum Status: Equatable { case idle, loading, playing, paused, error }
+        public var status: Status = .idle
+        public var positionMs: Int = 0
+        public var durationMs: Int = 0
+        public var errorMessage: String? = nil
+
+        public init() {}
+    }
+
+    /// Per-message playback state, keyed by a stable message id.
+    public private(set) var states: [String: PlaybackState] = [:]
+    /// Per-message waveform peaks (normalized 0...1, ~40 bars), cached.
+    public private(set) var waveforms: [String: [Float]] = [:]
+
+    @ObservationIgnored private var currentKey: String?
+    @ObservationIgnored private var player: AVAudioPlayer?
+    @ObservationIgnored private var progressTask: Task<Void, Never>?
+    @ObservationIgnored private var tempFiles: [URL] = []
+    @ObservationIgnored private let maxCacheEntries = 128
+
+    public init() {}
+
+    public func state(for key: String) -> PlaybackState {
+        states[key] ?? PlaybackState()
+    }
+
+    public func waveform(for key: String) -> [Float]? {
+        waveforms[key]
+    }
+
+    public var isPlaying: Bool {
+        if let key = currentKey { return states[key]?.status == .playing }
+        return false
+    }
+
+    // MARK: - Control
+
+    /// Load metadata/waveform for a message's attachment without playing.
+    public func prepare(key: String, attachment: AudioAttachment) {
+        var st = states[key] ?? PlaybackState()
+        if st.status == .idle || st.status == .error {
+            st.status = .idle
+            st.durationMs = resolveDurationMs(attachment)
+            st.positionMs = 0
+            states[key] = st
+        }
+        if waveform(for: key) == nil, let peaks = resolveWaveform(attachment) {
+            cacheWaveform(key, peaks)
+        }
+    }
+
+    /// Play a message. Replaces any in-flight playback.
+    public func play(key: String, attachment: AudioAttachment) {
+        stopCurrent()
+        currentKey = key
+        var st = states[key] ?? PlaybackState()
+        st.status = .loading
+        st.errorMessage = nil
+        st.positionMs = 0
+        st.durationMs = resolveDurationMs(attachment)
+        states[key] = st
+        if waveform(for: key) == nil, let peaks = resolveWaveform(attachment) {
+            cacheWaveform(key, peaks)
+        }
+        Task { [weak self] in
+            do {
+                try await self?.startPlayback(key: key, attachment: attachment)
+            } catch {
+                self?.markError(key, error.localizedDescription)
+            }
+        }
+    }
+
+    public func pause() {
+        guard let key = currentKey, let player else { return }
+        player.pause()
+        var st = states[key] ?? PlaybackState()
+        st.status = .paused
+        st.positionMs = Int(player.currentTime * 1_000)
+        states[key] = st
+    }
+
+    public func resume() {
+        guard let key = currentKey, let player else { return }
+        player.play()
+        states[key]?.status = .playing
+        startProgressPolling()
+    }
+
+    public func togglePlay(key: String, attachment: AudioAttachment) {
+        if currentKey == key {
+            if states[key]?.status == .playing { pause() }
+            else if states[key]?.status == .paused { resume() }
+        } else {
+            play(key: key, attachment: attachment)
+        }
+    }
+
+    public func stopCurrent() {
+        progressTask?.cancel()
+        progressTask = nil
+        player?.stop()
+        player = nil
+        if let key = currentKey {
+            var st = states[key] ?? PlaybackState()
+            st.status = .idle
+            st.positionMs = 0
+            states[key] = st
+        }
+        currentKey = nil
+    }
+
+    // MARK: - Playback start (off the main-actor hot path)
+
+    private func startPlayback(key: String, attachment: AudioAttachment) async throws {
+        let url = try renderToTempFile(attachment)
+        tempFiles.append(url)
+        let filePlayer = try AVAudioPlayer(contentsOf: url)
+        guard filePlayer.prepareToPlay() else {
+            throw PlayerError.unplayable
+        }
+        filePlayer.numberOfLoops = 0
+        filePlayer.volume = 1.0
+        player = filePlayer
+        filePlayer.play()
+        var st = states[key] ?? PlaybackState()
+        st.status = .playing
+        if st.durationMs == 0 { st.durationMs = Int((filePlayer.duration * 1_000).rounded()) }
+        states[key] = st
+        startProgressPolling()
+    }
+
+    private func startProgressPolling() {
+        progressTask?.cancel()
+        progressTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 250_000_000)
+                guard let self, let key = self.currentKey, let player = self.player else { return }
+                var st = self.states[key] ?? PlaybackState()
+                st.positionMs = Int((player.currentTime * 1_000).rounded())
+                self.states[key] = st
+                if !player.isPlaying {
+                    self.states[key]?.status = .idle
+                    self.stopCurrent()
+                    return
+                }
+            }
+        }
+    }
+
+    private func markError(_ key: String, _ message: String) {
+        stopCurrent()
+        var st = states[key] ?? PlaybackState()
+        st.status = .error
+        st.errorMessage = message
+        states[key] = st
+    }
+
+    // MARK: - Rendering
+
+    /// Materialize the attachment as a temp file the player can open.
+    private func renderToTempFile(_ attachment: AudioAttachment) throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("columba-voice-play", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        if attachment.mode.isCodec2 {
+            let decoded = try Codec2RawFile.decodePayload(attachment.bytes, mode: attachment.mode)
+            let wav = dir.appendingPathComponent("voice_\(UUID().uuidString).wav")
+            try Codec2RawFile.writeWave(decoded, to: wav)
+            return wav
+        }
+        // Ogg/Opus: AVFoundation plays .ogg directly.
+        let ogg = dir.appendingPathComponent("voice_\(UUID().uuidString).ogg")
+        try attachment.bytes.write(to: ogg)
+        return ogg
+    }
+
+    // MARK: - Metadata
+
+    private func resolveDurationMs(_ attachment: AudioAttachment) -> Int {
+        if let existing = states[currentKey ?? ""]?.durationMs, existing > 0 { return existing }
+        if attachment.mode.isCodec2 {
+            return (attachment.durationMs ?? 0)
+        }
+        if let meta = OggOpusMetadataReader.read([UInt8](attachment.bytes)) {
+            return meta.durationMs
+        }
+        return attachment.durationMs ?? 0
+    }
+
+    private func resolveWaveform(_ attachment: AudioAttachment) -> [Float]? {
+        let bars = 40
+        guard attachment.mode.isCodec2 else {
+            // Ogg: decoding the full file for peaks is heavy; use a neutral
+            // filled waveform (never block playback on it).
+            return Array(repeating: 0.5, count: bars)
+        }
+        guard let decoded = try? Codec2RawFile.decodePayload(attachment.bytes, mode: attachment.mode) else {
+            return Array(repeating: 0.5, count: bars)
+        }
+        return peaks(from: decoded.samples, bars: bars)
+    }
+
+    private func cacheWaveform(_ key: String, _ peaks: [Float]) {
+        if waveforms.count >= maxCacheEntries {
+            // Drop the oldest inserted key (FIFO approximation).
+            if let oldest = waveforms.keys.first { waveforms[oldest] = nil }
+        }
+        waveforms[key] = peaks
+    }
+
+    private func peaks(from pcm: [Int16], bars: Int) -> [Float] {
+        guard !pcm.isEmpty else { return Array(repeating: 0.0, count: bars) }
+        let chunk = max(1, pcm.count / bars)
+        var out = [Float](); out.reserveCapacity(bars)
+        var i = 0
+        while i < pcm.count && out.count < bars {
+            var maxAbs: Int16 = 0
+            let end = min(i + chunk, pcm.count)
+            for j in i..<end {
+                let a = abs(Int32(pcm[j]))
+                if a > Int32(maxAbs) { maxAbs = Int16(clamping: a) }
+            }
+            out.append(Float(Int(maxAbs)) / 32_768.0)
+            i = end
+        }
+        while out.count < bars { out.append(0) }
+        return out
+    }
+
+    public func tearDown() {
+        stopCurrent()
+        for url in tempFiles { try? FileManager.default.removeItem(at: url) }
+        tempFiles.removeAll()
+        states.removeAll()
+        waveforms.removeAll()
+    }
+
+    private enum PlayerError: Error { case unplayable }
+}

--- a/Sources/ColumbaApp/Voice/VoiceMessagePlayer.swift
+++ b/Sources/ColumbaApp/Voice/VoiceMessagePlayer.swift
@@ -55,6 +55,14 @@ public final class VoiceMessagePlayer {
     /// playback until we deactivate it. We release only a session we own:
     /// deactivating the recorder's or a call's session would clobber it.
     @ObservationIgnored private var ownsPlaybackSession = false
+    /// Monotonic playback generation. `stopCurrent` bumps it (covering
+    /// explicit stop, natural completion, error, teardown, and the view
+    /// disappearing), and `play` snapshots it before dispatching the
+    /// async startup. The startup re-checks it at its suspension points so
+    /// a start that was superseded by a stop cannot re-acquire the shared
+    /// audio session or publish playback state after the user already
+    /// stopped (Greptile finding, PR #194 iteration 3).
+    @ObservationIgnored private var playGeneration = 0
     @ObservationIgnored private let maxCacheEntries = 128
 
     public init() {}
@@ -99,12 +107,20 @@ public final class VoiceMessagePlayer {
         st.durationMs = resolveDurationMs(attachment)
         states[key] = st
         prepareWaveform(key: key, attachment: attachment)
+        // Snapshot the (just-bumped) generation: the async startup must
+        // prove it is still current at each suspension point.
+        let generation = playGeneration
         Task { [weak self] in
             do {
-                try await self?.startPlayback(key: key, attachment: attachment)
+                try await self?.startPlayback(key: key, attachment: attachment, generation: generation)
+            } catch let error as PlayerError where error == .superseded {
+                // A stop already ran for this generation; the UI is already
+                // idle (or playing a newer message). Do NOT mark an error -
+                // that would surface a false failure and stopCurrent() would
+                // stop whatever is current (possibly a newer playback).
             } catch {
                 DiagLog.log("[VOICE-PLAY] ERROR key=\(key.prefix(8)) \(error.localizedDescription)")
-                self?.markError(key, error.localizedDescription)
+                self?.markError(key, error.localizedDescription, generation: generation)
             }
         }
     }
@@ -146,6 +162,9 @@ public final class VoiceMessagePlayer {
             states[key] = st
         }
         currentKey = nil
+        // Invalidate any in-flight async startup so it cannot re-acquire the
+        // session or publish state after this stop (see playGeneration).
+        playGeneration += 1
         releasePlaybackSession()
     }
 
@@ -167,7 +186,11 @@ public final class VoiceMessagePlayer {
 
     // MARK: - Playback start (off the main-actor hot path)
 
-    private func startPlayback(key: String, attachment: AudioAttachment) async throws {
+    private func startPlayback(key: String, attachment: AudioAttachment, generation: Int) async throws {
+        // A stop that landed between play() and this point (view dismissed,
+        // explicit stop, teardown) already invalidated us: bail before
+        // touching the session or the player.
+        guard generation == playGeneration else { throw PlayerError.superseded }
         DiagLog.log("[VOICE-PLAY] start key=\(key.prefix(8)) mode=0x\(String(format: "%02x", attachment.mode.rawValue)) bytes=\(attachment.bytes.count)")
         let url = try renderToTempFile(attachment)
         tempFiles.append(url)
@@ -213,8 +236,22 @@ public final class VoiceMessagePlayer {
             // format; give it a short, bounded window before declaring defeat.
             for _ in 0..<10 {
                 try? await Task.sleep(nanoseconds: 100_000_000)
+                // The sleep is a suspension point: a stop/teardown that ran
+                // during it invalidated this startup. Bail before doing
+                // anything further with the shared session or state.
+                guard generation == playGeneration else {
+                    filePlayer.stop()
+                    throw PlayerError.superseded
+                }
                 if filePlayer.isPlaying { playing = true; break }
             }
+        }
+        // Final gate after every suspension point above: if we were stopped
+        // in the meantime, do not publish state, start progress polling, or
+        // leave the session we just activated in play.
+        guard generation == playGeneration else {
+            filePlayer.stop()
+            throw PlayerError.superseded
         }
         DiagLog.log("[VOICE-PLAY] isPlaying=\(playing) duration=\(filePlayer.duration)")
         guard playing else {
@@ -258,7 +295,11 @@ public final class VoiceMessagePlayer {
         }
     }
 
-    private func markError(_ key: String, _ message: String) {
+    private func markError(_ key: String, _ message: String, generation: Int) {
+        // A superseded startup (a stop already ran) must not surface a
+        // spurious error or stop whatever is current (possibly a newer
+        // playback). Only the still-current generation may mark an error.
+        guard generation == playGeneration else { return }
         stopCurrent()
         var st = states[key] ?? PlaybackState()
         st.status = .error
@@ -397,5 +438,10 @@ public final class VoiceMessagePlayer {
         isTornDown = true
     }
 
-    private enum PlayerError: Error { case unplayable }
+    private enum PlayerError: Error, Equatable {
+        case unplayable
+        /// The async startup was superseded by a stop/teardown; the caller
+        /// must treat this as a silent no-op, not a user-facing failure.
+        case superseded
+    }
 }

--- a/Sources/ColumbaApp/Voice/VoiceMessageRecorder.swift
+++ b/Sources/ColumbaApp/Voice/VoiceMessageRecorder.swift
@@ -535,12 +535,13 @@ final class AVEngineVoiceCapture: VoicePcmCapture {
         let input = engine.inputNode
         let hardware = input.inputFormat(forBus: 0)
         // Defensive: a degenerate input format (zero sample rate/channel
-        // count, seen when no usable input device is present) makes
+        // count, as seen when no usable input device is present - a simulator
+        // with no mic, a BT-only route, a busy/absent input) makes
         // `installTap(onBus:format:)` throw an ObjC NSException that Swift
-        // `try/catch` cannot intercept - a hard SIGABRT. The recorder's
-        // `captureHasInput` guard should prevent reaching this path, but keep
-        // the belt-and-braces check here so a format change between the guard
-        // and the tap can never abort the process.
+        // `try/catch` cannot intercept - a hard SIGABRT. `isSupported` only
+        // checks the permission, so this is the guard that keeps the recorder
+        // from aborting the process: fail with `unsupported` and let the UI
+        // publish its "not supported on this device" panel state.
         guard hardware.sampleRate > 0, Int(hardware.channelCount) > 0 else {
             try? session.setActive(false)
             throw VoiceRecorderError.unsupported

--- a/Sources/ColumbaApp/Voice/VoiceMessageRecorder.swift
+++ b/Sources/ColumbaApp/Voice/VoiceMessageRecorder.swift
@@ -183,6 +183,18 @@ public final class VoiceMessageRecorder {
             try? FileManager.default.removeItem(at: out)
             self.capture = nil
             self.outputFile = nil
+            // Preserve the unsupported distinction so the composer can show
+            // the dedicated "not supported on this device" row (Android
+            // `!isSupported` parity) rather than a generic failure. This
+            // covers the degenerate-input-format abort guard in the capture
+            // (no usable input device), not just the `isSupported` pre-check.
+            if error is VoiceRecorderError, (error as? VoiceRecorderError) == .unsupported {
+                let msg = String(localized: "Voice messages are not supported on this device.")
+                errorMessage = msg
+                lastFailureWasUnsupported = true
+                state = .failed(message: msg)
+                throw VoiceRecorderError.unsupported
+            }
             errorMessage = error.localizedDescription
             state = .failed(message: errorMessage!)
             throw VoiceRecorderError.captureStartFailed

--- a/Sources/ColumbaApp/Voice/VoiceMessageRecorder.swift
+++ b/Sources/ColumbaApp/Voice/VoiceMessageRecorder.swift
@@ -1,0 +1,585 @@
+//
+//  VoiceMessageRecorder.swift
+//  ColumbaApp
+//
+//  Records a voice message to a finalized file (.c2 for Codec2, .ogg for
+//  Ogg/Opus) in the chosen `VoiceMessageFormat`. Mirrors Android Columba's
+//  `VoiceMessageRecorder` + `Codec2VoiceRecorderBackend` / LXST Ogg recorder:
+//
+//   - a single 5-minute deadline auto-stops a recording;
+//   - a capture-worker failure atomically closes the engine, deletes the partial
+//     file, and publishes a terminal `.failed` (never a silent success or a
+//     stuck "recording");
+//   - a finalized recording is retained across engine teardown (route change,
+//     background, mic handoff) so it is not discarded while still selected by
+//     the composer.
+//
+//  Threading model (matches AudioManager): the blocking read/encode loop runs on
+a dedicated `Thread`; it snapshots the format/output/capture into locals and
+only reads the locked `VoiceStopLatch` stop flag. All observable state is published by
+//  hopping back to the `@MainActor` in `onCaptureDone`. `stop()`/`cancel()` are
+//  NON-blocking: they flip the flag(s) and return; the loop self-terminates
+//  (the capture `read` times out at 50 ms) and publishes the terminal state.
+//  The UI observes `state` / `selectedRecording`. The capture source is
+//  injectable so the state machine is testable without an audio device.
+//
+
+import Foundation
+import Observation
+import LXSTSwift
+import AVFoundation
+
+// MARK: - Capture abstraction
+
+/// A source of raw int16 PCM (mono at a known rate) for one recording session.
+/// `read` blocks up to a short timeout and returns the number of mono samples
+/// delivered (0 on timeout / end), so a blocking read is interruptible by stop.
+protocol VoicePcmCapture: AnyObject {
+    var isSupported: Bool { get }
+    var sampleRate: Int { get }
+    func start() throws
+    /// Read up to `capacity` mono samples into `buffer`. Returns samples read,
+    /// or 0 on timeout. Returns -1 on a hard capture error.
+    func read(into buffer: inout [Int16], capacity: Int) -> Int
+    func stop()
+    func close()
+}
+
+/// Factory for capture sessions (injected in tests; the real one wraps
+/// AVAudioEngine).
+protocol VoicePcmCaptureFactory: AnyObject {
+    func makeCapture(channels: Int, sampleRateHint: Int) -> VoicePcmCapture
+}
+
+// MARK: - Output
+
+/// A finalized recording ready to attach to a message.
+public struct VoiceRecording: Equatable {
+    public let url: URL
+    public let format: VoiceMessageFormat
+    public let durationMs: Int
+    public let sizeBytes: Int
+    public let audio: AudioAttachment
+}
+
+/// Recorder state (mirrors Android `VoiceMessageRecordingState`).
+public enum VoiceRecorderState: Equatable {
+    case idle
+    case recording(elapsedMs: Int)
+    case finalizing
+    case completed(VoiceRecording)
+    case failed(message: String)
+}
+
+public enum VoiceRecorderError: Error, Equatable {
+    case alreadyRecording
+    case unsupported
+    case captureStartFailed
+    case codecUnavailable
+    case noAudio
+}
+
+// MARK: - Stop latch
+
+/// Benign cross-thread stop latch (mirrors Android's `AtomicBoolean`): the
+/// `@MainActor` recorder writes it, the capture thread reads it. Locked so the
+/// cross-thread read is well-defined (a plain `var running` read on one thread
+/// while written on another is undefined behavior).
+final class VoiceStopLatch: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _running = false
+    var running: Bool {
+        get { lock.lock(); defer { lock.unlock() }; return _running }
+        set { lock.lock(); _running = newValue; lock.unlock() }
+    }
+}
+
+// MARK: - Recorder
+
+@available(iOS 17.0, *)
+@Observable
+@MainActor
+public final class VoiceMessageRecorder {
+
+    // Observable (UI-bound) state.
+    public private(set) var state: VoiceRecorderState = .idle
+    public private(set) var errorMessage: String? = nil
+    public private(set) var selectedRecording: VoiceRecording? = nil
+    public private(set) var selectedFormat: VoiceMessageFormat? = nil
+    /// True when the last `start()` failure was because the device cannot
+    /// record (as opposed to a transient capture error). Lets the composer
+    /// panel show the dedicated "not supported" row, mirroring Android's
+    /// `!isSupported` panel state.
+    public private(set) var lastFailureWasUnsupported = false
+
+    public static let maxDurationMillis = 5 * 60 * 1_000
+
+    // Engine (not observed).
+    @ObservationIgnored private let captureFactory: any VoicePcmCaptureFactory
+    @ObservationIgnored private var capture: VoicePcmCapture?
+    @ObservationIgnored private var format: VoiceMessageFormat?
+    @ObservationIgnored private var outputFile: URL?
+    @ObservationIgnored private var captureThread: Thread?
+    /// Stop flag read on the capture thread via the locked `VoiceStopLatch`
+    /// (mirrors Android's AtomicBoolean; `nonisolated`-safe by construction).
+    @ObservationIgnored private let stopLatch = VoiceStopLatch()
+    /// Cancel latch (distinct from a normal stop): a cancelled in-flight file is
+    /// deleted rather than finalized.
+    @ObservationIgnored private var cancelled = false
+    @ObservationIgnored private var elapsedMs = 0
+    @ObservationIgnored private var elapsedTask: Task<Void, Never>?
+    @ObservationIgnored private var deadlineTask: Task<Void, Never>?
+    @ObservationIgnored private var workerFailure: Error? = nil
+
+    public init(captureFactory: any VoicePcmCaptureFactory = AVEngineVoiceCaptureFactory()) {
+        self.captureFactory = captureFactory
+    }
+
+    public var isRecording: Bool {
+        if case .recording = state { return true }
+        return false
+    }
+
+    // MARK: - Start
+
+    @discardableResult
+    public func start(format: VoiceMessageFormat) throws -> URL {
+        if isRecording { throw VoiceRecorderError.alreadyRecording }
+        lastFailureWasUnsupported = false
+        let newCapture = captureFactory.makeCapture(
+            channels: format.opusProfile?.channels ?? 1,
+            sampleRateHint: format.opusProfile?.sampleRate ?? Codec2RawFile.sampleRate
+        )
+        guard newCapture.isSupported else {
+            let msg = String(localized: "Voice messages are not supported on this device.")
+            errorMessage = msg
+            lastFailureWasUnsupported = true
+            state = .failed(message: msg)
+            throw VoiceRecorderError.unsupported
+        }
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("columba-voice-notes", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let ext = format.isCodec2 ? "c2" : "ogg"
+        let out = dir.appendingPathComponent("voice_\(UUID().uuidString).\(ext)")
+        self.outputFile = out
+        self.format = format
+        self.capture = newCapture
+        self.cancelled = false
+        self.workerFailure = nil
+
+        do {
+            try newCapture.start()
+        } catch {
+            newCapture.close()
+            try? FileManager.default.removeItem(at: out)
+            self.capture = nil
+            self.outputFile = nil
+            errorMessage = error.localizedDescription
+            state = .failed(message: errorMessage!)
+            throw VoiceRecorderError.captureStartFailed
+        }
+
+        // A new recording supersedes any prior (unsent) selection, as on Android.
+        if let prior = selectedRecording {
+            try? FileManager.default.removeItem(at: prior.url)
+            selectedRecording = nil
+            selectedFormat = nil
+        }
+
+        stopLatch.running = true
+        elapsedMs = 0
+        state = .recording(elapsedMs: 0)
+        errorMessage = nil
+        startElapsed()
+        startDeadline()
+        spawnCaptureThread()
+        return out
+    }
+
+    // MARK: - Stop / cancel / remove (all non-blocking)
+
+    /// Finalize the active recording. Flips the stop flag and returns; the
+    /// capture loop self-terminates and publishes `.completed` (or `.failed`).
+    public func stop() {
+        guard stopLatch.running else { return }
+        stopLatch.running = false
+        cancelled = false
+        state = .finalizing
+    }
+
+    /// Discard the active recording. The in-flight file (if any) is deleted by
+    /// the capture loop's completion; an already-selected recording is cleared.
+    public func cancel() {
+        let wasRunning = stopLatch.running
+        stopLatch.running = false
+        cancelled = true
+        if let sel = selectedRecording {
+            try? FileManager.default.removeItem(at: sel.url)
+            selectedRecording = nil
+            selectedFormat = nil
+        }
+        state = .idle
+        if !wasRunning {
+            // No active loop to publish; ensure any stale engine is torn down.
+            capture?.close()
+            capture = nil
+            stopElapsedAndDeadline()
+        }
+    }
+
+    /// Remove a previously finalized (selected) recording from the composer.
+    @discardableResult
+    public func removeSelected() -> Bool {
+        guard let sel = selectedRecording else { return false }
+        try? FileManager.default.removeItem(at: sel.url)
+        selectedRecording = nil
+        selectedFormat = nil
+        if case .completed = state { state = .idle }
+        return true
+    }
+
+    /// Close the composer voice panel: tear down any active capture (the
+    /// in-flight file is deleted) and clear the last error, returning to
+    /// `.idle` with a clean ready row. Mirrors Android's panel `onCancel`.
+    public func closePanel() {
+        let wasRunning = stopLatch.running
+        stopLatch.running = false
+        cancelled = true
+        if let sel = selectedRecording {
+            try? FileManager.default.removeItem(at: sel.url)
+            selectedRecording = nil
+            selectedFormat = nil
+        }
+        errorMessage = nil
+        lastFailureWasUnsupported = false
+        state = .idle
+        if !wasRunning {
+            capture?.close()
+            capture = nil
+            stopElapsedAndDeadline()
+        }
+    }
+
+    /// Tear down any active capture WITHOUT discarding a finalized recording
+    /// still selected by the composer (route change / background / handoff).
+    public func teardownEnginePreservingSelection() {
+        if stopLatch.running {
+            // Let the in-flight recording finalize and be retained.
+            stopLatch.running = false
+            cancelled = false
+            state = .finalizing
+            return
+        }
+        capture?.close()
+        capture = nil
+        stopElapsedAndDeadline()
+        // selectedRecording / selectedFormat intentionally preserved.
+    }
+
+    // MARK: - Capture thread
+
+    private func spawnCaptureThread() {
+        // Snapshot the encode inputs so the capture thread only reads a plain
+        // `running` latch (matching AudioManager's "snapshot then detach").
+        guard let fmt = format, let out = outputFile, let cap = capture else {
+            Task { @MainActor in self?.onCaptureDone(failed: nil) }
+            return
+        }
+        // The loop runs nonisolated on the capture thread; the latch (not the
+        // actor-isolated recorder) is the only shared stop signal.
+        let latch = stopLatch
+        let thread = Thread { [weak self] in
+            self?.runCaptureLoop(capture: cap, format: fmt, out: out, latch: latch)
+        }
+        thread.qualityOfService = .userInitiated
+        thread.name = "columba.voice.capture"
+        captureThread = thread
+        thread.start()
+    }
+
+    /// Runs on the dedicated capture thread. Nonisolated by design: it reads
+    /// only its captured parameters and the stop latch, never actor-isolated
+    /// state, and hops to the main actor to publish.
+    nonisolated private func runCaptureLoop(
+        capture: VoicePcmCapture, format: VoiceMessageFormat, out: URL,
+        latch: VoiceStopLatch
+    ) {
+        var failed: Error? = nil
+        do {
+            if format.isCodec2, let c2 = format.codec2Mode {
+                try runCodec2(capture: capture, mode: c2, out: out, latch: latch)
+            } else if let profile = format.opusProfile {
+                try runOpus(capture: capture, profile: profile, out: out, latch: latch)
+            } else {
+                failed = VoiceRecorderError.unsupported
+            }
+        } catch {
+            failed = error
+        }
+        capture.stop()
+        capture.close()
+        Task { @MainActor [weak self, failed] in
+            self?.onCaptureDone(failed: failed)
+        }
+    }
+
+    /// Main-actor terminal transition, published after the capture thread exits.
+    private func onCaptureDone(failed: Error?) {
+        stopElapsedAndDeadline()
+        let wasCancelled = cancelled
+        let out = outputFile
+        let fmt = format
+        stopLatch.running = false
+        capture = nil
+        workerFailure = nil
+
+        // A cancelled in-flight recording: delete the partial file, go idle.
+        if wasCancelled {
+            if let out { try? FileManager.default.removeItem(at: out) }
+            outputFile = nil
+            state = .idle
+            return
+        }
+
+        guard let out, let fmt else {
+            state = .idle
+            return
+        }
+
+        if let failed {
+            try? FileManager.default.removeItem(at: out)
+            outputFile = nil
+            errorMessage = failed.localizedDescription
+            state = .failed(message: errorMessage!)
+            return
+        }
+
+        let size = (try? FileManager.default.attributesOfItem(atPath: out.path)[.size] as? Int) ?? 0
+        if !(FileManager.default.fileExists(atPath: out.path) && size > 0) {
+            try? FileManager.default.removeItem(at: out)
+            outputFile = nil
+            errorMessage = String(localized: "Voice message recording produced no audio.")
+            state = .failed(message: errorMessage!)
+            return
+        }
+
+        let audio = Self.buildAudio(from: out, format: fmt, fallbackDurationMs: elapsedMs)
+        let recording = VoiceRecording(url: out, format: fmt,
+                                       durationMs: audio.durationMs ?? elapsedMs,
+                                       sizeBytes: size, audio: audio)
+        selectedRecording = recording
+        selectedFormat = fmt
+        state = .completed(recording)
+        outputFile = nil
+    }
+
+    // MARK: - Encode loops (capture thread)
+
+    nonisolated private func runCodec2(
+        capture: VoicePcmCapture, mode: Codec2Mode, out: URL,
+        latch: VoiceStopLatch
+    ) throws {
+        guard let codec = try? Codec2Codec(mode: mode) else { throw VoiceRecorderError.codecUnavailable }
+        let geo = Codec2RawFile.geometry(for: mode)
+        let deviceRate = max(1, capture.sampleRate)
+        let cap = max(4096, geo.samplesPerFrame * 4)
+        var buffer = [Int16](repeating: 0, count: cap)
+        var accum = [Int16](); accum.reserveCapacity(geo.samplesPerFrame * 8)
+        FileManager.default.createFile(atPath: out.path, contents: nil)
+        let sink = try FileHandle(forWritingTo: out)
+        defer { try? sink.close() }
+        while latch.running {
+            let n = capture.read(into: &buffer, capacity: cap)
+            if !latch.running { break }
+            if n < 0 { throw VoiceRecorderError.captureStartFailed }
+            guard n > 0 else { continue } // 0 = timeout, keep polling the flag
+            let down = Resampler.resampleInt16(Array(buffer[0..<n]), channels: 1,
+                                               fromRate: deviceRate, toRate: Codec2RawFile.sampleRate)
+            accum.append(contentsOf: down)
+            while accum.count >= geo.samplesPerFrame {
+                let frame = Array(accum.prefix(geo.samplesPerFrame))
+                accum.removeFirst(geo.samplesPerFrame)
+                let raw = try Codec2RawFile.encodeFrame(pcm: frame, codec: codec)
+                try sink.write(contentsOf: raw)
+            }
+        }
+    }
+
+    nonisolated private func runOpus(
+        capture: VoicePcmCapture, profile: OpusProfile, out: URL,
+        latch: VoiceStopLatch
+    ) throws {
+        guard let codec = try? OpusCodec(profile: profile) else { throw VoiceRecorderError.codecUnavailable }
+        let targetRate = profile.sampleRate
+        let channels = profile.channels
+        let framePerChannel = max(1, Int((Double(targetRate) * 0.06).rounded())) // 60 ms
+        let preSkip = OggOpusFileWriter.preSkipForProfile(sampleRate: targetRate)
+        let writer = OggOpusFileWriter(channels: channels, preSkip: preSkip)
+        let deviceRate = max(1, capture.sampleRate)
+        let cap = max(4096, framePerChannel * 4)
+        var buffer = [Int16](repeating: 0, count: cap)
+        var accum = [Int16](); accum.reserveCapacity(framePerChannel * channels * 8)
+        while latch.running {
+            let n = capture.read(into: &buffer, capacity: cap)
+            if !latch.running { break }
+            if n < 0 { throw VoiceRecorderError.captureStartFailed }
+            guard n > 0 else { continue }
+            let mono = Array(buffer[0..<n])
+            let resampled: [Int16]
+            if channels == 1 {
+                resampled = Resampler.resampleInt16(mono, channels: 1,
+                                                    fromRate: deviceRate, toRate: targetRate)
+            } else {
+                let m = Resampler.resampleInt16(mono, channels: 1,
+                                                fromRate: deviceRate, toRate: targetRate)
+                var stereo = [Int16](); stereo.reserveCapacity(m.count * 2)
+                for s in m { stereo.append(s); stereo.append(s) }
+                resampled = stereo
+            }
+            accum.append(contentsOf: resampled)
+            let frameBytes = framePerChannel * channels
+            while accum.count >= frameBytes {
+                let frame = Array(accum.prefix(frameBytes))
+                accum.removeFirst(frameBytes)
+                let packet = try codec.encode(frame)
+                try writer.appendPacket([UInt8](packet))
+            }
+        }
+        let bytes = try writer.finish()
+        try OggOpusFileWriter.publishToDisk(Data(bytes), to: out)
+    }
+
+    // MARK: - Timers
+
+    private func startElapsed() {
+        elapsedTask?.cancel()
+        elapsedTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 1_000_000_000)
+                guard let self, self.stopLatch.running else { return }
+                self.elapsedMs = min(self.elapsedMs + 1_000, Self.maxDurationMillis)
+                if case .recording = self.state { self.state = .recording(elapsedMs: self.elapsedMs) }
+            }
+        }
+    }
+
+    private func startDeadline() {
+        deadlineTask?.cancel()
+        deadlineTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(Self.maxDurationMillis) * 1_000_000)
+            guard let self, self.stopLatch.running else { return }
+            self.stop()
+        }
+    }
+
+    private func stopElapsedAndDeadline() {
+        elapsedTask?.cancel(); elapsedTask = nil
+        deadlineTask?.cancel(); deadlineTask = nil
+    }
+
+    // MARK: - Audio build
+
+    private static func buildAudio(from url: URL, format: VoiceMessageFormat,
+                                   fallbackDurationMs: Int) -> AudioAttachment {
+        let data = (try? Data(contentsOf: url)) ?? Data()
+        if !format.isCodec2, let meta = OggOpusMetadataReader.read([UInt8](data)) {
+            return AudioAttachment(mode: format.audioMode, bytes: data, durationMs: meta.durationMs)
+        }
+        return AudioAttachment(mode: format.audioMode, bytes: data, durationMs: fallbackDurationMs)
+    }
+}
+
+// MARK: - AVAudioEngine capture (real device)
+
+/// AVAudioEngine-backed capture. A tap on the input node appends mono buffers to
+/// an in-memory queue; `read` blocks (bounded) on a condition variable and
+/// drains up to the requested capacity, returning 0 on timeout so a stop can
+/// interrupt a blocking read.
+@available(iOS 17.0, *)
+final class AVEngineVoiceCapture: VoicePcmCapture {
+    private let engine = AVAudioEngine()
+    private let requestedRate: Int
+    private(set) var deliveredRate = 44_100
+
+    private let lock = NSLock()
+    private let cond = NSCondition()
+    private var queue: [Int16] = []
+    private var isRunning = false
+    private var hardError: Error?
+
+    init(channels: Int, sampleRateHint: Int) {
+        self.requestedRate = sampleRateHint
+    }
+
+    var isSupported: Bool {
+        AVAudioSession.sharedInstance().recordPermission() == .granted
+    }
+    var sampleRate: Int { deliveredRate }
+
+    func start() throws {
+        let session = AVAudioSession.sharedInstance()
+        try session.setCategory(.playAndRecord, mode: .default,
+                                options: [.defaultToSpeaker, .allowBluetoothA2DP])
+        try session.setPreferredSampleRate(Double(requestedRate))
+        try session.setPreferredIOBufferDuration(0.02)
+        try session.setActive(true)
+        let input = engine.inputNode
+        let hardware = input.inputFormat(forBus: 0)
+        deliveredRate = max(1, Int(hardware.sampleRate))
+        // Deliver mono to the tap; the encode loop handles the profile's rate/channels.
+        input.installTap(onBus: 0, bufferSize: 1024, format: hardware) { [weak self] buffer, _ in
+            guard let self else { return }
+            let frames = Int(buffer.frameLength)
+            guard frames > 0, let data = buffer.floatChannelData else { return }
+            var ints = [Int16](); ints.reserveCapacity(frames)
+            for i in 0..<frames { ints.append(Int16(clamping: Int(data[0][i] * 32767))) }
+            self.cond.lock()
+            self.queue.append(contentsOf: ints)
+            self.cond.signal()
+            self.cond.unlock()
+        }
+        try engine.start()
+        cond.lock(); isRunning = true; cond.unlock()
+    }
+
+    func read(into buffer: inout [Int16], capacity: Int) -> Int {
+        cond.lock()
+        defer { cond.unlock() }
+        let deadline = Date().addingTimeInterval(0.05)
+        while true {
+            if !isRunning { return 0 }
+            if let e = hardError { hardError = nil; return -1 }
+            if queue.count >= capacity {
+                let head = Array(queue.prefix(capacity))
+                queue.removeFirst(capacity)
+                buffer.replaceSubrange(0..<capacity, with: head)
+                return capacity
+            }
+            let now = Date()
+            if now >= deadline { return 0 }
+            cond.wait(until: min(deadline, now.addingTimeInterval(0.02)))
+        }
+    }
+
+    func stop() {
+        cond.lock()
+        isRunning = false
+        cond.signal()
+        cond.unlock()
+        engine.inputNode.removeTap(onBus: 0)
+        if engine.isRunning { engine.stop() }
+    }
+
+    func close() {
+        stop()
+        if let s = AVAudioSession.sharedInstance() { try? s.setActive(false) }
+    }
+}
+
+@available(iOS 17.0, *)
+final class AVEngineVoiceCaptureFactory: VoicePcmCaptureFactory {
+    func makeCapture(channels: Int, sampleRateHint: Int) -> VoicePcmCapture {
+        AVEngineVoiceCapture(channels: channels, sampleRateHint: sampleRateHint)
+    }
+}

--- a/Sources/ColumbaApp/Voice/VoiceMessageRecorder.swift
+++ b/Sources/ColumbaApp/Voice/VoiceMessageRecorder.swift
@@ -34,7 +34,7 @@ import AVFoundation
 /// A source of raw int16 PCM (mono at a known rate) for one recording session.
 /// `read` blocks up to a short timeout and returns the number of mono samples
 /// delivered (0 on timeout / end), so a blocking read is interruptible by stop.
-protocol VoicePcmCapture: AnyObject {
+public protocol VoicePcmCapture: AnyObject {
     var isSupported: Bool { get }
     var sampleRate: Int { get }
     func start() throws
@@ -46,8 +46,9 @@ protocol VoicePcmCapture: AnyObject {
 }
 
 /// Factory for capture sessions (injected in tests; the real one wraps
-/// AVAudioEngine).
-protocol VoicePcmCaptureFactory: AnyObject {
+/// AVAudioEngine). Public so `VoiceMessageRecorder`'s public initializer can
+/// expose it.
+public protocol VoicePcmCaptureFactory: AnyObject {
     func makeCapture(channels: Int, sampleRateHint: Int) -> VoicePcmCapture
 }
 
@@ -131,10 +132,17 @@ public final class VoiceMessageRecorder {
     @ObservationIgnored private var deadlineTask: Task<Void, Never>?
     @ObservationIgnored private var workerFailure: Error? = nil
 
-    public init(captureFactory: any VoicePcmCaptureFactory = AVEngineVoiceCaptureFactory()) {
-        self.captureFactory = captureFactory
+    /// Production initializer: AVAudioEngine-backed capture.
+    public init() {
+        self.captureFactory = AVEngineVoiceCaptureFactory()
     }
 
+    /// Test initializer: inject a capture factory (fakes). Internal because it
+    /// only exists so `@testable` tests can drive the state machine without a
+    /// real microphone; the public no-arg `init()` is the production entry.
+    init(captureFactory: any VoicePcmCaptureFactory) {
+        self.captureFactory = captureFactory
+    }
     public var isRecording: Bool {
         if case .recording = state { return true }
         return false
@@ -283,7 +291,7 @@ public final class VoiceMessageRecorder {
         // Snapshot the encode inputs so the capture thread only reads a plain
         // `running` latch (matching AudioManager's "snapshot then detach").
         guard let fmt = format, let out = outputFile, let cap = capture else {
-            Task { @MainActor in self?.onCaptureDone(failed: nil) }
+            Task { @MainActor in self.onCaptureDone(failed: nil) }
             return
         }
         // The loop runs nonisolated on the capture thread; the latch (not the
@@ -513,7 +521,7 @@ final class AVEngineVoiceCapture: VoicePcmCapture {
     }
 
     var isSupported: Bool {
-        AVAudioSession.sharedInstance().recordPermission() == .granted
+        AVAudioSession.sharedInstance().recordPermission == .granted
     }
     var sampleRate: Int { deliveredRate }
 
@@ -573,7 +581,7 @@ final class AVEngineVoiceCapture: VoicePcmCapture {
 
     func close() {
         stop()
-        if let s = AVAudioSession.sharedInstance() { try? s.setActive(false) }
+        try? AVAudioSession.sharedInstance().setActive(false)
     }
 }
 

--- a/Sources/ColumbaApp/Voice/VoiceMessageRecorder.swift
+++ b/Sources/ColumbaApp/Voice/VoiceMessageRecorder.swift
@@ -389,7 +389,7 @@ public final class VoiceMessageRecorder {
         latch: VoiceStopLatch
     ) throws {
         guard let codec = try? Codec2Codec(mode: mode) else { throw VoiceRecorderError.codecUnavailable }
-        let geo = Codec2RawFile.geometry(for: mode)
+        let geo = Codec2RawFile.geometry(of: codec)
         let deviceRate = max(1, capture.sampleRate)
         let cap = max(4096, geo.samplesPerFrame * 4)
         var buffer = [Int16](repeating: 0, count: cap)

--- a/Sources/ColumbaApp/Voice/VoiceMessageRecorder.swift
+++ b/Sources/ColumbaApp/Voice/VoiceMessageRecorder.swift
@@ -534,6 +534,17 @@ final class AVEngineVoiceCapture: VoicePcmCapture {
         try session.setActive(true)
         let input = engine.inputNode
         let hardware = input.inputFormat(forBus: 0)
+        // Defensive: a degenerate input format (zero sample rate/channel
+        // count, seen when no usable input device is present) makes
+        // `installTap(onBus:format:)` throw an ObjC NSException that Swift
+        // `try/catch` cannot intercept - a hard SIGABRT. The recorder's
+        // `captureHasInput` guard should prevent reaching this path, but keep
+        // the belt-and-braces check here so a format change between the guard
+        // and the tap can never abort the process.
+        guard hardware.sampleRate > 0, Int(hardware.channelCount) > 0 else {
+            try? session.setActive(false)
+            throw VoiceRecorderError.unsupported
+        }
         deliveredRate = max(1, Int(hardware.sampleRate))
         // Deliver mono to the tap; the encode loop handles the profile's rate/channels.
         input.installTap(onBus: 0, bufferSize: 1024, format: hardware) { [weak self] buffer, _ in

--- a/Sources/ColumbaApp/Voice/VoiceMessageRecorder.swift
+++ b/Sources/ColumbaApp/Voice/VoiceMessageRecorder.swift
@@ -15,8 +15,8 @@
 //     the composer.
 //
 //  Threading model (matches AudioManager): the blocking read/encode loop runs on
-a dedicated `Thread`; it snapshots the format/output/capture into locals and
-only reads the locked `VoiceStopLatch` stop flag. All observable state is published by
+//  a dedicated `Thread`; it snapshots the format/output/capture into locals and
+//  only reads the locked `VoiceStopLatch` stop flag. All observable state is published by
 //  hopping back to the `@MainActor` in `onCaptureDone`. `stop()`/`cancel()` are
 //  NON-blocking: they flip the flag(s) and return; the loop self-terminates
 //  (the capture `read` times out at 50 ms) and publishes the terminal state.

--- a/Sources/ColumbaApp/Voice/VoiceQualityPickerSheet.swift
+++ b/Sources/ColumbaApp/Voice/VoiceQualityPickerSheet.swift
@@ -1,0 +1,167 @@
+//
+//  VoiceQualityPickerSheet.swift
+//  ColumbaApp
+//
+//  Quality picker for a new voice message. Ports Android Columba's
+//  `QualitySelectionDialog` (invoked from `MessagingScreen` with the voice
+//  options). Mirrors the iOS `ImageQualityPickerSheet` layout: a scrollable
+//  list of radio rows with the header and the Record / Cancel buttons pinned,
+//  a "Recommended" star chip on the default profile, and a confirm button that
+//  starts recording.
+//
+//  The exact strings live in `Localizable.xcstrings` (see Section 3 of the
+//  voice-messages parity plan); the static contract test asserts the literal
+//  values so a wording drift fails CI.
+//
+
+import SwiftUI
+import RNSAPI
+
+/// A bottom sheet for selecting a voice-message quality profile, then starting
+/// recording. `onConfirm` is called with the chosen profile when the user taps
+/// Record; `onCancel` when they dismiss.
+@available(iOS 17.0, macOS 14.0, *)
+public struct VoiceQualityPickerSheet: View {
+    var sheetHeight: CGFloat
+    @Binding var selectedFormat: VoiceMessageFormat
+    var onConfirm: (VoiceMessageFormat) -> Void
+    var onCancel: () -> Void
+
+    private let recommended = VoiceMessageFormat.defaultFormat
+
+    public init(
+        sheetHeight: CGFloat,
+        selectedFormat: Binding<VoiceMessageFormat>,
+        onConfirm: @escaping (VoiceMessageFormat) -> Void,
+        onCancel: @escaping () -> Void
+    ) {
+        self.sheetHeight = sheetHeight
+        self._selectedFormat = selectedFormat
+        self.onConfirm = onConfirm
+        self.onCancel = onCancel
+    }
+
+    public var body: some View {
+        VStack(spacing: 16) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(String(localized: "Select Voice Message Quality"))
+                    .font(.headline)
+                    .foregroundStyle(Theme.textPrimary)
+                    .accessibilityIdentifier("voice_quality_title")
+                Text(String(localized: "Choose the recording format and bandwidth"))
+                    .font(.subheadline)
+                    .foregroundStyle(Theme.textSecondary)
+                    .accessibilityIdentifier("voice_quality_subtitle")
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.top, 8)
+
+            // The quality options scroll independently while the header and the
+            // Record / Cancel buttons stay pinned (same pattern as the image
+            // quality sheet, issue #181).
+            ScrollView {
+                VStack(spacing: 8) {
+                    ForEach(VoiceMessageFormat.outboundOptions) { format in
+                        optionRow(format)
+                    }
+                }
+            }
+            .accessibilityIdentifier("voice_quality_options")
+
+            HStack(spacing: 12) {
+                Button(action: onCancel) {
+                    Text(String(localized: "Cancel"))
+                        .font(.body.weight(.medium))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 12)
+                        .background(Theme.backgroundTertiary)
+                        .clipShape(Capsule())
+                        .foregroundStyle(Theme.textPrimary)
+                }
+                .buttonStyle(VoicePickerScaleButtonStyle())
+                .accessibilityIdentifier("voice_quality_cancel_button")
+
+                Button {
+                    onConfirm(selectedFormat)
+                } label: {
+                    Text(String(localized: "Record"))
+                        .font(.body.weight(.semibold))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 12)
+                        .background(Theme.accentColor)
+                        .clipShape(Capsule())
+                        .foregroundStyle(.white)
+                }
+                .buttonStyle(VoicePickerScaleButtonStyle())
+                .accessibilityIdentifier("voice_quality_record_button")
+            }
+            .padding(.horizontal, 4)
+            .padding(.bottom, 8)
+        }
+        .frame(height: sheetHeight)
+        .background(Theme.backgroundSecondary)
+        .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+        .padding(.horizontal, 16)
+        .padding(.top, 12)
+    }
+
+    private func optionRow(_ format: VoiceMessageFormat) -> some View {
+        let isSelected = format == selectedFormat
+        let isRecommended = format.isRecommended
+        return Button {
+            selectedFormat = format
+        } label: {
+            HStack(spacing: 12) {
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .font(.system(size: 20))
+                    .foregroundStyle(isSelected ? Theme.accentColor : .gray)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack(spacing: 6) {
+                        Text(format.displayName)
+                            .font(.subheadline.weight(isRecommended ? .semibold : .medium))
+                            .foregroundStyle(Theme.textPrimary)
+                        if isRecommended {
+                            // Star chip = the "Recommended" badge (a11y label
+                            // mirrors Android's `RecommendedChip`).
+                            Image(systemName: "star.fill")
+                                .font(.system(size: 11))
+                                .foregroundStyle(Theme.accentColor)
+                                .accessibilityLabel("Recommended")
+                                .accessibilityIdentifier("voice_quality_recommended_badge")
+                        }
+                    }
+                    Text(format.description)
+                        .font(.caption)
+                        .foregroundStyle(Theme.textSecondary)
+                }
+                Spacer()
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .background(
+                isSelected
+                    ? Theme.accentColor.opacity(0.15)
+                    : Theme.backgroundTertiary
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .stroke(isSelected ? Theme.accentColor : Theme.divider, lineWidth: isSelected ? 1 : 0.5)
+            )
+        }
+        .buttonStyle(VoicePickerScaleButtonStyle())
+        .accessibilityIdentifier("voice_quality_option_\(format.id)")
+        .accessibilityLabel(Text(format.displayName))
+        .accessibilityHint(Text(format.description))
+    }
+}
+
+/// Button style that scales down slightly on press (matches the composer's).
+private struct VoicePickerScaleButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? 0.96 : 1.0)
+            .animation(.easeInOut(duration: 0.1), value: configuration.isPressed)
+    }
+}

--- a/Sources/ColumbaApp/Voice/VoiceWaveformBars.swift
+++ b/Sources/ColumbaApp/Voice/VoiceWaveformBars.swift
@@ -6,6 +6,15 @@
 //  bubble). Renders an array of normalized [0, 1] peaks as vertical bars; a
 //  playback progress (0...1) tints the played portion with the accent color.
 //
+//  The waveform is FLEXIBLE horizontally: it fills the remaining width of its
+//  row (Android parity - the Android bubble gives the waveform `weight(1f)`),
+//  so the bars scale to fit the available space instead of demanding a fixed
+//  intrinsic width. A fixed-width waveform (the old behavior) overflows a
+//  narrow "sent" bubble (which reserves a Spacer for the avatar gap), wrapping
+//  the progress text (taller bubble) and shifting the play button's hit region
+//  (taps miss, no audio). Measuring with a GeometryReader and dividing the
+//  measured width across the bars makes overflow impossible at any width.
+//
 
 import SwiftUI
 
@@ -15,6 +24,8 @@ public struct VoiceWaveformBars: View {
     let peaks: [Float]
     /// Playback progress in [0, 1]; bars at or below this index are "played".
     var progress: CGFloat = 0
+    /// Gap between bars. The bar width is whatever the measured row width
+    /// leaves after the gaps, so this only controls the bar-to-gap ratio.
     var barSpacing: CGFloat = 2
     var color: Color = Theme.textSecondary
     var playedColor: Color = Theme.accentColor
@@ -25,14 +36,25 @@ public struct VoiceWaveformBars: View {
     }
 
     public var body: some View {
-        HStack(alignment: .center, spacing: barSpacing) {
-            ForEach(Array(peaks.enumerated()), id: \.offset) { index, peak in
-                Capsule()
-                    .fill(index < Int(progress * CGFloat(peaks.count)) ? playedColor : color)
-                    .frame(width: 2.5, height: max(3, CGFloat(peak) * 28))
+        GeometryReader { geo in
+            let count = peaks.count
+            // Bars fill the measured width; each slot is (width - gaps)/count.
+            // Clamp to a 1pt minimum so a very narrow row still renders.
+            let barWidth = count > 0
+                ? max(1, (geo.size.width - barSpacing * CGFloat(count - 1)) / CGFloat(count))
+                : 0
+            HStack(alignment: .center, spacing: barSpacing) {
+                ForEach(Array(peaks.enumerated()), id: \.offset) { index, peak in
+                    Capsule()
+                        .fill(index < Int(progress * CGFloat(peaks.count)) ? playedColor : color)
+                        .frame(width: barWidth, height: max(3, CGFloat(peak) * 28))
+                }
             }
+            .frame(width: geo.size.width, height: geo.size.height, alignment: .leading)
         }
         .frame(height: 30)
+        // Claim the remaining row width (the flexible element in the row).
+        .frame(maxWidth: .infinity)
     }
 }
 

--- a/Sources/ColumbaApp/Voice/VoiceWaveformBars.swift
+++ b/Sources/ColumbaApp/Voice/VoiceWaveformBars.swift
@@ -37,10 +37,13 @@ public struct VoiceWaveformBars: View {
 }
 
 /// A default flat waveform used until the real peaks are computed (the player
-/// fills the waveform cache on first play; see `VoiceMessagePlayer.waveform`).
+/// fills the waveform cache asynchronously; see `VoiceMessagePlayer.waveform`).
 public enum VoiceWaveform {
     /// `n` bars at a flat midpoint, used as a placeholder before peaks load.
-    public static func placeholder(bars: Int = 32) -> [Float] {
+    /// The default matches the real waveform's 40-bar count
+    /// (`OggOpusWaveform.bars`) so the row width does not shift when the real
+    /// peaks arrive.
+    public static func placeholder(bars: Int = 40) -> [Float] {
         Array(repeating: 0.5, count: bars)
     }
 }

--- a/Sources/ColumbaApp/Voice/VoiceWaveformBars.swift
+++ b/Sources/ColumbaApp/Voice/VoiceWaveformBars.swift
@@ -1,0 +1,46 @@
+//
+//  VoiceWaveformBars.swift
+//  ColumbaApp
+//
+//  A small, static peak-bar waveform for voice messages (draft preview and
+//  bubble). Renders an array of normalized [0, 1] peaks as vertical bars; a
+//  playback progress (0...1) tints the played portion with the accent color.
+//
+
+import SwiftUI
+
+/// Renders a normalized peak array as vertical bars.
+public struct VoiceWaveformBars: View {
+    /// Normalized peaks, each in [0, 1] (height of the bar).
+    let peaks: [Float]
+    /// Playback progress in [0, 1]; bars at or below this index are "played".
+    var progress: CGFloat = 0
+    var barSpacing: CGFloat = 2
+    var color: Color = Theme.textSecondary
+    var playedColor: Color = Theme.accentColor
+
+    public init(peaks: [Float], progress: CGFloat = 0) {
+        self.peaks = peaks
+        self.progress = progress
+    }
+
+    public var body: some View {
+        HStack(alignment: .center, spacing: barSpacing) {
+            ForEach(Array(peaks.enumerated()), id: \.offset) { index, peak in
+                Capsule()
+                    .fill(index < Int(progress * CGFloat(peaks.count)) ? playedColor : color)
+                    .frame(width: 2.5, height: max(3, CGFloat(peak) * 28))
+            }
+        }
+        .frame(height: 30)
+    }
+}
+
+/// A default flat waveform used until the real peaks are computed (the player
+/// fills the waveform cache on first play; see `VoiceMessagePlayer.waveform`).
+public enum VoiceWaveform {
+    /// `n` bars at a flat midpoint, used as a placeholder before peaks load.
+    public static func placeholder(bars: Int = 32) -> [Float] {
+        Array(repeating: 0.5, count: bars)
+    }
+}

--- a/Sources/RNSAPI/Protocols/RnsLxmf.swift
+++ b/Sources/RNSAPI/Protocols/RnsLxmf.swift
@@ -22,6 +22,22 @@ public struct RnsFileAttachment: Sendable, Equatable {
     }
 }
 
+/// A voice-message audio payload carried in `FIELD_AUDIO` (0x07) as
+/// `[mode, bytes]`. `mode` is the canonical wire audio-mode value from
+/// `LxmfFields.AM_*` (Codec2 modes 0x03-0x09, AM_OPUS_OGG 0x10, AM_CUSTOM
+/// 0xFF). Kept as a raw Int so the RNSAPI layer does not depend on the app
+/// layer's `AudioMode` enum.
+public struct RnsAudio: Sendable, Equatable {
+    public let mode: Int
+    public let bytes: Data
+    public init(mode: Int, bytes: Data) {
+        self.mode = mode
+        self.bytes = bytes
+    }
+    /// The `FIELD_AUDIO` wire value: `[mode, bytes]`.
+    public var fieldValue: [Any] { [mode, bytes] }
+}
+
 public protocol RnsLxmf: AnyObject, Sendable {
 
     /// Send an LXMF message. Structured fields are passed typed; `extraFields`
@@ -38,6 +54,7 @@ public protocol RnsLxmf: AnyObject, Sendable {
         imageData: Data?,
         imageFormat: String?,
         fileAttachments: [RnsFileAttachment]?,
+        audioAttachment: RnsAudio?,
         iconAppearance: IconAppearance?,
         replyToMessageHashHex: String?,
         replyQuotedContent: String?,
@@ -56,6 +73,7 @@ public protocol RnsLxmf: AnyObject, Sendable {
         imageData: Data?,
         imageFormat: String?,
         fileAttachments: [RnsFileAttachment]?,
+        audioAttachment: RnsAudio?,
         iconAppearance: IconAppearance?,
         replyToMessageHashHex: String?,
         replyQuotedContent: String?,
@@ -90,6 +108,7 @@ public extension RnsLxmf {
         imageData: Data?,
         imageFormat: String?,
         fileAttachments: [RnsFileAttachment]?,
+        audioAttachment: RnsAudio?,
         iconAppearance: IconAppearance?,
         replyToMessageHashHex: String?,
         replyQuotedContent: String?,
@@ -102,6 +121,7 @@ public extension RnsLxmf {
             imageData: imageData,
             imageFormat: imageFormat,
             fileAttachments: fileAttachments,
+            audioAttachment: audioAttachment,
             iconAppearance: iconAppearance,
             replyToMessageHashHex: replyToMessageHashHex,
             replyQuotedContent: replyQuotedContent,
@@ -114,7 +134,8 @@ public extension RnsLxmf {
                          method: LXDeliveryMethod = .opportunistic) async throws -> SendOutcome {
         try await sendLxmfMessage(
             destHashHex: destHashHex, content: content, method: method,
-            imageData: nil, imageFormat: nil, fileAttachments: nil, iconAppearance: nil,
+            imageData: nil, imageFormat: nil, fileAttachments: nil, audioAttachment: nil,
+            iconAppearance: nil,
             replyToMessageHashHex: nil, replyQuotedContent: nil, extraFields: nil
         )
     }

--- a/Sources/RNSAPI/Util/LxmfFieldCodec.swift
+++ b/Sources/RNSAPI/Util/LxmfFieldCodec.swift
@@ -38,6 +38,7 @@ public enum LxmfFieldCodec {
         imageData: Data?,
         imageFormat: String?,
         fileAttachments: [RnsFileAttachment]?,
+        audioAttachment: RnsAudio?,
         iconAppearance: IconAppearance?,
         replyToMessageHashHex: String?,
         replyQuotedContent: String?,
@@ -49,6 +50,11 @@ public enum LxmfFieldCodec {
         }
         if let fileAttachments, !fileAttachments.isEmpty {
             fields[LxmfFields.FIELD_FILE_ATTACHMENTS] = fileAttachments.map { [$0.name, $0.data] as [Any] }
+        }
+        if let audioAttachment {
+            // FIELD_AUDIO (0x07) = [mode, bytes]. The mode is a plain Int so it
+            // encodes as a MessagePack int (matching Android's `[mode, bytes]`).
+            fields[LxmfFields.FIELD_AUDIO] = audioAttachment.fieldValue
         }
         if let iconAppearance {
             fields[LxmfFields.FIELD_ICON_APPEARANCE] = iconAppearance.toLXMFFieldValue()

--- a/Sources/RNSAPI/Util/LxmfFields.swift
+++ b/Sources/RNSAPI/Util/LxmfFields.swift
@@ -73,6 +73,39 @@ public enum LxmfFields {
     /// Sideband-compatible `FIELD_TELEMETRY` location share here. (Replaces the
     /// previously-invented 0x70, matching Android's migration.)
     public static let FIELD_CUSTOM_META: UInt8 = 0xFD
+
+    // MARK: - FIELD_AUDIO mode values
+    //
+    // `FIELD_AUDIO` (0x07) is `[mode, bytes]`. `mode` is one of the upstream
+    // LXMF audio-mode constants below. These WIRE values are defined by
+    // upstream LXMF (`LXMF/LXMF.py`), match Android Columba's `LxmfFields`, and
+    // are the values Sideband/MeshChatX read. NOTE they are a DIFFERENT
+    // numbering scheme from the LXST `Codec2Mode` header byte (700C=0x00,
+    // 1200=0x01, … 3200=0x06) — map by bitrate, never by raw value. See
+    // `AudioMode.codec2Mode` in ColumbaApp.
+
+    /// Codec2 450 PWB — not offered by Columba's picker; parse-only.
+    public static let AM_CODEC2_450PWB: UInt8 = 0x01
+    /// Codec2 450 — not offered by Columba's picker; parse-only.
+    public static let AM_CODEC2_450: UInt8 = 0x02
+    /// Codec2 700C.
+    public static let AM_CODEC2_700C: UInt8 = 0x03
+    /// Codec2 1200.
+    public static let AM_CODEC2_1200: UInt8 = 0x04
+    /// Codec2 1300 — not offered by Columba's picker; parse-only.
+    public static let AM_CODEC2_1300: UInt8 = 0x05
+    /// Codec2 1400 — not offered by Columba's picker; parse-only.
+    public static let AM_CODEC2_1400: UInt8 = 0x06
+    /// Codec2 1600 — not offered by Columba's picker; parse-only.
+    public static let AM_CODEC2_1600: UInt8 = 0x07
+    /// Codec2 2400.
+    public static let AM_CODEC2_2400: UInt8 = 0x08
+    /// Codec2 3200.
+    public static let AM_CODEC2_3200: UInt8 = 0x09
+    /// Ogg/Opus (the only Opus mode Columba emits; stored as an Ogg file).
+    public static let AM_OPUS_OGG: UInt8 = 0x10
+    /// Custom / unspecified audio mode (the client must self-describe).
+    public static let AM_CUSTOM: UInt8 = 0xFF
 }
 
 /// The message-body presentation Columba currently supports.

--- a/Sources/RNSBackendProxy/ProxyRnsBackend.swift
+++ b/Sources/RNSBackendProxy/ProxyRnsBackend.swift
@@ -394,6 +394,7 @@ public final class ProxyRnsBackend: RnsBackend, @unchecked Sendable {
         imageData: Data?,
         imageFormat: String?,
         fileAttachments: [RnsFileAttachment]?,
+        audioAttachment: RnsAudio?,
         iconAppearance: IconAppearance?,
         replyToMessageHashHex: String?,
         replyQuotedContent: String?,
@@ -406,7 +407,7 @@ public final class ProxyRnsBackend: RnsBackend, @unchecked Sendable {
         // method, fieldsData)`.
         let fields = LxmfFieldCodec.buildFieldMap(
             imageData: imageData, imageFormat: imageFormat,
-            fileAttachments: fileAttachments, iconAppearance: iconAppearance,
+            fileAttachments: fileAttachments, audioAttachment: audioAttachment, iconAppearance: iconAppearance,
             replyToMessageHashHex: replyToMessageHashHex, replyQuotedContent: replyQuotedContent,
             extraFields: extraFields)
         let fieldsData = fields.isEmpty ? Data() : LxmfFieldCodec.pack(fields)

--- a/Sources/RNSBackendProxy/ProxyRnsBackend.swift
+++ b/Sources/RNSBackendProxy/ProxyRnsBackend.swift
@@ -541,7 +541,8 @@ public final class ProxyRnsBackend: RnsBackend, @unchecked Sendable {
         if let customMeta { extra[LxmfFields.FIELD_CUSTOM_META] = customMeta }
         return try await sendLxmfMessage(
             destHashHex: destHashHex, content: "", method: .opportunistic,
-            imageData: nil, imageFormat: nil, fileAttachments: nil, iconAppearance: nil,
+            imageData: nil, imageFormat: nil, fileAttachments: nil,
+            audioAttachment: nil, iconAppearance: nil,
             replyToMessageHashHex: nil, replyQuotedContent: nil, extraFields: extra
         )
     }

--- a/Sources/RNSBackendPy/PythonRNSBackend.swift
+++ b/Sources/RNSBackendPy/PythonRNSBackend.swift
@@ -282,7 +282,8 @@ public final class PythonRNSBackend: RnsBackend, @unchecked Sendable {
         if let customMeta { extra[LxmfFields.FIELD_CUSTOM_META] = customMeta }
         return try await sendLxmfMessage(
             destHashHex: destHashHex, content: "", method: .opportunistic,
-            imageData: nil, imageFormat: nil, fileAttachments: nil, iconAppearance: nil,
+            imageData: nil, imageFormat: nil, fileAttachments: nil,
+            audioAttachment: nil, iconAppearance: nil,
             replyToMessageHashHex: nil, replyQuotedContent: nil, extraFields: extra
         )
     }

--- a/Sources/RNSBackendPy/PythonRNSBackend.swift
+++ b/Sources/RNSBackendPy/PythonRNSBackend.swift
@@ -126,6 +126,7 @@ public final class PythonRNSBackend: RnsBackend, @unchecked Sendable {
         imageData: Data?,
         imageFormat: String?,
         fileAttachments: [RnsFileAttachment]?,
+        audioAttachment: RnsAudio?,
         iconAppearance: IconAppearance?,
         replyToMessageHashHex: String?,
         replyQuotedContent: String?,
@@ -139,6 +140,7 @@ public final class PythonRNSBackend: RnsBackend, @unchecked Sendable {
             imageData: imageData,
             imageFormat: imageFormat,
             fileAttachments: fileAttachments,
+            audioAttachment: audioAttachment,
             iconAppearance: iconAppearance,
             replyToMessageHashHex: replyToMessageHashHex,
             replyQuotedContent: replyQuotedContent,
@@ -155,6 +157,7 @@ public final class PythonRNSBackend: RnsBackend, @unchecked Sendable {
         imageData: Data?,
         imageFormat: String?,
         fileAttachments: [RnsFileAttachment]?,
+        audioAttachment: RnsAudio?,
         iconAppearance: IconAppearance?,
         replyToMessageHashHex: String?,
         replyQuotedContent: String?,
@@ -173,7 +176,7 @@ public final class PythonRNSBackend: RnsBackend, @unchecked Sendable {
         // unpacks it onto the outbound LXMF message.
         let fields = LxmfFieldCodec.buildFieldMap(
             imageData: imageData, imageFormat: imageFormat,
-            fileAttachments: fileAttachments, iconAppearance: iconAppearance,
+            fileAttachments: fileAttachments, audioAttachment: audioAttachment, iconAppearance: iconAppearance,
             replyToMessageHashHex: replyToMessageHashHex, replyQuotedContent: replyQuotedContent,
             extraFields: extraFields)
         let fieldsHex = fields.isEmpty ? "" : LxmfFieldCodec.pack(fields).toHex()

--- a/Sources/RNSBackendSwift/SwiftRNSBackend.swift
+++ b/Sources/RNSBackendSwift/SwiftRNSBackend.swift
@@ -359,7 +359,8 @@ public final class SwiftRNSBackend: RnsBackend, @unchecked Sendable {
         if let customMeta { extra[LxmfFields.FIELD_CUSTOM_META] = customMeta }
         return try await sendLxmfMessage(
             destHashHex: destHashHex, content: "", method: .opportunistic,
-            imageData: nil, imageFormat: nil, fileAttachments: nil, iconAppearance: nil,
+            imageData: nil, imageFormat: nil, fileAttachments: nil,
+            audioAttachment: nil, iconAppearance: nil,
             replyToMessageHashHex: nil, replyQuotedContent: nil, extraFields: extra
         )
     }

--- a/Sources/RNSBackendSwift/SwiftRNSBackend.swift
+++ b/Sources/RNSBackendSwift/SwiftRNSBackend.swift
@@ -287,6 +287,7 @@ public final class SwiftRNSBackend: RnsBackend, @unchecked Sendable {
         imageData: Data?,
         imageFormat: String?,
         fileAttachments: [RnsFileAttachment]?,
+        audioAttachment: RnsAudio?,
         iconAppearance: RNSAPI.IconAppearance?,
         replyToMessageHashHex: String?,
         replyQuotedContent: String?,
@@ -299,7 +300,7 @@ public final class SwiftRNSBackend: RnsBackend, @unchecked Sendable {
         // so both backends encode identically). LXMessage.fields is [UInt8: Any].
         let fields = LxmfFieldCodec.buildFieldMap(
             imageData: imageData, imageFormat: imageFormat,
-            fileAttachments: fileAttachments, iconAppearance: iconAppearance,
+            fileAttachments: fileAttachments, audioAttachment: audioAttachment, iconAppearance: iconAppearance,
             replyToMessageHashHex: replyToMessageHashHex, replyQuotedContent: replyQuotedContent,
             extraFields: extraFields)
 

--- a/Tests/ColumbaAppTests/AudioModeTests.swift
+++ b/Tests/ColumbaAppTests/AudioModeTests.swift
@@ -1,0 +1,134 @@
+//
+//  AudioModeTests.swift
+//  ColumbaAppTests
+//
+//  Phase A (plan step 5): wire-mode constants, the wire-vs-LXST Codec2 header
+//  reconciliation, `fromWireValue` leniency, and the profile ->
+//  (rate/channels/bitrate) table matching Android exactly.
+//
+
+import XCTest
+import RNSAPI
+import LXSTSwift
+@testable import ColumbaApp
+
+final class AudioModeTests: XCTestCase {
+
+    // MARK: - Wire constants (Section 1)
+
+    func testWireConstantsMatchAndroidAndUpstream() {
+        XCTAssertEqual(LxmfFields.FIELD_AUDIO, 0x07)
+        XCTAssertEqual(LxmfFields.AM_CODEC2_450PWB, 0x01)
+        XCTAssertEqual(LxmfFields.AM_CODEC2_450, 0x02)
+        XCTAssertEqual(LxmfFields.AM_CODEC2_700C, 0x03)
+        XCTAssertEqual(LxmfFields.AM_CODEC2_1200, 0x04)
+        XCTAssertEqual(LxmfFields.AM_CODEC2_1300, 0x05)
+        XCTAssertEqual(LxmfFields.AM_CODEC2_1400, 0x06)
+        XCTAssertEqual(LxmfFields.AM_CODEC2_1600, 0x07)
+        XCTAssertEqual(LxmfFields.AM_CODEC2_2400, 0x08)
+        XCTAssertEqual(LxmfFields.AM_CODEC2_3200, 0x09)
+        XCTAssertEqual(LxmfFields.AM_OPUS_OGG, 0x10)
+        XCTAssertEqual(LxmfFields.AM_CUSTOM, 0xFF)
+        // App-layer enum must stay in lockstep with RNSAPI.
+        XCTAssertEqual(AudioMode.codec2_1200.rawValue, LxmfFields.AM_CODEC2_1200)
+        XCTAssertEqual(AudioMode.opusOgg.rawValue, LxmfFields.AM_OPUS_OGG)
+        XCTAssertEqual(AudioMode.custom.rawValue, LxmfFields.AM_CUSTOM)
+    }
+
+    // MARK: - Wire <-> LXST header reconciliation (MUST NOT conflate)
+
+    func testCodec2ModeMapsToLXSTHeaderByteByBitrate() {
+        // Wire mode and LXST Codec2Mode header byte are DIFFERENT numbering.
+        XCTAssertEqual(AudioMode.codec2_700C.codec2Mode, .codec2_700C)
+        XCTAssertEqual(AudioMode.codec2_700C.codec2HeaderByte, 0x00)
+        XCTAssertEqual(AudioMode.codec2_1200.codec2Mode, .codec2_1200)
+        XCTAssertEqual(AudioMode.codec2_1200.codec2HeaderByte, 0x01)
+        XCTAssertEqual(AudioMode.codec2_1300.codec2HeaderByte, 0x02)
+        XCTAssertEqual(AudioMode.codec2_1400.codec2HeaderByte, 0x03)
+        XCTAssertEqual(AudioMode.codec2_1600.codec2HeaderByte, 0x04)
+        XCTAssertEqual(AudioMode.codec2_2400.codec2HeaderByte, 0x05)
+        XCTAssertEqual(AudioMode.codec2_3200.codec2HeaderByte, 0x06)
+        // 450/450PWB exist on the wire but LXST does not implement them.
+        XCTAssertNil(AudioMode.codec2_450.codec2Mode)
+        XCTAssertNil(AudioMode.codec2_450.codec2HeaderByte)
+        XCTAssertNil(AudioMode.opusOgg.codec2Mode)
+        XCTAssertNil(AudioMode.custom.codec2Mode)
+    }
+
+    func testCodec2Bitrates() {
+        XCTAssertEqual(AudioMode.codec2_450PWB.codec2Bitrate, 450)
+        XCTAssertEqual(AudioMode.codec2_700C.codec2Bitrate, 700)
+        XCTAssertEqual(AudioMode.codec2_1200.codec2Bitrate, 1200)
+        XCTAssertEqual(AudioMode.codec2_2400.codec2Bitrate, 2400)
+        XCTAssertEqual(AudioMode.codec2_3200.codec2Bitrate, 3200)
+        XCTAssertNil(AudioMode.opusOgg.codec2Bitrate)
+        XCTAssertNil(AudioMode.custom.codec2Bitrate)
+    }
+
+    func testIsCodec2() {
+        XCTAssertTrue(AudioMode.codec2_700C.isCodec2)
+        XCTAssertTrue(AudioMode.codec2_1200.isCodec2)
+        XCTAssertTrue(AudioMode.codec2_2400.isCodec2)
+        XCTAssertTrue(AudioMode.codec2_3200.isCodec2)
+        XCTAssertFalse(AudioMode.opusOgg.isCodec2)
+        XCTAssertFalse(AudioMode.custom.isCodec2)
+    }
+
+    // MARK: - fromWireValue leniency
+
+    func testWireValueInitAcceptsCanonicalValues() {
+        XCTAssertEqual(AudioMode(wireValue: 0x03), .codec2_700C)
+        XCTAssertEqual(AudioMode(wireValue: 0x08), .codec2_2400)
+        XCTAssertEqual(AudioMode(wireValue: 0x10), .opusOgg)
+        XCTAssertEqual(AudioMode(wireValue: 0xFF), .custom)
+    }
+
+    func testWireValueInitMapsUnknownToCustom() {
+        // Non-canonical bytes must render as .custom (non-playable), not nil.
+        XCTAssertEqual(AudioMode(wireValue: 0x00), .custom)
+        XCTAssertEqual(AudioMode(wireValue: 0x11), .custom)
+        XCTAssertEqual(AudioMode(wireValue: 0x7F), .custom)
+    }
+
+    func testAttachmentFromWireValueAcceptsIntegerTypesAndData() {
+        let payload = Data([1, 2, 3, 4])
+        let fromInt = AudioAttachment.fromWireValue([Int(0x04), payload])
+        XCTAssertEqual(fromInt?.mode, .codec2_1200)
+        XCTAssertEqual(fromInt?.bytes, payload)
+
+        let fromUInt8 = AudioAttachment.fromWireValue([UInt8(0x10), payload])
+        XCTAssertEqual(fromUInt8?.mode, .opusOgg)
+
+        let fromInt32 = AudioAttachment.fromWireValue([Int32(0x08), payload])
+        XCTAssertEqual(fromInt32?.mode, .codec2_2400)
+    }
+
+    func testAttachmentFromWireValueRejectsBadShapes() {
+        XCTAssertNil(AudioAttachment.fromWireValue(nil))
+        XCTAssertNil(AudioAttachment.fromWireValue([Int(0x04)]))              // too short
+        XCTAssertNil(AudioAttachment.fromWireValue(["x", Data([1])] as [Any])) // mode not int
+        XCTAssertNil(AudioAttachment.fromWireValue([Int(0x04), "bytes"]))      // payload not Data
+        XCTAssertEqual(AudioAttachment.fromWireValue([Int(0x11), Data([1])])?.mode, .custom)
+    }
+
+    func testAttachmentFieldValueRoundTrip() {
+        let payload = Data([9, 8, 7])
+        let attachment = AudioAttachment(mode: .codec2_2400, bytes: payload, durationMs: 1234)
+        XCTAssertEqual(attachment.sizeBytes, 3)
+        XCTAssertEqual(attachment.durationSeconds, 1.234, accuracy: 0.0001)
+        let field = attachment.fieldValue
+        let mode = (field[0] as? Int) ?? Int((field[0] as? UInt8) ?? 0)
+        XCTAssertEqual(mode, 0x08)
+        XCTAssertEqual(field[1] as? Data, payload)
+        let back = AudioAttachment.fromWireValue(field)
+        XCTAssertEqual(back?.mode, .codec2_2400)
+        XCTAssertEqual(back?.bytes, payload)
+        // durationMs is best-effort and NOT carried on the wire.
+        XCTAssertNil(back?.durationMs)
+    }
+
+    func testZeroDurationSeconds() {
+        XCTAssertEqual(AudioAttachment(mode: .opusOgg, bytes: Data(), durationMs: nil).durationSeconds, 0)
+        XCTAssertEqual(AudioAttachment(mode: .opusOgg, bytes: Data(), durationMs: 0).durationSeconds, 0)
+    }
+}

--- a/Tests/ColumbaAppTests/Codec2RawFileTests.swift
+++ b/Tests/ColumbaAppTests/Codec2RawFileTests.swift
@@ -1,0 +1,181 @@
+//
+//  Codec2RawFileTests.swift
+//  ColumbaAppTests
+//
+//  Phase B (plan step 8): the Codec2 raw-frame file codec. Pins the interop
+//  contract: NO telephone header byte on disk/wire, raw complete-frame
+//  concatenation, the header byte prefixed only at decode time, the
+//  bitrate×samplesPerFrame/8000 geometry, the 5-minute decode ceiling, and a
+//  valid WAV bridge for AVAudioPlayer.
+//
+
+import XCTest
+import Foundation
+import LXSTSwift
+@testable import ColumbaApp
+
+final class Codec2RawFileTests: XCTestCase {
+
+    private func makeCodec(_ mode: Codec2Mode = .codec2_2400) throws -> Codec2Codec {
+        try Codec2Codec(mode: mode)
+    }
+
+    // MARK: - Encode (header stripped)
+
+    func testEncodeFrameStripsHeaderByte() throws {
+        let codec = try makeCodec(.codec2_2400)
+        let geo = Codec2RawFile.geometry(for: .codec2_2400)
+        let frame = VoiceTestSupport.pcm(count: geo.samplesPerFrame)
+        let raw = try Codec2RawFile.encodeFrame(pcm: frame, codec: codec)
+        // Raw frame size = bytesPerFrame (header byte removed).
+        XCTAssertEqual(raw.count, geo.bytesPerFrame)
+        // LXSTSwift encode prepends the header byte; stripping it must leave
+        // exactly the frame bytes.
+        let full = try codec.encode(frame)
+        XCTAssertEqual(full.count, geo.bytesPerFrame + 1)
+        XCTAssertEqual(full[0], 0x05, "LXST header byte for codec2_2400")
+        XCTAssertEqual(full[1...], raw as [UInt8])
+    }
+
+    func testEncodeFrameRejectsEmpty() {
+        let codec = try! makeCodec()
+        XCTAssertThrowsError(try Codec2RawFile.encodeFrame(pcm: [], codec: codec)) {
+            XCTAssertEqual($0 as? Codec2FileError, .emptyPcm)
+        }
+    }
+
+    // MARK: - Decode (header prefixed, bounds enforced)
+
+    func testDecodeRoundTrip() throws {
+        let codec = try makeCodec(.codec2_2400)
+        let geo = Codec2RawFile.geometry(for: .codec2_2400)
+        let pcm = VoiceTestSupport.pcm(count: geo.samplesPerFrame * 5)
+        let raw = try Codec2RawFile.encodeAll(pcm: pcm, codec: codec)
+        XCTAssertEqual(raw.count, geo.bytesPerFrame * 5)
+        let decoded = try Codec2RawFile.decode(raw, mode: .codec2_2400, codec: codec)
+        XCTAssertEqual(decoded.sampleRateHz, 8_000)
+        XCTAssertEqual(decoded.samples.count, geo.samplesPerFrame * 5)
+        XCTAssertEqual(decoded.durationMs, (geo.samplesPerFrame * 5) * 1_000 / 8_000)
+    }
+
+    func testDecodePayloadConvenience() throws {
+        let codec = try makeCodec(.codec2_3200)
+        let geo = Codec2RawFile.geometry(for: .codec2_3200)
+        let raw = try Codec2RawFile.encodeAll(pcm: VoiceTestSupport.pcm(count: geo.samplesPerFrame * 3),
+                                              codec: codec)
+        let decoded = try Codec2RawFile.decodePayload(raw, mode: .codec2_3200)
+        XCTAssertEqual(decoded.samples.count, geo.samplesPerFrame * 3)
+    }
+
+    func testDecodeRejectsIncompleteTail() throws {
+        let codec = try makeCodec(.codec2_2400)
+        let geo = Codec2RawFile.geometry(for: .codec2_2400)
+        let raw = try Codec2RawFile.encodeAll(pcm: VoiceTestSupport.pcm(count: geo.samplesPerFrame * 2),
+                                              codec: codec)
+        var bad = [UInt8](raw)
+        bad.append(0xAB) // one extra byte -> not a whole number of frames
+        XCTAssertThrowsError(try Codec2RawFile.decode(Data(bad), mode: .codec2_2400, codec: codec)) {
+            XCTAssertEqual($0 as? Codec2FileError, .incompleteFrame)
+        }
+    }
+
+    func testDecodeRejectsEmptyAndWrongMode() throws {
+        let codec = try makeCodec()
+        XCTAssertThrowsError(try Codec2RawFile.decode(Data(), mode: .codec2_2400, codec: codec)) {
+            XCTAssertEqual($0 as? Codec2FileError, .noFrames)
+        }
+        // Non-Codec2 mode has no header byte to prefix.
+        let one = try Codec2RawFile.encodeAll(pcm: VoiceTestSupport.pcm(count: 320), codec: codec)
+        XCTAssertThrowsError(try Codec2RawFile.decode(one, mode: .opusOgg, codec: codec)) {
+            XCTAssertEqual($0 as? Codec2FileError, .noFrames)
+        }
+    }
+
+    func testDecodeRejectsWrongCodecGeometry() throws {
+        // Encode at 1200 (36-byte frames) but decode as 2400 (96-byte frames)
+        // -> the byte count is not a whole number of 96-byte frames.
+        let codec1200 = try makeCodec(.codec2_1200)
+        let raw = try Codec2RawFile.encodeAll(pcm: VoiceTestSupport.pcm(count: 240 * 4), codec: codec1200)
+        let codec2400 = try makeCodec(.codec2_2400)
+        XCTAssertThrowsError(try Codec2RawFile.decode(raw, mode: .codec2_2400, codec: codec2400)) {
+            XCTAssertEqual($0 as? Codec2FileError, .incompleteFrame)
+        }
+    }
+
+    func testDecodeEnforcesFiveMinuteCeiling() {
+        // 2400 geometry: 96-byte frames, 320 samples/frame. A payload sized as
+        // a whole number of 2400 frames whose decoded samples exceed 5 minutes
+        // (8000*300) must be rejected BEFORE any allocation (wide arithmetic).
+        let geo = Codec2RawFile.geometry(for: .codec2_2400)
+        // frames such that frames*320 > 2_400_000 (5 min at 8k).
+        let frames = 8_000 * 300 / geo.samplesPerFrame + 1
+        let payload = Data(repeating: 0x00, count: frames * geo.bytesPerFrame)
+        XCTAssertThrowsError(try Codec2RawFile.decode(payload, mode: .codec2_2400, codec: try! makeCodec(.codec2_2400))) {
+            XCTAssertEqual($0 as? Codec2FileError, .exceedsDecodeCeiling)
+        }
+    }
+
+    // MARK: - WAV bridge
+
+    func testWriteWaveProducesValidRIFF() throws {
+        let codec = try makeCodec(.codec2_1600)
+        let geo = Codec2RawFile.geometry(for: .codec2_1600)
+        let raw = try Codec2RawFile.encodeAll(pcm: VoiceTestSupport.pcm(count: geo.samplesPerFrame * 2),
+                                              codec: codec)
+        let decoded = try Codec2RawFile.decode(raw, mode: .codec2_1600, codec: codec)
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("columba-voice-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let url = Codec2RawFile.writeWave(decoded, to: dir.appendingPathComponent("v.wav"))
+
+        let wav = try Data(contentsOf: url)
+        XCTAssertEqual(wav.prefix(4), Data("RIFF".utf8))
+        XCTAssertEqual(Int(littleEndian32(wav, 4)), 36 + decoded.samples.count * 2)
+        XCTAssertEqual(wav[8..<12], Data("WAVE".utf8))
+        XCTAssertEqual(wav[12..<16], Data("fmt ".utf8))
+        XCTAssertEqual(Int(littleEndian32(wav, 16)), 16)      // fmt size
+        XCTAssertEqual(Int(littleEndian16(wav, 20)), 1)       // PCM
+        XCTAssertEqual(Int(littleEndian16(wav, 22)), 1)       // mono
+        XCTAssertEqual(Int(littleEndian32(wav, 24)), 8_000)   // rate
+        XCTAssertEqual(Int(littleEndian32(wav, 28)), 16_000)  // byte rate
+        XCTAssertEqual(Int(littleEndian16(wav, 32)), 16)      // bits
+        XCTAssertEqual(wav[36..<40], Data("data".utf8))
+        XCTAssertEqual(Int(littleEndian32(wav, 40)), decoded.samples.count * 2)
+    }
+
+    func testLargeRoundTripIsStable() throws {
+        let codec = try makeCodec(.codec2_1200)
+        let geo = Codec2RawFile.geometry(for: .codec2_1200)
+        let frames = 50
+        let raw = try Codec2RawFile.encodeAll(pcm: VoiceTestSupport.pcm(count: geo.samplesPerFrame * frames),
+                                              codec: codec)
+        XCTAssertEqual(raw.count, geo.bytesPerFrame * frames)
+        let decoded = try Codec2RawFile.decode(raw, mode: .codec2_1200, codec: codec)
+        XCTAssertEqual(decoded.samples.count, geo.samplesPerFrame * frames)
+    }
+
+    // MARK: - Geometry (libcodec2 table, bitrate × spf / 8000)
+
+    func testGeometryTable() {
+        let expectations: [Codec2Mode: (Int, Int)] = [
+            .codec2_700C: (160, 14), .codec2_1200: (240, 36), .codec2_1300: (240, 39),
+            .codec2_1400: (240, 42), .codec2_1600: (240, 48), .codec2_2400: (320, 96),
+            .codec2_3200: (320, 128),
+        ]
+        for (mode, (spf, bpf)) in expectations {
+            let g = Codec2RawFile.geometry(for: mode)
+            XCTAssertEqual(g.samplesPerFrame, spf, "\(mode)")
+            XCTAssertEqual(g.bytesPerFrame, bpf, "\(mode)")
+            // Self-consistency: bytes = bitrate * spf / 8000.
+            XCTAssertEqual(g.bytesPerFrame, Int(Double(mode.bitrate) * Double(g.samplesPerFrame) / 8000.0))
+        }
+    }
+
+    private func littleEndian16(_ d: Data, _ off: Int) -> UInt16 {
+        UInt16(d[d.startIndex + off]) | (UInt16(d[d.startIndex + off + 1]) << 8)
+    }
+    private func littleEndian32(_ d: Data, _ off: Int) -> UInt32 {
+        UInt32(d[d.startIndex + off]) | (UInt32(d[d.startIndex + off + 1]) << 8)
+        | (UInt32(d[d.startIndex + off + 2]) << 16) | (UInt32(d[d.startIndex + off + 3]) << 24)
+    }
+}

--- a/Tests/ColumbaAppTests/Codec2RawFileTests.swift
+++ b/Tests/ColumbaAppTests/Codec2RawFileTests.swift
@@ -153,7 +153,8 @@ final class Codec2RawFileTests: XCTestCase {
         XCTAssertEqual(Int(littleEndian16(wav, 22)), 1)       // mono
         XCTAssertEqual(Int(littleEndian32(wav, 24)), 8_000)   // rate
         XCTAssertEqual(Int(littleEndian32(wav, 28)), 16_000)  // byte rate
-        XCTAssertEqual(Int(littleEndian16(wav, 32)), 16)      // bits
+        XCTAssertEqual(Int(littleEndian16(wav, 32)), 2)       // block align
+        XCTAssertEqual(Int(littleEndian16(wav, 34)), 16)      // bits per sample
         XCTAssertEqual(wav[36..<40], Data("data".utf8))
         XCTAssertEqual(Int(littleEndian32(wav, 40)), decoded.samples.count * 2)
     }

--- a/Tests/ColumbaAppTests/Codec2RawFileTests.swift
+++ b/Tests/ColumbaAppTests/Codec2RawFileTests.swift
@@ -92,22 +92,28 @@ final class Codec2RawFileTests: XCTestCase {
     }
 
     func testDecodeRejectsWrongCodecGeometry() throws {
-        // Encode at 1200 (36-byte frames) but decode as 2400 (96-byte frames)
-        // -> the byte count is not a whole number of 96-byte frames.
-        let codec1200 = try makeCodec(.codec2_1200)
-        let raw = try Codec2RawFile.encodeAll(pcm: VoiceTestSupport.pcm(count: 240 * 4), codec: codec1200)
+        // A payload whose byte count is NOT a whole number of frames must be
+        // rejected as incomplete, regardless of the exact frame size. Sized as
+        // (frames × bytesPerFrame) + 1 from the LIVE geometry so the test is
+        // robust to the real codec's bytesPerFrame (the old version assumed
+        // 1200/2400 frame sizes whose ratio happened to work with the buggy
+        // 8x-inflated table).
         let codec2400 = try makeCodec(.codec2_2400)
-        XCTAssertThrowsError(try Codec2RawFile.decode(raw, mode: .codec2_2400, codec: codec2400)) {
+        let geo = Codec2RawFile.geometry(of: codec2400)
+        let raw = try Codec2RawFile.encodeAll(
+            pcm: VoiceTestSupport.pcm(count: geo.samplesPerFrame * 4), codec: codec2400)
+        var bad = [UInt8](raw); bad.append(0xAB) // one extra byte
+        XCTAssertThrowsError(try Codec2RawFile.decode(Data(bad), mode: .codec2_2400, codec: codec2400)) {
             XCTAssertEqual($0 as? Codec2FileError, .incompleteFrame)
         }
     }
 
     func testDecodeEnforcesFiveMinuteCeiling() {
-        // 2400 geometry: 96-byte frames, 320 samples/frame. A payload sized as
-        // a whole number of 2400 frames whose decoded samples exceed 5 minutes
-        // (8000*300) must be rejected BEFORE any allocation (wide arithmetic).
+        // A payload sized as a whole number of 2400 frames whose decoded
+        // samples exceed 5 minutes (8000*300) must be rejected BEFORE any
+        // allocation (wide arithmetic). Uses the live geometry's frame size.
         let geo = Codec2RawFile.geometry(for: .codec2_2400)
-        // frames such that frames*320 > 2_400_000 (5 min at 8k).
+        // frames such that frames*spf > 2_400_000 (5 min at 8k).
         let frames = 8_000 * 300 / geo.samplesPerFrame + 1
         let payload = Data(repeating: 0x00, count: frames * geo.bytesPerFrame)
         XCTAssertThrowsError(try Codec2RawFile.decode(payload, mode: .codec2_2400, codec: try! makeCodec(.codec2_2400))) {
@@ -154,20 +160,29 @@ final class Codec2RawFileTests: XCTestCase {
         XCTAssertEqual(decoded.samples.count, geo.samplesPerFrame * frames)
     }
 
-    // MARK: - Geometry (libcodec2 table, bitrate × spf / 8000)
+    // MARK: - Geometry (derived from the live codec)
 
-    func testGeometryTable() {
-        let expectations: [Codec2Mode: (Int, Int)] = [
-            .codec2_700C: (160, 14), .codec2_1200: (240, 36), .codec2_1300: (240, 39),
-            .codec2_1400: (240, 42), .codec2_1600: (240, 48), .codec2_2400: (320, 96),
-            .codec2_3200: (320, 128),
-        ]
-        for (mode, (spf, bpf)) in expectations {
-            let g = Codec2RawFile.geometry(for: mode)
-            XCTAssertEqual(g.samplesPerFrame, spf, "\(mode)")
-            XCTAssertEqual(g.bytesPerFrame, bpf, "\(mode)")
-            // Self-consistency: bytes = bitrate * spf / 8000.
-            XCTAssertEqual(g.bytesPerFrame, Int(Double(mode.bitrate) * Double(g.samplesPerFrame) / 8000.0))
+    /// The derived geometry must be self-consistent with the codec itself, for
+    /// every mode: N frames of `samplesPerFrame` samples encode to exactly
+    /// N × bytesPerFrame raw bytes, and `samplesPerFrame - 1` samples is not
+    /// enough for one frame (encode throws). The live codec is the oracle -
+    /// the old static table hardcoded (spf, bpf) pairs whose bpf was 8x too
+    /// large (computed in bits, not bytes), which broke every encode/decode
+    /// size assertion.
+    func testGeometryMatchesLiveCodec() throws {
+        for mode in Codec2Mode.allCases {
+            let codec = try makeCodec(mode)
+            let g = Codec2RawFile.geometry(of: codec)
+            XCTAssertGreaterThan(g.samplesPerFrame, 0, "\(mode): samplesPerFrame")
+            XCTAssertGreaterThan(g.bytesPerFrame, 0, "\(mode): bytesPerFrame")
+            // 3 full frames -> exactly 3 × bytesPerFrame raw bytes.
+            let raw = try Codec2RawFile.encodeAll(
+                pcm: VoiceTestSupport.pcm(count: g.samplesPerFrame * 3), codec: codec)
+            XCTAssertEqual(raw.count, g.bytesPerFrame * 3, "\(mode): 3-frame raw size")
+            // samplesPerFrame - 1 samples cannot make one frame.
+            XCTAssertThrowsError(
+                try codec.encode(VoiceTestSupport.pcm(count: g.samplesPerFrame - 1)),
+                "\(mode): one frame below spf must throw")
         }
     }
 

--- a/Tests/ColumbaAppTests/Codec2RawFileTests.swift
+++ b/Tests/ColumbaAppTests/Codec2RawFileTests.swift
@@ -23,15 +23,21 @@ final class Codec2RawFileTests: XCTestCase {
     // MARK: - Encode (header stripped)
 
     func testEncodeFrameStripsHeaderByte() throws {
-        let codec = try makeCodec(.codec2_2400)
+        // Codec2 is a STATEFUL codec: consecutive encode() calls on the same
+        // instance keep internal state and produce different bytes. So the
+        // "encodeFrame strips the header" invariant is checked by encoding the
+        // SAME pcm with a FRESH codec on each side - then the only difference
+        // between `codec.encode(frame)` and `encodeFrame` is the header byte.
         let geo = Codec2RawFile.geometry(for: .codec2_2400)
         let frame = VoiceTestSupport.pcm(count: geo.samplesPerFrame)
-        let raw = try Codec2RawFile.encodeFrame(pcm: frame, codec: codec)
+        let a = try makeCodec(.codec2_2400)
+        let b = try makeCodec(.codec2_2400)
+        let raw = try Codec2RawFile.encodeFrame(pcm: frame, codec: a)
         // Raw frame size = bytesPerFrame (header byte removed).
         XCTAssertEqual(raw.count, geo.bytesPerFrame)
         // LXSTSwift encode prepends the header byte; stripping it must leave
-        // exactly the frame bytes.
-        let full = try codec.encode(frame)
+        // exactly the frame bytes (encoded fresh, so the payload is identical).
+        let full = try b.encode(frame)
         XCTAssertEqual(full.count, geo.bytesPerFrame + 1)
         XCTAssertEqual(full[0], 0x05, "LXST header byte for codec2_2400")
         XCTAssertEqual(Array(full[1...]), Array(raw))
@@ -131,6 +137,9 @@ final class Codec2RawFileTests: XCTestCase {
         let decoded = try Codec2RawFile.decode(raw, mode: .codec2_1600, codec: codec)
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("columba-voice-tests-\(UUID().uuidString)", isDirectory: true)
+        // writeWave writes the WAV to `url` without creating the parent dir
+        // (the production player creates its own). Create it here.
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: dir) }
         let url = try Codec2RawFile.writeWave(decoded, to: dir.appendingPathComponent("v.wav"))
 

--- a/Tests/ColumbaAppTests/Codec2RawFileTests.swift
+++ b/Tests/ColumbaAppTests/Codec2RawFileTests.swift
@@ -34,7 +34,7 @@ final class Codec2RawFileTests: XCTestCase {
         let full = try codec.encode(frame)
         XCTAssertEqual(full.count, geo.bytesPerFrame + 1)
         XCTAssertEqual(full[0], 0x05, "LXST header byte for codec2_2400")
-        XCTAssertEqual(full[1...], raw as [UInt8])
+        XCTAssertEqual(Array(full[1...]), Array(raw))
     }
 
     func testEncodeFrameRejectsEmpty() {
@@ -126,7 +126,7 @@ final class Codec2RawFileTests: XCTestCase {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("columba-voice-tests-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager.default.removeItem(at: dir) }
-        let url = Codec2RawFile.writeWave(decoded, to: dir.appendingPathComponent("v.wav"))
+        let url = try Codec2RawFile.writeWave(decoded, to: dir.appendingPathComponent("v.wav"))
 
         let wav = try Data(contentsOf: url)
         XCTAssertEqual(wav.prefix(4), Data("RIFF".utf8))

--- a/Tests/ColumbaAppTests/MessageAttachmentPreviewTests.swift
+++ b/Tests/ColumbaAppTests/MessageAttachmentPreviewTests.swift
@@ -522,7 +522,8 @@ final class MessageAttachmentRoutingTests: XCTestCase {
             onShowDeliveryFailure: { _ in },
             onOpenLink: { _ in },
             onOpenImage: onOpenImage,
-            onOpenFileAttachment: onOpenFile
+            onOpenFileAttachment: onOpenFile,
+            voicePlayer: nil
         )
     }
 }

--- a/Tests/ColumbaAppTests/MessageAudioFieldTests.swift
+++ b/Tests/ColumbaAppTests/MessageAudioFieldTests.swift
@@ -1,0 +1,162 @@
+//
+//  MessageAudioFieldTests.swift
+//  ColumbaAppTests
+//
+//  Phase D (plan step 16): the wire field-7 contract. Covers the outbound
+//  `buildFieldMap` dual-write target (`[FIELD_AUDIO]: [mode, bytes]`), the
+//  inbound lenient `[Int, Data]` parse at the Message boundary, unsupported
+//  / custom mode handling, and the RnsAudio <-> AudioAttachment value mapping.
+//
+
+import XCTest
+import RNSAPI
+@testable import ColumbaApp
+
+final class MessageAudioFieldTests: XCTestCase {
+
+    // MARK: - Outbound: buildFieldMap writes FIELD_AUDIO = [mode, bytes]
+
+    func testBuildFieldMapWritesAudioField() {
+        let audio = RnsAudio(mode: Int(LxmfFields.AM_CODEC2_2400), bytes: Data([1, 2, 3]))
+        let fields = LxmfFieldCodec.buildFieldMap(
+            imageData: nil, imageFormat: nil, fileAttachments: nil,
+            audioAttachment: audio, iconAppearance: nil,
+            replyToMessageHashHex: nil, replyQuotedContent: nil, extraFields: nil
+        )
+        let value = fields[LxmfFields.FIELD_AUDIO] as? [Any]
+        XCTAssertNotNil(value, "FIELD_AUDIO must be written when an audio attachment is set")
+        XCTAssertEqual(value?.count, 2)
+        guard let value, let mode = (value[0] as? Int) ?? (value[0] as? UInt8).map(Int.init) else {
+            XCTFail("FIELD_AUDIO must be [Int mode, Data bytes]"); return
+        }
+        XCTAssertEqual(mode, Int(LxmfFields.AM_CODEC2_2400))
+        XCTAssertEqual(value[1] as? Data, Data([1, 2, 3]))
+        // Round-trips through the lenient inbound parser.
+        let back = AudioAttachment.fromWireValue(value)
+        XCTAssertEqual(back?.mode, .codec2_2400)
+        XCTAssertEqual(back?.bytes, Data([1, 2, 3]))
+    }
+
+    func testBuildFieldMapOmitsAudioWhenNil() {
+        let fields = LxmfFieldCodec.buildFieldMap(
+            imageData: nil, imageFormat: nil, fileAttachments: nil,
+            audioAttachment: nil, iconAppearance: nil,
+            replyToMessageHashHex: nil, replyQuotedContent: nil, extraFields: nil
+        )
+        XCTAssertNil(fields[LxmfFields.FIELD_AUDIO])
+    }
+
+    func testBuildFieldMapAudioCoexistsWithImage() {
+        let img = Data([0xFF, 0xD8, 0xFF])
+        let audio = RnsAudio(mode: Int(LxmfFields.AM_OPUS_OGG), bytes: Data([9]))
+        let fields = LxmfFieldCodec.buildFieldMap(
+            imageData: img, imageFormat: "jpeg", fileAttachments: nil,
+            audioAttachment: audio, iconAppearance: nil,
+            replyToMessageHashHex: nil, replyQuotedContent: nil, extraFields: nil
+        )
+        XCTAssertNotNil(fields[LxmfFields.FIELD_IMAGE])
+        guard let v = fields[LxmfFields.FIELD_AUDIO] as? [Any], let m = v[0] as? Int else {
+            XCTFail("FIELD_AUDIO must be [Int mode, Data bytes]"); return
+        }
+        XCTAssertEqual(m, Int(LxmfFields.AM_OPUS_OGG))
+    }
+
+    // MARK: - Inbound: Message.audioAttachment(from:) lenient parse
+
+    private func fields(_ value: Any?) -> [UInt8: Any] {
+        [LxmfFields.FIELD_AUDIO: value]
+    }
+
+    func testInboundParseAcceptsCanonicalShapes() {
+        let payload = Data([5, 6, 7])
+        // Plain Int mode.
+        let m1 = Message.audioAttachment(from: fields([Int(0x08), payload]))
+        XCTAssertEqual(m1?.mode, .codec2_2400)
+        XCTAssertEqual(m1?.bytes, payload)
+        // Unsigned 8-bit mode.
+        let m2 = Message.audioAttachment(from: fields([UInt8(0x10), payload]))
+        XCTAssertEqual(m2?.mode, .opusOgg)
+        // 32-bit mode.
+        let m3 = Message.audioAttachment(from: fields([Int32(0x04), payload]))
+        XCTAssertEqual(m3?.mode, .codec2_1200)
+    }
+
+    func testInboundParseRejectsBadShapes() {
+        XCTAssertNil(Message.audioAttachment(from: nil))
+        var empty: [UInt8: Any] = [:]
+        XCTAssertNil(Message.audioAttachment(from: empty))
+        XCTAssertNil(Message.audioAttachment(from: fields(Data([1, 2]))))          // not an array
+        XCTAssertNil(Message.audioAttachment(from: fields([Int(0x04)])))            // too short
+        XCTAssertNil(Message.audioAttachment(from: fields(["x", Data([1])] as [Any]))) // non-int mode
+        XCTAssertNil(Message.audioAttachment(from: fields([Int(0x04), "nope"])))    // non-Data payload
+    }
+
+    func testInboundUnsupportedModeRendersAsCustom() {
+        // A non-canonical wire mode is accepted as .custom so the message
+        // still renders (as a non-playable bubble) instead of being dropped.
+        let m = Message.audioAttachment(from: fields([Int(0x42), Data([1, 2])]))
+        XCTAssertEqual(m?.mode, .custom)
+        XCTAssertFalse(m?.mode.isCodec2 ?? true)
+        XCTAssertNil(VoiceMessageFormat.fromWireMode(0x42))
+    }
+
+    func testInboundOpusModeHasNoRecoverableProfile() {
+        // Opus bitrate is not on the wire: the attachment parses, but there is
+        // no canonical VoiceMessageFormat (playback uses the mode only).
+        let m = Message.audioAttachment(from: fields([Int(0x10), Data([3])]))
+        XCTAssertEqual(m?.mode, .opusOgg)
+        XCTAssertNil(VoiceMessageFormat.fromWireMode(LxmfFields.AM_OPUS_OGG))
+        // Codec2 modes resolve 1:1.
+        XCTAssertEqual(VoiceMessageFormat.fromWireMode(LxmfFields.AM_CODEC2_1200), .codec2_1200)
+        XCTAssertEqual(VoiceMessageFormat.fromWireMode(LxmfFields.AM_CODEC2_2400), .codec2_2400)
+        XCTAssertEqual(VoiceMessageFormat.fromWireMode(LxmfFields.AM_CODEC2_3200), .codec2_3200)
+    }
+
+    // MARK: - Message init carries the attachment through
+
+    func testMessageInitCarriesAudioAttachment() {
+        let attachment = AudioAttachment(mode: .codec2_1200, bytes: Data([1, 1, 1]), durationMs: 500)
+        let message = Message(id: "voice-1", content: "", isFromMe: true, audioAttachment: attachment)
+        XCTAssertEqual(message.audioAttachment?.mode, .codec2_1200)
+        XCTAssertEqual(message.audioAttachment?.bytes, Data([1, 1, 1]))
+        XCTAssertEqual(message.audioAttachment?.durationMs, 500)
+        // A text-only message has no audio.
+        let plain = Message(id: "text-1", content: "hi", isFromMe: false)
+        XCTAssertNil(plain.audioAttachment)
+    }
+
+    func testMessageFromLxMessageParsesAudioField() {
+        let payload = Data([0x98, 0x11, 0x11])
+        let lx = LXMessage(
+            destinationHash: Data([0xAA, 0xBB]),
+            sourceIdentity: nil,
+            content: Data(),
+            fields: [LxmfFields.FIELD_AUDIO: [Int(0x10), payload] as [Any]]
+        )
+        let message = Message(from: lx, localHash: Data([0x01]))
+        XCTAssertEqual(message.audioAttachment?.mode, .opusOgg)
+        XCTAssertEqual(message.audioAttachment?.bytes, payload)
+    }
+
+    func testMessageFromLxMessageWithoutAudioField() {
+        let lx = LXMessage(
+            destinationHash: Data([0xAA, 0xBB]),
+            sourceIdentity: nil,
+            content: Data("hello".utf8),
+            fields: nil
+        )
+        let message = Message(from: lx, localHash: Data([0x01]))
+        XCTAssertNil(message.audioAttachment)
+    }
+
+    // MARK: - Wire constants
+
+    func testWireConstants() {
+        XCTAssertEqual(LxmfFields.FIELD_AUDIO, 0x07)
+        XCTAssertEqual(LxmfFields.AM_CODEC2_1200, 0x04)
+        XCTAssertEqual(LxmfFields.AM_CODEC2_2400, 0x08)
+        XCTAssertEqual(LxmfFields.AM_CODEC2_3200, 0x09)
+        XCTAssertEqual(LxmfFields.AM_OPUS_OGG, 0x10)
+        XCTAssertEqual(LxmfFields.AM_CUSTOM, 0xFF)
+    }
+}

--- a/Tests/ColumbaAppTests/OggOpusFileWriterTests.swift
+++ b/Tests/ColumbaAppTests/OggOpusFileWriterTests.swift
@@ -133,6 +133,26 @@ final class OggOpusFileWriterTests: XCTestCase {
         XCTAssertEqual(OggOpusFileWriter.maxFileBytes, 8 * 1024 * 1024)
     }
 
+    func testEveryPageUsesOggVersionZero() {
+        // Regression: the original writer emitted version byte 2 on every page,
+        // which strict Ogg parsers (Sideband's libopusfile, ffmpeg) reject
+        // ("Invalid Ogg vers!" / "Failed to open"). The OggS spec mandates
+        // version 0. iOS's own AVAudioPlayer is lenient about this byte, so the
+        // bug was invisible to our own player but broke every OTHER receiver of
+        // our outbound voice. Assert version 0 on every emitted page.
+        let w = makeWriter(channels: 2, preSkip: 480)
+        _ = try? w.appendPacket(VoiceTestSupport.opusPacket(toc: 0x98, size: 40))
+        _ = try? w.appendPacket(VoiceTestSupport.opusPacket(toc: 0x98, size: 33))
+        _ = try? w.appendPacket(VoiceTestSupport.opusPacket(toc: 0x90, size: 27))
+        let data = try! w.finish()
+        let pages = walk(data)
+        for p in pages {
+            XCTAssertEqual(data[p.pageStart + 4], 0,
+                "page @\(p.pageStart) Ogg version byte must be 0 (OggS spec); " +
+                "a regression to 2 breaks Sideband/ffmpeg playback of our outbound voice")
+        }
+    }
+
     func testPublishToDiskIsAtomicAndBounded() throws {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("columba-voice-tests-\(UUID().uuidString)", isDirectory: true)

--- a/Tests/ColumbaAppTests/OggOpusFileWriterTests.swift
+++ b/Tests/ColumbaAppTests/OggOpusFileWriterTests.swift
@@ -1,0 +1,214 @@
+//
+//  OggOpusFileWriterTests.swift
+//  ColumbaAppTests
+//
+//  Phase B (plan step 8): the Ogg/Opus muxer output. The load-bearing interop
+//  assertion is that each audio page carries CUMULATIVE END-OF-PACKET 48 kHz
+//  granules (one packet per page), so Android's Ogg normalizer is a NO-OP on
+//  our bytes - the exact condition that makes the file playable by Sideband's
+//  LXST/libopusfile path. The page walk below is independent of the writer's
+//  own bookkeeping.
+//
+
+import XCTest
+import Foundation
+@testable import ColumbaApp
+
+final class OggOpusFileWriterTests: XCTestCase {
+
+    private func makeWriter(channels: Int = 1, preSkip: Int = 240) -> OggOpusFileWriter {
+        OggOpusFileWriter(channels: channels, preSkip: preSkip)
+    }
+
+    private func walk(_ data: [UInt8]) -> [VoiceTestSupport.OggPage] {
+        guard let pages = VoiceTestSupport.oggPages(data) else {
+            XCTFail("bytes are not a well-formed Ogg page sequence")
+            return []
+        }
+        return pages
+    }
+
+    private func page(_ pages: [VoiceTestSupport.OggPage], _ data: [UInt8], _ i: Int) -> (header: [UInt8], payloadStart: Int, payload: [UInt8], end: Int) {
+        let start = pages[i].pageStart
+        let segCount = Int(data[start + 26])
+        var payloadSize = 0
+        for k in 0..<segCount { payloadSize += Int(data[start + 27 + k]) }
+        let payloadStart = start + 27 + segCount
+        return (Array(data[start..<(start + 27)]), payloadStart,
+                Array(data[payloadStart..<(payloadStart + payloadSize)]), payloadStart + payloadSize)
+    }
+
+    func testHeaderPagesAndBOSFlags() {
+        let writer = makeWriter(channels: 2, preSkip: 480)
+        _ = try? writer.appendPacket(VoiceTestSupport.opusPacket())
+        let data = try! writer.finish()
+        let pages = walk(data)
+        XCTAssertEqual(pages.count, 3)
+
+        // Page 0: OpusHead, BOS set, granule -1.
+        let h0 = page(pages, data, 0)
+        XCTAssertEqual(data[h0.payloadStart..<h0.payloadStart + 8],
+                       Array("OpusHead".utf8))
+        XCTAssertEqual(data[h0.payloadStart + 8], 1)                 // version
+        XCTAssertEqual(data[h0.payloadStart + 9], 2)                 // channels
+        let preSkip = Int(data[h0.payloadStart + 10]) | (Int(data[h0.payloadStart + 11]) << 8)
+        XCTAssertEqual(preSkip, 480)
+        XCTAssertEqual(h0.header[5] & 0x02, 0x02, "page 0 must be begin-of-stream")
+        XCTAssertEqual(OggOpusGranule.readUInt64LE(h0.header, 6), UInt64.max, "granule -1")
+
+        // Page 1: OpusTags, no BOS.
+        let h1 = page(pages, data, 1)
+        XCTAssertEqual(data[h1.payloadStart..<h1.payloadStart + 8], Array("OpusTags".utf8))
+        XCTAssertEqual(h1.header[5] & 0x02, 0x00)
+
+        // Every page's CRC must validate.
+        for (i, p) in pages.enumerated() {
+            let end = i + 1 < pages.count ? pages[i + 1].pageStart : data.count
+            XCTAssertTrue(VoiceTestSupport.oggPageCRCValid(data, pageStart: p.pageStart, pageEnd: end),
+                          "CRC mismatch on page \(i)")
+        }
+    }
+
+    func testCumulativeEndOfPacketGranulesAreANormalizerNoOp() {
+        let writer = makeWriter(channels: 1, preSkip: 240)
+        let packets: [[UInt8]] = [
+            VoiceTestSupport.opusPacket(toc: 0x98, size: 40),  // 960
+            VoiceTestSupport.opusPacket(toc: 0x98, size: 33),  // 960
+            VoiceTestSupport.opusPacket(toc: 0x90, size: 27),  // 480
+            VoiceTestSupport.opusPacket(toc: 0x98, size: 51),  // 960
+            VoiceTestSupport.opusPacket(toc: 0x88, size: 19),  // 240
+        ]
+        let perPacket = packets.map { try! OggOpusGranule.packetSamples48k($0) }
+        for (i, p) in packets.enumerated() { try! writer.appendPacket(p) }
+        let data = try! writer.finish()
+        let pages = walk(data)
+        XCTAssertEqual(pages.count, 2 + packets.count)
+
+        var running: UInt64 = 0
+        for (i, packet) in packets.enumerated() {
+            let pi = i + 2
+            let h = page(pages, data, pi)
+            // One packet per page, exact size.
+            let segCount = Int(data[pages[pi].pageStart + 26])
+            XCTAssertEqual(segCount, 1)
+            XCTAssertEqual(data[pages[pi].pageStart + 27], UInt8(packet.count))
+            XCTAssertEqual(h.payload, packet)
+            // Granule = CUMULATIVE END-OF-PACKET 48 kHz samples.
+            running += UInt64(perPacket[i])
+            let granule = OggOpusGranule.readUInt64LE(h.header, 6)
+            XCTAssertEqual(granule, running,
+                           "page \(pi) granule must equal cumulative end-of-packet samples; " +
+                           "a regression to packet-START granules breaks Sideband interop")
+        }
+        XCTAssertEqual(writer.finalGranuleValue, running)
+
+        // Duration via the (independent) metadata reader.
+        let meta = OggOpusMetadataReader.read(data)
+        XCTAssertEqual(meta?.preSkip, 240)
+        XCTAssertEqual(meta?.finalGranule, Int(running))
+        XCTAssertEqual(meta?.durationMs, ((Int(running) - 240) * 1_000) / 48_000)
+    }
+
+    func testWriterRejectsEmptyAndOversizedPackets() {
+        let writer = makeWriter()
+        XCTAssertThrowsError(try writer.appendPacket([]))
+        let huge = [UInt8](repeating: 0x98, count: 65_026)
+        XCTAssertThrowsError(try writer.appendPacket(huge))
+    }
+
+    func testFinishRequiresAudio() {
+        let writer = makeWriter()
+        XCTAssertThrowsError(try writer.finish())
+        _ = try? writer.appendPacket(VoiceTestSupport.opusPacket())
+        XCTAssertNoThrow(try writer.finish())
+    }
+
+    func testPreSkipForProfileIsFsOver100() {
+        XCTAssertEqual(OggOpusFileWriter.preSkipForProfile(sampleRate: 24_000), 240)
+        XCTAssertEqual(OggOpusFileWriter.preSkipForProfile(sampleRate: 48_000), 480)
+        XCTAssertEqual(OggOpusFileWriter.preSkipForProfile(sampleRate: 8_000), 80)
+    }
+
+    func testMaxFileBytesIs8MiB() {
+        XCTAssertEqual(OggOpusFileWriter.maxFileBytes, 8 * 1024 * 1024)
+    }
+
+    func testPublishToDiskIsAtomicAndBounded() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("columba-voice-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let url = dir.appendingPathComponent("out.ogg")
+
+        let writer = makeWriter()
+        _ = try writer.appendPacket(VoiceTestSupport.opusPacket())
+        let bytes = try writer.finish()
+        try OggOpusFileWriter.publishToDisk(Data(bytes), to: url)
+        XCTAssertEqual(try Data(contentsOf: url), Data(bytes))
+        // No temp litter.
+        let remaining = try FileManager.default.contentsOfDirectory(atPath: dir.path)
+        XCTAssertEqual(remaining, ["out.ogg"])
+
+        // Empty and over-limit payloads are rejected.
+        XCTAssertThrowsError(try OggOpusFileWriter.publishToDisk(Data(), to: url))
+        let over = Data(repeating: 0, count: OggOpusFileWriter.maxFileBytes + 1)
+        XCTAssertThrowsError(try OggOpusFileWriter.publishToDisk(over, to: url))
+        // Re-publishing over an existing file works.
+        let w2 = makeWriter()
+        _ = try w2.appendPacket(VoiceTestSupport.opusPacket(size: 11))
+        _ = try w2.appendPacket(VoiceTestSupport.opusPacket(size: 12))
+        let bytes2 = try w2.finish()
+        try OggOpusFileWriter.publishToDisk(Data(bytes2), to: url)
+        XCTAssertEqual(try Data(contentsOf: url), Data(bytes2))
+    }
+}
+
+// MARK: - Metadata reader (fail-closed, duration = (finalGranule - preSkip) @48k)
+
+final class OggOpusMetadataReaderTests: XCTestCase {
+
+    func testReadsDurationFromWriterOutput() {
+        let writer = OggOpusFileWriter(channels: 1, preSkip: 240)
+        // 960 + 960 + 480 = 2400 granules.
+        _ = try? writer.appendPacket(VoiceTestSupport.opusPacket(toc: 0x98))
+        _ = try? writer.appendPacket(VoiceTestSupport.opusPacket(toc: 0x98))
+        _ = try? writer.appendPacket(VoiceTestSupport.opusPacket(toc: 0x90))
+        let bytes = try! writer.finish()
+        let meta = OggOpusMetadataReader.read(bytes)
+        XCTAssertEqual(meta?.finalGranule, 2400)
+        XCTAssertEqual(meta?.preSkip, 240)
+        // (2400 - 240) / 48000 * 1000 = 45 ms.
+        XCTAssertEqual(meta?.durationMs, 45)
+    }
+
+    func testReadsCustomPreSkipAndChannels() {
+        let writer = OggOpusFileWriter(channels: 2, preSkip: 480)
+        _ = try? writer.appendPacket(VoiceTestSupport.opusPacket(toc: 0x98))  // 960
+        let meta = OggOpusMetadataReader.read(try! writer.finish())
+        XCTAssertEqual(meta?.preSkip, 480)
+        XCTAssertEqual(meta?.finalGranule, 960)
+        // (960 - 480) / 48000 * 1000 = 10 ms.
+        XCTAssertEqual(meta?.durationMs, 10)
+    }
+
+    func testFailClosedOnInvalidStreams() throws {
+        XCTAssertNil(OggOpusMetadataReader.read([]))
+        XCTAssertNil(OggOpusMetadataReader.read(Array("not an ogg stream".utf8)))
+        // Headers only (no audio page => no final granule).
+        XCTAssertNil(OggOpusMetadataReader.read(try headerOnlyStream()))
+        // A truncated final audio page (payload extends past EOF).
+        let full = try makeOggWithOnePacket()
+        XCTAssertNil(OggOpusMetadataReader.read(Array(full[0..<(full.count - 3)])))
+    }
+
+    /// A 2-page (OpusHead + OpusTags) stream with no audio page.
+    private func headerOnlyStream() throws -> [UInt8] {
+        let w = OggOpusFileWriter(channels: 1, preSkip: 240)
+        return w.completedBytes
+    }
+
+    private func makeOggWithOnePacket() throws -> [UInt8] {
+        let w = OggOpusFileWriter(channels: 1, preSkip: 240)
+        try w.appendPacket(VoiceTestSupport.opusPacket())
+        return try w.finish()
+    }
+}

--- a/Tests/ColumbaAppTests/OggOpusFileWriterTests.swift
+++ b/Tests/ColumbaAppTests/OggOpusFileWriterTests.swift
@@ -47,7 +47,7 @@ final class OggOpusFileWriterTests: XCTestCase {
 
         // Page 0: OpusHead, BOS set, granule -1.
         let h0 = page(pages, data, 0)
-        XCTAssertEqual(data[h0.payloadStart..<h0.payloadStart + 8],
+        XCTAssertEqual(Array(data[h0.payloadStart..<h0.payloadStart + 8]),
                        Array("OpusHead".utf8))
         XCTAssertEqual(data[h0.payloadStart + 8], 1)                 // version
         XCTAssertEqual(data[h0.payloadStart + 9], 2)                 // channels
@@ -58,7 +58,7 @@ final class OggOpusFileWriterTests: XCTestCase {
 
         // Page 1: OpusTags, no BOS.
         let h1 = page(pages, data, 1)
-        XCTAssertEqual(data[h1.payloadStart..<h1.payloadStart + 8], Array("OpusTags".utf8))
+        XCTAssertEqual(Array(data[h1.payloadStart..<h1.payloadStart + 8]), Array("OpusTags".utf8))
         XCTAssertEqual(h1.header[5] & 0x02, 0x00)
 
         // Every page's CRC must validate.

--- a/Tests/ColumbaAppTests/OggOpusGranuleTests.swift
+++ b/Tests/ColumbaAppTests/OggOpusGranuleTests.swift
@@ -1,0 +1,117 @@
+//
+//  OggOpusGranuleTests.swift
+//  ColumbaAppTests
+//
+//  Phase B (plan step 8): the pure granule/TOC/CRC math. `packetSamples48k`
+//  is ported bit-for-bit from Android's normalizer, so these assertions pin
+//  the exact Sideband-interop contract (48 kHz code 2.5/5/10/20 ms, 60 ms,
+//  20 ms fixed, N+1 multi-frame, the 120 ms ceiling, and error cases).
+//
+
+import XCTest
+@testable import ColumbaApp
+
+final class OggOpusGranuleTests: XCTestCase {
+
+    // MARK: - TOC decode (packetSamples48k)
+
+    func test48khzCodeDurations() {
+        // s=1: 48 kHz, 2.5 / 5 / 10 / 20 ms.
+        XCTAssertEqual(try OggOpusGranule.packetSamples48k([0x80, 0x00]), 120)   // 2.5 ms
+        XCTAssertEqual(try OggOpusGranule.packetSamples48k([0x88, 0x00]), 240)   // 5 ms
+        XCTAssertEqual(try OggOpusGranule.packetSamples48k([0x90, 0x00]), 480)   // 10 ms
+        XCTAssertEqual(try OggOpusGranule.packetSamples48k([0x98, 0x00]), 960)   // 20 ms
+    }
+
+    func testCode60ms() {
+        // s=0 (bit7 clear, bits5,6 not both 1), code=3 (bits3,4 set) -> 60 ms
+        // = 48000*60/1000 = 2880. 0x18: bit7=0, bits6,5=0, bits4,3=1, c=0.
+        XCTAssertEqual(try OggOpusGranule.packetSamples48k([0x18, 0x00]), 2880)
+        // Sanity: the neighbouring size=2 (bits3,4 = 10) maps to 40 ms = 1920.
+        XCTAssertEqual(try OggOpusGranule.packetSamples48k([0x30, 0x00]), 1920)
+    }
+
+    func testCodeFixed() {
+        // s=0, code=11 (bits5,6 set, bit7 clear): bit3 selects 20 ms vs 10 ms.
+        // 0x60 (bit3=0) -> 48000/100 = 480 (10 ms); 0x68 (bit3=1) -> 48000/50 = 960 (20 ms).
+        XCTAssertEqual(try OggOpusGranule.packetSamples48k([0x60, 0x00]), 480)
+        XCTAssertEqual(try OggOpusGranule.packetSamples48k([0x68, 0x00]), 960)
+    }
+
+    func testMultiFrameNPlus1() {
+        // c=3: frame count in the next byte (low 6 bits).
+        // 2 frames x 2.5 ms = 240.
+        XCTAssertEqual(try OggOpusGranule.packetSamples48k([0x83, 0x02]), 240)
+        // 3 frames x 20 ms (48 kHz) = 2880.
+        XCTAssertEqual(try OggOpusGranule.packetSamples48k([0x9B, 0x03]), 2880)
+    }
+
+    func testInvalidFrameCountThrows() {
+        // c=3 with count 0 -> invalid.
+        XCTAssertThrowsError(try OggOpusGranule.packetSamples48k([0x83, 0x00])) {
+            XCTAssertEqual($0 as? OggOpusWriterError, .invalidFrameCount)
+        }
+        // c=3 with count 49 (> 48) -> invalid.
+        XCTAssertThrowsError(try OggOpusGranule.packetSamples48k([0x83, 0x31])) {
+            XCTAssertEqual($0 as? OggOpusWriterError, .invalidFrameCount)
+        }
+    }
+
+    func testEmptyAndTruncatedPacketsThrow() {
+        XCTAssertThrowsError(try OggOpusGranule.packetSamples48k([])) {
+            XCTAssertEqual($0 as? OggOpusWriterError, .emptyPacket)
+        }
+        // c=3 but no second byte -> truncated multi-frame.
+        XCTAssertThrowsError(try OggOpusGranule.packetSamples48k([0x83])) {
+            XCTAssertEqual($0 as? OggOpusWriterError, .truncatedMultiFrame)
+        }
+    }
+
+    // MARK: - CRC-32 (libogg table + algorithm)
+
+    func testCRCTableMatchesPolynomial() {
+        XCTAssertEqual(OggOpusGranule.crcTable.count, 256)
+        XCTAssertEqual(OggOpusGranule.crcTable[0], 0)
+        // table[i] = 8-step non-reflected CRC of the single byte i<<24.
+        for i in [1, 2, 3, 7, 0x10, 0x7F, 0x80, 0xFF] {
+            var v = UInt32(i) << 24
+            for _ in 0..<8 {
+                v = (v & 0x8000_0000) != 0 ? ((v << 1) ^ 0x04C1_1DB7) : (v << 1)
+            }
+            XCTAssertEqual(OggOpusGranule.crcTable[i], v, "table[\(i)]")
+        }
+    }
+
+    func testChecksumZeroEmptyRangeIsZero() {
+        XCTAssertEqual(OggOpusGranule.oggChecksum([], 0, 0), 0)
+    }
+
+    func testChecksumIsSensitivityToStoredFieldOnlyWhenZeroed() {
+        var page = [UInt8](repeating: 0, count: 27)
+        for i in 0..<27 { page[i] = UInt8(i & 0xFF) }
+        let normal = OggOpusGranule.oggChecksum(page, 0, 27, zeroStoredChecksum: false)
+        let zeroed = OggOpusGranule.oggChecksum(page, 0, 27, zeroStoredChecksum: true)
+        // The stored-field bytes (22..25) are non-zero, so zeroing changes the CRC.
+        XCTAssertNotEqual(normal, zeroed)
+    }
+
+    // MARK: - Endianness helpers + constants
+
+    func testLittleEndianRoundTrip() {
+        var buf = [UInt8](repeating: 0, count: 8)
+        OggOpusGranule.writeIntLE(0x12345678, into: &buf, 0)
+        XCTAssertEqual(OggOpusGranule.readIntLE(buf, 0), 0x12345678)
+        OggOpusGranule.writeUInt64LE(0x0102030405060708, into: &buf, 0)
+        XCTAssertEqual(OggOpusGranule.readUInt64LE(buf, 0), 0x0102030405060708)
+        // Negative INT64 granule (-1) round-trips.
+        OggOpusGranule.writeUInt64LE(OggOpusGranule.granuleUndefined, into: &buf, 0)
+        XCTAssertEqual(OggOpusGranule.readUInt64LE(buf, 0), UInt64.max)
+    }
+
+    func testContainerConstants() {
+        XCTAssertEqual(OggOpusGranule.sampleRate, 48_000)
+        XCTAssertEqual(OggOpusGranule.oggHeaderSize, 27)
+        XCTAssertEqual(OggOpusGranule.checksumOffset, 22)
+        XCTAssertEqual(OggOpusGranule.capturePattern, [0x4F, 0x67, 0x67, 0x53])
+    }
+}

--- a/Tests/ColumbaAppTests/OggOpusInboundNormalizerTests.swift
+++ b/Tests/ColumbaAppTests/OggOpusInboundNormalizerTests.swift
@@ -205,6 +205,27 @@ final class OggOpusInboundNormalizerTests: XCTestCase {
         XCTAssertThrowsError(try OggOpusInboundNormalizer.normalize(truncated))
     }
 
+    func testLacingTableShorterThanDeclaredSegmentCountThrows() {
+        // Hostile page: the header declares 100 lacing segments but only a
+        // handful exist before EOF. Without the pre-read bounds guard this
+        // indexed `data[off + 27 + i]` past the buffer and trapped (fatal
+        // error) instead of throwing - Greptile finding on PR #194.
+        var page = [UInt8](repeating: 0, count: 27)
+        page.replaceSubrange(0..<4, with: [0x4F, 0x67, 0x67, 0x53])
+        page[4] = 0
+        for i in 0..<8 { page[6 + i] = UInt8((UInt64.max >> (i * 8)) & 0xFF) }
+        for i in 0..<4 { page[14 + i] = UInt8((1 >> (i * 8)) & 0xFF) }
+        for i in 0..<4 { page[18 + i] = UInt8((0 >> (i * 8)) & 0xFF) }
+        page[26] = 100 // declared segment count
+        page.append(contentsOf: [0x13]) // only 1 lacing byte exists
+        page.append(contentsOf: opusHead())
+        let crc = OggOpusGranule.oggChecksum(page, 0, page.count, zeroStoredChecksum: true)
+        for i in 0..<4 { page[OggOpusGranule.checksumOffset + i] = UInt8((crc >> (i * 8)) & 0xFF) }
+        XCTAssertThrowsError(try OggOpusInboundNormalizer.normalize(page)) { error in
+            XCTAssertEqual(error as? OggOpusInboundNormalizer.NormalizeError, .malformedPage)
+        }
+    }
+
     // MARK: - helpers
 
     private func walk(_ data: [UInt8]) -> [VoiceTestSupport.OggPage] {

--- a/Tests/ColumbaAppTests/OggOpusInboundNormalizerTests.swift
+++ b/Tests/ColumbaAppTests/OggOpusInboundNormalizerTests.swift
@@ -1,0 +1,227 @@
+//
+//  OggOpusInboundNormalizerTests.swift
+//  ColumbaAppTests
+//
+//  The inbound Ogg/Opus re-muxer (OggOpusInboundNormalizer). The load-bearing
+//  case is the Sideband "High-quality voice" layout: many Opus packets packed
+//  into a single Ogg page, which libopusfile decodes fine but iOS's
+//  AVAudioPlayer refuses. These tests prove the normalizer (a) passes
+//  one-packet-per-page streams through UNCHANGED (the common path costs a
+//  single page walk), and (b) re-muxes multi-packet-per-page streams into the
+//  one-packet-per-page / cumulative-granule / version=0 layout that AVAudio
+//  Player plays, copying every Opus packet verbatim (no re-encode) and
+//  recomputing cumulative end-of-packet granules (no re-encode, so the decoded
+//  audio is bit-identical). The page walker + CRC checks are independent of
+//  the writer's own bookkeeping.
+//
+
+import XCTest
+import Foundation
+@testable import ColumbaApp
+
+final class OggOpusInboundNormalizerTests: XCTestCase {
+
+    // MARK: - raw page builders (independent of the production writer)
+
+    /// Emit one Ogg page: 27-byte header (OggS, version 0, flags, granule,
+    /// serial, sequence) + lacing table + payload, with a valid Ogg CRC.
+    private func rawPage(payload: [UInt8], lacing: [UInt8], granule: UInt64,
+                         flags: UInt8, serial: UInt32 = 1,
+                         seq: Int32 = 0) -> [UInt8] {
+        var page = [UInt8](repeating: 0, count: 27)
+        page.replaceSubrange(0..<4, with: [0x4F, 0x67, 0x67, 0x53]) // "OggS"
+        page[4] = 0 // version (OggS)
+        page[5] = flags
+        for i in 0..<8 { page[6 + i] = UInt8((granule >> (i * 8)) & 0xFF) }
+        for i in 0..<4 { page[14 + i] = UInt8((serial >> (i * 8)) & 0xFF) }
+        for i in 0..<4 { page[18 + i] = UInt8((UInt32(seq) >> (i * 8)) & 0xFF) }
+        page[26] = UInt8(lacing.count)
+        page.append(contentsOf: lacing)
+        page.append(contentsOf: payload)
+        let crc = OggOpusGranule.oggChecksum(page, 0, page.count, zeroStoredChecksum: true)
+        for i in 0..<4 { page[OggOpusGranule.checksumOffset + i] = UInt8((crc >> (i * 8)) & 0xFF) }
+        return page
+    }
+
+    private func opusHead(channels: Int = 1, preSkip: Int = 240) -> [UInt8] {
+        var h = Array("OpusHead".utf8)
+        h.append(0x01)
+        h.append(UInt8(channels))
+        h.append(UInt8(preSkip & 0xFF)); h.append(UInt8((preSkip >> 8) & 0xFF))
+        h.append(contentsOf: [UInt8(48_000 & 0xFF), 0x38, 0x00, 0x00]) // 48000 LE
+        h.append(contentsOf: [0x00, 0x00]) // gain
+        h.append(0x00) // mapping family
+        return h
+    }
+
+    private func opusTags() -> [UInt8] {
+        Array("OpusTags".utf8) + [0, 0, 0, 0, 0, 0, 0, 0]
+    }
+
+    /// A valid Opus 20 ms single-frame packet (TOC 0x98) of `size` bytes.
+    private func p20(size: Int) -> [UInt8] { VoiceTestSupport.opusPacket(toc: 0x98, size: size) }
+
+    // MARK: - A: pass-through (already one-packet-per-page)
+
+    func testCanonicalWriterOutputPassesThroughUnchanged() throws {
+        let w = OggOpusFileWriter(channels: 1, preSkip: 240)
+        try w.appendPacket(p20(size: 40))
+        try w.appendPacket(p20(size: 33))
+        try w.appendPacket(VoiceTestSupport.opusPacket(toc: 0x90, size: 27)) // 480
+        let input = try w.finish()
+
+        let out = try OggOpusInboundNormalizer.normalize(input)
+        XCTAssertFalse(out.remuxed, "one-packet-per-page must not be re-muxed")
+        XCTAssertEqual(out.bytes, input, "pass-through must return the SAME bytes")
+    }
+
+    // MARK: - B: multi-packet-per-page re-mux (the Sideband PyOgg layout)
+
+    /// Two 20 ms Opus packets packed into ONE audio page (granule = cumulative
+    /// end-of-last-packet = 1920). This is the layout AVAudioPlayer rejects.
+    private func sidebandStyleStream() -> [UInt8] {
+        let p1 = p20(size: 30)
+        let p2 = p20(size: 25)
+        var bytes = [UInt8]()
+        bytes.append(contentsOf: rawPage(payload: opusHead(channels: 1, preSkip: 240),
+                                         lacing: [UInt8(opusHead(channels: 1, preSkip: 240).count)],
+                                         granule: UInt64.max, flags: 0x02)) // OpusHead, BOS
+        bytes.append(contentsOf: rawPage(payload: opusTags(),
+                                         lacing: [UInt8(opusTags().count)],
+                                         granule: UInt64.max, flags: 0x00)) // OpusTags
+        // ONE audio page holding BOTH packets.
+        bytes.append(contentsOf: rawPage(payload: p1 + p2, lacing: [30, 25],
+                                         granule: 1920, flags: 0x00))
+        return bytes
+    }
+
+    func testMultiPacketPerPageIsRemuxedToOnePacketPerPage() throws {
+        let input = sidebandStyleStream()
+        let out = try OggOpusInboundNormalizer.normalize(input)
+        XCTAssertTrue(out.remuxed, "a multi-packet page must trigger a re-mux")
+
+        let pages = walk(out.bytes)
+        // 2 header pages + 2 audio pages (one per packet) = 4.
+        XCTAssertEqual(pages.count, 4, "re-mux must split the packed page to one packet/page")
+
+        // Every page version 0 + CRC valid (independent walker).
+        for (i, p) in pages.enumerated() {
+            let end = i + 1 < pages.count ? pages[i + 1].pageStart : out.bytes.count
+            XCTAssertEqual(out.bytes[p.pageStart + 4], 0)
+            XCTAssertTrue(VoiceTestSupport.oggPageCRCValid(out.bytes, pageStart: p.pageStart, pageEnd: end),
+                          "CRC mismatch on re-muxed page \(i)")
+        }
+
+        // Header packets preserved verbatim. The payload starts AFTER the
+        // 27-byte header and the lacing table (not at a fixed offset).
+        let headStart = 27 + Int(out.bytes[26])
+        XCTAssertEqual(Array(out.bytes[headStart..<(headStart + 8)]), Array("OpusHead".utf8))
+        // preSkip + channels carried over (duration math preserved).
+        XCTAssertEqual(out.bytes[headStart + 9], 1) // channels
+        let preSkip = Int(out.bytes[headStart + 10]) | (Int(out.bytes[headStart + 11]) << 8)
+        XCTAssertEqual(preSkip, 240)
+
+        // The two audio pages carry the ORIGINAL packets verbatim (no
+        // re-encode), each on its own page with a cumulative granule.
+        let p1 = p20(size: 30)
+        let p2 = p20(size: 25)
+        let a0 = audioPayload(of: pages, in: out.bytes, audioPageIndex: 0)
+        let a1 = audioPayload(of: pages, in: out.bytes, audioPageIndex: 1)
+        XCTAssertEqual(a0, p1, "first Opus packet must be copied verbatim")
+        XCTAssertEqual(a1, p2, "second Opus packet must be copied verbatim")
+        // Granules: cumulative end-of-packet (960, then 1920).
+        XCTAssertEqual(pages[2].granule, 960)
+        XCTAssertEqual(pages[3].granule, 1920)
+
+        // Duration reads back from the re-muxed granules (independent reader):
+        // (1920 - 240) / 48000 * 1000 = 35 ms.
+        let meta = OggOpusMetadataReader.read(out.bytes)
+        XCTAssertEqual(meta?.finalGranule, 1920)
+        XCTAssertEqual(meta?.durationMs, 35)
+    }
+
+    // MARK: - C: non-zero page version triggers a re-mux
+
+    func testNonZeroPageVersionTriggersRemux() throws {
+        // Build a one-packet-per-page stream, then corrupt every version byte
+        // to 2 (the original writer bug). Layout is fine; only version is not.
+        let w = OggOpusFileWriter(channels: 1, preSkip: 240)
+        try w.appendPacket(p20(size: 40))
+        try w.appendPacket(p20(size: 33))
+        var corrupted = try w.finish()
+        // Flip byte 4 (version) of each page to 2.
+        var off = 0
+        while off + 27 <= corrupted.count {
+            XCTAssertEqual(corrupted[off], 0x4F) // sanity: page boundary
+            corrupted[off + 4] = 2
+            let seg = Int(corrupted[off + 26])
+            var payloadSize = 0
+            for i in 0..<seg { payloadSize += Int(corrupted[off + 27 + i]) }
+            off += 27 + seg + payloadSize
+        }
+
+        let out = try OggOpusInboundNormalizer.normalize(corrupted)
+        XCTAssertTrue(out.remuxed, "a non-zero version byte must trigger a re-mux")
+        // Output is back to version 0 on every page.
+        let pages = walk(out.bytes)
+        for p in pages { XCTAssertEqual(out.bytes[p.pageStart + 4], 0) }
+        // Audio still present + decodable duration.
+        XCTAssertGreaterThan(out.bytes.count, 100)
+        XCTAssertNotNil(OggOpusMetadataReader.read(out.bytes))
+    }
+
+    // MARK: - D: fail-closed on non-Ogg / truncated / missing-audio
+
+    func testNonOggInputThrows() {
+        XCTAssertThrowsError(try OggOpusInboundNormalizer.normalize(Array("definitely not an ogg stream, far too long to be a page".utf8))) { error in
+            _ = error
+        }
+        // The first page's capture pattern is absent -> notOgg/malformedPage.
+        XCTAssertThrowsError(try OggOpusInboundNormalizer.normalize([0x00, 0x01, 0x02, 0x03, 0x04]))
+    }
+
+    func testEmptyAndOversizedInputThrows() {
+        XCTAssertThrowsError(try OggOpusInboundNormalizer.normalize([]))
+        let over = [UInt8](repeating: 0x4F, count: OggOpusInboundNormalizer.maxFileBytes + 1)
+        XCTAssertThrowsError(try OggOpusInboundNormalizer.normalize(over))
+    }
+
+    func testHeadersOnlyNoAudioThrows() {
+        // A valid OpusHead + OpusTags stream with zero audio pages.
+        var bytes = [UInt8]()
+        bytes.append(contentsOf: rawPage(payload: opusHead(), lacing: [19], granule: UInt64.max, flags: 0x02))
+        bytes.append(contentsOf: rawPage(payload: opusTags(), lacing: [16], granule: UInt64.max, flags: 0x00))
+        XCTAssertThrowsError(try OggOpusInboundNormalizer.normalize(bytes)) { error in
+            XCTAssertEqual(error as? OggOpusInboundNormalizer.NormalizeError, .noAudioPackets)
+        }
+    }
+
+    func testTruncatedStreamThrows() {
+        // A complete first page, then a second page whose payload runs past EOF.
+        var bytes = [UInt8]()
+        bytes.append(contentsOf: rawPage(payload: opusHead(), lacing: [19], granule: UInt64.max, flags: 0x02))
+        bytes.append(contentsOf: rawPage(payload: p20(size: 30), lacing: [30], granule: 960, flags: 0x00))
+        let truncated = Array(bytes[0..<(bytes.count - 3)])
+        XCTAssertThrowsError(try OggOpusInboundNormalizer.normalize(truncated))
+    }
+
+    // MARK: - helpers
+
+    private func walk(_ data: [UInt8]) -> [VoiceTestSupport.OggPage] {
+        guard let pages = VoiceTestSupport.oggPages(data) else {
+            XCTFail("re-muxed bytes are not a well-formed Ogg page sequence")
+            return []
+        }
+        return pages
+    }
+
+    /// The payload of the nth audio page (skipping the 2 header pages).
+    private func audioPayload(of pages: [VoiceTestSupport.OggPage], in data: [UInt8], audioPageIndex: Int) -> [UInt8] {
+        let p = pages[2 + audioPageIndex]
+        let seg = Int(data[p.pageStart + 26])
+        var payloadSize = 0
+        for i in 0..<seg { payloadSize += Int(data[p.pageStart + 27 + i]) }
+        let payloadStart = p.pageStart + 27 + seg
+        return Array(data[payloadStart..<(payloadStart + payloadSize)])
+    }
+}

--- a/Tests/ColumbaAppTests/OggOpusWaveformTests.swift
+++ b/Tests/ColumbaAppTests/OggOpusWaveformTests.swift
@@ -1,0 +1,148 @@
+//
+//  OggOpusWaveformTests.swift
+//  ColumbaAppTests
+//
+//  The real-amplitude waveform path (Android parity):
+//   - `peaksFromEnergy` is PURE (synthetic energy in, no codec / no AVFoundation)
+//     so it runs identically on the simulator CI and pins Android's exact
+//     display curve: per-bucket RMS normalized to
+//     `0.12 + 0.88 * (rms/peak)^0.7`, clamped to [0.12, 1].
+//   - `peaks(fromBytes:decodeEnergy:)` is pure orchestration with an injected
+//     decode, so CI pins the fail-open contract (decode failure or no audio
+//     -> nil, caller keeps the neutral placeholder).
+//   - `realWaveform` (the AVAudioFile glue) is verified on-device, not here:
+//     the simulator's AVFoundation is unreliable for Ogg, exactly why the
+//     player treats decode failure as non-fatal.
+//
+
+import Foundation
+import XCTest
+import LXSTSwift
+@testable import ColumbaApp
+
+final class OggOpusWaveformTests: XCTestCase {
+
+    // MARK: - peaksFromEnergy (pure curve)
+
+    func testConstantEnergyIsFlatAtFullHeight() {
+        let energy = [Double](repeating: 0.25, count: 4_000)
+        let peaks = OggOpusInboundNormalizer.peaksFromEnergy(energy, preSkip: 0, bars: 40)
+        XCTAssertEqual(peaks.count, 40)
+        // Every bucket has the same RMS; the peak bucket normalizes to 1.0.
+        for p in peaks {
+            XCTAssertEqual(p, 1.0, accuracy: 0.0001)
+        }
+    }
+
+    func testLoudestBucketIsOneSilentBucketsAreMinLevel() {
+        // 40 buckets of 100 frames: all silence except bucket 10 (amplitude 1).
+        var energy = [Double](repeating: 0, count: 4_000)
+        for i in (10 * 100)..<(11 * 100) { energy[i] = 1.0 }
+        let peaks = OggOpusInboundNormalizer.peaksFromEnergy(energy, preSkip: 0, bars: 40)
+        XCTAssertEqual(peaks[10], 1.0, accuracy: 0.0001)
+        for (index, p) in peaks.enumerated() where index != 10 {
+            XCTAssertEqual(p, 0.12, accuracy: 0.0001, "bucket \(index)")
+        }
+    }
+
+    func testShapeTracksVolumeRamp() {
+        // Amplitude ramps linearly 0 -> 1 over the stream: the last bar must
+        // be the loudest and strictly above the first.
+        let n = 4_000
+        var energy = [Double](repeating: 0, count: n)
+        for i in 0..<n {
+            let a = Double(i) / Double(n - 1)
+            energy[i] = a * a
+        }
+        let peaks = OggOpusInboundNormalizer.peaksFromEnergy(energy, preSkip: 0, bars: 40)
+        XCTAssertEqual(peaks.max() ?? 0, 1.0, accuracy: 0.0001)
+        let argmax = peaks.indices.max { peaks[$0] < peaks[$1] }!
+        XCTAssertEqual(argmax, 39)
+        XCTAssertGreaterThan(peaks[39], peaks[0])
+        // All bars stay within the display band.
+        for p in peaks {
+            XCTAssertGreaterThanOrEqual(p, 0.12)
+            XCTAssertLessThanOrEqual(p, 1.0)
+        }
+    }
+
+    func testPreSkipTrimsEncoderDelay() {
+        // Silence for the first 400 frames (the delay), then constant tone.
+        // With preSkip = 400 the whole visible stream is the tone -> flat 1.0;
+        // with preSkip = 0 the leading silence pulls the first buckets down.
+        var energy = [Double](repeating: 0, count: 4_400)
+        for i in 400..<4_400 { energy[i] = 0.25 }
+        let trimmed = OggOpusInboundNormalizer.peaksFromEnergy(energy, preSkip: 400, bars: 40)
+        let untrimmed = OggOpusInboundNormalizer.peaksFromEnergy(energy, preSkip: 0, bars: 40)
+        for p in trimmed { XCTAssertEqual(p, 1.0, accuracy: 0.0001) }
+        XCTAssertLessThan(untrimmed[0], 1.0)
+        // The trimmed timeline is strictly no lower anywhere.
+        for i in 0..<40 { XCTAssertGreaterThanOrEqual(trimmed[i], untrimmed[i] - 0.0001) }
+    }
+
+    func testEmptyAndDegenerateInputs() {
+        XCTAssertEqual(
+            OggOpusInboundNormalizer.peaksFromEnergy([], preSkip: 0, bars: 40).count, 0)
+        // preSkip past the end: all buckets empty -> flat min level.
+        let allMin = OggOpusInboundNormalizer.peaksFromEnergy(
+            [Double](repeating: 0.5, count: 100), preSkip: 1_000, bars: 40)
+        XCTAssertEqual(allMin.count, 40)
+        for p in allMin { XCTAssertEqual(p, 0.12, accuracy: 0.0001) }
+        // All-silence: flat min level.
+        let silent = OggOpusInboundNormalizer.peaksFromEnergy(
+            [Double](repeating: 0, count: 1_000), preSkip: 0, bars: 40)
+        for p in silent { XCTAssertEqual(p, 0.12, accuracy: 0.0001) }
+    }
+
+    // MARK: - peaks(fromBytes:decodeEnergy:) (injected-decode orchestration)
+
+    func testInjectedDecodeYieldsNormalizedPeaks() {
+        let bytes = Data([0x01, 0x02, 0x03])
+        let energy: [Double] = (0..<4_000).map { i in
+            let a = 0.1 + 0.9 * (sin(Double(i) / 200) * 0.5 + 0.5)
+            return a * a
+        }
+        let peaks = OggOpusWaveform.peaks(
+            fromBytes: bytes) { _ in energy }
+        XCTAssertEqual(peaks?.count, OggOpusWaveform.bars)
+        guard let peaks else { return XCTFail("expected peaks") }
+        for p in peaks {
+            XCTAssertGreaterThanOrEqual(p, 0.12)
+            XCTAssertLessThanOrEqual(p, 1.0)
+        }
+        // Varied input must not produce a flat line.
+        XCTAssertNotEqual(Set(peaks).count, 1)
+    }
+
+    func testDecodeFailureFailsOpenToNil() {
+        struct Boom: Error {}
+        let peaks = OggOpusWaveform.peaks(fromBytes: Data([0xFF])) { _ in
+            throw Boom()
+        }
+        XCTAssertNil(peaks)
+    }
+
+    func testEmptyDecodeFailsOpenToNil() {
+        let peaks = OggOpusWaveform.peaks(fromBytes: Data([0xFF])) { _ in [] }
+        XCTAssertNil(peaks)
+    }
+
+    // MARK: - realWaveform shape invariants (best-effort on the sim)
+
+    /// `realWaveform` runs AVAudioFile, which the simulator handles
+    /// unreliably for Ogg. Whatever it returns, the contract is: nil OR a
+    /// band-limited 40-bar array. (Load-bearing verification of non-nil output
+    /// is the device smoke: the bubble bars must be non-uniform.)
+    func testRealWaveformContractOnSampleFiles() {
+        let writer = OggOpusFileWriter(channels: 1, preSkip: 240)
+        for _ in 0..<50 { _ = try? writer.appendPacket(VoiceTestSupport.opusPacket(toc: 0x98)) }
+        let bytes = Data(try! writer.finish())
+        let peaks = OggOpusWaveform.realWaveform(from: bytes)
+        guard let peaks else { return } // Sim decode may fail; that's the fail-open path.
+        XCTAssertEqual(peaks.count, OggOpusWaveform.bars)
+        for p in peaks {
+            XCTAssertGreaterThanOrEqual(p, 0.12)
+            XCTAssertLessThanOrEqual(p, 1.0)
+        }
+    }
+}

--- a/Tests/ColumbaAppTests/VoiceMessageFormatTests.swift
+++ b/Tests/ColumbaAppTests/VoiceMessageFormatTests.swift
@@ -1,0 +1,95 @@
+//
+//  VoiceMessageFormatTests.swift
+//  ColumbaAppTests
+//
+//  Phase A (plan step 5): the six quality profiles map 1:1 to Android's
+//  rate/channel/bitrate table; Medium Quality is the recommended default;
+//  inbound Opus has no recoverable profile.
+//
+
+import XCTest
+import RNSAPI
+import LXSTSwift
+@testable import ColumbaApp
+
+final class VoiceMessageFormatTests: XCTestCase {
+
+    func testOutboundOrderMatchesAndroid() {
+        XCTAssertEqual(VoiceMessageFormat.outboundOptions,
+                       [.codec2_1200, .codec2_2400, .codec2_3200,
+                        .opusMedium, .opusHigh, .opusMaximum])
+        XCTAssertEqual(VoiceMessageFormat.allCases.count, 6)
+    }
+
+    func testDefaultIsMediumAndRecommended() {
+        XCTAssertEqual(VoiceMessageFormat.defaultFormat, .opusMedium)
+        XCTAssertTrue(VoiceMessageFormat.opusMedium.isRecommended)
+        XCTAssertFalse(VoiceMessageFormat.codec2_1200.isRecommended)
+        XCTAssertFalse(VoiceMessageFormat.opusMaximum.isRecommended)
+    }
+
+    func testWireModes() {
+        XCTAssertEqual(VoiceMessageFormat.codec2_1200.wireMode, LxmfFields.AM_CODEC2_1200)
+        XCTAssertEqual(VoiceMessageFormat.codec2_2400.wireMode, LxmfFields.AM_CODEC2_2400)
+        XCTAssertEqual(VoiceMessageFormat.codec2_3200.wireMode, LxmfFields.AM_CODEC2_3200)
+        XCTAssertEqual(VoiceMessageFormat.opusMedium.wireMode, LxmfFields.AM_OPUS_OGG)
+        XCTAssertEqual(VoiceMessageFormat.opusHigh.wireMode, LxmfFields.AM_OPUS_OGG)
+        XCTAssertEqual(VoiceMessageFormat.opusMaximum.wireMode, LxmfFields.AM_OPUS_OGG)
+    }
+
+    func testCodec2ProfilesMapToAudioModeAndCodec2Mode() {
+        XCTAssertEqual(VoiceMessageFormat.codec2_1200.audioMode, .codec2_1200)
+        XCTAssertEqual(VoiceMessageFormat.codec2_2400.audioMode, .codec2_2400)
+        XCTAssertEqual(VoiceMessageFormat.codec2_3200.audioMode, .codec2_3200)
+        XCTAssertEqual(VoiceMessageFormat.codec2_1200.codec2Mode, .codec2_1200)
+        XCTAssertEqual(VoiceMessageFormat.codec2_2400.codec2Mode, .codec2_2400)
+        XCTAssertEqual(VoiceMessageFormat.codec2_3200.codec2Mode, .codec2_3200)
+        XCTAssertTrue(VoiceMessageFormat.codec2_1200.isCodec2)
+        XCTAssertFalse(VoiceMessageFormat.opusMedium.isCodec2)
+    }
+
+    func testOpusProfilesMatchAndroidRateChannelBitrateTable() {
+        // Android RecordingConfig: medium 24k/mono/8k, high 48k/mono/16k,
+        // maximum 48k/stereo/32k.
+        let medium = VoiceMessageFormat.opusMedium.opusProfile
+        XCTAssertEqual(medium, .voiceMedium)
+        XCTAssertEqual(medium?.sampleRate, 24_000)
+        XCTAssertEqual(medium?.channels, 1)
+        XCTAssertEqual(medium?.bitrateCeiling, 8_000)
+
+        let high = VoiceMessageFormat.opusHigh.opusProfile
+        XCTAssertEqual(high, .voiceHigh)
+        XCTAssertEqual(high?.sampleRate, 48_000)
+        XCTAssertEqual(high?.channels, 1)
+        XCTAssertEqual(high?.bitrateCeiling, 16_000)
+
+        let max = VoiceMessageFormat.opusMaximum.opusProfile
+        XCTAssertEqual(max, .voiceMax)
+        XCTAssertEqual(max?.sampleRate, 48_000)
+        XCTAssertEqual(max?.channels, 2)
+        XCTAssertEqual(max?.bitrateCeiling, 32_000)
+
+        // All three carry the same wire mode (bitrate is not on the wire).
+        XCTAssertEqual(VoiceMessageFormat.opusMedium.audioMode, .opusOgg)
+        XCTAssertEqual(VoiceMessageFormat.opusHigh.audioMode, .opusOgg)
+        XCTAssertEqual(VoiceMessageFormat.opusMaximum.audioMode, .opusOgg)
+    }
+
+    func testFromWireModeResolvesCodec2Only() {
+        XCTAssertEqual(VoiceMessageFormat.fromWireMode(LxmfFields.AM_CODEC2_1200), .codec2_1200)
+        XCTAssertEqual(VoiceMessageFormat.fromWireMode(LxmfFields.AM_CODEC2_2400), .codec2_2400)
+        XCTAssertEqual(VoiceMessageFormat.fromWireMode(LxmfFields.AM_CODEC2_3200), .codec2_3200)
+        // Opus bitrate is not recoverable from the wire mode -> no profile.
+        XCTAssertNil(VoiceMessageFormat.fromWireMode(LxmfFields.AM_OPUS_OGG))
+        // 1300/1400/1600 are valid wire modes but not voice-message profiles.
+        XCTAssertNil(VoiceMessageFormat.fromWireMode(LxmfFields.AM_CODEC2_1300))
+        XCTAssertNil(VoiceMessageFormat.fromWireMode(LxmfFields.AM_CUSTOM))
+        XCTAssertNil(VoiceMessageFormat.fromWireMode(0x20))
+    }
+
+    func testIdentifiableAndHashable() {
+        XCTAssertEqual(VoiceMessageFormat.codec2_1200.id, VoiceMessageFormat.codec2_1200.rawValue)
+        let set: Set<VoiceMessageFormat> = Set(VoiceMessageFormat.outboundOptions)
+        XCTAssertEqual(set.count, 6)
+    }
+}

--- a/Tests/ColumbaAppTests/VoiceMessagePlayerTests.swift
+++ b/Tests/ColumbaAppTests/VoiceMessagePlayerTests.swift
@@ -112,4 +112,38 @@ final class VoiceMessagePlayerTests: XCTestCase {
         XCTAssertEqual(player.state(for: "m6").status, .idle)
         XCTAssertFalse(player.isPlaying)
     }
+
+    /// Greptile finding (PR #194, iteration 3): the async startup can resume
+    /// AFTER a stop/teardown that ran during one of its suspension points.
+    /// Without a generation guard it would re-acquire the shared audio
+    /// session and publish `.playing` (or a spurious `.error`) after the user
+    /// already stopped.
+    ///
+    /// What this test pins: `play()` + immediate `stopCurrent()` (both
+    /// synchronous on the main actor) must converge to `.idle`, never
+    /// `.playing` and never `.error`. That is the deterministic
+    /// interleaving - the stop lands before the startup task begins, so the
+    /// startup's entry guard must observe the generation bump and bail as a
+    /// silent `.superseded` no-op. The identical guard at the in-flight
+    /// suspension points (stop landing mid-startup) is the same check and
+    /// cannot be forced deterministically without a decode-delay seam.
+    func testSupersededStartupConvergesToIdle() async throws {
+        let player = VoiceMessagePlayer()
+        let attachment = try codec2Attachment(frames: 40, durationMs: 800)
+        player.play(key: "m7", attachment: attachment)
+        // Immediately stop, as if the user dismissed the conversation while
+        // the async startup was still in flight.
+        player.stopCurrent()
+        // Give the (possibly still in-flight) startup task a bounded window
+        // to resume at a suspension point and observe the generation bump.
+        for _ in 0..<50 {
+            if player.state(for: "m7").status == .idle { break }
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+        let st = player.state(for: "m7")
+        XCTAssertEqual(st.status, .idle, "a superseded startup must leave the message idle")
+        XCTAssertFalse(player.isPlaying)
+        XCTAssertNil(st.errorMessage, "a superseded startup must not surface a spurious error")
+        player.tearDown()
+    }
 }

--- a/Tests/ColumbaAppTests/VoiceMessagePlayerTests.swift
+++ b/Tests/ColumbaAppTests/VoiceMessagePlayerTests.swift
@@ -65,16 +65,38 @@ final class VoiceMessagePlayerTests: XCTestCase {
         XCTAssertTrue(peaks.max() ?? 0 > 0.0)
     }
 
-    func testOggWaveformIsNeutralFilled() async {
+    /// Ogg waveforms are now decoded ASYNC on a background task (Android
+    /// parity; the views render the neutral placeholder until the peaks land
+    /// or the decode fails open). `prepare` must stay non-blocking: the
+    /// duration is resolved synchronously and the waveform is either absent
+    /// (decode still running / failed on this environment) or a band-limited
+    /// 40-bar array - it must never be the old hard-coded flat 0.5 fill.
+    func testOggWaveformIsAsyncNeverBlocking() async {
         let player = VoiceMessagePlayer()
         defer { player.tearDown() }
         let writer = OggOpusFileWriter(channels: 1, preSkip: 240)
         _ = try? writer.appendPacket(VoiceTestSupport.opusPacket())
         let attachment = AudioAttachment(mode: .opusOgg, bytes: Data(try! writer.finish()), durationMs: nil)
+        let start = Date()
         player.prepare(key: "m4", attachment: attachment)
-        let waveform = player.waveform(for: "m4")
-        XCTAssertEqual(waveform?.count, 40)
-        XCTAssertEqual(Set(waveform ?? []).first, 0.5)
+        // Synchronous work only: no decode may run on the calling thread.
+        XCTAssertLessThan(Date().timeIntervalSince(start), 0.5)
+        // Duration is resolved synchronously from the granules.
+        XCTAssertEqual(player.state(for: "m4").durationMs, ((960 - 240) * 1_000) / 48_000)
+        // Give the background decode a bounded chance to land.
+        for _ in 0..<20 {
+            if player.waveform(for: "m4") != nil { break }
+            try? await Task.sleep(nanoseconds: 100_000_000)
+        }
+        // Whatever the (sim) decode returns, the contract is: nil (fail-open)
+        // or a band-limited 40-bar array - never the flat 0.5 placeholder.
+        if let waveform = player.waveform(for: "m4") {
+            XCTAssertEqual(waveform.count, 40)
+            for p in waveform {
+                XCTAssertGreaterThanOrEqual(p, 0.12)
+                XCTAssertLessThanOrEqual(p, 1.0)
+            }
+        }
     }
 
     func testTearDownClearsCachedStateAndWaveforms() async throws {

--- a/Tests/ColumbaAppTests/VoiceMessagePlayerTests.swift
+++ b/Tests/ColumbaAppTests/VoiceMessagePlayerTests.swift
@@ -1,0 +1,93 @@
+//
+//  VoiceMessagePlayerTests.swift
+//  ColumbaAppTests
+//
+//  Phase C (plan step 11): the player's PURE metadata/waveform resolution
+//  (no AVAudioPlayer needed on the sim): Codec2 duration comes from the
+//  attachment, Ogg duration is read from the granules, waveforms are bounded
+//  to ~40 normalized bars, and stopCurrent() resets state.
+//
+
+import XCTest
+import LXSTSwift
+@testable import ColumbaApp
+
+@MainActor
+final class VoiceMessagePlayerTests: XCTestCase {
+
+    private func codec2Attachment(mode: AudioMode = .codec2_2400,
+                                  frames: Int = 10,
+                                  durationMs: Int) throws -> AudioAttachment {
+        let codec = try Codec2Codec(mode: mode.codec2Mode!)
+        let geo = Codec2RawFile.geometry(for: mode.codec2Mode!)
+        let raw = try Codec2RawFile.encodeAll(pcm: VoiceTestSupport.pcm(count: geo.samplesPerFrame * frames),
+                                              codec: codec)
+        return AudioAttachment(mode: mode, bytes: raw, durationMs: durationMs)
+    }
+
+    func testPrepareResolvesCodec2DurationFromAttachment() async throws {
+        let player = VoiceMessagePlayer()
+        defer { player.tearDown() }
+        let attachment = try codec2Attachment(durationMs: 400)
+        player.prepare(key: "m1", attachment: attachment)
+        let st = player.state(for: "m1")
+        XCTAssertEqual(st.durationMs, 400)
+        XCTAssertEqual(st.status, .idle)
+    }
+
+    func testPrepareResolvesOggDurationFromGranules() async {
+        let player = VoiceMessagePlayer()
+        defer { player.tearDown() }
+        let writer = OggOpusFileWriter(channels: 1, preSkip: 240)
+        _ = try? writer.appendPacket(VoiceTestSupport.opusPacket(toc: 0x98))  // 960
+        _ = try? writer.appendPacket(VoiceTestSupport.opusPacket(toc: 0x98))  // 960
+        let bytes = try! writer.finish()
+        let attachment = AudioAttachment(mode: .opusOgg, bytes: Data(bytes), durationMs: nil)
+        player.prepare(key: "m2", attachment: attachment)
+        // Duration is read from the Ogg granules, not the (nil) attachment.
+        XCTAssertEqual(player.state(for: "m2").durationMs, ((1920 - 240) * 1_000) / 48_000)
+    }
+
+    func testPrepareCachesNormalizedWaveform() async throws {
+        let player = VoiceMessagePlayer()
+        defer { player.tearDown() }
+        let attachment = try codec2Attachment(frames: 20, durationMs: 800)
+        player.prepare(key: "m3", attachment: attachment)
+        let waveform = player.waveform(for: "m3")
+        XCTAssertNotNil(waveform)
+        XCTAssertEqual(waveform?.count, 40)
+        let peaks = waveform!
+        for p in peaks {
+            XCTAssertGreaterThanOrEqual(p, 0)
+            XCTAssertLessThanOrEqual(p, 1)
+        }
+        // A 440 Hz sine should produce some non-zero peaks.
+        XCTAssertTrue(peaks.max() ?? 0 > 0.0)
+    }
+
+    func testOggWaveformIsNeutralFilled() async {
+        let player = VoiceMessagePlayer()
+        defer { player.tearDown() }
+        let writer = OggOpusFileWriter(channels: 1, preSkip: 240)
+        _ = try? writer.appendPacket(VoiceTestSupport.opusPacket())
+        let attachment = AudioAttachment(mode: .opusOgg, bytes: Data(try! writer.finish()), durationMs: nil)
+        player.prepare(key: "m4", attachment: attachment)
+        let waveform = player.waveform(for: "m4")
+        XCTAssertEqual(waveform?.count, 40)
+        XCTAssertEqual(Set(waveform ?? []).first, 0.5)
+    }
+
+    func testTearDownClearsCachedStateAndWaveforms() async throws {
+        let player = VoiceMessagePlayer()
+        let attachment = try codec2Attachment(durationMs: 400)
+        player.prepare(key: "m6", attachment: attachment)
+        XCTAssertNotNil(player.waveform(for: "m6"))
+        XCTAssertGreaterThan(player.state(for: "m6").durationMs, 0)
+        player.tearDown()
+        // After teardown the cache is empty: no waveform, default (idle, 0) state.
+        XCTAssertNil(player.waveform(for: "m6"))
+        XCTAssertEqual(player.state(for: "m6").durationMs, 0)
+        XCTAssertEqual(player.state(for: "m6").status, .idle)
+        XCTAssertFalse(player.isPlaying)
+    }
+}

--- a/Tests/ColumbaAppTests/VoiceMessageRecorderTests.swift
+++ b/Tests/ColumbaAppTests/VoiceMessageRecorderTests.swift
@@ -16,6 +16,7 @@
 //
 
 import XCTest
+import LXSTSwift
 @testable import ColumbaApp
 
 // MARK: - File-scope capture fakes (nonisolated, safe for the capture thread)

--- a/Tests/ColumbaAppTests/VoiceMessageRecorderTests.swift
+++ b/Tests/ColumbaAppTests/VoiceMessageRecorderTests.swift
@@ -243,6 +243,28 @@ final class VoiceMessageRecorderTests: XCTestCase {
         XCTAssertNil(recorder.selectedRecording)
     }
 
+    // MARK: - Capture start() throwing .unsupported (degenerate input format)
+
+    func testCaptureStartThrowingUnsupportedPublishesTerminalUnsupported() async {
+        // Mirrors the production abort guard: the capture reports supported
+        // (permission granted) but start() throws .unsupported when the
+        // input format is degenerate (no usable input device). The recorder
+        // must surface the dedicated unsupported state, not a generic
+        // captureStartFailed, so the composer shows the "not supported on
+        // this device" row (Android !isSupported parity).
+        let factory = FakeVoiceCaptureFactory(startError: VoiceRecorderError.unsupported, supported: true)
+        let recorder = VoiceMessageRecorder(captureFactory: factory)
+        XCTAssertThrowsError(try recorder.start(format: .opusMedium)) {
+            XCTAssertEqual($0 as? VoiceRecorderError, .unsupported)
+        }
+        if case .failed = recorder.state {} else { XCTFail("expected .failed, got \(recorder.state)") }
+        XCTAssertTrue(recorder.lastFailureWasUnsupported)
+        XCTAssertEqual(recorder.errorMessage, "Voice messages are not supported on this device.")
+        // The capture must be closed and no partial file left behind.
+        XCTAssertEqual(factory.madeCaptures.first?.closeCount, 1)
+        XCTAssertNil(recorder.selectedRecording)
+    }
+
     // MARK: - Double start rejected
 
     func testDoubleStartRejected() async throws {

--- a/Tests/ColumbaAppTests/VoiceMessageRecorderTests.swift
+++ b/Tests/ColumbaAppTests/VoiceMessageRecorderTests.swift
@@ -62,6 +62,16 @@ final class VoiceMessageRecorderTests: XCTestCase {
         let fileCreated = await VoiceTestSupport.awaitFile(at: out, exists: true)
         XCTAssertTrue(fileCreated, "capture thread should create the .c2 file")
 
+        // Deterministic finalization gate: wait for the finite fake buffer to
+        // be fully read AND for the encode loop to stop growing the file
+        // (the final read-batch's frames are written after the read that
+        // drained, so a file-exists or drain-only stop can drop them). Then
+        // stop: every frame is already on disk.
+        guard let cap = factory.madeCaptures.first else { XCTFail("no capture"); return }
+        _ = await VoiceTestSupport.awaitDrained(cap)
+        let settled = await VoiceTestSupport.awaitFileSettled(at: out)
+        XCTAssertTrue(settled, "capture loop should settle before stop")
+
         recorder.stop()
         let state = await waitForRecorderState(recorder) { s in
             if case .completed = s { return true }; if case .failed = s { return true }; return false
@@ -76,8 +86,11 @@ final class VoiceMessageRecorderTests: XCTestCase {
         // .c2 extension, size is a whole number of 2400 frames (96 bytes),
         // payload decodes cleanly (no header byte, complete frames only).
         XCTAssertEqual(out.pathExtension, "c2")
-        let frames = rec.sizeBytes / 96
-        XCTAssertEqual(rec.sizeBytes, frames * 96)
+        // Frame size comes from the LIVE codec (bytes/frame), not a magic
+        // number: the old test hardcoded 96 (the buggy table's bit-value).
+        let bytesPerFrame = Codec2RawFile.geometry(for: .codec2_2400).bytesPerFrame
+        let frames = rec.sizeBytes / bytesPerFrame
+        XCTAssertEqual(rec.sizeBytes, frames * bytesPerFrame)
         // ~300 frames of 320 samples (8 kHz -> 8 kHz resample is ~identity).
         XCTAssertTrue((295...305).contains(frames), "expected ~300 frames, got \(frames)")
         _ = try Codec2RawFile.decodePayload(rec.audio.bytes, mode: .codec2_2400)
@@ -102,6 +115,13 @@ final class VoiceMessageRecorderTests: XCTestCase {
         defer { recorder.teardownEnginePreservingSelection() }
 
         let out = try recorder.start(format: .opusMedium)
+        // The Ogg file only appears at the END (atomic publish after all
+        // packets are encoded), so it cannot be awaited pre-stop. Instead wait
+        // for the finite fake buffer to be fully read: the loop then encodes
+        // every packet and finishes on its own next iteration. (Production:
+        // the mic never drains, so this gate is a no-op there.)
+        guard let cap = factory.madeCaptures.first else { XCTFail("no capture"); return }
+        _ = await VoiceTestSupport.awaitDrained(cap)
         recorder.stop()
         let state = await waitForRecorderState(recorder) { s in
             if case .completed = s { return true }; if case .failed = s { return true }; return false
@@ -233,6 +253,12 @@ final class VoiceMessageRecorderTests: XCTestCase {
         let factory = FakeVoiceCaptureFactory(samples: VoiceTestSupport.pcm(count: Self.c2Samples))
         let recorder = VoiceMessageRecorder(captureFactory: factory)
         let out = try recorder.start(format: .codec2_2400)
+        // Let the finite fake buffer drain and the loop settle so the stop
+        // finalizes a complete (non-empty) recording - see the codec2 test.
+        if let cap = factory.madeCaptures.first {
+            _ = await VoiceTestSupport.awaitDrained(cap)
+            _ = await VoiceTestSupport.awaitFileSettled(at: out)
+        }
         recorder.stop()
         _ = await waitForRecorderState(recorder) { s in
             if case .completed = s { return true }; if case .failed = s { return true }; return false
@@ -253,6 +279,10 @@ final class VoiceMessageRecorderTests: XCTestCase {
         let recorder = VoiceMessageRecorder(captureFactory: factory)
         defer { recorder.teardownEnginePreservingSelection() }
         let out = try recorder.start(format: .codec2_2400)
+        if let cap = factory.madeCaptures.first {
+            _ = await VoiceTestSupport.awaitDrained(cap)
+            _ = await VoiceTestSupport.awaitFileSettled(at: out)
+        }
         recorder.stop()
         _ = await waitForRecorderState(recorder) { s in
             if case .completed = s { return true }; if case .failed = s { return true }; return false

--- a/Tests/ColumbaAppTests/VoiceMessageRecorderTests.swift
+++ b/Tests/ColumbaAppTests/VoiceMessageRecorderTests.swift
@@ -59,8 +59,8 @@ final class VoiceMessageRecorderTests: XCTestCase {
         XCTAssertTrue(recorder.isRecording)
         if case .recording = recorder.state {} else { XCTFail("expected .recording") }
         // The capture thread creates the file; wait for it (bounded).
-        XCTAssertTrue(await VoiceTestSupport.awaitFile(at: out, exists: true),
-                      "capture thread should create the .c2 file")
+        let fileCreated = await VoiceTestSupport.awaitFile(at: out, exists: true)
+        XCTAssertTrue(fileCreated, "capture thread should create the .c2 file")
 
         recorder.stop()
         let state = await waitForRecorderState(recorder) { s in
@@ -189,8 +189,8 @@ final class VoiceMessageRecorderTests: XCTestCase {
         recorder.cancel()
         // cancel() is non-blocking: wait for the loop to delete the in-flight
         // file (done in onCaptureDone on the main actor).
-        XCTAssertTrue(await VoiceTestSupport.awaitFile(at: out, exists: false, timeout: 5),
-                      "cancelled in-flight file must be deleted")
+        let fileDeleted = await VoiceTestSupport.awaitFile(at: out, exists: false, timeout: 5)
+        XCTAssertTrue(fileDeleted, "cancelled in-flight file must be deleted")
         XCTAssertEqual(factory.madeCaptures.first?.closeCount, 1)
         XCTAssertEqual(factory.madeCaptures.first?.stopCount, 1)
         XCTAssertNil(recorder.selectedRecording)

--- a/Tests/ColumbaAppTests/VoiceMessageRecorderTests.swift
+++ b/Tests/ColumbaAppTests/VoiceMessageRecorderTests.swift
@@ -191,8 +191,8 @@ final class VoiceMessageRecorderTests: XCTestCase {
         // file (done in onCaptureDone on the main actor).
         XCTAssertTrue(await VoiceTestSupport.awaitFile(at: out, exists: false, timeout: 5),
                       "cancelled in-flight file must be deleted")
-        XCTAssertEqual(factory.capture.closeCount, 1)
-        XCTAssertEqual(factory.capture.stopCount, 1)
+        XCTAssertEqual(factory.madeCaptures.first?.closeCount, 1)
+        XCTAssertEqual(factory.madeCaptures.first?.stopCount, 1)
         XCTAssertNil(recorder.selectedRecording)
         if case .idle = recorder.state {} else { XCTFail("expected .idle, got \(recorder.state)") }
     }

--- a/Tests/ColumbaAppTests/VoiceMessageRecorderTests.swift
+++ b/Tests/ColumbaAppTests/VoiceMessageRecorderTests.swift
@@ -1,0 +1,267 @@
+//
+//  VoiceMessageRecorderTests.swift
+//  ColumbaAppTests
+//
+//  Phase C (plan step 11): the recorder state machine with an injected
+//  VoicePcmCaptureFactory (no audio device needed). Covers: backend selection
+//  by format (.c2 vs .ogg), non-blocking stop -> .completed, worker-failure
+//  cleanup (capture closed, partial file deleted, terminal state published),
+//  empty-output .failed, cancel file deletion, unsupported-device terminal
+//  state, double-start rejection, finalized-file retention across teardown,
+//  and removeSelected().
+//
+//  NOTE: the fake capture types are FILE-SCOPE (not nested): the capture loop
+//  runs on a plain Thread and calls them synchronously, so they must NOT be
+//  implicitly @MainActor-isolated by living inside the @MainActor test class.
+//
+
+import XCTest
+@testable import ColumbaApp
+
+// MARK: - File-scope capture fakes (nonisolated, safe for the capture thread)
+
+/// Capture that starts fine but reports a hard error (-1) on the first read.
+final class FailingReadVoiceCapture: VoicePcmCapture, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _closeCount = 0
+    private var _stopCount = 0
+    var closeCount: Int { lock.lock(); defer { lock.unlock() }; return _closeCount }
+    var stopCount: Int { lock.lock(); defer { lock.unlock() }; return _stopCount }
+    var isSupported: Bool { true }
+    var sampleRate: Int { 8_000 }
+    func start() throws {}
+    func read(into buffer: inout [Int16], capacity: Int) -> Int { -1 }
+    func stop() { lock.lock(); _stopCount += 1; lock.unlock() }
+    func close() { lock.lock(); _closeCount += 1; lock.unlock() }
+}
+
+final class FailingReadVoiceCaptureFactory: VoicePcmCaptureFactory, @unchecked Sendable {
+    let capture = FailingReadVoiceCapture()
+    func makeCapture(channels: Int, sampleRateHint: Int) -> VoicePcmCapture { capture }
+}
+
+// MARK: - Recorder state machine
+
+@MainActor
+final class VoiceMessageRecorderTests: XCTestCase {
+
+    private static let c2Frames = 300
+    private static let c2Samples = 320 * c2Frames   // codec2_2400: 320 spf
+
+    // MARK: - Codec2 finalization
+
+    func testStartThenStopFinalizesCodec2File() async throws {
+        let factory = FakeVoiceCaptureFactory(samples: VoiceTestSupport.pcm(count: Self.c2Samples))
+        let recorder = VoiceMessageRecorder(captureFactory: factory)
+        defer { recorder.teardownEnginePreservingSelection() }
+
+        let out = try recorder.start(format: .codec2_2400)
+        XCTAssertTrue(recorder.isRecording)
+        if case .recording = recorder.state {} else { XCTFail("expected .recording") }
+        // The capture thread creates the file; wait for it (bounded).
+        XCTAssertTrue(await VoiceTestSupport.awaitFile(at: out, exists: true),
+                      "capture thread should create the .c2 file")
+
+        recorder.stop()
+        let state = await waitForRecorderState(recorder) { s in
+            if case .completed = s { return true }; if case .failed = s { return true }; return false
+        }
+        guard case .completed(let rec) = state else {
+            XCTFail("expected .completed, got \(state)"); return
+        }
+        XCTAssertEqual(rec.format, .codec2_2400)
+        XCTAssertEqual(rec.url, out)
+        XCTAssertEqual(rec.audio.mode, .codec2_2400)
+        XCTAssertTrue(rec.audio.bytes.count > 0)
+        // .c2 extension, size is a whole number of 2400 frames (96 bytes),
+        // payload decodes cleanly (no header byte, complete frames only).
+        XCTAssertEqual(out.pathExtension, "c2")
+        let frames = rec.sizeBytes / 96
+        XCTAssertEqual(rec.sizeBytes, frames * 96)
+        // ~300 frames of 320 samples (8 kHz -> 8 kHz resample is ~identity).
+        XCTAssertTrue((295...305).contains(frames), "expected ~300 frames, got \(frames)")
+        _ = try Codec2RawFile.decodePayload(rec.audio.bytes, mode: .codec2_2400)
+        // Audio bytes mirror the file exactly (dual-write consistency).
+        XCTAssertEqual(rec.audio.bytes, try Data(contentsOf: out))
+        XCTAssertEqual(rec.audio.sizeBytes, rec.sizeBytes)
+        // Codec2 duration is best-effort (wall-clock fallback), always set.
+        XCTAssertNotNil(rec.audio.durationMs)
+        // The capture was torn down by the loop.
+        XCTAssertEqual(factory.madeCaptures.first?.closeCount, 1)
+        XCTAssertTrue(recorder.selectedRecording != nil)
+        XCTAssertEqual(recorder.selectedFormat, .codec2_2400)
+    }
+
+    // MARK: - Opus finalization
+
+    func testStartThenStopFinalizesOggFile() async throws {
+        // 8 kHz mono sine -> opusMedium (24 kHz mono): ~1.5x resample.
+        let factory = FakeVoiceCaptureFactory(samples: VoiceTestSupport.pcm(count: 192_000),
+                                              rate: 8_000)
+        let recorder = VoiceMessageRecorder(captureFactory: factory)
+        defer { recorder.teardownEnginePreservingSelection() }
+
+        let out = try recorder.start(format: .opusMedium)
+        recorder.stop()
+        let state = await waitForRecorderState(recorder) { s in
+            if case .completed = s { return true }; if case .failed = s { return true }; return false
+        }
+        guard case .completed(let rec) = state else {
+            XCTFail("expected .completed, got \(state)"); return
+        }
+        XCTAssertEqual(rec.format, .opusMedium)
+        XCTAssertEqual(rec.audio.mode, .opusOgg)
+        XCTAssertEqual(out.pathExtension, "ogg")
+        // The published file is a valid Ogg/Opus stream the metadata reader
+        // accepts, and the attachment duration comes from the granules.
+        let bytes = try Data(contentsOf: out)
+        XCTAssertEqual(Array(bytes.prefix(4)), [0x4F, 0x67, 0x67, 0x53])
+        let meta = OggOpusMetadataReader.read([UInt8](bytes))
+        XCTAssertNotNil(meta)
+        XCTAssertEqual(rec.audio.durationMs, meta?.durationMs)
+        XCTAssertGreaterThan(rec.audio.durationMs ?? 0, 0)
+        XCTAssertEqual(rec.sizeBytes, bytes.count)
+    }
+
+    // MARK: - Empty output -> .failed, file deleted
+
+    func testEmptyOutputFailsAndDeletesFile() async throws {
+        let factory = FakeVoiceCaptureFactory(samples: [], rate: 8_000)
+        let recorder = VoiceMessageRecorder(captureFactory: factory)
+        defer { recorder.teardownEnginePreservingSelection() }
+        let out = try recorder.start(format: .codec2_2400)
+        // Ensure the (empty) file exists, then stop so finalization runs.
+        _ = await VoiceTestSupport.awaitFile(at: out, exists: true)
+        recorder.stop()
+        let state = await waitForRecorderState(recorder) { s in
+            if case .failed = s { return true }; return false
+        }
+        guard case .failed(let message) = state else {
+            XCTFail("expected .failed, got \(state)"); return
+        }
+        XCTAssertFalse(message.isEmpty)
+        // onCaptureDone deletes the empty file before publishing .failed.
+        XCTAssertFalse(FileManager.default.fileExists(atPath: out.path),
+                       "partial empty file must be deleted")
+        XCTAssertNil(recorder.selectedRecording)
+    }
+
+    // MARK: - Worker failure -> .failed, capture closed, file deleted
+
+    func testWorkerFailureClosesCaptureAndPublishesFailed() async throws {
+        let factory = FailingReadVoiceCaptureFactory()
+        let recorder = VoiceMessageRecorder(captureFactory: factory)
+        defer { recorder.teardownEnginePreservingSelection() }
+        let out = try recorder.start(format: .codec2_2400)
+        let state = await waitForRecorderState(recorder) { s in
+            if case .failed = s { return true }; return false
+        }
+        guard case .failed = state else {
+            XCTFail("expected .failed, got \(state)"); return
+        }
+        XCTAssertNotNil(recorder.errorMessage)
+        XCTAssertEqual(factory.capture.closeCount, 1)
+        XCTAssertEqual(factory.capture.stopCount, 1)
+        // The (empty) partial file is deleted on the failure path.
+        XCTAssertFalse(FileManager.default.fileExists(atPath: out.path))
+    }
+
+    func testCaptureStartFailureClosesCaptureAndPublishesFailed() async {
+        struct StartError: Error {}
+        let factory = FakeVoiceCaptureFactory(startError: StartError())
+        let recorder = VoiceMessageRecorder(captureFactory: factory)
+        XCTAssertThrowsError(try recorder.start(format: .codec2_2400)) {
+            XCTAssertEqual($0 as? VoiceRecorderError, .captureStartFailed)
+        }
+        if case .failed = recorder.state {} else { XCTFail("expected .failed, got \(recorder.state)") }
+        XCTAssertNotNil(recorder.errorMessage)
+        XCTAssertEqual(factory.madeCaptures.first?.closeCount, 1)
+    }
+
+    // MARK: - Cancel deletes in-flight file
+
+    func testCancelDeletesInFlightFileAndGoesIdle() async throws {
+        let factory = FakeVoiceCaptureFactory(samples: VoiceTestSupport.pcm(count: Self.c2Samples))
+        let recorder = VoiceMessageRecorder(captureFactory: factory)
+        defer { recorder.teardownEnginePreservingSelection() }
+        let out = try recorder.start(format: .codec2_2400)
+        _ = await VoiceTestSupport.awaitFile(at: out, exists: true)
+        recorder.cancel()
+        // cancel() is non-blocking: wait for the loop to delete the in-flight
+        // file (done in onCaptureDone on the main actor).
+        XCTAssertTrue(await VoiceTestSupport.awaitFile(at: out, exists: false, timeout: 5),
+                      "cancelled in-flight file must be deleted")
+        XCTAssertEqual(factory.capture.closeCount, 1)
+        XCTAssertEqual(factory.capture.stopCount, 1)
+        XCTAssertNil(recorder.selectedRecording)
+        if case .idle = recorder.state {} else { XCTFail("expected .idle, got \(recorder.state)") }
+    }
+
+    // MARK: - Unsupported device
+
+    func testUnsupportedDevicePublishesTerminalFailed() async {
+        let factory = FakeVoiceCaptureFactory(supported: false)
+        let recorder = VoiceMessageRecorder(captureFactory: factory)
+        XCTAssertThrowsError(try recorder.start(format: .codec2_1200)) {
+            XCTAssertEqual($0 as? VoiceRecorderError, .unsupported)
+        }
+        if case .failed = recorder.state {} else { XCTFail("expected .failed, got \(recorder.state)") }
+        XCTAssertTrue(recorder.lastFailureWasUnsupported)
+        XCTAssertNotNil(recorder.errorMessage)
+        XCTAssertNil(recorder.selectedRecording)
+    }
+
+    // MARK: - Double start rejected
+
+    func testDoubleStartRejected() async throws {
+        let factory = FakeVoiceCaptureFactory(samples: VoiceTestSupport.pcm(count: Self.c2Samples))
+        let recorder = VoiceMessageRecorder(captureFactory: factory)
+        defer { recorder.teardownEnginePreservingSelection() }
+        _ = try recorder.start(format: .codec2_2400)
+        XCTAssertThrowsError(try recorder.start(format: .opusMedium)) {
+            XCTAssertEqual($0 as? VoiceRecorderError, .alreadyRecording)
+        }
+        recorder.stop()
+        _ = await waitForRecorderState(recorder) { s in
+            if case .completed = s { return true }; if case .failed = s { return true }; return false
+        }
+    }
+
+    // MARK: - Finalized file retained across teardown
+
+    func testTeardownRetainsFinalizedRecording() async throws {
+        let factory = FakeVoiceCaptureFactory(samples: VoiceTestSupport.pcm(count: Self.c2Samples))
+        let recorder = VoiceMessageRecorder(captureFactory: factory)
+        let out = try recorder.start(format: .codec2_2400)
+        recorder.stop()
+        _ = await waitForRecorderState(recorder) { s in
+            if case .completed = s { return true }; if case .failed = s { return true }; return false
+        }
+        XCTAssertNotNil(recorder.selectedRecording)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: out.path))
+        // Simulate route change / background: engine torn down, selection kept.
+        recorder.teardownEnginePreservingSelection()
+        XCTAssertEqual(recorder.selectedRecording?.url, out)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: out.path))
+        if case .completed = recorder.state {} else { XCTFail("expected .completed, got \(recorder.state)") }
+    }
+
+    // MARK: - removeSelected
+
+    func testRemoveSelectedDeletesFileAndClearsState() async throws {
+        let factory = FakeVoiceCaptureFactory(samples: VoiceTestSupport.pcm(count: Self.c2Samples))
+        let recorder = VoiceMessageRecorder(captureFactory: factory)
+        defer { recorder.teardownEnginePreservingSelection() }
+        let out = try recorder.start(format: .codec2_2400)
+        recorder.stop()
+        _ = await waitForRecorderState(recorder) { s in
+            if case .completed = s { return true }; if case .failed = s { return true }; return false
+        }
+        XCTAssertTrue(recorder.removeSelected())
+        XCTAssertFalse(FileManager.default.fileExists(atPath: out.path))
+        XCTAssertNil(recorder.selectedRecording)
+        XCTAssertNil(recorder.selectedFormat)
+        if case .idle = recorder.state {} else { XCTFail("expected .idle, got \(recorder.state)") }
+        XCTAssertFalse(recorder.removeSelected(), "second remove must be a no-op")
+    }
+}

--- a/Tests/ColumbaAppTests/VoiceMessageRecorderTests.swift
+++ b/Tests/ColumbaAppTests/VoiceMessageRecorderTests.swift
@@ -45,13 +45,23 @@ final class FailingReadVoiceCaptureFactory: VoicePcmCaptureFactory, @unchecked S
 @MainActor
 final class VoiceMessageRecorderTests: XCTestCase {
 
-    private static let c2Frames = 300
-    private static let c2Samples = 320 * c2Frames   // codec2_2400: 320 spf
+    /// Feed 300 frames' worth of samples. The samples-per-frame for a given
+    /// Codec2 mode is derived from the LIVE codec (see
+    /// `Codec2RawFile.geometry(of:)`), so we size the buffer off the live
+    /// geometry rather than hardcoding an spf that may differ from what the
+    /// bundled codec2 actually uses. codec2_2400 is 160 samples/frame in the
+    /// C codec (NOT 320), so the old `320 * 300` buffer over-fed 2x and the
+    /// (correct) recorder produced 600 frames instead of 300.
+    private static func c2Samples(for mode: Codec2Mode, frames: Int) -> Int {
+        let codec = try! Codec2Codec(mode: mode)
+        let geo = Codec2RawFile.geometry(of: codec)
+        return geo.samplesPerFrame * frames
+    }
 
     // MARK: - Codec2 finalization
 
     func testStartThenStopFinalizesCodec2File() async throws {
-        let factory = FakeVoiceCaptureFactory(samples: VoiceTestSupport.pcm(count: Self.c2Samples))
+        let factory = FakeVoiceCaptureFactory(samples: VoiceTestSupport.pcm(count: Self.c2Samples(for: .codec2_2400, frames: 300)))
         let recorder = VoiceMessageRecorder(captureFactory: factory)
         defer { recorder.teardownEnginePreservingSelection() }
 
@@ -91,7 +101,8 @@ final class VoiceMessageRecorderTests: XCTestCase {
         let bytesPerFrame = Codec2RawFile.geometry(for: .codec2_2400).bytesPerFrame
         let frames = rec.sizeBytes / bytesPerFrame
         XCTAssertEqual(rec.sizeBytes, frames * bytesPerFrame)
-        // ~300 frames of 320 samples (8 kHz -> 8 kHz resample is ~identity).
+        // ~300 frames of 160 samples (codec2_2400 live spf; 8 kHz -> 8 kHz
+        // resample is ~identity, so 300*160 = 48,000 samples -> 300 frames).
         XCTAssertTrue((295...305).contains(frames), "expected ~300 frames, got \(frames)")
         _ = try Codec2RawFile.decodePayload(rec.audio.bytes, mode: .codec2_2400)
         // Audio bytes mirror the file exactly (dual-write consistency).
@@ -201,7 +212,7 @@ final class VoiceMessageRecorderTests: XCTestCase {
     // MARK: - Cancel deletes in-flight file
 
     func testCancelDeletesInFlightFileAndGoesIdle() async throws {
-        let factory = FakeVoiceCaptureFactory(samples: VoiceTestSupport.pcm(count: Self.c2Samples))
+        let factory = FakeVoiceCaptureFactory(samples: VoiceTestSupport.pcm(count: Self.c2Samples(for: .codec2_2400, frames: 300)))
         let recorder = VoiceMessageRecorder(captureFactory: factory)
         defer { recorder.teardownEnginePreservingSelection() }
         let out = try recorder.start(format: .codec2_2400)
@@ -234,7 +245,7 @@ final class VoiceMessageRecorderTests: XCTestCase {
     // MARK: - Double start rejected
 
     func testDoubleStartRejected() async throws {
-        let factory = FakeVoiceCaptureFactory(samples: VoiceTestSupport.pcm(count: Self.c2Samples))
+        let factory = FakeVoiceCaptureFactory(samples: VoiceTestSupport.pcm(count: Self.c2Samples(for: .codec2_2400, frames: 300)))
         let recorder = VoiceMessageRecorder(captureFactory: factory)
         defer { recorder.teardownEnginePreservingSelection() }
         _ = try recorder.start(format: .codec2_2400)
@@ -250,7 +261,7 @@ final class VoiceMessageRecorderTests: XCTestCase {
     // MARK: - Finalized file retained across teardown
 
     func testTeardownRetainsFinalizedRecording() async throws {
-        let factory = FakeVoiceCaptureFactory(samples: VoiceTestSupport.pcm(count: Self.c2Samples))
+        let factory = FakeVoiceCaptureFactory(samples: VoiceTestSupport.pcm(count: Self.c2Samples(for: .codec2_2400, frames: 300)))
         let recorder = VoiceMessageRecorder(captureFactory: factory)
         let out = try recorder.start(format: .codec2_2400)
         // Let the finite fake buffer drain and the loop settle so the stop
@@ -275,7 +286,7 @@ final class VoiceMessageRecorderTests: XCTestCase {
     // MARK: - removeSelected
 
     func testRemoveSelectedDeletesFileAndClearsState() async throws {
-        let factory = FakeVoiceCaptureFactory(samples: VoiceTestSupport.pcm(count: Self.c2Samples))
+        let factory = FakeVoiceCaptureFactory(samples: VoiceTestSupport.pcm(count: Self.c2Samples(for: .codec2_2400, frames: 300)))
         let recorder = VoiceMessageRecorder(captureFactory: factory)
         defer { recorder.teardownEnginePreservingSelection() }
         let out = try recorder.start(format: .codec2_2400)

--- a/Tests/ColumbaAppTests/VoiceTestSupport.swift
+++ b/Tests/ColumbaAppTests/VoiceTestSupport.swift
@@ -82,7 +82,7 @@ enum VoiceTestSupport {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
             if FileManager.default.fileExists(atPath: url.path) == exists { return true }
-            await Task.sleep(nanoseconds: 20_000_000)
+            try? await Task.sleep(nanoseconds: 20_000_000)
         }
         return FileManager.default.fileExists(atPath: url.path) == exists
     }
@@ -167,7 +167,7 @@ func waitForRecorderState(
     let deadline = Date().addingTimeInterval(timeout)
     while !done(recorder.state) {
         if Date() > deadline { break }
-        await Task.sleep(nanoseconds: 50_000_000)
+        try? await Task.sleep(nanoseconds: 50_000_000)
     }
     return recorder.state
 }
@@ -182,7 +182,7 @@ func waitForPlayerStatus(
     let deadline = Date().addingTimeInterval(timeout)
     while !done(player.state(for: key).status) {
         if Date() > deadline { break }
-        await Task.sleep(nanoseconds: 50_000_000)
+        try? await Task.sleep(nanoseconds: 50_000_000)
     }
     return player.state(for: key).status
 }

--- a/Tests/ColumbaAppTests/VoiceTestSupport.swift
+++ b/Tests/ColumbaAppTests/VoiceTestSupport.swift
@@ -56,7 +56,7 @@ enum VoiceTestSupport {
             let end = off + 27 + seg + payloadSize
             guard end <= data.count else { return nil }
             var g: Int64 = 0
-            for i in 0..<8 { g |= Int64(Int8(bitPattern: data[off + 6 + i])) << (i * 8) }
+            for i in 0..<8 { g |= Int64(UInt64(data[off + 6 + i])) << (i * 8) }
             let payload = Array(data[(off + 27 + seg)..<end])
             pages.append(OggPage(granule: g, payload: payload, pageStart: off))
             off = end

--- a/Tests/ColumbaAppTests/VoiceTestSupport.swift
+++ b/Tests/ColumbaAppTests/VoiceTestSupport.swift
@@ -86,6 +86,42 @@ enum VoiceTestSupport {
         }
         return FileManager.default.fileExists(atPath: url.path) == exists
     }
+
+    /// Poll (bounded) until the fake capture's buffer is fully drained by the
+    /// capture thread. Call this BEFORE `recorder.stop()` in tests: the fake
+    /// capture serves its whole finite buffer within a few milliseconds, so
+    /// stopping the instant the output file appears can race the encode loop
+    /// (0-1 frames written -> "no audio" / wrong frame count). Production is
+    /// unaffected: a real microphone never "drains" - the loop spins on
+    /// read()==0 until the latch flips.
+    static func awaitDrained(_ capture: FakeVoiceCapture, timeout: TimeInterval = 5) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while capture.remaining > 0 {
+            if Date() > deadline { return false }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        return true
+    }
+
+    /// Poll (bounded) until the file's on-disk size stops changing (two reads
+    /// `settle` apart are equal and non-zero). Call AFTER the capture buffer is
+    /// drained: the drain guarantees all samples are read, but the final
+    /// read-batch's frames are encoded+written *after* the read that drained,
+    /// so a drain-only stop can drop that last batch (count lands ~6 frames low).
+    /// Waiting for the size to settle waits for the loop to actually stop
+    /// writing. Deterministic and independent of the exact final frame count.
+    static func awaitFileSettled(at url: URL, timeout: TimeInterval = 5,
+                                 settle: TimeInterval = 0.05) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        var last = -1
+        while Date() < deadline {
+            let s = (try? FileManager.default.attributesOfItem(atPath: url.path)[.size] as? Int) ?? 0
+            if s > 0 && s == last { return true }
+            last = s
+            try? await Task.sleep(nanoseconds: UInt64(settle * 1_000_000_000))
+        }
+        return false
+    }
 }
 
 /// Bounded, thread-safe fake capture. `read` returns up to `capacity` mono
@@ -98,6 +134,12 @@ final class FakeVoiceCapture: VoicePcmCapture, @unchecked Sendable {
     var stopCount = 0
     let support: Bool
     let rate: Int
+
+    /// Samples still queued for `read`. Tests use this to wait for the capture
+    /// thread to fully drain a finite fake buffer before stopping the recorder
+    /// (a file-exists wait alone is not enough: the fake returns its whole
+    /// buffer in milliseconds, so the loop could still be mid-encode).
+    var remaining: Int { lock.lock(); defer { lock.unlock() }; return queue.count }
 
     init(samples: [Int16] = [], rate: Int = 8_000, startError: Error? = nil,
          supported: Bool = true) {

--- a/Tests/ColumbaAppTests/VoiceTestSupport.swift
+++ b/Tests/ColumbaAppTests/VoiceTestSupport.swift
@@ -1,0 +1,188 @@
+//
+//  VoiceTestSupport.swift
+//  ColumbaAppTests
+//
+//  Shared helpers for the voice-message XCTest suites: deterministic PCM, a
+//  valid 48 kHz Opus TOC packet, an Ogg page walker (structure + CRC checks,
+//  independent of the writer's own bookkeeping), a bounded fake audio capture
+//  for the recorder state-machine tests, and a MainActor state poller.
+//
+
+import XCTest
+import Foundation
+import LXSTSwift
+@testable import ColumbaApp
+
+enum VoiceTestSupport {
+
+    /// `count` mono int16 samples of a 440 Hz sine at 8 kHz.
+    static func pcm(count: Int, rate: Int = 8_000) -> [Int16] {
+        (0..<count).map { i in
+            Int16((sin(2 * .pi * 440 * Double(i) / Double(rate))) * 12_000)
+        }
+    }
+
+    /// A valid Opus packet TOC byte (48 kHz, 20 ms, single frame = 960
+    /// samples at 48 kHz) + filler payload. `0x98`: s=1 (48k), code=3 (20ms),
+    /// c=0 (one frame). Returns 960 from `OggOpusGranule.packetSamples48k`.
+    static func opusPacket(toc: UInt8 = 0x98, size: Int = 40) -> [UInt8] {
+        [toc] + [UInt8](repeating: 0x11, count: size - 1)
+    }
+
+    // MARK: - Ogg page walking
+
+    struct OggPage {
+        let granule: Int64
+        let payload: [UInt8]
+        let pageStart: Int
+    }
+
+    /// Walk a byte stream's Ogg pages. Returns nil when any page is malformed
+    /// or the stream does not terminate cleanly on a page boundary.
+    static func oggPages(_ data: [UInt8]) -> [OggPage]? {
+        guard data.count >= 27,
+              data[0] == 0x4F, data[1] == 0x67, data[2] == 0x67, data[3] == 0x53
+        else { return nil }
+        var pages: [OggPage] = []
+        var off = 0
+        while off < data.count {
+            guard off + 27 <= data.count,
+                  data[off] == 0x4F, data[off + 1] == 0x67, data[off + 2] == 0x67,
+                  data[off + 3] == 0x53
+            else { return nil }
+            let seg = Int(data[off + 26])
+            var payloadSize = 0
+            for i in 0..<seg { payloadSize += Int(data[off + 27 + i]) }
+            let end = off + 27 + seg + payloadSize
+            guard end <= data.count else { return nil }
+            var g: Int64 = 0
+            for i in 0..<8 { g |= Int64(Int8(bitPattern: data[off + 6 + i])) << (i * 8) }
+            let payload = Array(data[(off + 27 + seg)..<end])
+            pages.append(OggPage(granule: g, payload: payload, pageStart: off))
+            off = end
+        }
+        return pages
+    }
+
+    /// True when the page's stored Ogg CRC (bytes 22..25) matches a
+    /// recomputation over the page with the stored field zeroed.
+    static func oggPageCRCValid(_ data: [UInt8], pageStart: Int, pageEnd: Int) -> Bool {
+        let stored = UInt32(data[pageStart + 22])
+            | (UInt32(data[pageStart + 23]) << 8)
+            | (UInt32(data[pageStart + 24]) << 16)
+            | (UInt32(data[pageStart + 25]) << 24)
+        let computed = OggOpusGranule.oggChecksum(data, pageStart, pageEnd,
+                                                  zeroStoredChecksum: true)
+        return stored == computed
+    }
+
+    /// Poll (bounded) for a file to (not) exist. Async so the MainActor stays
+    /// free to run the recorder's completion task.
+    static func awaitFile(at url: URL, exists: Bool, timeout: TimeInterval = 5) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if FileManager.default.fileExists(atPath: url.path) == exists { return true }
+            await Task.sleep(nanoseconds: 20_000_000)
+        }
+        return FileManager.default.fileExists(atPath: url.path) == exists
+    }
+}
+
+/// Bounded, thread-safe fake capture. `read` returns up to `capacity` mono
+/// samples from a pre-generated buffer (0 once exhausted); `start` may throw.
+final class FakeVoiceCapture: VoicePcmCapture, @unchecked Sendable {
+    private let lock = NSLock()
+    private var queue: [Int16]
+    private var startError: Error?
+    var closeCount = 0
+    var stopCount = 0
+    let support: Bool
+    let rate: Int
+
+    init(samples: [Int16] = [], rate: Int = 8_000, startError: Error? = nil,
+         supported: Bool = true) {
+        self.queue = samples
+        self.rate = rate
+        self.startError = startError
+        self.support = supported
+    }
+
+    var isSupported: Bool { support }
+    var sampleRate: Int { rate }
+
+    func start() throws {
+        if let startError { throw startError }
+    }
+
+    func read(into buffer: inout [Int16], capacity: Int) -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        let n = min(capacity, queue.count)
+        for i in 0..<n { buffer[i] = queue.removeFirst() }
+        return n
+    }
+
+    func stop() {
+        lock.lock(); stopCount += 1; lock.unlock()
+    }
+
+    func close() {
+        lock.lock(); closeCount += 1; lock.unlock()
+    }
+}
+
+final class FakeVoiceCaptureFactory: VoicePcmCaptureFactory, @unchecked Sendable {
+    let samples: [Int16]
+    let rate: Int
+    let startError: Error?
+    let supported: Bool
+    private(set) var madeCaptures: [FakeVoiceCapture] = []
+    private let lock = NSLock()
+
+    init(samples: [Int16] = [], rate: Int = 8_000, startError: Error? = nil,
+         supported: Bool = true) {
+        self.samples = samples
+        self.rate = rate
+        self.startError = startError
+        self.supported = supported
+    }
+
+    func makeCapture(channels: Int, sampleRateHint: Int) -> VoicePcmCapture {
+        let cap = FakeVoiceCapture(samples: samples, rate: rate,
+                                   startError: startError, supported: supported)
+        lock.lock(); madeCaptures.append(cap); lock.unlock()
+        return cap
+    }
+}
+
+/// Poll the recorder's state (MainActor) until it reaches `done`, with a
+/// bounded timeout. Runs while the MainActor is free to process the capture
+/// loop's completion task.
+@MainActor
+func waitForRecorderState(
+    _ recorder: VoiceMessageRecorder,
+    timeout: TimeInterval = 5,
+    done: @escaping (VoiceRecorderState) -> Bool
+) async -> VoiceRecorderState {
+    let deadline = Date().addingTimeInterval(timeout)
+    while !done(recorder.state) {
+        if Date() > deadline { break }
+        await Task.sleep(nanoseconds: 50_000_000)
+    }
+    return recorder.state
+}
+
+@MainActor
+func waitForPlayerStatus(
+    _ player: VoiceMessagePlayer,
+    key: String,
+    timeout: TimeInterval = 10,
+    done: @escaping (VoiceMessagePlayer.PlaybackState.Status) -> Bool
+) async -> VoiceMessagePlayer.PlaybackState.Status {
+    let deadline = Date().addingTimeInterval(timeout)
+    while !done(player.state(for: key).status) {
+        if Date() > deadline { break }
+        await Task.sleep(nanoseconds: 50_000_000)
+    }
+    return player.state(for: key).status
+}

--- a/Tests/RNSAPITests/AttachmentFieldRoundTripTests.swift
+++ b/Tests/RNSAPITests/AttachmentFieldRoundTripTests.swift
@@ -36,7 +36,7 @@ final class AttachmentFieldRoundTripTests: XCTestCase {
         let imageBytes = Data((0..<256).map { UInt8($0) })
         let fields = LxmfFieldCodec.buildFieldMap(
             imageData: imageBytes, imageFormat: "jpeg",
-            fileAttachments: nil, iconAppearance: nil,
+            fileAttachments: nil, audioAttachment: nil, iconAppearance: nil,
             replyToMessageHashHex: nil, replyQuotedContent: nil,
             extraFields: nil
         )
@@ -80,7 +80,7 @@ final class AttachmentFieldRoundTripTests: XCTestCase {
         let imageBytes = Data((0..<10_000).map { _ in UInt8.random(in: 0...255, using: &rng) })
         let fields = LxmfFieldCodec.buildFieldMap(
             imageData: imageBytes, imageFormat: "webp",
-            fileAttachments: nil, iconAppearance: nil,
+            fileAttachments: nil, audioAttachment: nil, iconAppearance: nil,
             replyToMessageHashHex: nil, replyQuotedContent: nil,
             extraFields: nil
         )
@@ -101,7 +101,7 @@ final class AttachmentFieldRoundTripTests: XCTestCase {
         let b = RnsFileAttachment(name: "log.bin", data: Data([0x00, 0xFF, 0x42]))
         let fields = LxmfFieldCodec.buildFieldMap(
             imageData: nil, imageFormat: nil,
-            fileAttachments: [a, b],
+            fileAttachments: [a, b], audioAttachment: nil,
             iconAppearance: nil,
             replyToMessageHashHex: nil, replyQuotedContent: nil,
             extraFields: nil
@@ -215,7 +215,7 @@ final class AttachmentFieldRoundTripTests: XCTestCase {
     func testEmptyFieldMapProducesEmptyPackedAndNilUnpack() {
         let empty = LxmfFieldCodec.buildFieldMap(
             imageData: nil, imageFormat: nil,
-            fileAttachments: nil, iconAppearance: nil,
+            fileAttachments: nil, audioAttachment: nil, iconAppearance: nil,
             replyToMessageHashHex: nil, replyQuotedContent: nil,
             extraFields: nil
         )

--- a/Tests/interop/conftest.py
+++ b/Tests/interop/conftest.py
@@ -93,6 +93,23 @@ def _yaml_escape(s: str) -> str:
     )
 
 
+def content_tag(content: str) -> str:
+    """FNV-1a 32-bit tag of a message body, lowercase 8-hex.
+
+    Must stay byte-for-byte in sync with `VoiceMessageBubble.contentTag` in
+    Sources/ColumbaApp/Voice/VoiceMessageBubble.swift (same offset basis
+    0x811C9DC5, same prime 0x01000193, over the content's UTF-8 bytes). The
+    interop flows use it to address the voice bubble belonging to the note
+    each test just sent: the conversation accumulates one bubble per note,
+    so a bare `voice_bubble_play` id would match every bubble in the list
+    and Maestro would act on the FIRST (oldest) one.
+    """
+    h = 0x811C9DC5
+    for b in content.encode("utf-8"):
+        h ^= b
+        h = (h * 0x01000193) & 0xFFFFFFFF
+    return format(h, "08x")
+
 def _booted_udid() -> str:
     """Return the UDID of the currently booted iPhone simulator. Fails the
     test session if zero or more-than-one is booted."""
@@ -833,7 +850,6 @@ class Simulator:
             ]
         return lines
 
-    @staticmethod
     def assert_voice_bubble_visible(
         self,
         *,
@@ -843,52 +859,62 @@ class Simulator:
         timeout: float = 30.0,
     ) -> None:
         """Navigate to the conversation and assert the field-7 voice
-        bubble rendered. `playable=True` additionally asserts the play
-        control is present (the decode succeeded).
+        bubble rendered (title), plus the play control when
+        `playable=True` (the decode succeeded).
 
         Pins the render half of the inbound voice path: LXMRouter
         delivery -> IncomingMessageHandler -> LXMFDatabase ->
         Message.audioAttachment -> MessageBubble -> VoiceMessageBubble.
         A non-playable decode (unrecognized mode / corrupted payload)
         surfaces `voice_bubble_unavailable` / `voice_bubble_unsupported`
-        instead of the play control, so this assertion is the decode
-        verdict.
+        instead of the play control, so `playable=True` is the decode
+        verdict for this direction.
+
+        `content` is required: the per-bubble ids are
+        `voice_bubble_<base>_<tag>` where the tag is the FNV-1a 32 tag of
+        the message body (see `content_tag`), so the harness targets
+        THIS test's bubble instead of the first matching id in the
+        conversation.
         """
+        assert content is not None, "content is required to tag the voice bubble"
+        tag = content_tag(content)
+        title_id = f"voice_bubble_title_{tag}"
+        play_id = f"voice_bubble_play_{tag}"
         lines = [
             'appId: ' + BUNDLE_ID,
             '---',
-            "- tapOn: { text: \"Allow\", optional: true }",
-            "- tapOn: { text: \"Don't Allow\", optional: true }",
-            "- waitForAnimationToEnd: { timeout: 1500 }",
+            # Stale notification-permission alert blocks the Chats tap.
+            # First-launch only, so optional.
+            '- tapOn: { text: "Allow", optional: true }',
+            '- tapOn: { text: "Don\'t Allow", optional: true }',
+            '- waitForAnimationToEnd: { timeout: 1500 }',
         ]
+        # A contact sheet left open by a pin test is modal and covers the
+        # tab bar, so the Chats navigation below would no-op. Dismiss it
+        # first - a no-op when none is open.
         lines += self._sheet_dismiss_lines()
         lines += [
-            "- back",
-            "- waitForAnimationToEnd: { timeout: 800 }",
-            "- back",
-            "- waitForAnimationToEnd: { timeout: 800 }",
-            "- tapOn:",
-            "    text: \"Chats\"",
-            "    optional: true",
-            "- waitForAnimationToEnd: { timeout: 2000 }",
-            f'- tapOn: \"{_yaml_escape(peer_display_name)}\"',
-            "- waitForAnimationToEnd: { timeout: 2500 }",
-        ]
-        if content is not None:
-            lines += [
-                "- assertVisible:",
-                f'    text: \"{_yaml_escape(content)}\"',
-            ]
-        # The bubble title is present whenever a field-7 attachment
-        # decoded at all.
-        lines += [
-            "- assertVisible:",
-            '    id: "voice_bubble_title"',
+            '- back',
+            '- waitForAnimationToEnd: { timeout: 800 }',
+            '- back',
+            '- waitForAnimationToEnd: { timeout: 800 }',
+            '- tapOn:',
+            '    text: "Chats"',
+            '    optional: true',
+            '- waitForAnimationToEnd: { timeout: 2000 }',
+            f'- tapOn: "{_yaml_escape(peer_display_name)}"',
+            '- waitForAnimationToEnd: { timeout: 2500 }',
+            '- assertVisible:',
+            f'    text: "{_yaml_escape(content)}"',
+            # The title renders whenever a field-7 attachment decoded at
+            # all, before the player has done anything.
+            '- assertVisible:',
+            f'    id: "{title_id}"',
         ]
         if playable:
             lines += [
-                "- assertVisible:",
-                '    id: "voice_bubble_play"',
+                '- assertVisible:',
+                f'    id: "{play_id}"',
             ]
         flow_path = Path(os.environ.get("TMPDIR", "/tmp")) / f"_interop_voice_{os.getpid()}.yaml"
         flow_path.write_text("\n".join(lines) + "\n")
@@ -910,48 +936,56 @@ class Simulator:
         peer_display_name: str = "Anonymous Peer",
         timeout: float = 25.0,
     ) -> None:
-        """Tap the voice bubble's play control and assert the player
-        state machine left `.loading` and reached a playable steady
-        state (progress text + play control present). This is the
-        actual decode + AVAudioPlayer exercise: a malformed Ogg granule
-        or undecodable payload surfaces `voice_bubble_unavailable` / an
-        error row instead.
+        """Tap THIS message's voice play control and assert the player
+        left `.loading` without surfacing the unavailable/error state.
 
-        We do NOT assert audible output (headless sim); we assert the
-        player reached a playable state, which is exactly what the Ogg
-        granule fix changes (granule parse failure vs success).
+        The load-bearing decode + AVAudioPlayer exercise: a malformed Ogg
+        granule or undecodable payload lands the state machine in
+        `.error` (rendered as `voice_bubble_unavailable`) instead of the
+        progress row, and the assert below fails the cell. Headless sim,
+        so we assert the state machine reached the playable row, not
+        audible output.
         """
+        tag = content_tag(content)
+        play_id = f"voice_bubble_play_{tag}"
+        progress_id = f"voice_bubble_progress_{tag}"
+        unavailable_id = f"voice_bubble_unavailable_{tag}"
+        unsupported_id = f"voice_bubble_unsupported_{tag}"
         lines = [
             'appId: ' + BUNDLE_ID,
             '---',
-            "- tapOn: { text: \"Allow\", optional: true }",
-            "- tapOn: { text: \"Don't Allow\", optional: true }",
-            "- waitForAnimationToEnd: { timeout: 1500 }",
+            '- tapOn: { text: "Allow", optional: true }',
+            '- tapOn: { text: "Don\'t Allow", optional: true }',
+            '- waitForAnimationToEnd: { timeout: 1500 }',
         ]
         lines += self._sheet_dismiss_lines()
         lines += [
-            "- back",
-            "- waitForAnimationToEnd: { timeout: 800 }",
-            "- back",
-            "- waitForAnimationToEnd: { timeout: 800 }",
-            "- tapOn:",
-            "    text: \"Chats\"",
-            "    optional: true",
-            "- waitForAnimationToEnd: { timeout: 2000 }",
-            f'- tapOn: \"{_yaml_escape(peer_display_name)}\"',
-            "- waitForAnimationToEnd: { timeout: 2500 }",
-            "- assertVisible:",
-            '    id: "voice_bubble_play"',
-            "- tapOn:",
-            '    id: "voice_bubble_play"',
-            "- waitForAnimationToEnd: { timeout: 4000 }",
-            # After prepare+toggle the state is .playing or .paused (a
-            # short clip may have completed). Either way the progress
-            # text is present and no unavailable/error row is shown.
-            "- assertVisible:",
-            '    id: "voice_bubble_progress"',
-            "- assertVisible:",
-            '    id: "voice_bubble_play"',
+            '- back',
+            '- waitForAnimationToEnd: { timeout: 800 }',
+            '- back',
+            '- waitForAnimationToEnd: { timeout: 800 }',
+            '- tapOn:',
+            '    text: "Chats"',
+            '    optional: true',
+            '- waitForAnimationToEnd: { timeout: 2000 }',
+            f'- tapOn: "{_yaml_escape(peer_display_name)}"',
+            '- waitForAnimationToEnd: { timeout: 2500 }',
+            '- tapOn:',
+            f'    id: "{play_id}"',
+            # renderToTempFile (Opus/Codec2 decode) + AVAudioPlayer start is
+            # async, so the progress row appears after a beat. Maestro 1.39
+            # has no sleep step; an optional tapOn blocks until the element
+            # exists (the tap on the progress Text is harmless), then the
+            # assert below is the real verdict.
+            '- tapOn:',
+            f'    id: "{progress_id}"',
+            '    optional: true',
+            '- assertVisible:',
+            f'    id: "{progress_id}"',
+            '- assertNotVisible:',
+            f'    id: "{unavailable_id}"',
+            '- assertNotVisible:',
+            f'    id: "{unsupported_id}"',
         ]
         flow_path = Path(os.environ.get("TMPDIR", "/tmp")) / f"_interop_voiceplay_{os.getpid()}.yaml"
         flow_path.write_text("\n".join(lines) + "\n")
@@ -966,6 +1000,7 @@ class Simulator:
         finally:
             flow_path.unlink(missing_ok=True)
 
+    @staticmethod
     def _sheet_dismiss_lines() -> list[str]:
         """Steps that dismiss a leftover `PeerContactSheet` if one is
         open, harmlessly no-op if not. The pin flows leave the sheet

--- a/Tests/interop/conftest.py
+++ b/Tests/interop/conftest.py
@@ -922,9 +922,10 @@ class Simulator:
             _sh(["maestro", "--device", self.udid, "test", str(flow_path)],
                 timeout=timeout + 30)
         except subprocess.CalledProcessError as e:
+            out = e.output if isinstance(e.output, str) else (e.output or b"").decode("utf-8", "replace")
             pytest.fail(
                 f"voice bubble assertion failed (playable={playable}): "
-                f"{(e.output or b'').decode('utf-8', 'replace')[-1200:]}"
+                f"{(out or e.stderr or '')[-1200:]}"
             )
         finally:
             flow_path.unlink(missing_ok=True)
@@ -993,9 +994,10 @@ class Simulator:
             _sh(["maestro", "--device", self.udid, "test", str(flow_path)],
                 timeout=timeout + 30)
         except subprocess.CalledProcessError as e:
+            out = e.output if isinstance(e.output, str) else (e.output or b"").decode("utf-8", "replace")
             pytest.fail(
                 f"voice playback did not reach a playable state: "
-                f"{(e.output or b'').decode('utf-8', 'replace')[-1200:]}"
+                f"{(out or e.stderr or '')[-1200:]}"
             )
         finally:
             flow_path.unlink(missing_ok=True)

--- a/Tests/interop/conftest.py
+++ b/Tests/interop/conftest.py
@@ -341,6 +341,8 @@ class Simulator:
         image_format: Optional[str] = None,
         file_bytes: Optional[bytes] = None,
         file_name: Optional[str] = None,
+        audio_bytes: Optional[bytes] = None,
+        audio_mode: Optional[int] = None,
         wait: float = 30.0,
     ) -> TestSendResult:
         """Drive `lxma://test-send?…` via Maestro (so the iOS "Open in
@@ -357,6 +359,9 @@ class Simulator:
         if file_bytes is not None and file_name:
             params.append(f"file_hex={file_bytes.hex()}")
             params.append(f"file_name={quote(file_name, safe='')}")
+        if audio_bytes is not None and audio_mode is not None:
+            params.append(f"audio_mode={audio_mode}")
+            params.append(f"audio_hex={audio_bytes.hex()}")
         url = "lxma://test-send?" + "&".join(params)
 
         # Snapshot file position so we only scan lines written AFTER the
@@ -829,6 +834,138 @@ class Simulator:
         return lines
 
     @staticmethod
+    def assert_voice_bubble_visible(
+        self,
+        *,
+        peer_display_name: str = "Anonymous Peer",
+        content: Optional[str] = None,
+        playable: bool = True,
+        timeout: float = 30.0,
+    ) -> None:
+        """Navigate to the conversation and assert the field-7 voice
+        bubble rendered. `playable=True` additionally asserts the play
+        control is present (the decode succeeded).
+
+        Pins the render half of the inbound voice path: LXMRouter
+        delivery -> IncomingMessageHandler -> LXMFDatabase ->
+        Message.audioAttachment -> MessageBubble -> VoiceMessageBubble.
+        A non-playable decode (unrecognized mode / corrupted payload)
+        surfaces `voice_bubble_unavailable` / `voice_bubble_unsupported`
+        instead of the play control, so this assertion is the decode
+        verdict.
+        """
+        lines = [
+            'appId: ' + BUNDLE_ID,
+            '---',
+            "- tapOn: { text: \"Allow\", optional: true }",
+            "- tapOn: { text: \"Don't Allow\", optional: true }",
+            "- waitForAnimationToEnd: { timeout: 1500 }",
+        ]
+        lines += self._sheet_dismiss_lines()
+        lines += [
+            "- back",
+            "- waitForAnimationToEnd: { timeout: 800 }",
+            "- back",
+            "- waitForAnimationToEnd: { timeout: 800 }",
+            "- tapOn:",
+            "    text: \"Chats\"",
+            "    optional: true",
+            "- waitForAnimationToEnd: { timeout: 2000 }",
+            f'- tapOn: \"{_yaml_escape(peer_display_name)}\"',
+            "- waitForAnimationToEnd: { timeout: 2500 }",
+        ]
+        if content is not None:
+            lines += [
+                "- assertVisible:",
+                f'    text: \"{_yaml_escape(content)}\"',
+            ]
+        # The bubble title is present whenever a field-7 attachment
+        # decoded at all.
+        lines += [
+            "- assertVisible:",
+            '    id: "voice_bubble_title"',
+        ]
+        if playable:
+            lines += [
+                "- assertVisible:",
+                '    id: "voice_bubble_play"',
+            ]
+        flow_path = Path(os.environ.get("TMPDIR", "/tmp")) / f"_interop_voice_{os.getpid()}.yaml"
+        flow_path.write_text("\n".join(lines) + "\n")
+        try:
+            _sh(["maestro", "--device", self.udid, "test", str(flow_path)],
+                timeout=timeout + 30)
+        except subprocess.CalledProcessError as e:
+            pytest.fail(
+                f"voice bubble assertion failed (playable={playable}): "
+                f"{(e.output or b'').decode('utf-8', 'replace')[-1200:]}"
+            )
+        finally:
+            flow_path.unlink(missing_ok=True)
+
+    def assert_voice_playback_advances(
+        self,
+        *,
+        content: str,
+        peer_display_name: str = "Anonymous Peer",
+        timeout: float = 25.0,
+    ) -> None:
+        """Tap the voice bubble's play control and assert the player
+        state machine left `.loading` and reached a playable steady
+        state (progress text + play control present). This is the
+        actual decode + AVAudioPlayer exercise: a malformed Ogg granule
+        or undecodable payload surfaces `voice_bubble_unavailable` / an
+        error row instead.
+
+        We do NOT assert audible output (headless sim); we assert the
+        player reached a playable state, which is exactly what the Ogg
+        granule fix changes (granule parse failure vs success).
+        """
+        lines = [
+            'appId: ' + BUNDLE_ID,
+            '---',
+            "- tapOn: { text: \"Allow\", optional: true }",
+            "- tapOn: { text: \"Don't Allow\", optional: true }",
+            "- waitForAnimationToEnd: { timeout: 1500 }",
+        ]
+        lines += self._sheet_dismiss_lines()
+        lines += [
+            "- back",
+            "- waitForAnimationToEnd: { timeout: 800 }",
+            "- back",
+            "- waitForAnimationToEnd: { timeout: 800 }",
+            "- tapOn:",
+            "    text: \"Chats\"",
+            "    optional: true",
+            "- waitForAnimationToEnd: { timeout: 2000 }",
+            f'- tapOn: \"{_yaml_escape(peer_display_name)}\"',
+            "- waitForAnimationToEnd: { timeout: 2500 }",
+            "- assertVisible:",
+            '    id: "voice_bubble_play"',
+            "- tapOn:",
+            '    id: "voice_bubble_play"',
+            "- waitForAnimationToEnd: { timeout: 4000 }",
+            # After prepare+toggle the state is .playing or .paused (a
+            # short clip may have completed). Either way the progress
+            # text is present and no unavailable/error row is shown.
+            "- assertVisible:",
+            '    id: "voice_bubble_progress"',
+            "- assertVisible:",
+            '    id: "voice_bubble_play"',
+        ]
+        flow_path = Path(os.environ.get("TMPDIR", "/tmp")) / f"_interop_voiceplay_{os.getpid()}.yaml"
+        flow_path.write_text("\n".join(lines) + "\n")
+        try:
+            _sh(["maestro", "--device", self.udid, "test", str(flow_path)],
+                timeout=timeout + 30)
+        except subprocess.CalledProcessError as e:
+            pytest.fail(
+                f"voice playback did not reach a playable state: "
+                f"{(e.output or b'').decode('utf-8', 'replace')[-1200:]}"
+            )
+        finally:
+            flow_path.unlink(missing_ok=True)
+
     def _sheet_dismiss_lines() -> list[str]:
         """Steps that dismiss a leftover `PeerContactSheet` if one is
         open, harmlessly no-op if not. The pin flows leave the sheet

--- a/Tests/interop/fixtures/make_voice_fixtures.py
+++ b/Tests/interop/fixtures/make_voice_fixtures.py
@@ -98,31 +98,37 @@ def generate_all(out_dir: str) -> dict:
         info["src"] = "pycodec2"
         manifest[f"c2_{bitrate}"] = info
 
+    # Two Opus fixture sets, because the two matrix directions take
+    # different transport paths:
+    #   * _short (0.25s): iOS->Sideband rides the lxma://test-send deep link,
+    #     and iOS truncates long custom-scheme URLs at a fixed point
+    #     (measured cap ~954B payload; audio_hex is the last param and
+    #     absorbs the cut). 0.25s keeps even the 48k-stereo Maximum under
+    #     that cap while still exercising the Opus container, granules, and
+    #     each profile's rate/channel config.
+    #   * _long (2.0s): Sideband->iOS is mesh-sent (no URL cap), and the
+    #     playback assertion needs the clip still playing when Maestro
+    #     checks the progress row - a sub-second clip finishes before the
+    #     assert runs and the bubble returns to its idle play button.
     opus_profiles = [
         ("opus_medium", 24000, 1, "6k"),    # voiceMedium: 24k mono
         ("opus_high", 48000, 1, "10k"),     # voiceHigh: 48k mono
         ("opus_max", 48000, 2, "16k"),      # voiceMax: 48k stereo
     ]
-    # 0.5s clips: the iOS->Sideband cells ride the lxma://test-send deep link,
-    # and the custom-scheme URL is truncated at a fixed point (~954B payload).
-    # 0.5s keeps every Opus fixture under that cap while still exercising the
-    # Opus container, granules, and rate/channel config. (Codec2 cells use
-    # 2.0s above and already pass byte-identical - they prove the field-7
-    # packing path.)
-    OPUS_SECS = 0.5
     for name, rate, ch, br in opus_profiles:
-        if ch == 2:
-            mono = sine_pcm(rate, OPUS_SECS)
-            stereo = bytearray()
-            for i in range(0, len(mono), 2):
-                stereo += mono[i:i + 2] + mono[i:i + 2]
-            pcm = bytes(stereo)
-        else:
-            pcm = sine_pcm(rate, OPUS_SECS)
-        info = encode_opus(pcm, rate, ch, br, f"{out_dir}/{name}.ogg")
-        info["wire_mode"] = 0x10
-        info["src"] = f"ffmpeg-libopus-{rate}hz-{ch}ch-{OPUS_SECS}s"
-        manifest[name] = info
+        for suffix, secs in (("short", 0.25), ("long", 2.0)):
+            if ch == 2:
+                mono = sine_pcm(rate, secs)
+                stereo = bytearray()
+                for i in range(0, len(mono), 2):
+                    stereo += mono[i:i + 2] + mono[i:i + 2]
+                pcm = bytes(stereo)
+            else:
+                pcm = sine_pcm(rate, secs)
+            info = encode_opus(pcm, rate, ch, br, f"{out_dir}/{name}_{suffix}.ogg")
+            info["wire_mode"] = 0x10
+            info["src"] = f"ffmpeg-libopus-{rate}hz-{ch}ch-{secs}s"
+            manifest[f"{name}_{suffix}"] = info
 
     import json
     with open(f"{out_dir}/manifest.json", "w") as f:

--- a/Tests/interop/fixtures/make_voice_fixtures.py
+++ b/Tests/interop/fixtures/make_voice_fixtures.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Generate voice interop fixtures deterministically.
+
+Codec2 (wire modes 0x04/0x08/0x09): pycodec2 encode of a 2.0s 8k mono
+440 Hz sine, raw frame concatenation - NO header byte, exactly what iOS
+`Codec2RawFile` and Android emit. Byte count is pinned to
+`bytes_per_frame * n_frames`; a deviation fails the build.
+
+Opus (wire mode 0x10): valid Ogg/Opus produced by ffmpeg libopus at each
+iOS profile's rate/channel count. These are small enough to ride the
+`lxma://test-send` deep link (hex param well under iOS's URL cap).
+
+The Ogg granule correctness that makes Sideband playback work is NOT
+produced here - it is produced by iOS's own `OggOpusFileWriter` (outbound
+iOS->Sideband tests exercise that) and by Sideband's own toolchain
+(inbound Sideband->iOS tests use Sideband-originated Ogg, the
+known-good reference). Fixtures here are *inputs* to both directions.
+"""
+import math
+import os
+import struct
+import subprocess
+import sys
+
+import numpy as np
+
+FFMPEG = os.environ.get("FFMPEG", "ffmpeg")
+FFPROBE = os.environ.get("FFPROBE", "ffprobe")
+
+
+def sine_pcm(rate: int, secs: float, freq: float = 440.0, amp: int = 8000) -> bytes:
+    n = int(rate * secs)
+    out = bytearray()
+    for i in range(n):
+        out += struct.pack("<h", int(amp * math.sin(2 * math.pi * freq * i / rate)))
+    return bytes(out)
+
+
+def encode_codec2(samples: bytes, rate: int, bitrate: int, out_path: str) -> dict:
+    import pycodec2
+    c2 = pycodec2.Codec2(int(bitrate))
+    spf = c2.samples_per_frame()
+    bpf = c2.bytes_per_frame()
+    n_samples = len(samples) // 2
+    n_frames = n_samples // spf
+    pcm = np.frombuffer(samples, dtype=np.int16)
+    out = bytearray()
+    for i in range(n_frames):
+        out += c2.encode(pcm[i * spf:(i + 1) * spf])
+    data = bytes(out)
+    expected = bpf * n_frames
+    if len(data) != expected:
+        raise AssertionError(
+            f"codec2_{bitrate}: pycodec2 emitted {len(data)} bytes, "
+            f"expected {expected} (bpf={bpf} x {n_frames} frames)"
+        )
+    with open(out_path, "wb") as f:
+        f.write(data)
+    return {"spf": spf, "bpf": bpf, "frames": n_frames, "bytes": len(data)}
+
+
+def encode_opus(pcm: bytes, rate: int, channels: int, bitrate: str,
+                out_path: str) -> dict:
+    tmp = out_path + ".pcm"
+    with open(tmp, "wb") as f:
+        f.write(pcm)
+    subprocess.run(
+        [FFMPEG, "-hide_banner", "-loglevel", "error", "-y",
+         "-f", "s16le", "-ar", str(rate), "-ac", str(channels), "-i", tmp,
+         "-c:a", "libopus", "-b:a", bitrate, "-application", "voip", out_path],
+        check=True,
+    )
+    os.unlink(tmp)
+    # ffprobe must agree it is a real Ogg/Opus stream (the plan requires
+    # the artifact to be validated before the live matrix counts it).
+    probe = subprocess.run(
+        [FFPROBE, "-hide_banner", "-v", "error", "-show_entries",
+         "format=format_name:stream=codec_name,sample_rate,channels",
+         "-of", "default=nw=1", out_path],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    assert "ogg" in probe.lower(), f"{out_path}: ffprobe format != ogg:\n{probe}"
+    assert "opus" in probe.lower(), f"{out_path}: ffprobe codec != opus:\n{probe}"
+    return {"bytes": os.path.getsize(out_path), "probe": probe.strip()}
+
+
+def generate_all(out_dir: str) -> dict:
+    os.makedirs(out_dir, exist_ok=True)
+    manifest = {}
+
+    codec2_modes = {0x04: 1200, 0x08: 2400, 0x09: 3200}
+    for mode, bitrate in codec2_modes.items():
+        info = encode_codec2(
+            sine_pcm(8000, 2.0), 8000, bitrate,
+            f"{out_dir}/c2_{bitrate}.c2",
+        )
+        info["wire_mode"] = mode
+        info["src"] = "pycodec2"
+        manifest[f"c2_{bitrate}"] = info
+
+    opus_profiles = [
+        ("opus_medium", 24000, 1, "6k"),    # voiceMedium: 24k mono
+        ("opus_high", 48000, 1, "10k"),     # voiceHigh: 48k mono
+        ("opus_max", 48000, 2, "16k"),      # voiceMax: 48k stereo
+    ]
+    for name, rate, ch, br in opus_profiles:
+        if ch == 2:
+            mono = sine_pcm(rate, 2.0)
+            stereo = bytearray()
+            for i in range(0, len(mono), 2):
+                stereo += mono[i:i + 2] + mono[i:i + 2]
+            pcm = bytes(stereo)
+        else:
+            pcm = sine_pcm(rate, 2.0)
+        info = encode_opus(pcm, rate, ch, br, f"{out_dir}/{name}.ogg")
+        info["wire_mode"] = 0x10
+        info["src"] = f"ffmpeg-libopus-{rate}hz-{ch}ch"
+        manifest[name] = info
+
+    import json
+    with open(f"{out_dir}/manifest.json", "w") as f:
+        json.dump(manifest, f, indent=2)
+    return manifest
+
+
+if __name__ == "__main__":
+    out = generate_all(sys.argv[1] if len(sys.argv) > 1 else "fixtures")
+    for name, info in out.items():
+        print(f"{name}: mode=0x{info['wire_mode']:02x} bytes={info['bytes']} src={info['src']}")
+    print(f"\n{len(out)} fixtures -> {sys.argv[1] if len(sys.argv) > 1 else 'fixtures'}/")

--- a/Tests/interop/fixtures/make_voice_fixtures.py
+++ b/Tests/interop/fixtures/make_voice_fixtures.py
@@ -103,18 +103,25 @@ def generate_all(out_dir: str) -> dict:
         ("opus_high", 48000, 1, "10k"),     # voiceHigh: 48k mono
         ("opus_max", 48000, 2, "16k"),      # voiceMax: 48k stereo
     ]
+    # 0.5s clips: the iOS->Sideband cells ride the lxma://test-send deep link,
+    # and the custom-scheme URL is truncated at a fixed point (~954B payload).
+    # 0.5s keeps every Opus fixture under that cap while still exercising the
+    # Opus container, granules, and rate/channel config. (Codec2 cells use
+    # 2.0s above and already pass byte-identical - they prove the field-7
+    # packing path.)
+    OPUS_SECS = 0.5
     for name, rate, ch, br in opus_profiles:
         if ch == 2:
-            mono = sine_pcm(rate, 2.0)
+            mono = sine_pcm(rate, OPUS_SECS)
             stereo = bytearray()
             for i in range(0, len(mono), 2):
                 stereo += mono[i:i + 2] + mono[i:i + 2]
             pcm = bytes(stereo)
         else:
-            pcm = sine_pcm(rate, 2.0)
+            pcm = sine_pcm(rate, OPUS_SECS)
         info = encode_opus(pcm, rate, ch, br, f"{out_dir}/{name}.ogg")
         info["wire_mode"] = 0x10
-        info["src"] = f"ffmpeg-libopus-{rate}hz-{ch}ch"
+        info["src"] = f"ffmpeg-libopus-{rate}hz-{ch}ch-{OPUS_SECS}s"
         manifest[name] = info
 
     import json

--- a/Tests/interop/fixtures/make_voice_fixtures.py
+++ b/Tests/interop/fixtures/make_voice_fixtures.py
@@ -106,17 +106,21 @@ def generate_all(out_dir: str) -> dict:
     #     absorbs the cut). 0.25s keeps even the 48k-stereo Maximum under
     #     that cap while still exercising the Opus container, granules, and
     #     each profile's rate/channel config.
-    #   * _long (2.0s): Sideband->iOS is mesh-sent (no URL cap), and the
+    #   * _long (6.0s): Sideband->iOS is mesh-sent (no URL cap), and the
     #     playback assertion needs the clip still playing when Maestro
-    #     checks the progress row - a sub-second clip finishes before the
-    #     assert runs and the bubble returns to its idle play button.
+    #     checks the progress row. Measured: a 2.0s clip finishes before
+    #     the optional progress tap + assert run (the bubble returns to
+    #     its idle play button and the assert false-negatives); a 4.0s
+    #     clip provably reaches the progress row mid-playback (live
+    #     hierarchy diagnostic, 2026-09-01). 6.0s leaves a comfortable
+    #     ~3.5s window for Maestro's tap + assert round-trip.
     opus_profiles = [
         ("opus_medium", 24000, 1, "6k"),    # voiceMedium: 24k mono
         ("opus_high", 48000, 1, "10k"),     # voiceHigh: 48k mono
         ("opus_max", 48000, 2, "16k"),      # voiceMax: 48k stereo
     ]
     for name, rate, ch, br in opus_profiles:
-        for suffix, secs in (("short", 0.25), ("long", 2.0)):
+        for suffix, secs in (("short", 0.25), ("long", 6.0)):
             if ch == 2:
                 mono = sine_pcm(rate, secs)
                 stereo = bytearray()

--- a/Tests/interop/test_voice.py
+++ b/Tests/interop/test_voice.py
@@ -1,0 +1,211 @@
+"""iOS-Columba ⇄ Sideband interop matrix for LXMF FIELD_AUDIO (0x07).
+
+Mirrors test_attachments.py but for the voice-message field, per the
+plan's Section 9 target matrix:
+
+  | iOS Columba | Sideband | 1200/2400/3200 | every Opus profile |
+  | Sideband    | iOS      | 1200/2400/3200 | every Opus profile |
+
+The load-bearing cell (plan §4.1) is Sideband→iOS **Opus**: Sideband's
+LXST/libopusfile path rejects Ogg with packet-start granules, so a
+Sideband-toolchain Ogg that iOS decodes and plays end-to-end proves the
+inbound Ogg/Opus path against the real reference. The outbound
+iOS→Sideband Ogg granule fix is pinned separately by
+OggOpusFileWriterTests (unit) and by Sideband capturing the iOS Ogg
+byte-for-byte (wire half) below.
+
+Fixtures are generated at runtime (fixtures/make_voice_fixtures.py):
+  - Codec2: pycodec2 raw frame concatenation (no header byte), exactly
+    what iOS Codec2RawFile and Android emit.
+  - Opus: ffmpeg libopus at each iOS profile's rate/channel count.
+Both artifact types are ffprobe-validated before the matrix runs, per
+the plan.
+
+Run with:
+    cd Tests/interop
+    ~/.reticulum-host/venv/bin/pytest -v test_voice.py
+"""
+
+from __future__ import annotations
+import time
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).parent
+sys_path_added = False
+import sys
+if str(HERE / "fixtures") not in sys.path:
+    sys.path.insert(0, str(HERE / "fixtures"))
+    sys_path_added = True
+
+from make_voice_fixtures import generate_all  # noqa: E402
+
+# Wire modes (LxmfFields.AM_*).
+AM_CODEC2_1200 = 0x04
+AM_CODEC2_2400 = 0x08
+AM_CODEC2_3200 = 0x09
+AM_OPUS_OGG = 0x10
+FIELD_AUDIO = 0x07
+
+
+@pytest.fixture(scope="module")
+def voice_fixtures(tmp_path_factory) -> Path:
+    """Generate the fixtures once per module run; return the directory."""
+    d = tmp_path_factory.mktemp("voice_fixtures")
+    generate_all(str(d))
+    return d
+
+
+def _fix(voice_fixtures: Path, name: str, ext: str) -> bytes:
+    return (voice_fixtures / f"{name}.{ext}").read_bytes()
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# iOS → Sideband (iOS produces the field-7 payload; Sideband must capture
+# it with the matching mode + byte-for-byte payload).
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _assert_audio_field(lxm, *, expected_mode: int, expected_bytes: bytes) -> None:
+    """Sideband-side assertion that the inbound FIELD_AUDIO matches what
+    iOS sent. The mode slot may arrive as any signed/unsigned int after
+    the msgpack round-trip; the payload must be byte-identical."""
+    assert FIELD_AUDIO in lxm.fields, f"FIELD_AUDIO missing: fields={sorted(lxm.fields.keys())}"
+    field = lxm.fields[FIELD_AUDIO]
+    assert isinstance(field, list) and len(field) == 2, f"FIELD_AUDIO shape wrong: {field!r}"
+    mode = int(field[0])
+    assert mode == expected_mode, f"audio mode mismatch: 0x{mode:02x} != 0x{expected_mode:02x}"
+    data = field[1] if isinstance(field[1], (bytes, bytearray)) else bytes(field[1])
+    assert bytes(data) == expected_bytes, (
+        f"audio payload mismatch: got {len(data)}B, expected {len(expected_bytes)}B"
+    )
+
+
+@pytest.mark.parametrize("name,mode", [
+    ("c2_1200", AM_CODEC2_1200),
+    ("c2_2400", AM_CODEC2_2400),
+    ("c2_3200", AM_CODEC2_3200),
+])
+def test_codec2_ios_to_sideband(sim, sideband, voice_fixtures, name, mode):
+    """iOS sends a Codec2 voice note; Sideband captures field 7 with the
+    exact mode and byte-identical raw-frame payload."""
+    payload = _fix(voice_fixtures, name, "c2")
+    body = f"v-c2-{name}-{int(time.time() * 1000)}"
+    result = sim.test_send(
+        to_hex=sideband.identity_hex,
+        content=body,
+        method="opportunistic",
+        audio_bytes=payload,
+        audio_mode=mode,
+    )
+    assert result.error is None, f"iOS-side send failed: {result.error}"
+    assert result.sent_hash_hex, "iOS didn't surface a message hash"
+    lxm = sideband.wait_for_tapped_message(
+        from_hex=sim.lxmf_delivery_hex,
+        field_id=FIELD_AUDIO,
+        content_match=body,
+        timeout=30.0,
+    )
+    assert lxm.signature_validated, "Sideband couldn't verify iOS's signature"
+    assert lxm.hash.hex() == result.sent_hash_hex
+    _assert_audio_field(lxm, expected_mode=mode, expected_bytes=payload)
+
+
+def test_opus_ios_to_sideband(sim, sideband, voice_fixtures):
+    """iOS sends a Medium-Quality (24k mono) Ogg/Opus note; Sideband must
+    capture field 7 with mode 0x10 and the byte-identical Ogg. Sideband
+    persisting the Ogg without error is the wire half of the granule-fix
+    story (the decode half is pinned by OggOpusFileWriterTests + the
+    Sideband→iOS Opus cell below)."""
+    payload = _fix(voice_fixtures, "opus_medium", "ogg")
+    body = f"v-opus-medium-{int(time.time() * 1000)}"
+    result = sim.test_send(
+        to_hex=sideband.identity_hex,
+        content=body,
+        method="opportunistic",
+        audio_bytes=payload,
+        audio_mode=AM_OPUS_OGG,
+    )
+    assert result.error is None, f"iOS-side send failed: {result.error}"
+    lxm = sideband.wait_for_tapped_message(
+        from_hex=sim.lxmf_delivery_hex,
+        field_id=FIELD_AUDIO,
+        content_match=body,
+        timeout=30.0,
+    )
+    _assert_audio_field(lxm, expected_mode=AM_OPUS_OGG, expected_bytes=payload)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Sideband → iOS (Sideband produces the field-7 payload; iOS must persist
+# it AND render a playable voice bubble).
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("name,mode", [
+    ("c2_1200", AM_CODEC2_1200),
+    ("c2_2400", AM_CODEC2_2400),
+    ("c2_3200", AM_CODEC2_3200),
+])
+def test_codec2_sideband_to_ios(sim, sideband, voice_fixtures, name, mode):
+    """Sideband sends a Codec2 voice note; iOS persists it and the bubble
+    renders a playable play-control (not the 'unavailable' state)."""
+    payload = _fix(voice_fixtures, name, "c2")
+    body = f"v-c2-{name}-from-sideband-{int(time.time() * 1000)}"
+    assert sideband.send_audio(
+        dest_hex=sim.lxmf_delivery_hex,
+        content=body,
+        audio_bytes=payload,
+        codec_tag=mode,
+    ), "Sideband-side send_audio returned False"
+    _wait_for_diag_inbound(sim, sideband, content=body)
+    sim.assert_voice_bubble_visible(content=body, playable=True)
+
+
+@pytest.mark.parametrize("name", ["opus_medium", "opus_high", "opus_max"])
+def test_opus_sideband_to_ios(sim, sideband, voice_fixtures, name):
+    """Sideband sends an Ogg/Opus note (Sideband toolchain's ffmpeg
+    output); iOS must decode it and render a PLAYABLE voice bubble. This
+    is the load-bearing cell of the plan's interop matrix - the exact
+    path that failed on Android before the granule fix. A malformed
+    granule would surface voice_bubble_unavailable/error, not the play
+    control."""
+    payload = _fix(voice_fixtures, name, "ogg")
+    body = f"v-opus-{name}-from-sideband-{int(time.time() * 1000)}"
+    assert sideband.send_audio(
+        dest_hex=sim.lxmf_delivery_hex,
+        content=body,
+        audio_bytes=payload,
+        codec_tag=AM_OPUS_OGG,
+    ), "Sideband-side send_audio returned False"
+    _wait_for_diag_inbound(sim, sideband, content=body)
+    sim.assert_voice_bubble_visible(content=body, playable=True)
+    # Playback state: tap the play control and confirm the progress text
+    # advances (or the state leaves .loading) without an error. This is
+    # the actual decode + AVAudioPlayer exercise.
+    sim.assert_voice_playback_advances(content=body, timeout=25.0)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# helpers
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _wait_for_diag_inbound(sim, sideband, *, content: str, timeout: float = 30.0) -> None:
+    """Same correlation as test_attachments._wait_for_diag_inbound, but
+    inlined so this module is self-contained."""
+    expected_len = len(content.encode("utf-8"))
+    source8 = sideband.identity_hex[:8]
+    before_size = sim.diag_log.stat().st_size if sim.diag_log.exists() else 0
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        for line in sim._read_diag_since(before_size):
+            if (f"[RNS] inbound source={source8} " in line
+                    and f"len={expected_len} " in line):
+                return
+        time.sleep(0.4)
+    pytest.fail(
+        f"iOS didn't record inbound (source={source8} len={expected_len}) "
+        f"within {timeout}s"
+    )

--- a/Tests/interop/test_voice.py
+++ b/Tests/interop/test_voice.py
@@ -33,11 +33,9 @@ from pathlib import Path
 import pytest
 
 HERE = Path(__file__).parent
-sys_path_added = False
 import sys
 if str(HERE / "fixtures") not in sys.path:
     sys.path.insert(0, str(HERE / "fixtures"))
-    sys_path_added = True
 
 from make_voice_fixtures import generate_all  # noqa: E402
 
@@ -112,14 +110,16 @@ def test_codec2_ios_to_sideband(sim, sideband, voice_fixtures, name, mode):
     _assert_audio_field(lxm, expected_mode=mode, expected_bytes=payload)
 
 
-def test_opus_ios_to_sideband(sim, sideband, voice_fixtures):
-    """iOS sends a Medium-Quality (24k mono) Ogg/Opus note; Sideband must
-    capture field 7 with mode 0x10 and the byte-identical Ogg. Sideband
-    persisting the Ogg without error is the wire half of the granule-fix
-    story (the decode half is pinned by OggOpusFileWriterTests + the
-    Sideband→iOS Opus cell below)."""
-    payload = _fix(voice_fixtures, "opus_medium", "ogg")
-    body = f"v-opus-medium-{int(time.time() * 1000)}"
+@pytest.mark.parametrize("name", ["opus_medium", "opus_high", "opus_max"])
+def test_opus_ios_to_sideband(sim, sideband, voice_fixtures, name):
+    """iOS sends an Ogg/Opus note at one of the three Opus profile
+    rates (24k mono / 48k mono / 48k stereo); Sideband must capture
+    field 7 with mode 0x10 and the byte-identical Ogg. Sideband
+    persisting the Ogg without error is the wire half of the
+    granule-fix story (the decode half is pinned by
+    OggOpusFileWriterTests + the Sideband->iOS Opus cells below)."""
+    payload = _fix(voice_fixtures, name, "ogg")
+    body = f"v-opus-{name}-{int(time.time() * 1000)}"
     result = sim.test_send(
         to_hex=sideband.identity_hex,
         content=body,
@@ -128,12 +128,15 @@ def test_opus_ios_to_sideband(sim, sideband, voice_fixtures):
         audio_mode=AM_OPUS_OGG,
     )
     assert result.error is None, f"iOS-side send failed: {result.error}"
+    assert result.sent_hash_hex, "iOS didn't surface a message hash"
     lxm = sideband.wait_for_tapped_message(
         from_hex=sim.lxmf_delivery_hex,
         field_id=FIELD_AUDIO,
         content_match=body,
         timeout=30.0,
     )
+    assert lxm.signature_validated, "Sideband couldn't verify iOS's signature"
+    assert lxm.hash.hex() == result.sent_hash_hex
     _assert_audio_field(lxm, expected_mode=AM_OPUS_OGG, expected_bytes=payload)
 
 

--- a/Tests/interop/test_voice.py
+++ b/Tests/interop/test_voice.py
@@ -110,16 +110,22 @@ def test_codec2_ios_to_sideband(sim, sideband, voice_fixtures, name, mode):
     _assert_audio_field(lxm, expected_mode=mode, expected_bytes=payload)
 
 
-@pytest.mark.parametrize("name", ["opus_medium", "opus_high", "opus_max"])
+@pytest.mark.parametrize("name", ["opus_medium_short", "opus_high_short", "opus_max_short"])
 def test_opus_ios_to_sideband(sim, sideband, voice_fixtures, name):
     """iOS sends an Ogg/Opus note at one of the three Opus profile
     rates (24k mono / 48k mono / 48k stereo); Sideband must capture
     field 7 with mode 0x10 and the byte-identical Ogg. Sideband
     persisting the Ogg without error is the wire half of the
     granule-fix story (the decode half is pinned by
-    OggOpusFileWriterTests + the Sideband->iOS Opus cells below)."""
+    OggOpusFileWriterTests + the Sideband->iOS Opus cells below).
+
+    The `_short` (0.25s) fixture is used because this direction rides
+    the lxma://test-send deep link, which truncates long custom-scheme
+    URLs (a 1757B/3065B Ogg both arrived at ~954B); 0.25s keeps every
+    profile under the cap while still exercising the Opus container,
+    granules, and rate/channel config."""
     payload = _fix(voice_fixtures, name, "ogg")
-    body = f"v-opus-{name}-{int(time.time() * 1000)}"
+    body = f"v-{name}-{int(time.time() * 1000)}"
     result = sim.test_send(
         to_hex=sideband.identity_hex,
         content=body,
@@ -152,8 +158,9 @@ def test_opus_ios_to_sideband(sim, sideband, voice_fixtures, name):
     ("c2_3200", AM_CODEC2_3200),
 ])
 def test_codec2_sideband_to_ios(sim, sideband, voice_fixtures, name, mode):
-    """Sideband sends a Codec2 voice note; iOS persists it and the bubble
-    renders a playable play-control (not the 'unavailable' state)."""
+    """Sideband sends a Codec2 voice note; iOS persists it, renders a
+    playable voice bubble, and actually plays it (the player decodes the
+    raw frames to a temp WAV and reaches the progress row)."""
     payload = _fix(voice_fixtures, name, "c2")
     body = f"v-c2-{name}-from-sideband-{int(time.time() * 1000)}"
     assert sideband.send_audio(
@@ -164,18 +171,25 @@ def test_codec2_sideband_to_ios(sim, sideband, voice_fixtures, name, mode):
     ), "Sideband-side send_audio returned False"
     _wait_for_diag_inbound(sim, sideband, content=body)
     sim.assert_voice_bubble_visible(content=body, playable=True)
+    sim.assert_voice_playback_advances(content=body, timeout=25.0)
 
 
-@pytest.mark.parametrize("name", ["opus_medium", "opus_high", "opus_max"])
+@pytest.mark.parametrize("name", ["opus_medium_long", "opus_high_long", "opus_max_long"])
 def test_opus_sideband_to_ios(sim, sideband, voice_fixtures, name):
     """Sideband sends an Ogg/Opus note (Sideband toolchain's ffmpeg
-    output); iOS must decode it and render a PLAYABLE voice bubble. This
-    is the load-bearing cell of the plan's interop matrix - the exact
+    output); iOS must decode it and render a PLAYABLE voice bubble, and
+    the player must reach the progress row without an error. This is
+    the load-bearing cell of the plan's interop matrix - the exact
     path that failed on Android before the granule fix. A malformed
     granule would surface voice_bubble_unavailable/error, not the play
-    control."""
+    control or progress row.
+
+    The `_long` (2.0s) fixture is used because the playback assertion
+    needs the clip still playing when Maestro checks the progress row;
+    a sub-second clip finishes first and the bubble returns to its idle
+    play button."""
     payload = _fix(voice_fixtures, name, "ogg")
-    body = f"v-opus-{name}-from-sideband-{int(time.time() * 1000)}"
+    body = f"v-{name}-from-sideband-{int(time.time() * 1000)}"
     assert sideband.send_audio(
         dest_hex=sim.lxmf_delivery_hex,
         content=body,

--- a/Tests/static/test_voice_messages.py
+++ b/Tests/static/test_voice_messages.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Static contract: iOS voice-message parity (issue #168).
+
+Pins, at the grep level, the load-bearing pieces of the port so a wording
+drift, a lost dual-write, a lost retry rehydration, or an unregistered
+`Voice/` source file fails CI before it ships:
+
+  1. Every Section-3 picker/panel/bubble string is present in
+     `Sources/ColumbaApp/Resources/Localizable.xcstrings` with the EXACT
+     Android `strings.xml` value (assert the literal, so a wording drift
+     fails). The two parameterized keys use the iOS `%@` form (the plan's
+     deterministic-key rule).
+  2. The composer mic button exists with a11y id `voice_message_button` and
+     the exact label "Record a voice message" in `MessageInputBar.swift`.
+  3. The outbound path writes field 7 (FIELD_AUDIO) into BOTH the local
+     `LXMessage.fields` (so reload preserves the audio) AND the typed
+     `OutboundSendRequest.audioAttachment` (the wire), in
+     `MessagingViewModel.swift` (the plan's dual-write guard). The plan's
+     "extraFields" slot is the typed `RnsAudio` parameter here, because the
+     app's `[UInt8: Data]` extraFields cannot carry the `[mode_int, bytes]`
+     shape; the guard checks both write sites.
+  4. The retry path rehydrates the audio attachment (plan Section 4.5):
+     `retryMessage` passes `failedMessage.audioAttachment` into
+     `sendMessage`.
+  5. Every new `Sources/ColumbaApp/Voice/*.swift` file is registered in
+     `Columba.xcodeproj` (PBXFileReference + the two app targets' Sources
+     phases). An unregistered file compiles into nothing (hand-maintained
+     pbxproj, no folder sync), so disk presence is not build presence.
+"""
+
+import json
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+XCSTRINGS = ROOT / "Sources/ColumbaApp/Resources/Localizable.xcstrings"
+INPUT_BAR = ROOT / "Sources/ColumbaApp/Views/Messaging/MessageInputBar.swift"
+VIEW_MODEL = ROOT / "Sources/ColumbaApp/ViewModels/MessagingViewModel.swift"
+PBXPROJ = ROOT / "Columba.xcodeproj/project.pbxproj"
+VOICE_DIR = ROOT / "Sources/ColumbaApp/Voice"
+
+FIELD_AUDIO = "FIELD_AUDIO"
+
+# Section 3 of the parity plan - EXACT Android values (the two parameterized
+# keys in their iOS %@ form).
+SECTION3_STRINGS = [
+    # Picker (the "exact same text" strings)
+    "Select Voice Message Quality",
+    "Choose the recording format and bandwidth",
+    "Record",
+    "Codec2 1200",
+    "Very low bandwidth voice",
+    "Codec2 2400",
+    "Low bandwidth voice",
+    "Codec2 3200",
+    "Clearer speech at low bandwidth",
+    "Medium Quality",
+    "Opus 8 kbps mono - good balance of quality and bandwidth",
+    "High Quality",
+    "Opus 16 kbps mono - higher fidelity audio",
+    "Maximum Quality",
+    "Opus 32 kbps stereo - best audio, requires more bandwidth",
+    # Composer / panel
+    "Voice",
+    "Record a voice message",
+    "Voice message",
+    "Start recording",
+    "Stop recording",
+    "Cancel recording",
+    "Remove recording",
+    "Microphone permission is required to record a voice message.",
+    "Voice messages are not supported on this device.",
+    "Recording",
+    "Finalizing",
+    "Selected voice message",
+    "Recording error: %@",
+    "Ready to record a voice message",
+    "Grant microphone access",
+    "Microphone access is disabled. Enable it in app settings.",
+    "Open settings",
+    "Voice recording is unavailable during a call.",
+    # Bubble / player
+    "Play voice message",
+    "Pause voice message",
+    "Loading voice message",
+    "Voice message unavailable",
+    "Unsupported voice message",
+    "%@ of %@",
+    "Unable to play voice message",
+]
+
+
+def _catalog() -> dict:
+    data = json.loads(XCSTRINGS.read_text(encoding="utf-8"))
+    return data["strings"]
+
+
+class VoiceStringsContract(unittest.TestCase):
+    def test_section3_strings_present_with_exact_values(self):
+        strings = _catalog()
+        missing = [s for s in SECTION3_STRINGS if s not in strings]
+        self.assertEqual(
+            missing, [],
+            f"missing Section-3 strings in Localizable.xcstrings: {missing}",
+        )
+        for s in SECTION3_STRINGS:
+            entry = strings[s]
+            en = entry["localizations"]["en"]["stringUnit"]
+            self.assertEqual(
+                en["value"], s,
+                f"catalog value drifted for {s!r}: {en['value']!r}",
+            )
+
+
+class MicButtonContract(unittest.TestCase):
+    def test_mic_button_a11y_id_and_label(self):
+        src = INPUT_BAR.read_text(encoding="utf-8")
+        self.assertIn('accessibilityIdentifier("voice_message_button")', src)
+        self.assertIn('String(localized: "Record a voice message")', src)
+
+
+class DualWriteContract(unittest.TestCase):
+    """Field 7 must be written into BOTH the local LXMessage.fields (reload)
+    and the typed OutboundSendRequest.audioAttachment (wire)."""
+
+    def setUp(self):
+        self.src = VIEW_MODEL.read_text(encoding="utf-8")
+
+    def test_local_fields_field_audio_write(self):
+        # `fields[LXMessage.FIELD_AUDIO] = ...` inside sendMessage, sourced
+        # from the audio attachment (the [mode_int, bytes] wire shape).
+        self.assertRegex(
+            self.src,
+            r"fields\[LXMessage\.FIELD_AUDIO\]\s*=\s*audioAttachment\.fieldValue",
+            "field 7 is not written into the local LXMessage.fields",
+        )
+
+    def test_outbound_request_audio_attachment(self):
+        # The typed wire param: OutboundSendRequest.audioAttachment is built
+        # from the attachment as RnsAudio(mode:, bytes:) at both send sites
+        # (direct + relay-retry).
+        hits = re.findall(
+            r"audioAttachment:\s*audioAttachment\.map\s*\{\s*RnsAudio\(mode:\s*Int\(\$0\.mode\.rawValue\),\s*bytes:\s*\$0\.bytes\)\s*\}",
+            self.src,
+        )
+        self.assertGreaterEqual(
+            len(hits), 2,
+            "OutboundSendRequest must carry the audioAttachment (RnsAudio) at "
+            f"the direct and relay-retry send sites; found {len(hits)}",
+        )
+
+    def test_sendoutbound_threads_audio_to_backend(self):
+        self.assertRegex(
+            self.src,
+            r"audioAttachment:\s*request\.audioAttachment",
+            "sendOutbound does not thread audioAttachment into sendLxmfMessage",
+        )
+
+    def test_optimistic_and_failed_messages_carry_audio(self):
+        # Both the optimistic bubble and the failed-row reconstruction must
+        # carry the attachment so in-memory retry rehydrates field 7.
+        hits = re.findall(
+            r"audioAttachment:\s*audioAttachment\s*,\s*\n\s*replyToId:\s*replyToId",
+            self.src,
+        )
+        self.assertGreaterEqual(
+            len(hits), 2,
+            "the Message(...) optimistic + failed-row constructions must carry "
+            f"audioAttachment; found {len(hits)}",
+        )
+
+
+class RetryRehydrationContract(unittest.TestCase):
+    def test_retry_passes_audio_attachment(self):
+        src = VIEW_MODEL.read_text(encoding="utf-8")
+        # retryMessage calls sendMessage twice (staged-recovery path +
+        # direct path); both must pass failedMessage.audioAttachment.
+        hits = re.findall(
+            r"audioAttachment:\s*failedMessage\.audioAttachment", src
+        )
+        self.assertGreaterEqual(
+            len(hits), 2,
+            f"retryMessage must rehydrate audioAttachment in both sendMessage "
+            f"calls; found {len(hits)}",
+        )
+
+
+class PbxprojRegistrationContract(unittest.TestCase):
+    def test_all_voice_files_registered(self):
+        files = sorted(p.name for p in VOICE_DIR.glob("*.swift"))
+        self.assertGreaterEqual(len(files), 12, f"expected >=12 Voice files, got {len(files)}")
+        src = PBXPROJ.read_text(encoding="utf-8")
+        problems = []
+        for name in files:
+            refs = len(re.findall(
+                r"isa = PBXFileReference; lastKnownFileType = sourcecode\.swift; path = "
+                + re.escape(name) + r";", src))
+            builds = len(re.findall(
+                r"/\* " + re.escape(name) + r" in Sources \*/ = \{isa = PBXBuildFile", src))
+            phases = len(re.findall(
+                r"\t\t\t\t[0-9A-Za-z]+ /\* " + re.escape(name) + r" in Sources \*/,$",
+                src, re.M))
+            if refs != 1:
+                problems.append(f"{name}: file references = {refs} (want 1)")
+            if builds != 2:
+                problems.append(f"{name}: build files = {builds} (want 2, one per app target)")
+            if phases != 2:
+                problems.append(f"{name}: phase entries = {phases} (want 2, one per app target)")
+        self.assertEqual(
+            problems, [],
+            "unregistered Voice/ files would compile into nothing:\n  "
+            + "\n  ".join(problems),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What this PR does

Implements voice messages for Columba iOS (Codec2 + Ogg/Opus) with Android parity, fixing outbound/inbound interop so voice messages recorded on iOS play correctly on Android Columba and Sideband, and vice versa.

### Outbound interop (iOS -> Android/Sideband)
- `OggOpusFileWriter`: every Ogg page now carries version byte 0 (was 0x02 on some pages), producing files that Android and Sideband accept.
- Inbound messages that fail AVFoundation validation are re-muxed to one-packet-per-page (`OggOpusInboundNormalizer`) before playback, so rejected-but-valid Opus streams play.

### Amplitude waveform (Android parity)
- `OggOpusWaveform`: real per-bucket RMS waveform decode via AVAudioFile (pure math in `OggOpusInboundNormalizer.peaksFromEnergy`, same 0.12 + (1-0.12)*(rms/peak)^0.7 curve as `AndroidPcmWaveformReader`).
- Async, single-flighted, cached, fail-open decode in `VoiceMessagePlayer` - playback never waits on waveform decode; computed on bubble `onAppear`.

### Layout + playback regression fixes
- `VoiceWaveformBars`: fixed 178pt intrinsic width replaced with flexible GeometryReader fill (Android `weight(1f)` equivalent) - the fixed width overflowed voice rows, wrapping the progress text (taller bubbles) and re-anchoring the scroll on play-tap.
- `VoiceMessagePlayer`: sets `AVAudioSession` to `.playback` and activates before playback. The recorder leaves `.playAndRecord`, which the mute switch silences - this made playback inaudible with `isPlaying=true` on both Ogg/Opus and Codec2. Guarded so an active call is not clobbered; privacy-safe `[VOICE-SESSION]` route/volume diagnostic added.

## Verification
- Focused unit tests: 32/32 green (writer, metadata, normalizer, player, waveform suites)
- Static contract suite: 337 passed, 1 skipped
- Device-verified on physical iPhone: real bars render at correct amplitudes; normal bubble height; tap-play no longer re-anchors the scroll; audio audible on Ogg/Opus and Codec2 after the `.playback` session fix; Sideband interop confirmed on device.
- Real-artifact harness: 5/5 real Ogg files decoded to non-uniform 40-bar waveforms in 2-13 ms; Sideband-HQ file REJECTED by AVAudioPlayer renders PLAYING after re-mux.

Closes #168