### PR TITLE
feat(ios): interface discovery + Network Status discovery UX (issue #193)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,7 +82,8 @@ jobs:
             Tests.static.test_nomadnet_text_selection \
             Tests.static.test_ui_screenshotter_readiness \
             Tests.static.test_collect_maestro_screenshots \
-            Tests.static.test_voice_messages
+            Tests.static.test_voice_messages \
+            Tests.static.test_discovered_interfaces_contract
 
       # Verify a standalone production-layout app before xcodebuild test embeds
       # ColumbaAppTests.xctest under PlugIns in its hosted test copy.

--- a/Columba.xcodeproj/project.pbxproj
+++ b/Columba.xcodeproj/project.pbxproj
@@ -422,6 +422,7 @@
 		VBMR0 /* VoiceWaveformBars.swift in Sources */ = {isa = PBXBuildFile; fileRef = V0CR0 /* VoiceWaveformBars.swift */; };
 		A4EA60E22E1A3A65C6AFA5E7 /* OneShotLocationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = E284643CB4F95B1B3DBA965B /* OneShotLocationProvider.swift */; };
 		099A0C66CE2C1444E52912D0 /* DiscoveredInterfacesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D8D7406682429BCE36865C3 /* DiscoveredInterfacesViewModel.swift */; };
+		8ECF8834E8FE33D8455E3B42 /* DiscoveredInterfacesScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6CAE98185D8B2D41D2ACA7E /* DiscoveredInterfacesScreen.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -709,6 +710,7 @@
 		V0CR0 /* VoiceWaveformBars.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceWaveformBars.swift; sourceTree = "<group>"; };
 		E284643CB4F95B1B3DBA965B /* OneShotLocationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OneShotLocationProvider.swift; sourceTree = "<group>"; };
 		4D8D7406682429BCE36865C3 /* DiscoveredInterfacesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoveredInterfacesViewModel.swift; sourceTree = "<group>"; };
+		F6CAE98185D8B2D41D2ACA7E /* DiscoveredInterfacesScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoveredInterfacesScreen.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1058,6 +1060,7 @@
 				F017 /* MyIdentityView.swift */,
 				F018 /* ExpandableSettingsCard.swift */,
 				F031 /* InterfaceManagementScreen.swift */,
+				F6CAE98185D8B2D41D2ACA7E /* DiscoveredInterfacesScreen.swift */,
 				F035 /* NetworkStatusView.swift */,
 				BGTF /* BackgroundTransportView.swift */,
 				F038 /* IconPickerView.swift */,
@@ -1718,6 +1721,7 @@
 				33E0E91CAEFB07F13C04637D /* SwiftRNSBackend.swift in Sources */,
 				6965E7A95909A97BDBA20535 /* NomadNetFetch.swift in Sources */,
 				4A784BAFF47E7074DAD6F9D2 /* ModelBInboundReplay.swift in Sources */,
+				8ECF8834E8FE33D8455E3B42 /* DiscoveredInterfacesScreen.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1913,6 +1917,7 @@
 				55F3BF7D600C32E07B7B8C26 /* TCPClientWizard.swift in Sources */,
 				F4E9991226B4D464017DA247 /* Lucide.swift in Sources */,
 				1FC4483D48CABE8BF49850EF /* SyncStatusBottomSheet.swift in Sources */,
+				8ECF8834E8FE33D8455E3B42 /* DiscoveredInterfacesScreen.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Columba.xcodeproj/project.pbxproj
+++ b/Columba.xcodeproj/project.pbxproj
@@ -156,6 +156,7 @@
 		238336F8024494A8B57F9419 /* CeaseTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF48C97880B30682DC35613C /* CeaseTelemetry.swift */; };
 		266929D6972E8D373E7A926D /* ReticulumSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 021FA3D73B6F8B711A97D40F /* ReticulumSwift */; };
 		26D564FAEE8E3C750E8E2442 /* PythonConfigWriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C8CFC274AF9EF63E9A75238 /* PythonConfigWriterTests.swift */; };
+		2BD6F16BEA0EC587E6433034 /* DiscoveredInterfaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8ACAE7518CFD5E0C149B9F /* DiscoveredInterfaceTests.swift */; };
 		26D6E3545012268714C637D9 /* ThemeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F065 /* ThemeManager.swift */; };
 		2AFE85F0CA5EFEDF75A7C1E5 /* IncomingCallScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D4C54CECCAF0B117FB6C197 /* IncomingCallScreen.swift */; };
 		2B3A3E3FB59D1E22B424E109 /* AudioRingBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE307E24C72DBA41D76C9A6C /* AudioRingBufferTests.swift */; };
@@ -542,6 +543,7 @@
 		D001472BC7DFD3CD7BF27F0C /* app */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; path = app; sourceTree = "<group>"; };
 		D33D0252383165C6829D2767 /* ColumbaModelBAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ColumbaModelBAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D691F2029BDC2C1024AA9B01 /* VoiceCallScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VoiceCallScreen.swift; sourceTree = "<group>"; };
+		DB8ACAE7518CFD5E0C149B9F /* DiscoveredInterfaceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DiscoveredInterfaceTests.swift; sourceTree = "<group>"; };
 		DA586EB5F8EB62D2579CEAAB /* Lucide.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Lucide.swift; sourceTree = "<group>"; };
 		DE307E24C72DBA41D76C9A6C /* AudioRingBufferTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudioRingBufferTests.swift; sourceTree = "<group>"; };
 		E4AB432DD1264CAE1F35B22A /* JetBrainsMono-Regular.ttf */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; path = "JetBrainsMono-Regular.ttf"; sourceTree = "<group>"; };
@@ -1157,6 +1159,7 @@
 			CHF001 /* CallHistoryFormattingTests.swift */,
 			CHRT01 /* CallHistoryRepositoryTests.swift */,
 				B9DA888204CA742BD1403A51 /* DirectionsLauncherTests.swift */,
+				DB8ACAE7518CFD5E0C149B9F /* DiscoveredInterfaceTests.swift */,
 				AB56A9C5F062142B6EF61DA2 /* PeerLocationRemovalTests.swift */,
 				A1B2C3D4E5F60718293A4B5D /* MessageBubbleLayoutTests.swift */,
 				APVT001 /* MessageAttachmentPreviewTests.swift */,
@@ -1927,6 +1930,7 @@
 			files = (
 				47B4E413633097429123BC2F /* PeerLocationRemovalTests.swift in Sources */,
 				E4FCBD54560B74AC8CCB1C91 /* DirectionsLauncherTests.swift in Sources */,
+				2BD6F16BEA0EC587E6433034 /* DiscoveredInterfaceTests.swift in Sources */,
 				CC067EE77A33341C829CBDE8 /* PeerLocationFormattingTests.swift in Sources */,
 			CHF002 /* CallHistoryFormattingTests.swift in Sources */,
 			CHRT02 /* CallHistoryRepositoryTests.swift in Sources */,

--- a/Columba.xcodeproj/project.pbxproj
+++ b/Columba.xcodeproj/project.pbxproj
@@ -420,6 +420,8 @@
 		VBMP0 /* VoiceQualityPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = V0CP0 /* VoiceQualityPickerSheet.swift */; };
 		VBSR0 /* VoiceWaveformBars.swift in Sources */ = {isa = PBXBuildFile; fileRef = V0CR0 /* VoiceWaveformBars.swift */; };
 		VBMR0 /* VoiceWaveformBars.swift in Sources */ = {isa = PBXBuildFile; fileRef = V0CR0 /* VoiceWaveformBars.swift */; };
+		A4EA60E22E1A3A65C6AFA5E7 /* OneShotLocationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = E284643CB4F95B1B3DBA965B /* OneShotLocationProvider.swift */; };
+		099A0C66CE2C1444E52912D0 /* DiscoveredInterfacesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D8D7406682429BCE36865C3 /* DiscoveredInterfacesViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -705,6 +707,8 @@
 		V0CM0 /* VoiceMessageRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceMessageRecorder.swift; sourceTree = "<group>"; };
 		V0CP0 /* VoiceQualityPickerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceQualityPickerSheet.swift; sourceTree = "<group>"; };
 		V0CR0 /* VoiceWaveformBars.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceWaveformBars.swift; sourceTree = "<group>"; };
+		E284643CB4F95B1B3DBA965B /* OneShotLocationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OneShotLocationProvider.swift; sourceTree = "<group>"; };
+		4D8D7406682429BCE36865C3 /* DiscoveredInterfacesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoveredInterfacesViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1096,6 +1100,7 @@
 			children = (
 				BGPSYNCREF001 /* BackgroundPropagationSync.swift */,
 				F024 /* AppServices.swift */,
+				E284643CB4F95B1B3DBA965B /* OneShotLocationProvider.swift */,
 				BKF002 /* BackendFactory.swift */,
 				F025 /* MessageRepository.swift */,
 				CHF003 /* CallHistoryFormatting.swift */,
@@ -1213,6 +1218,7 @@
 				DA143A000000000000000001 /* DraftAutosaveController.swift */,
 				F006 /* SettingsViewModel.swift */,
 				F030 /* InterfaceManagementViewModel.swift */,
+				4D8D7406682429BCE36865C3 /* DiscoveredInterfacesViewModel.swift */,
 				F034 /* NetworkStatusViewModel.swift */,
 				F052 /* OnboardingViewModel.swift */,
 				F05A /* RNodeWizardViewModel.swift */,
@@ -1605,6 +1611,8 @@
 				87358446F5D54F616D07CCEE /* IncomingMessageHandler.swift in Sources */,
 				B5A7B590DEFA2B213D8D5754 /* InterfaceRepository.swift in Sources */,
 				147A84617097826BCE5DBD49 /* InterfaceManagementViewModel.swift in Sources */,
+				A4EA60E22E1A3A65C6AFA5E7 /* OneShotLocationProvider.swift in Sources */,
+				099A0C66CE2C1444E52912D0 /* DiscoveredInterfacesViewModel.swift in Sources */,
 				8EF58D2BD45FCDF79EDB49AB /* InterfaceManagementScreen.swift in Sources */,
 				B2EF01CCB8B50326073D8171 /* NodeDetailsView.swift in Sources */,
 				98FE1EAB00C655BFF7D46594 /* PropagationNodeManager.swift in Sources */,
@@ -1802,6 +1810,8 @@
 				021 /* MapView.swift in Sources */,
 				048 /* MapLibreMapView.swift in Sources */,
 				024 /* AppServices.swift in Sources */,
+				A4EA60E22E1A3A65C6AFA5E7 /* OneShotLocationProvider.swift in Sources */,
+				099A0C66CE2C1444E52912D0 /* DiscoveredInterfacesViewModel.swift in Sources */,
 				BKF001 /* BackendFactory.swift in Sources */,
 				025 /* MessageRepository.swift in Sources */,
 				CHF004 /* CallHistoryFormatting.swift in Sources */,

--- a/Columba.xcodeproj/project.pbxproj
+++ b/Columba.xcodeproj/project.pbxproj
@@ -157,6 +157,7 @@
 		266929D6972E8D373E7A926D /* ReticulumSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 021FA3D73B6F8B711A97D40F /* ReticulumSwift */; };
 		26D564FAEE8E3C750E8E2442 /* PythonConfigWriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C8CFC274AF9EF63E9A75238 /* PythonConfigWriterTests.swift */; };
 		2BD6F16BEA0EC587E6433034 /* DiscoveredInterfaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8ACAE7518CFD5E0C149B9F /* DiscoveredInterfaceTests.swift */; };
+		A1F3C0010000000000000001 /* NetworkStatusEndpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E4D1020000000000000002 /* NetworkStatusEndpointTests.swift */; };
 		26D6E3545012268714C637D9 /* ThemeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F065 /* ThemeManager.swift */; };
 		2AFE85F0CA5EFEDF75A7C1E5 /* IncomingCallScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D4C54CECCAF0B117FB6C197 /* IncomingCallScreen.swift */; };
 		2B3A3E3FB59D1E22B424E109 /* AudioRingBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE307E24C72DBA41D76C9A6C /* AudioRingBufferTests.swift */; };
@@ -544,6 +545,7 @@
 		D33D0252383165C6829D2767 /* ColumbaModelBAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ColumbaModelBAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D691F2029BDC2C1024AA9B01 /* VoiceCallScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VoiceCallScreen.swift; sourceTree = "<group>"; };
 		DB8ACAE7518CFD5E0C149B9F /* DiscoveredInterfaceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DiscoveredInterfaceTests.swift; sourceTree = "<group>"; };
+		B2E4D1020000000000000002 /* NetworkStatusEndpointTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NetworkStatusEndpointTests.swift; sourceTree = "<group>"; };
 		DA586EB5F8EB62D2579CEAAB /* Lucide.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Lucide.swift; sourceTree = "<group>"; };
 		DE307E24C72DBA41D76C9A6C /* AudioRingBufferTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudioRingBufferTests.swift; sourceTree = "<group>"; };
 		E4AB432DD1264CAE1F35B22A /* JetBrainsMono-Regular.ttf */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; path = "JetBrainsMono-Regular.ttf"; sourceTree = "<group>"; };
@@ -1160,6 +1162,7 @@
 			CHRT01 /* CallHistoryRepositoryTests.swift */,
 				B9DA888204CA742BD1403A51 /* DirectionsLauncherTests.swift */,
 				DB8ACAE7518CFD5E0C149B9F /* DiscoveredInterfaceTests.swift */,
+				B2E4D1020000000000000002 /* NetworkStatusEndpointTests.swift */,
 				AB56A9C5F062142B6EF61DA2 /* PeerLocationRemovalTests.swift */,
 				A1B2C3D4E5F60718293A4B5D /* MessageBubbleLayoutTests.swift */,
 				APVT001 /* MessageAttachmentPreviewTests.swift */,
@@ -1931,6 +1934,7 @@
 				47B4E413633097429123BC2F /* PeerLocationRemovalTests.swift in Sources */,
 				E4FCBD54560B74AC8CCB1C91 /* DirectionsLauncherTests.swift in Sources */,
 				2BD6F16BEA0EC587E6433034 /* DiscoveredInterfaceTests.swift in Sources */,
+				A1F3C0010000000000000001 /* NetworkStatusEndpointTests.swift in Sources */,
 				CC067EE77A33341C829CBDE8 /* PeerLocationFormattingTests.swift in Sources */,
 			CHF002 /* CallHistoryFormattingTests.swift in Sources */,
 			CHRT02 /* CallHistoryRepositoryTests.swift in Sources */,

--- a/Sources/ColumbaApp/Resources/Localizable.xcstrings
+++ b/Sources/ColumbaApp/Resources/Localizable.xcstrings
@@ -91,6 +91,16 @@
         }
       }
     },
+    "Tap to configure RNS 1.1.x interface discovery": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap to configure RNS 1.1.x interface discovery"
+          }
+        }
+      }
+    },
     "Manage": {
       "localizations": {
         "en": {
@@ -2233,6 +2243,16 @@
         }
       }
     },
+    "Discovery enabled - no interfaces found yet": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Discovery enabled - no interfaces found yet"
+          }
+        }
+      }
+    },
     "Off": {
       "localizations": {
         "en": {
@@ -2699,6 +2719,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "%lld m"
+          }
+        }
+      }
+    },
+    "%lld interfaces found via RNS Discovery": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld interfaces found via RNS Discovery"
           }
         }
       }

--- a/Sources/ColumbaApp/Resources/Localizable.xcstrings
+++ b/Sources/ColumbaApp/Resources/Localizable.xcstrings
@@ -2192,6 +2192,576 @@
           }
         }
       }
+    },
+    "Discovered Interfaces": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Discovered Interfaces"
+          }
+        }
+      }
+    },
+    "Interface Discovery": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Interface Discovery"
+          }
+        }
+      }
+    },
+    "Enable discovery": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable discovery"
+          }
+        }
+      }
+    },
+    "Discovers interfaces announced by other RNS nodes. Changes apply after a brief restart of Reticulum.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Discovers interfaces announced by other RNS nodes. Changes apply after a brief restart of Reticulum."
+          }
+        }
+      }
+    },
+    "Off": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Off"
+          }
+        }
+      }
+    },
+    "Bootstrap interfaces": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bootstrap interfaces"
+          }
+        }
+      }
+    },
+    "These auto-detach once discovered interfaces connect.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "These auto-detach once discovered interfaces connect."
+          }
+        }
+      }
+    },
+    "Restarting…": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restarting…"
+          }
+        }
+      }
+    },
+    "Active – discovering interfaces": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Active – discovering interfaces"
+          }
+        }
+      }
+    },
+    "Auto-connect up to %lld discovered interfaces": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto-connect up to %lld discovered interfaces"
+          }
+        }
+      }
+    },
+    "Discovered": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Discovered"
+          }
+        }
+      }
+    },
+    "Available": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Available"
+          }
+        }
+      }
+    },
+    "Unknown": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown"
+          }
+        }
+      }
+    },
+    "Sort": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sort"
+          }
+        }
+      }
+    },
+    "Quality": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quality"
+          }
+        }
+      }
+    },
+    "Nearest": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nearest"
+          }
+        }
+      }
+    },
+    "Search interfaces…": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search interfaces…"
+          }
+        }
+      }
+    },
+    "IFAC only": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IFAC only"
+          }
+        }
+      }
+    },
+    "%lld of %lld": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld of %lld"
+          }
+        }
+      }
+    },
+    "Clear": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear"
+          }
+        }
+      }
+    },
+    "Transport:": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transport:"
+          }
+        }
+      }
+    },
+    "IFAC:": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IFAC:"
+          }
+        }
+      }
+    },
+    "Last heard: %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last heard: %@"
+          }
+        }
+      }
+    },
+    "%lld hops": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld hops"
+          }
+        }
+      }
+    },
+    "Yggdrasil": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yggdrasil"
+          }
+        }
+      }
+    },
+    "All announced fields": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "All announced fields"
+          }
+        }
+      }
+    },
+    "Transport ID": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transport ID"
+          }
+        }
+      }
+    },
+    "Network ID": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Network ID"
+          }
+        }
+      }
+    },
+    "Status code": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Status code"
+          }
+        }
+      }
+    },
+    "Last heard (unix)": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last heard (unix)"
+          }
+        }
+      }
+    },
+    "Heard count": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Heard count"
+          }
+        }
+      }
+    },
+    "Stamp value": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stamp value"
+          }
+        }
+      }
+    },
+    "Reachable on": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reachable on"
+          }
+        }
+      }
+    },
+    "Port": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Port"
+          }
+        }
+      }
+    },
+    "Frequency": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Frequency"
+          }
+        }
+      }
+    },
+    "Bandwidth": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bandwidth"
+          }
+        }
+      }
+    },
+    "Spreading factor": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spreading factor"
+          }
+        }
+      }
+    },
+    "Coding rate": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coding rate"
+          }
+        }
+      }
+    },
+    "Modulation": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modulation"
+          }
+        }
+      }
+    },
+    "Channel": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Channel"
+          }
+        }
+      }
+    },
+    "Latitude": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Latitude"
+          }
+        }
+      }
+    },
+    "Longitude": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Longitude"
+          }
+        }
+      }
+    },
+    "Height": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Height"
+          }
+        }
+      }
+    },
+    "IFAC passphrase": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IFAC passphrase"
+          }
+        }
+      }
+    },
+    "Transport": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transport"
+          }
+        }
+      }
+    },
+    "Discovery hash": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Discovery hash"
+          }
+        }
+      }
+    },
+    "Received at": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Received at"
+          }
+        }
+      }
+    },
+    "Discovered at": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Discovered at"
+          }
+        }
+      }
+    },
+    "Port %lld": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Port %lld"
+          }
+        }
+      }
+    },
+    "Open in Maps": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open in Maps"
+          }
+        }
+      }
+    },
+    "%lld m": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld m"
+          }
+        }
+      }
+    },
+    "%.0fm away": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%.0fm away"
+          }
+        }
+      }
+    },
+    "%.1f km away": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%.1f km away"
+          }
+        }
+      }
+    },
+    "Restarting Reticulum…": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restarting Reticulum…"
+          }
+        }
+      }
+    },
+    "No interfaces discovered yet. Enable discovery above to start finding interfaces announced by other RNS nodes.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No interfaces discovered yet. Enable discovery above to start finding interfaces announced by other RNS nodes."
+          }
+        }
+      }
+    },
+    "No interfaces match your filters.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No interfaces match your filters."
+          }
+        }
+      }
+    },
+    "Clear filters": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear filters"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Sources/ColumbaApp/Resources/Localizable.xcstrings
+++ b/Sources/ColumbaApp/Resources/Localizable.xcstrings
@@ -2792,6 +2792,46 @@
           }
         }
       }
+    },
+    "Add to Config": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add to Config"
+          }
+        }
+      }
+    },
+    "Copy LoRa Params": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy LoRa Params"
+          }
+        }
+      }
+    },
+    "Use for RNode": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use for RNode"
+          }
+        }
+      }
+    },
+    "Copied": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copied"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Sources/ColumbaApp/Resources/Localizable.xcstrings
+++ b/Sources/ColumbaApp/Resources/Localizable.xcstrings
@@ -2233,16 +2233,6 @@
         }
       }
     },
-    "Discovers interfaces announced by other RNS nodes. Changes apply after a brief restart of Reticulum.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Discovers interfaces announced by other RNS nodes. Changes apply after a brief restart of Reticulum."
-          }
-        }
-      }
-    },
     "Discovery enabled - no interfaces found yet": {
       "localizations": {
         "en": {
@@ -2829,6 +2819,56 @@
           "stringUnit": {
             "state": "translated",
             "value": "Copied"
+          }
+        }
+      }
+    },
+    "Restart failed — discovery settings were not applied.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restart failed — discovery settings were not applied."
+          }
+        }
+      }
+    },
+    "Discovers interfaces announced by other RNS nodes. Changes take effect after you tap Apply and Restart.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Discovers interfaces announced by other RNS nodes. Changes take effect after you tap Apply and Restart."
+          }
+        }
+      }
+    },
+    "Changes pending — tap Apply and Restart": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Changes pending — tap Apply and Restart"
+          }
+        }
+      }
+    },
+    "Apply and Restart": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apply and Restart"
+          }
+        }
+      }
+    },
+    "Discard": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Discard"
           }
         }
       }

--- a/Sources/ColumbaApp/Resources/Localizable.xcstrings
+++ b/Sources/ColumbaApp/Resources/Localizable.xcstrings
@@ -2872,6 +2872,16 @@
           }
         }
       }
+    },
+    "IFAC network name": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IFAC network name"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Sources/ColumbaApp/Resources/Localizable.xcstrings
+++ b/Sources/ColumbaApp/Resources/Localizable.xcstrings
@@ -2922,6 +2922,28 @@
           }
         }
       }
+    },
+    "Saved. Applies on the next app relaunch because an AutoInterface is active.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Saved. Applies on the next app relaunch because an AutoInterface is active."
+          }
+        }
+      }
+    },
+    "Interface discovery is unavailable in this build.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Interface discovery is unavailable in this build."
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Sources/ColumbaApp/Resources/Localizable.xcstrings
+++ b/Sources/ColumbaApp/Resources/Localizable.xcstrings
@@ -2882,6 +2882,46 @@
           }
         }
       }
+    },
+    "Via discovery": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Via discovery"
+          }
+        }
+      }
+    },
+    "Auto-connected from discovery": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto-connected from discovery"
+          }
+        }
+      }
+    },
+    "Endpoint": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Endpoint"
+          }
+        }
+      }
+    },
+    "Source": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Source"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -1609,7 +1609,11 @@ public final class AppServices {
         // Settings → Advanced → Transport Mode); changing it requires
         // tapping Apply & Restart on the same screen.
         let transportEnabled = SharedDefaults.suite.bool(forKey: "transport_enabled")
-        let configText = PythonConfigWriter.write(interfaces: interfaces, enableTransport: transportEnabled)
+        // Interface-discovery settings (T-C): read from the same App Group
+        // suite the toggle persists to, so the config matches the UI.
+        let discoverOn = await settingsRepository.getDiscoverInterfacesEnabled()
+        let autoCount = await settingsRepository.getAutoconnectDiscoveredCount()
+        let configText = PythonConfigWriter.write(interfaces: interfaces, enableTransport: transportEnabled, discoverInterfaces: discoverOn, autoconnectDiscoveredCount: autoCount)
         let configFile = pyDir.appendingPathComponent("config")
         do {
             try configText.write(to: configFile, atomically: true, encoding: .utf8)
@@ -2461,7 +2465,7 @@ public final class AppServices {
         // the current discovery settings (writePythonConfig reads discovery
         // settings — T-C) before tearing down, so the re-init reads fresh values.
         let fresh = InterfaceRepository().getEnabledInterfaces()
-        writePythonConfig(interfaces: fresh)
+        _ = await writePythonConfig(interfaces: fresh)
         DiagLog.log("[RNS] restartPythonBackend: config written (\(fresh.count) interfaces); restarting in-process")
         do {
             try await withLifecycleOperation {
@@ -2537,13 +2541,19 @@ public final class AppServices {
     /// `remove_interface` reads this file but the running stack is reconfigured
     /// by `applyInterfaceChanges()`.
     @discardableResult
-    private func writePythonConfig(interfaces: [InterfaceEntity]) -> Bool {
+    private func writePythonConfig(interfaces: [InterfaceEntity]) async -> Bool {
         guard let pyDir = pythonConfigDirURL() else {
             DiagLog.log("[RNS] writePythonConfig skipped — no start identity")
             return false
         }
         let transportEnabled = SharedDefaults.suite.bool(forKey: "transport_enabled")
-        let configText = PythonConfigWriter.write(interfaces: interfaces, enableTransport: transportEnabled)
+        // RNS 1.1.x interface discovery is restart-gated: the generated config
+        // must carry the user's discovery settings (T-C) or the toggle would
+        // persist in UserDefaults while the backend keeps seeing the defaults
+        // (discover_interfaces = no).
+        let discoverOn = await settingsRepository.getDiscoverInterfacesEnabled()
+        let autoCount = await settingsRepository.getAutoconnectDiscoveredCount()
+        let configText = PythonConfigWriter.write(interfaces: interfaces, enableTransport: transportEnabled, discoverInterfaces: discoverOn, autoconnectDiscoveredCount: autoCount)
         let configFile = pyDir.appendingPathComponent("config")
         do {
             try configText.write(to: configFile, atomically: true, encoding: .utf8)
@@ -2601,7 +2611,7 @@ public final class AppServices {
         let freshById = Dictionary(uniqueKeysWithValues: fresh.map { ($0.id, $0) })
 
         // 1. Durability — always persist, even if there's no live backend.
-        writePythonConfig(interfaces: fresh)
+        _ = await writePythonConfig(interfaces: fresh)
 
         guard let backend = backend else {
             DiagLog.log("[RNS-HOT] no running backend — config written, applies on next launch")

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -2463,15 +2463,26 @@ public final class AppServices {
         let fresh = InterfaceRepository().getEnabledInterfaces()
         writePythonConfig(interfaces: fresh)
         DiagLog.log("[RNS] restartPythonBackend: config written (\(fresh.count) interfaces); restarting in-process")
-        try? await withLifecycleOperation {
-            await shutdownUnlocked()
-            // Small delay to ensure clean shutdown (matches switchIdentityUnlocked).
-            try? await Task.sleep(for: .milliseconds(200))
-            try await initializeUnlocked(
-                identity: identity,
-                identityHash: identity.hexHash,
-                tcpServerAddress: addr
-            )
+        do {
+            try await withLifecycleOperation {
+                await shutdownUnlocked()
+                // Small delay to ensure clean shutdown (matches switchIdentityUnlocked).
+                try? await Task.sleep(for: .milliseconds(200))
+                try await initializeUnlocked(
+                    identity: identity,
+                    identityHash: identity.hexHash,
+                    tcpServerAddress: addr
+                )
+            }
+        } catch {
+            // shutdownUnlocked() has already run (backend = nil, isConnected =
+            // false) and the re-init threw — the stack is now DOWN. Do NOT post
+            // the "back up" notification and do NOT log success; log the real
+            // error so a swallowed backend death (e.g. the documented
+            // AutoInterface multicast-socket re-init flake) is diagnosable.
+            logger.error("[RNS] restartPythonBackend FAILED: \(error) — backend is down")
+            DiagLog.log("[RNS] restartPythonBackend FAILED: \(error)")
+            return
         }
         // Signal the UI that the stack is back up so it can re-poll discovery
         // state. (Replaces the dead ColumbaRelaunchRequired notification.)
@@ -3183,6 +3194,10 @@ public final class AppServices {
         DiagLog.log("[INIT2] Starting with identity: \(identityHash), tcp: \(tcpServerAddress)")
 
         self.identity = identity
+        // Cache the tcp-server address used at this (re)start so a same-identity
+        // restart (restartPythonBackend) re-inits with the real address. The
+        // launch path uses THIS 3-arg overload, not the 1-arg one.
+        self.lastTcpServerAddress = tcpServerAddress
         self.localIdentityHashHex = localIdentityHash.map { String(format: "%02x", $0) }.joined()
         // Model B: make this identity reachable by the in-NE node. This overload
         // receives the identity pre-loaded (multi-identity path) and never calls

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -627,6 +627,11 @@ public final class AppServices {
     /// interfaces, without making AppServices re-derive it.
     private var pythonStartIdentity: Identity?
 
+    /// The tcpServerAddress used at the last successful start, so a
+    /// same-identity restart (restartPythonBackend) can re-init without the
+    /// caller re-deriving it. Empty until the first start.
+    private var lastTcpServerAddress: String = ""
+
     /// The interface entities currently live in the Python RNS stack, keyed by
     /// entity id. Seeded when the backend starts and updated incrementally by
     /// `applyInterfaceChanges()` as interfaces are hot-added / hot-removed.
@@ -1184,6 +1189,7 @@ public final class AppServices {
     }
 
     private func initializeUnlocked(tcpServerAddress: String) async throws {
+        self.lastTcpServerAddress = tcpServerAddress
         DiagLog.log("[STARTUP] AppServices initialization beginning")
         let monitorLease = RuntimeActivityMonitor.shared.acquire()
         var initializationSucceeded = false
@@ -2435,41 +2441,44 @@ public final class AppServices {
         }
     }
 
-    /// Stop the running Python RNS stack, regenerate the RNS config file
-    /// from `InterfaceRepository.getEnabledInterfaces()`, and start a fresh
-    /// instance. Called from the InterfaceManagementScreen's "Apply &
-    /// Restart" button after the user adds, edits, toggles, or removes an
-    /// interface. RNS has no hot-reload — the only way to pick up a new
-    /// `[interfaces]` section is a full Reticulum re-init.
+    /// Restart the running Python RNS stack IN-PROCESS: full teardown
+    /// (`shutdownUnlocked()`) then re-init (`initializeUnlocked`) with the SAME
+    /// identity — the exact primitives identity-switch already uses. Used to
+    /// apply restart-gated config (discovery, autoconnect count, bootstrap,
+    /// transport mode). Causes a ~1-2s connectivity outage.
     ///
-    /// Causes a ~1-2s connectivity outage. Caller should reflect the
-    /// transition in the UI (the Apply button already shows a
-    /// ProgressView while `isApplyingChanges` is set).
+    /// This replaces the previous "write config + post ColumbaRelaunchRequired"
+    /// stub, which had no UI consumer and required a manual app relaunch. The
+    /// `ColumbaBackendRestarted` notification below tells the UI the stack is
+    /// back up so it can re-poll (discovery screen, transport toggle).
     public func restartPythonBackend() async {
         guard let identity = pythonStartIdentity else {
-            DiagLog.log("[RNS] restart skipped — backend was never started")
+            DiagLog.log("[RNS] restartPythonBackend skipped — backend was never started")
             return
         }
-        // Rewrite the RNS config on disk so the new interface set is
-        // captured. The actual Python-side restart is DELIBERATELY skipped
-        // — in-place restart of the embedded interpreter is flaky on iOS
-        // (Reticulum is a class-level singleton, AutoInterface holds
-        // multicast socket threads that don't tear down deterministically,
-        // and the embedded Python aborts ~130ms into the second
-        // `Reticulum.__init__` when the previous instance's threads still
-        // hold the multicast bind). RNS has no hot-reload of [interfaces]
-        // anyway, so the right model is: write the config, tell the user
-        // to relaunch Columba. The full app launch on the next start gets
-        // a clean Python + clean RNS singleton.
-        _ = identity // pythonStartIdentity presence is the only precondition
+        let addr = lastTcpServerAddress
+        // Durability: rewrite the RNS config with the current interface set AND
+        // the current discovery settings (writePythonConfig reads discovery
+        // settings — T-C) before tearing down, so the re-init reads fresh values.
         let fresh = InterfaceRepository().getEnabledInterfaces()
         writePythonConfig(interfaces: fresh)
-        DiagLog.log("[RNS] restartPythonBackend: config written (\(fresh.count) interfaces); awaiting next app launch to apply")
-        // Notify the UI so it can show a "relaunch Columba" prompt.
+        DiagLog.log("[RNS] restartPythonBackend: config written (\(fresh.count) interfaces); restarting in-process")
+        try? await withLifecycleOperation {
+            await shutdownUnlocked()
+            // Small delay to ensure clean shutdown (matches switchIdentityUnlocked).
+            try? await Task.sleep(for: .milliseconds(200))
+            try await initializeUnlocked(
+                identity: identity,
+                identityHash: identity.hexHash,
+                tcpServerAddress: addr
+            )
+        }
+        // Signal the UI that the stack is back up so it can re-poll discovery
+        // state. (Replaces the dead ColumbaRelaunchRequired notification.)
         NotificationCenter.default.post(
-            name: Notification.Name("ColumbaRelaunchRequired"),
-            object: nil
+            name: Notification.Name("ColumbaBackendRestarted"), object: nil
         )
+        DiagLog.log("[RNS] restartPythonBackend: in-process restart complete")
     }
 
     /// Force the Python RNS stack to flush its path table + known destinations

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -2463,6 +2463,17 @@ public final class AppServices {
                     iface.state = newState
                     iface.online = status.online
                 }
+                // Sync the configured display name from the entity. The
+                // connect path seeds the stub with a hardcoded type label
+                // ("TCP Server" — even for TCP clients), so without this the
+                // Network Status card can never show the name the user typed
+                // in Manage Interfaces (issue #193 follow-up). Fall back to
+                // the existing name when the entity is gone/empty. Syncing
+                // here also picks up renames without a restart.
+                let configuredName = entityById[entityId]?.name
+                if let configuredName, !configuredName.isEmpty, iface.name != configuredName {
+                    iface.name = configuredName
+                }
                 // Live endpoint (host:port) from Python's friendly str(iface),
                 // so the row shows which host this TCP client is talking to —
                 // previously the subtitle was just the user's label and every
@@ -4548,9 +4559,21 @@ public final class AppServices {
             throw AppServicesError.transportNotConnected
         }
 
+        // Prefer the configured name the user typed in Manage Interfaces.
+        // This path historically hardcoded "TCP Server" — even for TCP
+        // clients — which is what the Network Status card showed instead of
+        // the user's name (issue #193 follow-up). The onboarding "tcp-server"
+        // relay has no InterfaceEntity, so it keeps the legacy type label.
+        // The status poll re-syncs this on rename.
+        let configuredName: String
+        if let entity = pythonInterfaceEntities[entityId], !entity.name.isEmpty {
+            configuredName = entity.name
+        } else {
+            configuredName = "TCP Server"
+        }
         let config = InterfaceConfig(
             id: entityId,
-            name: "TCP Server",
+            name: configuredName,
             type: .tcp,
             enabled: true,
             mode: .full,

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -2325,6 +2325,32 @@ public final class AppServices {
         #endif
     }
 
+    /// Parse the endpoint + peer name out of a Python friendly `str(iface)`
+    /// of the form `TypeLabel[<peer>/<host:port>]` (e.g.
+    /// `TCPInterface[Home/10.0.4.63:4242]`, `BackboneInterface[Synth
+    /// Hub/127.0.0.1:43221]`). Splits the bracketed content on the LAST `/`
+    /// so IPv6 brackets (`[2001:db8::1]:4242`) and peer names containing
+    /// spaces survive. Returns `(peer, endpoint)`; either may be nil when the
+    /// name has no bracketed endpoint (e.g. a bare section name).
+    static func parseFriendlyEndpoint(_ friendly: String) -> (peer: String?, endpoint: String?) {
+        guard let open = friendly.firstIndex(of: "["),
+              let close = friendly.lastIndex(of: "]"),
+              open < close else { return (nil, nil) }
+        let inner = friendly[friendly.index(after: open)..<close]
+        // Only treat it as a peer/endpoint split when there's a "/" AND the
+        // last segment looks host-ish (contains ":" or a dotted-quad). This
+        // keeps "en0/fe80::1"-style AutoInterfacePeer addresses from being
+        // mislabelled, though that path is handled separately.
+        guard let slash = inner.lastIndex(of: "/"), slash > inner.startIndex else {
+            return (String(inner), nil)
+        }
+        let peer = String(inner[inner.startIndex..<slash])
+        let endpoint = String(inner[inner.index(after: slash)...])
+        let endpointLooksHostlike = endpoint.contains(":") || endpoint.split(separator: ".").count >= 2
+        guard endpointLooksHostlike else { return (peer, nil) }
+        return (peer, endpoint)
+    }
+
     /// Look up the matching Python interface for each user `InterfaceEntity`
     /// and update the Compat TCPInterface stub's `state` to reflect the
     /// `online` flag RNS.Transport reports.
@@ -2362,33 +2388,61 @@ public final class AppServices {
         // peer address from there for the row subtitle.
         var auxiliary: [InterfaceSnapshot] = []
         for status in snapshot.interfaces where !matchedSectionNames.contains(status.sectionName) {
-            // Skip user-defined sections we just couldn't match for some
-            // reason (rename race, etc.) — only emit synthetic rows for
-            // peer-style names.
             let isAutoPeer = status.name.hasPrefix("AutoInterfacePeer")
             let isBlePeer = status.name.hasPrefix("BLEPeerInterface") || status.name.hasPrefix("BLEPeer")
-            guard isAutoPeer || isBlePeer else { continue }
-            let typeLabel = isAutoPeer ? "AutoInterfacePeer" : "BLEPeer"
-            // Peel out the bracketed addr — "AutoInterfacePeer[en0/fe80::1]"
-            // gives "en0/fe80::1".
-            let peerAddress: String? = {
-                guard let open = status.name.firstIndex(of: "["),
-                      let close = status.name.lastIndex(of: "]"),
-                      open < close else { return nil }
-                return String(status.name[status.name.index(after: open)..<close])
-            }()
-            auxiliary.append(InterfaceSnapshot(
-                id: "py-aux:\(status.sectionName.isEmpty ? status.name : status.sectionName)",
-                name: status.name,
-                online: status.online,
-                typeLabel: typeLabel,
-                type: isAutoPeer ? .autoInterface : .ble,
-                state: status.online ? .connected : .disconnected,
-                isAutoInterfacePeer: isAutoPeer,
-                isBLEPeerInterface: isBlePeer,
-                peerAddress: peerAddress,
-                lastErrorDescription: nil
-            ))
+            // `isAutoconnect` is the authoritative discovery marker (the
+            // `autoconnect_hash` attr set by Discovery.autoconnect) — an
+            // auto-connected interface is a BackboneClientInterface whose
+            // friendly name is "BackboneInterface[<peer>/host:port]", which
+            // matches NEITHER peer prefix above and was therefore silently
+            // dropped here (issue #193 follow-up: the user could not tell
+            // which interfaces were auto-connected from discovery).
+            let isAutoconnect = status.isAutoconnect ?? false
+            guard isAutoPeer || isBlePeer || isAutoconnect else { continue }
+
+            if isAutoPeer || isBlePeer {
+                let typeLabel = isAutoPeer ? "AutoInterfacePeer" : "BLEPeer"
+                // Keep the existing peer-row subtitle: the full bracketed
+                // content ("AutoInterfacePeer[en0/fe80::1]" -> "en0/fe80::1").
+                let peerAddress: String? = {
+                    guard let open = status.name.firstIndex(of: "["),
+                          let close = status.name.lastIndex(of: "]"),
+                          open < close else { return nil }
+                    return String(status.name[status.name.index(after: open)..<close])
+                }()
+                auxiliary.append(InterfaceSnapshot(
+                    id: "py-aux:\(status.sectionName.isEmpty ? status.name : status.sectionName)",
+                    name: status.name,
+                    online: status.online,
+                    typeLabel: typeLabel,
+                    type: isAutoPeer ? .autoInterface : .ble,
+                    state: status.online ? .connected : .disconnected,
+                    isAutoInterfacePeer: isAutoPeer,
+                    isBLEPeerInterface: isBlePeer,
+                    peerAddress: peerAddress,
+                    lastErrorDescription: nil
+                ))
+            } else {
+                // Auto-connected from discovery: show the peer's friendly name
+                // + host:port endpoint, badged "via discovery". Peel the
+                // bracketed "<peer>/<host:port>" and split on the LAST "/"
+                // so IPv6 brackets ("[2001:db8::1]:4242") survive.
+                let parts = Self.parseFriendlyEndpoint(status.name)
+                auxiliary.append(InterfaceSnapshot(
+                    id: "py-aux:\(status.sectionName.isEmpty ? status.name : status.sectionName)",
+                    name: parts.peer ?? status.name,
+                    online: status.online,
+                    typeLabel: "TCPClient",
+                    type: .tcp,
+                    state: status.online ? .connected : .disconnected,
+                    isAutoInterfacePeer: false,
+                    isBLEPeerInterface: false,
+                    peerAddress: nil,
+                    lastErrorDescription: nil,
+                    endpoint: parts.endpoint,
+                    isAutoconnect: true
+                ))
+            }
         }
         if let transport = transport {
             transport.setPythonAuxiliarySnapshots(auxiliary)
@@ -2409,6 +2463,17 @@ public final class AppServices {
                     iface.state = newState
                     iface.online = status.online
                 }
+                // Live endpoint (host:port) from Python's friendly str(iface),
+                // so the row shows which host this TCP client is talking to —
+                // previously the subtitle was just the user's label and every
+                // row read "TCPClient" (issue #193 follow-up). Refresh every
+                // poll: the endpoint can change (reconnect to a new host), so
+                // assign unconditionally (cheap string compare avoids log spam).
+                let endpoint = Self.parseFriendlyEndpoint(status.name).endpoint
+                if iface.endpoint != endpoint {
+                    iface.endpoint = endpoint
+                }
+                iface.isAutoconnect = status.isAutoconnect ?? false
                 continue
             }
             // Auto + BLE interfaces are singletons on AppServices, keyed by

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -3599,6 +3599,17 @@ public final class AppServices {
         announceManager.start()
     }
 
+    /// Copy of the transport's Python-discovered auxiliary interfaces
+    /// (AutoInterfacePeer / discovery auto-connects / BLEPeer). The Settings
+    /// Network card and the connection-state observer read this — the aux
+    /// snapshots are pushed into the transport by `applyPythonInterfaceStatus`
+    /// but are not user-configured stubs, so `tcpInterfaces` alone never sees
+    /// an interface RNS auto-connected from a discovery announce
+    /// (issue #193 follow-up).
+    public func auxiliaryInterfaceSnapshots() -> [InterfaceSnapshot] {
+        transport?.pythonAuxiliarySnapshotList() ?? []
+    }
+
     // MARK: - State Observation
 
     /// Start observing interface state for UI updates.
@@ -3621,6 +3632,12 @@ public final class AppServices {
                 let autoIface = await MainActor.run { self.autoInterface }
                 let rnodeIface = await MainActor.run { self.rnodeInterface }
                 let bleIface = await MainActor.run { self.bleInterface }
+                // Discovery auto-connects / LAN / BLE peers live only in the
+                // transport's auxiliary snapshot (not in tcpInterfaces), so a
+                // discovery-only connection would otherwise read "Disconnected".
+                let auxOnlineCount = await MainActor.run {
+                    self.auxiliaryInterfaceSnapshots().filter { $0.online }.count
+                }
 
                 // Aggregate TCP state across all interfaces
                 var anyTCPConnected = false
@@ -3654,7 +3671,7 @@ public final class AppServices {
                     bleConnected = false
                 }
 
-                let anyConnected = tcpConnected || autoConnected || rnodeConnected || bleConnected
+                let anyConnected = tcpConnected || autoConnected || rnodeConnected || bleConnected || auxOnlineCount > 0
                 let tcpReconnecting = anyTCPReconnecting && !anyTCPConnected
 
                 // Batch all UI mutations into a single MainActor.run

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -2455,10 +2455,17 @@ public final class AppServices {
     /// stub, which had no UI consumer and required a manual app relaunch. The
     /// `ColumbaBackendRestarted` notification below tells the UI the stack is
     /// back up so it can re-poll (discovery screen, transport toggle).
-    public func restartPythonBackend() async {
+    ///
+    /// Returns true when the in-process restart completed and the stack is
+    /// back up; false when it was skipped (backend never started) or failed
+    /// (re-init threw — the stack is down). Callers that need to know
+    /// whether their restart-gated change is now LIVE (the discovery
+    /// settings apply flow) must check this rather than assume success.
+    @discardableResult
+    public func restartPythonBackend() async -> Bool {
         guard let identity = pythonStartIdentity else {
             DiagLog.log("[RNS] restartPythonBackend skipped — backend was never started")
-            return
+            return false
         }
         let addr = lastTcpServerAddress
         // Durability: rewrite the RNS config with the current interface set AND
@@ -2486,7 +2493,7 @@ public final class AppServices {
             // AutoInterface multicast-socket re-init flake) is diagnosable.
             logger.error("[RNS] restartPythonBackend FAILED: \(error) — backend is down")
             DiagLog.log("[RNS] restartPythonBackend FAILED: \(error)")
-            return
+            return false
         }
         // Signal the UI that the stack is back up so it can re-poll discovery
         // state. (Replaces the dead ColumbaRelaunchRequired notification.)
@@ -2494,6 +2501,7 @@ public final class AppServices {
             name: Notification.Name("ColumbaBackendRestarted"), object: nil
         )
         DiagLog.log("[RNS] restartPythonBackend: in-process restart complete")
+        return true
     }
 
     /// Force the Python RNS stack to flush its path table + known destinations

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -2521,6 +2521,48 @@ public final class AppServices {
         }
     }
 
+    /// Outcome of an in-process `restartPythonBackend()` attempt. Closed enum
+    /// (house style) so callers can distinguish the four states: the restart
+    /// completed and the change is LIVE, it was skipped (backend never
+    /// started), it failed (the stack is DOWN), or it was refused because an
+    /// AutoInterface is configured and same-process re-init is unsafe
+    /// (settings persisted — they apply on the next clean relaunch).
+    public enum PythonBackendRestartOutcome: Equatable, CustomStringConvertible {
+        case applied
+        case skipped
+        case failed
+        case requiresRelaunch
+        /// True only when the restart actually completed and the change is
+        /// live — the single "did it work?" predicate for callers that don't
+        /// need to branch on the other outcomes.
+        public var didApply: Bool { self == .applied }
+        public var description: String {
+            switch self {
+            case .applied: return "applied"
+            case .skipped: return "skipped"
+            case .failed: return "failed"
+            case .requiresRelaunch: return "requiresRelaunch"
+            }
+        }
+    }
+
+    /// True when the configured interface set contains an AutoInterface — the
+    /// one case where a SAME-PROCESS Reticulum re-initialization is unsafe
+    /// (issue #193 / Greptile P1 #2). `AutoInterface.detach()` only sets
+    /// `online = False` and never closes its multicast sockets (local vars,
+    /// not stored on the instance) or joins its daemon threads, so re-init in
+    /// the same process hits the documented multicast-bind collision and the
+    /// re-init error path takes the whole backend down. Pure logic, split out
+    /// of `restartPythonBackend` so it can be unit-tested without a running
+    /// backend; `nonisolated` because it touches no actor state (and tests
+    /// call it from a nonisolated context).
+    nonisolated static func inProcessRestartBlockedByAutoInterface(_ interfaces: [InterfaceEntity]) -> Bool {
+        interfaces.contains {
+            if case .autoInterface = $0.config { return true }
+            return false
+        }
+    }
+
     /// Restart the running Python RNS stack IN-PROCESS: full teardown
     /// (`shutdownUnlocked()`) then re-init (`initializeUnlocked`) with the SAME
     /// identity — the exact primitives identity-switch already uses. Used to
@@ -2532,16 +2574,27 @@ public final class AppServices {
     /// `ColumbaBackendRestarted` notification below tells the UI the stack is
     /// back up so it can re-poll (discovery screen, transport toggle).
     ///
-    /// Returns true when the in-process restart completed and the stack is
-    /// back up; false when it was skipped (backend never started) or failed
-    /// (re-init threw — the stack is down). Callers that need to know
-    /// whether their restart-gated change is now LIVE (the discovery
-    /// settings apply flow) must check this rather than assume success.
+    /// **AutoInterface guard (issue #193 / Greptile P1 #2):** when an enabled
+    /// AutoInterface is configured we REFUSE the same-process restart and
+    /// return `.requiresRelaunch`. `AutoInterface.detach()` only sets
+    /// `self.online = False` — its multicast sockets (local vars, not stored on
+    /// the instance) and daemon threads are never released, so re-initializing
+    /// Reticulum in the same process 200ms later deterministically hits the
+    /// documented multicast-bind collision and the re-init error path leaves
+    /// the whole backend down. The settings are still persisted, so they take
+    /// effect on the next clean relaunch.
+    ///
+    /// Returns the outcome: `.applied` when the in-process restart completed
+    /// and the stack is back up; `.skipped` when the backend was never
+    /// started; `.requiresRelaunch` when an AutoInterface makes in-process
+    /// re-init unsafe; `.failed` when the re-init threw (the stack is down).
+    /// Callers that need to know whether their restart-gated change is now
+    /// LIVE must check this rather than assume success.
     @discardableResult
-    public func restartPythonBackend() async -> Bool {
+    public func restartPythonBackend() async -> PythonBackendRestartOutcome {
         guard let identity = pythonStartIdentity else {
             DiagLog.log("[RNS] restartPythonBackend skipped — backend was never started")
-            return false
+            return .skipped
         }
         let addr = lastTcpServerAddress
         // Durability: rewrite the RNS config with the current interface set AND
@@ -2549,6 +2602,15 @@ public final class AppServices {
         // settings — T-C) before tearing down, so the re-init reads fresh values.
         let fresh = InterfaceRepository().getEnabledInterfaces()
         _ = await writePythonConfig(interfaces: fresh)
+        // AutoInterface guard: its teardown does not release the multicast
+        // sockets / daemon threads (see doc comment), so a same-process
+        // re-init would hit the multicast-bind collision and take the backend
+        // down. Refuse; the config write above persisted the change, so it
+        // applies on the next clean relaunch.
+        if Self.inProcessRestartBlockedByAutoInterface(fresh) {
+            DiagLog.log("[RNS] restartPythonBackend: AutoInterface configured — same-process re-init is unsafe (multicast sockets are not released on detach); refusing; change persisted for the next relaunch")
+            return .requiresRelaunch
+        }
         DiagLog.log("[RNS] restartPythonBackend: config written (\(fresh.count) interfaces); restarting in-process")
         do {
             try await withLifecycleOperation {
@@ -2565,11 +2627,10 @@ public final class AppServices {
             // shutdownUnlocked() has already run (backend = nil, isConnected =
             // false) and the re-init threw — the stack is now DOWN. Do NOT post
             // the "back up" notification and do NOT log success; log the real
-            // error so a swallowed backend death (e.g. the documented
-            // AutoInterface multicast-socket re-init flake) is diagnosable.
+            // error so a swallowed backend death is diagnosable.
             logger.error("[RNS] restartPythonBackend FAILED: \(error) — backend is down")
             DiagLog.log("[RNS] restartPythonBackend FAILED: \(error)")
-            return false
+            return .failed
         }
         // Signal the UI that the stack is back up so it can re-poll discovery
         // state. (Replaces the dead ColumbaRelaunchRequired notification.)
@@ -2577,7 +2638,7 @@ public final class AppServices {
             name: Notification.Name("ColumbaBackendRestarted"), object: nil
         )
         DiagLog.log("[RNS] restartPythonBackend: in-process restart complete")
-        return true
+        return .applied
     }
 
     /// Force the Python RNS stack to flush its path table + known destinations

--- a/Sources/ColumbaApp/Services/InterfaceRepository.swift
+++ b/Sources/ColumbaApp/Services/InterfaceRepository.swift
@@ -200,16 +200,34 @@ public struct TCPClientConfig: Codable, Equatable, Sendable {
     /// Optional passphrase (IFAC)
     public var passphrase: String?
 
+    /// Bootstrap-only: RNS auto-detaches this interface once discovered
+    /// interfaces connect (RNS 1.1.x bootstrap semantics).
+    public var bootstrapOnly: Bool
+
     public init(
         targetHost: String,
         targetPort: UInt16 = 4242,
         networkName: String? = nil,
-        passphrase: String? = nil
+        passphrase: String? = nil,
+        bootstrapOnly: Bool = false
     ) {
         self.targetHost = targetHost
         self.targetPort = targetPort
         self.networkName = networkName
         self.passphrase = passphrase
+        self.bootstrapOnly = bootstrapOnly
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        targetHost = try container.decode(String.self, forKey: .targetHost)
+        targetPort = try container.decode(UInt16.self, forKey: .targetPort)
+        networkName = try container.decodeIfPresent(String.self, forKey: .networkName)
+        passphrase = try container.decodeIfPresent(String.self, forKey: .passphrase)
+        // Added after initial release: old stored interface JSON lacks the key.
+        // `decodeIfPresent` falls back to `false` so pre-existing configs
+        // keep decoding (synthesized Codable would throw keyNotFound).
+        bootstrapOnly = try container.decodeIfPresent(Bool.self, forKey: .bootstrapOnly) ?? false
     }
 }
 

--- a/Sources/ColumbaApp/Services/OneShotLocationProvider.swift
+++ b/Sources/ColumbaApp/Services/OneShotLocationProvider.swift
@@ -63,8 +63,8 @@ final class OneShotLocationProvider: NSObject, CLLocationManagerDelegate {
     /// shown: unauthorized statuses deliver `nil` immediately.
     @MainActor
     func request() {
-        switch CLLocationManager.authorizationStatus() {
-        case .whenInUse, .always:
+        switch self.manager.authorizationStatus {
+        case .authorizedWhenInUse, .authorizedAlways:
             startTimeout()
             manager.requestLocation()
         case .denied, .restricted, .notDetermined:
@@ -81,7 +81,7 @@ final class OneShotLocationProvider: NSObject, CLLocationManagerDelegate {
     private func deliver(_ coordinate: CLLocationCoordinate2D?) {
         guard !delivered else { return }
         delivered = true
-        manager.stopLocationUpdates()
+        manager.stopUpdatingLocation()
         completion(coordinate)
     }
 

--- a/Sources/ColumbaApp/Services/OneShotLocationProvider.swift
+++ b/Sources/ColumbaApp/Services/OneShotLocationProvider.swift
@@ -1,0 +1,116 @@
+//
+//  OneShotLocationProvider.swift
+//  ColumbaApp
+//
+//  Minimal one-shot CoreLocation wrapper for the discovered-interfaces
+//  screen (issue #193). The VM needs the user's current coordinates to
+//  enable distance display / proximity sort, but must NOT trigger a fresh
+//  "allow location" permission prompt from that screen: if authorization
+//  is not already granted (.whenInUse / .always) this provider simply
+//  delivers `nil` and never calls `requestWhenInUseAuthorization()`.
+//
+//  Bounded: a fix that does not arrive within ~10s delivers `nil` so the
+//  calling screen can never hang. Completion always runs on the main
+//  actor.
+//
+
+#if os(iOS)
+import Foundation
+import CoreLocation
+
+/// Delivers a single one-shot location fix (or `nil`) without ever
+/// prompting for location permission.
+///
+/// Mirrors the house CoreLocation pattern in `LocationSharingManager`
+/// (`NSObject` + `CLLocationManagerDelegate`, manager held as a property
+/// so delegate callbacks fire, delegate methods `nonisolated` with the
+/// `Task { @MainActor in }` hop — delegate callbacks already arrive on
+/// the main thread).
+@available(iOS 17.0, macOS 14.0, *)
+final class OneShotLocationProvider: NSObject, CLLocationManagerDelegate {
+
+    /// One-shot fix deadline (seconds). GPS cold starts can take several
+    /// seconds; 10s keeps the UI responsive without cutting off a fix
+    /// that would arrive shortly.
+    private static let timeout: TimeInterval = 10
+
+    /// Deliver the first fix, or `nil` (unauthorized / error / timeout).
+    /// Always called exactly once, on the main actor.
+    private let completion: (CLLocationCoordinate2D?) -> Void
+
+    /// Retained for the lifetime of the one-shot request — `requestLocation`
+    /// requires a live manager to deliver its delegate callbacks.
+    private let manager: CLLocationManager
+
+    /// Guards against double-delivery (fix arriving after the timeout
+    /// fired, or an error racing the timeout).
+    private var delivered = false
+
+    /// Create a provider. Call `request()` to start the one-shot fix.
+    ///
+    /// - Parameter completion: Called exactly once, on the main actor,
+    ///   with the first fix's coordinates or `nil`.
+    @MainActor
+    init(completion: @escaping @MainActor (CLLocationCoordinate2D?) -> Void) {
+        self.completion = completion
+        self.manager = CLLocationManager()
+        super.init()
+        self.manager.delegate = self
+        self.manager.desiredAccuracy = kCLLocationAccuracyHundredMeters
+    }
+
+    /// Start the one-shot location request. No permission prompt is ever
+    /// shown: unauthorized statuses deliver `nil` immediately.
+    @MainActor
+    func request() {
+        switch CLLocationManager.authorizationStatus() {
+        case .whenInUse, .always:
+            startTimeout()
+            manager.requestLocation()
+        case .denied, .restricted, .notDetermined:
+            // Never prompt from the discovery screen (spec assumption 6).
+            deliver(nil)
+        @unknown default:
+            deliver(nil)
+        }
+    }
+
+    // MARK: - Delivery
+
+    @MainActor
+    private func deliver(_ coordinate: CLLocationCoordinate2D?) {
+        guard !delivered else { return }
+        delivered = true
+        manager.stopLocationUpdates()
+        completion(coordinate)
+    }
+
+    /// Bound the request so a never-arriving fix can't hang the screen.
+    @MainActor
+    private func startTimeout() {
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(OneShotLocationProvider.timeout * 1_000_000_000))
+            guard let self, !Task.isCancelled else { return }
+            self.deliver(nil)
+        }
+    }
+
+    // MARK: - CLLocationManagerDelegate
+
+    /// First fix: deliver it, then stop. Delegate callbacks are on the
+    /// main thread already (house pattern — see LocationSharingManager).
+    nonisolated func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        guard let location = locations.first else { return }
+        Task { @MainActor [weak self] in
+            self?.deliver(CLLocationCoordinate2D(latitude: location.coordinate.latitude,
+                                                longitude: location.coordinate.longitude))
+        }
+    }
+
+    nonisolated func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        Task { @MainActor [weak self] in
+            self?.deliver(nil)
+        }
+    }
+}
+#endif

--- a/Sources/ColumbaApp/Services/PythonConfigWriter.swift
+++ b/Sources/ColumbaApp/Services/PythonConfigWriter.swift
@@ -39,11 +39,20 @@ enum PythonConfigWriter {
     ///     Mode" toggle (stored in App Group UserDefaults under
     ///     `transport_enabled`). Changing this requires an Apply &
     ///     Restart since RNS reads it at `Reticulum.__init__` time.
+    ///   - discoverInterfaces: whether RNS should enable interface discovery
+    ///     (RNS 1.1.x `discover_interfaces`). Restart-gated: RNS reads it at
+    ///     `Reticulum.__init__` time, so a change only takes effect on the
+    ///     next Apply & Restart.
+    ///   - autoconnectDiscoveredCount: max number of discovered interfaces
+    ///     RNS should auto-connect to (0-10; 0 = discovery without
+    ///     autoconnect). Also restart-gated.
     /// - Returns: ConfigObj-format text suitable for writing to
     ///   `<configDir>/config`.
     static func write(
         interfaces: [InterfaceEntity],
-        enableTransport: Bool = false
+        enableTransport: Bool = false,
+        discoverInterfaces: Bool = false,
+        autoconnectDiscoveredCount: Int = 0
     ) -> String {
         var lines: [String] = []
 
@@ -51,6 +60,12 @@ enum PythonConfigWriter {
         lines.append("  enable_transport = \(enableTransport ? "yes" : "no")")
         lines.append("  share_instance = no")
         lines.append("  panic_on_interface_error = no")
+        // RNS 1.1.x interface discovery. Restart-gated: RNS reads these at
+        // Reticulum.__init__. discover_interfaces lists announced interfaces;
+        // autoconnect_discovered_interfaces auto-connects up to N discovered
+        // interfaces (0 = discovery without autoconnect).
+        lines.append("  discover_interfaces = \(discoverInterfaces ? "yes" : "no")")
+        lines.append("  autoconnect_discovered_interfaces = \(autoconnectDiscoveredCount)")
         lines.append("")
         lines.append("[logging]")
         lines.append("  loglevel = 4")
@@ -109,6 +124,9 @@ enum PythonConfigWriter {
             appendValue("target_host", cfg.targetHost, to: &lines)
             lines.append("    target_port = \(cfg.targetPort)")
             appendIFAC(networkName: cfg.networkName, passphrase: cfg.passphrase, to: &lines)
+            if cfg.bootstrapOnly {
+                lines.append("    bootstrap_only = yes")
+            }
         case .tcpServer(let cfg):
             lines.append("    type = TCPServerInterface")
             lines.append("    listen_ip = \(cfg.listenIp)")

--- a/Sources/ColumbaApp/Services/SettingsRepository.swift
+++ b/Sources/ColumbaApp/Services/SettingsRepository.swift
@@ -58,6 +58,8 @@ public actor SettingsRepository {
         static let iconName = "profileIconName"
         static let iconFgColor = "profileIconFgColor"
         static let iconBgColor = "profileIconBgColor"
+        static let discoverInterfacesEnabled = "discover_interfaces_enabled"
+        static let autoconnectDiscoveredCount = "autoconnect_discovered_count"
     }
 
     // MARK: - Properties
@@ -330,6 +332,31 @@ public actor SettingsRepository {
     /// Persist the global conversation message-body scale in 10% increments.
     public func setMessageTextScale(_ value: Double) {
         defaults.set(MessageTextScale.normalize(value), forKey: Keys.messageTextScale)
+    }
+
+    // MARK: - Interface Discovery
+
+    /// RNS 1.1.x interface-discovery master switch (config-restart-gated).
+    public func getDiscoverInterfacesEnabled() -> Bool {
+        defaults.bool(forKey: Keys.discoverInterfacesEnabled)
+    }
+
+    /// Set the interface-discovery master switch.
+    public func setDiscoverInterfacesEnabled(_ v: Bool) {
+        defaults.set(v, forKey: Keys.discoverInterfacesEnabled)
+    }
+
+    /// Max discovered interfaces to auto-connect (0-10). 0 doubles as the
+    /// "never configured" sentinel (UserDefaults.integer returns 0 for a
+    /// missing key) — the UI defaults to 3 on first enable.
+    public func getAutoconnectDiscoveredCount() -> Int {
+        let raw = defaults.integer(forKey: Keys.autoconnectDiscoveredCount)
+        return min(max(raw, 0), 10)
+    }
+
+    /// Persist the max discovered interfaces to auto-connect, clamped to 0-10.
+    public func setAutoconnectDiscoveredCount(_ v: Int) {
+        defaults.set(min(max(v, 0), 10), forKey: Keys.autoconnectDiscoveredCount)
     }
 
     /// Get last sync timestamp.

--- a/Sources/ColumbaApp/ViewModels/DiscoveredInterfacesViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/DiscoveredInterfacesViewModel.swift
@@ -107,6 +107,15 @@ public final class DiscoveredInterfacesViewModel {
     /// transport toggle, test deep-link).
     private var backendRestartObserver: NSObjectProtocol?
 
+#if os(iOS)
+    /// Retains the active one-shot location provider. The provider owns its
+    /// `CLLocationManager`, but nothing else retains the provider (the
+    /// manager→delegate edge is weak), so a local in `requestUserLocation()`
+    /// would deallocate at method exit and the fix/timeout could never
+    /// deliver. Released from the provider's completion once delivered.
+    private var locationProvider: OneShotLocationProvider?
+#endif
+
     // MARK: - Initialization
 
     public init(appServices: AppServices, settings: SettingsRepository) {
@@ -271,9 +280,17 @@ public final class DiscoveredInterfacesViewModel {
     public func requestUserLocation() {
         #if os(iOS)
         let provider = OneShotLocationProvider { [weak self] coordinate in
+            // Release the one-shot provider now that the fix (or timeout)
+            // has delivered, so the manager deallocates and GPS acquisition
+            // is fully dropped. Only if still the active provider — a newer
+            // request may already have replaced us.
+            if self?.locationProvider === provider {
+                self?.locationProvider = nil
+            }
             guard let coordinate else { return }
             self?.setUserLocation(lat: coordinate.latitude, lon: coordinate.longitude)
         }
+        locationProvider = provider
         provider.request()
         #endif
     }

--- a/Sources/ColumbaApp/ViewModels/DiscoveredInterfacesViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/DiscoveredInterfacesViewModel.swift
@@ -114,6 +114,13 @@ public final class DiscoveredInterfacesViewModel {
     /// would deallocate at method exit and the fix/timeout could never
     /// deliver. Released from the provider's completion once delivered.
     private var locationProvider: OneShotLocationProvider?
+    /// Monotonic request generation — the completion releases the provider
+    /// slot only if its own request is still the newest (a late timeout from
+    /// an earlier request must not clobber a newer in-flight provider). A
+    /// generation counter is used instead of capturing the provider itself
+    /// because the completion closure cannot reference the `let` it
+    /// initializes.
+    private var locationRequestGeneration = 0
 #endif
 
     // MARK: - Initialization
@@ -279,13 +286,16 @@ public final class DiscoveredInterfacesViewModel {
     @MainActor
     public func requestUserLocation() {
         #if os(iOS)
+        locationRequestGeneration += 1
+        let generation = locationRequestGeneration
         let provider = OneShotLocationProvider { [weak self] coordinate in
             // Release the one-shot provider now that the fix (or timeout)
             // has delivered, so the manager deallocates and GPS acquisition
-            // is fully dropped. Only if still the active provider — a newer
-            // request may already have replaced us.
-            if self?.locationProvider === provider {
-                self?.locationProvider = nil
+            // is fully dropped — but only if this request is still the
+            // newest (a late timeout from a superseded request must not
+            // clobber a newer in-flight provider).
+            if let self, self.locationRequestGeneration == generation {
+                self.locationProvider = nil
             }
             guard let coordinate else { return }
             self?.setUserLocation(lat: coordinate.latitude, lon: coordinate.longitude)

--- a/Sources/ColumbaApp/ViewModels/DiscoveredInterfacesViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/DiscoveredInterfacesViewModel.swift
@@ -1,0 +1,376 @@
+//
+//  DiscoveredInterfacesViewModel.swift
+//  ColumbaApp
+//
+//  ViewModel for the discovered interfaces screen (RNS 1.1.x discovery).
+//  Port of Android's DiscoveredInterfacesViewModel (issue #193): shows the
+//  interfaces announced by other nodes, with search / type-chip / IFAC-only
+//  DISPLAY filters, proximity sorting, and the discovery + autoconnect
+//  settings (persisted to SettingsRepository and applied through a real
+//  in-process backend restart).
+//
+//  All pure sort / filter / haversine logic lives in RNSAPI (T-A:
+//  DiscoveredSorter, DiscoveredFilter, haversineDistanceKm) — this VM only
+//  orchestrates UI state.
+//
+
+import Foundation
+import RNSAPI
+import SwiftUI
+import os.log
+
+private let logger = Logger(subsystem: "network.columba.Columba", category: "DiscoveredIfacesVM")
+
+// MARK: - Discovered Interfaces ViewModel
+
+/// ViewModel for the discovered interfaces screen.
+///
+/// Manages the visible (filtered + sorted) interface list, the raw backend
+/// list, search / type / IFAC display filters, the user location for
+/// distance display, and the discovery + autoconnect settings. Toggling the
+/// settings persists them, then applies them via
+/// `appServices.restartPythonBackend()` (in-process restart +
+/// `ColumbaBackendRestarted`), then re-polls live discovery state.
+@available(iOS 17.0, macOS 14.0, *)
+@Observable
+public final class DiscoveredInterfacesViewModel {
+
+    // MARK: - Dependencies
+
+    private let appServices: AppServices
+    private let settings: SettingsRepository
+
+    // MARK: - List State
+
+    /// Interfaces currently visible (display-filtered + sorted).
+    public var interfaces: [DiscoveredInterface] = []
+
+    /// Raw list from the backend, before display filters — the source for
+    /// re-filtering when the user changes search / type / IFAC filters.
+    public var originalInterfaces: [DiscoveredInterface] = []
+
+    /// Whether the discovery list is loading.
+    public var isLoading: Bool = true
+
+    /// Whether a discovery-settings change is being applied (backend restart).
+    public var isRestarting: Bool = false
+
+    /// Current error message (set on load / apply failures).
+    public var errorMessage: String?
+
+    /// Count of discovered interfaces in each status bucket.
+    public var availableCount: Int = 0
+    public var unknownCount: Int = 0
+    public var staleCount: Int = 0
+
+    // MARK: - Display Filters
+
+    /// Sort mode for the interface list.
+    public var sortMode: DiscoveredSortMode = .availabilityAndQuality
+
+    /// Free-form search filter, matched against name + reachableOn + type.
+    public var searchQuery: String = ""
+
+    /// Multi-select type filter. Empty set = no filtering (all types shown).
+    public var typeFilters: Set<DiscoveredTypeFilter> = []
+
+    /// When true, only show interfaces that announced an IFAC network name.
+    public var ifacOnly: Bool = false
+
+    // MARK: - User Location
+
+    /// The user's current location for distance calculation (nil = unknown).
+    public var userLatitude: Double?
+    public var userLongitude: Double?
+
+    // MARK: - Discovery Settings (persisted preferences + runtime state)
+
+    /// User preference: the interface-discovery master switch (persisted).
+    public var discoverInterfacesEnabled: Bool = false
+
+    /// User preference: max discovered interfaces to autoconnect (persisted).
+    public var autoconnectCount: Int = 0
+
+    /// Runtime state: whether the running backend has discovery enabled.
+    public var isDiscoveryEnabled: Bool = false
+
+    /// Endpoints ("host:port") the backend has autoconnected to.
+    public var autoconnectedEndpoints: Set<String> = []
+
+    /// Names of the bootstrap-only TCP client interfaces (they enable discovery).
+    public var bootstrapInterfaceNames: [String] = []
+
+    // MARK: - Private State
+
+    /// Observer token for `ColumbaBackendRestarted` — re-polls the list
+    /// whenever the backend restarts from anywhere (settings toggle here,
+    /// transport toggle, test deep-link).
+    private var backendRestartObserver: NSObjectProtocol?
+
+    // MARK: - Initialization
+
+    public init(appServices: AppServices, settings: SettingsRepository) {
+        self.appServices = appServices
+        self.settings = settings
+        startBackendRestartObserver()
+        load()
+    }
+
+    deinit {
+        if let observer = backendRestartObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+    }
+
+    // MARK: - Loading
+
+    /// Kick off an initial load (called from init; mirrors the house
+    /// `Task { @MainActor in }` spawn pattern).
+    public func load() {
+        Task { @MainActor in
+            await self.loadAsync()
+        }
+    }
+
+    /// Load discovered interfaces from the running RNS backend, plus the
+    /// persisted discovery settings, then recompute the visible list.
+    @MainActor
+    public func loadAsync() async {
+        isLoading = true
+        errorMessage = nil
+
+        // `pythonBackend` is compiled only into the shipping (Python) build;
+        // Model B has no app-side discovery — show an honest message instead
+        // of a nil-unwrap crash.
+        let snapshot: DiscoverySnapshot?
+        #if COLUMBA_RUNTIME_PYTHON
+        snapshot = await appServices.pythonBackend?.discovery()
+        #else
+        snapshot = nil
+        #endif
+
+        guard let snapshot else {
+            isLoading = false
+            errorMessage = String(localized: "Interface discovery is unavailable in this build.")
+            logger.warning("Discovery unavailable — no Python backend")
+            return
+        }
+
+        originalInterfaces = snapshot.discovered
+        availableCount = snapshot.discovered.filter { $0.status == "available" }.count
+        unknownCount = snapshot.discovered.filter { $0.status == "unknown" }.count
+        staleCount = snapshot.discovered.filter { $0.status == "stale" }.count
+        isDiscoveryEnabled = snapshot.enabled
+        autoconnectedEndpoints = Set(snapshot.autoconnected)
+
+        await loadSettings()
+        recomputeVisible()
+        isLoading = false
+
+        logger.info("Loaded \(snapshot.discovered.count) discovered interfaces, \(autoconnectedEndpoints.count) auto-connected")
+    }
+
+    /// Load discovery settings (persisted preferences) and the bootstrap-only
+    /// interface names.
+    @MainActor
+    public func loadSettings() async {
+        discoverInterfacesEnabled = await settings.getDiscoverInterfacesEnabled()
+
+        let saved = await settings.getAutoconnectDiscoveredCount()
+        // 0 doubles as the "never configured" sentinel — the UI defaults to
+        // 3 in toggleDiscovery() on first enable (mirror of Android).
+        autoconnectCount = saved >= 0 ? saved : 0
+
+        // Synchronous, non-actor-isolated house pattern: InterfaceRepository
+        // is a plain final class (see the direct call sites in AppServices).
+        bootstrapInterfaceNames = InterfaceRepository()
+            .getEnabledInterfaces()
+            .filter { entity in
+                guard case .tcpClient(let config) = entity.config else { return false }
+                return config.bootstrapOnly
+            }
+            .map { $0.name }
+    }
+
+    /// Recompute the visible list from the raw backend list + the current
+    /// display filters. Pure logic is delegated to RNSAPI (T-A).
+    private func recomputeVisible() {
+        interfaces = DiscoveredSorter.sort(
+            DiscoveredFilter.apply(
+                originalInterfaces,
+                searchQuery: searchQuery,
+                typeFilters: typeFilters,
+                ifacOnly: ifacOnly
+            ),
+            mode: sortMode,
+            userLatitude: userLatitude,
+            userLongitude: userLongitude
+        )
+    }
+
+    // MARK: - Search / Filter / Sort Mutators
+
+    /// Update the free-form search query and recompute the visible list.
+    public func setSearchQuery(_ query: String) {
+        searchQuery = query
+        recomputeVisible()
+    }
+
+    /// Insert or remove a type chip and recompute the visible list.
+    public func toggleTypeFilter(_ filter: DiscoveredTypeFilter) {
+        if typeFilters.contains(filter) {
+            typeFilters.remove(filter)
+        } else {
+            typeFilters.insert(filter)
+        }
+        recomputeVisible()
+    }
+
+    /// Toggle the IFAC-only display filter and recompute the visible list.
+    public func toggleIfacOnlyFilter() {
+        ifacOnly.toggle()
+        recomputeVisible()
+    }
+
+    /// Clear all display filters and recompute the visible list.
+    public func clearFilters() {
+        searchQuery = ""
+        typeFilters = []
+        ifacOnly = false
+        recomputeVisible()
+    }
+
+    /// Switch sort mode. Switching to `.proximity` is IGNORED (stay in the
+    /// current mode) while the user location is unknown — mirror of the
+    /// Android guard.
+    public func setSortMode(_ mode: DiscoveredSortMode) {
+        if mode == .proximity, userLatitude == nil || userLongitude == nil {
+            logger.info("Ignoring proximity sort request — no user location fix yet")
+            return
+        }
+        sortMode = mode
+        recomputeVisible()
+    }
+
+    // MARK: - User Location
+
+    /// Record the user's current location so distances can be shown; re-sorts
+    /// when in proximity mode.
+    public func setUserLocation(lat: Double, lon: Double) {
+        userLatitude = lat
+        userLongitude = lon
+        if sortMode == .proximity {
+            recomputeVisible()
+        }
+    }
+
+    /// Fetch the user's current location with a one-shot GPS fix (bounded
+    /// ~10s, never prompts for permission). On a fix, records it via
+    /// `setUserLocation(lat:lon:)`.
+    @MainActor
+    public func requestUserLocation() {
+        #if os(iOS)
+        let provider = OneShotLocationProvider { [weak self] coordinate in
+            guard let coordinate else { return }
+            self?.setUserLocation(lat: coordinate.latitude, lon: coordinate.longitude)
+        }
+        provider.request()
+        #endif
+    }
+
+    // MARK: - Distance / Autoconnect
+
+    /// Distance in km from the user to an interface, or nil when either
+    /// location is unknown. Pure haversine math lives in RNSAPI (T-A).
+    public func calculateDistance(_ iface: DiscoveredInterface) -> Double? {
+        guard let userLatitude, let userLongitude,
+              iface.hasLocation,
+              let lat = iface.latitude,
+              let lon = iface.longitude else {
+            return nil
+        }
+        return haversineDistanceKm(lat1: userLatitude, lon1: userLongitude, lat2: lat, lon2: lon)
+    }
+
+    /// Whether the backend has autoconnected to this interface's endpoint.
+    public func isAutoconnected(_ iface: DiscoveredInterface) -> Bool {
+        guard !autoconnectedEndpoints.isEmpty,
+              let host = iface.reachableOn,
+              let port = iface.port else {
+            return false
+        }
+        return autoconnectedEndpoints.contains("\(host):\(port)")
+    }
+
+    // MARK: - Discovery Settings (persist + in-process restart)
+
+    /// Toggle interface discovery on/off.
+    ///
+    /// When enabling: restores the user's saved autoconnect preference (or
+    /// defaults to 3 on first enable). When disabling: the UI shows 0 but the
+    /// saved preference is NOT overwritten (preserved for the next enable).
+    /// Persists to settings, applies via the real in-process backend restart
+    /// (T-D), then re-polls live discovery state once back up.
+    public func toggleDiscovery() {
+        let newEnabled = !discoverInterfacesEnabled
+        let newCount: Int
+        if newEnabled {
+            // Restore the user's saved preference, or default 3 on first enable.
+            let saved = autoconnectCount   // already loaded by loadSettings
+            newCount = saved > 0 ? saved : 3
+        } else {
+            newCount = 0   // UI shows 0; we do NOT persist 0 (preserve preference)
+        }
+
+        // Update the UI immediately to show the restarting state.
+        discoverInterfacesEnabled = newEnabled
+        autoconnectCount = newEnabled ? newCount : 0
+        isRestarting = true
+
+        Task { @MainActor in
+            await settings.setDiscoverInterfacesEnabled(newEnabled)
+            // Only persist the count when enabling (preserve the user's
+            // preference when disabling).
+            if newEnabled {
+                await settings.setAutoconnectDiscoveredCount(newCount)
+            }
+            // Rewrites the config (fresh discovery settings, T-C) and does
+            // the real in-process restart (T-D), posting
+            // `ColumbaBackendRestarted` on success.
+            await appServices.restartPythonBackend()
+            await loadAsync()   // re-poll live discovery state once back up
+            isRestarting = false
+        }
+    }
+
+    /// Set the number of discovered interfaces to autoconnect (clamped 0-10).
+    /// Persists, applies via the in-process restart, then re-polls.
+    public func setAutoconnectCount(_ count: Int) {
+        let clamped = min(max(count, 0), 10)
+        autoconnectCount = clamped
+        isRestarting = true
+        Task { @MainActor in
+            await settings.setAutoconnectDiscoveredCount(clamped)
+            await appServices.restartPythonBackend()
+            await loadAsync()
+            isRestarting = false
+        }
+    }
+
+    // MARK: - Backend Restart Observation
+
+    /// Re-poll whenever the backend restarts from anywhere, so a restart
+    /// driven by the transport toggle or a test deep-link refreshes this
+    /// list (house pattern: token stored, removed in deinit).
+    private func startBackendRestartObserver() {
+        backendRestartObserver = NotificationCenter.default.addObserver(
+            forName: Notification.Name("ColumbaBackendRestarted"),
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                await self?.loadAsync()
+            }
+        }
+    }
+}

--- a/Sources/ColumbaApp/ViewModels/DiscoveredInterfacesViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/DiscoveredInterfacesViewModel.swift
@@ -183,7 +183,8 @@ public final class DiscoveredInterfacesViewModel {
         recomputeVisible()
         isLoading = false
 
-        logger.info("Loaded \(snapshot.discovered.count) discovered interfaces, \(autoconnectedEndpoints.count) auto-connected")
+        let endpointCount = autoconnectedEndpoints.count
+        logger.info("Loaded \(snapshot.discovered.count) discovered interfaces, \(endpointCount) auto-connected")
     }
 
     /// Load discovery settings (persisted preferences) and the bootstrap-only

--- a/Sources/ColumbaApp/ViewModels/DiscoveredInterfacesViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/DiscoveredInterfacesViewModel.swift
@@ -27,10 +27,17 @@ private let logger = Logger(subsystem: "network.columba.Columba", category: "Dis
 ///
 /// Manages the visible (filtered + sorted) interface list, the raw backend
 /// list, search / type / IFAC display filters, the user location for
-/// distance display, and the discovery + autoconnect settings. Toggling the
-/// settings persists them, then applies them via
-/// `appServices.restartPythonBackend()` (in-process restart +
-/// `ColumbaBackendRestarted`), then re-polls live discovery state.
+/// distance display, and the discovery + autoconnect settings.
+///
+/// Settings are PENDING-STATE, not immediate (issue #193): the toggle and
+/// the slider (which fires on every drag tick) only mutate the pending
+/// values. The single `applyDiscoverySettings()` intent is the ONLY path
+/// that persists them and calls `appServices.restartPythonBackend()`
+/// (config rewrite + in-process restart + `ColumbaBackendRestarted`).
+/// Applying immediately on every change restarted Reticulum mid-drag, and
+/// each transient not-started poll emptied the list and flipped the
+/// "enabled" indicator — the controls now wait for an explicit
+/// "Apply and Restart".
 @available(iOS 17.0, macOS 14.0, *)
 @Observable
 public final class DiscoveredInterfacesViewModel {
@@ -90,6 +97,29 @@ public final class DiscoveredInterfacesViewModel {
 
     /// User preference: max discovered interfaces to autoconnect (persisted).
     public var autoconnectCount: Int = 0
+
+    // MARK: - Pending discovery settings (apply-and-restart flow, issue #193)
+
+    /// Snapshot of the discovery toggle value that is currently LIVE on the
+    /// running backend (last successfully applied / loaded from settings).
+    /// Pending changes are held in `discoverInterfacesEnabled` and compared
+    /// against this to derive `hasPendingDiscoveryChanges`.
+    private(set) var appliedDiscoverInterfacesEnabled: Bool = false
+
+    /// Snapshot of the auto-connect count currently LIVE on the running
+    /// backend (last successfully applied / loaded from settings).
+    private(set) var appliedAutoconnectCount: Int = 0
+
+    /// True when the pending settings differ from what the running backend
+    /// has applied — the "Apply and Restart" button shows while this is set.
+    public var hasPendingDiscoveryChanges: Bool {
+        discoverInterfacesEnabled != appliedDiscoverInterfacesEnabled
+            || autoconnectCount != appliedAutoconnectCount
+    }
+
+    /// Whether `loadSettings()` has seeded the pending settings once (guards
+    /// re-polls from clobbering in-flight pending changes).
+    private var hasLoadedDiscoverySettings = false
 
     /// Runtime state: whether the running backend has discovery enabled.
     public var isDiscoveryEnabled: Bool = false
@@ -189,14 +219,28 @@ public final class DiscoveredInterfacesViewModel {
 
     /// Load discovery settings (persisted preferences) and the bootstrap-only
     /// interface names.
+    ///
+    /// The persisted values seed the pending settings ONLY on the first load
+    /// (which also establishes the applied baseline — the startup config is
+    /// always written from these same settings, so persisted == live at that
+    /// point). Later re-polls (refresh button, backend-restarted
+    /// notification) must NOT clobber in-flight pending changes the user has
+    /// made but not applied yet.
     @MainActor
     public func loadSettings() async {
-        discoverInterfacesEnabled = await settings.getDiscoverInterfacesEnabled()
+        if !hasLoadedDiscoverySettings {
+            discoverInterfacesEnabled = await settings.getDiscoverInterfacesEnabled()
 
-        let saved = await settings.getAutoconnectDiscoveredCount()
-        // 0 doubles as the "never configured" sentinel — the UI defaults to
-        // 3 in toggleDiscovery() on first enable (mirror of Android).
-        autoconnectCount = saved >= 0 ? saved : 0
+            let saved = await settings.getAutoconnectDiscoveredCount()
+            // 0 doubles as the "never configured" sentinel — enabling from
+            // off defaults the pending count to 3 (setDiscoverInterfacesEnabled,
+            // mirror of Android).
+            autoconnectCount = saved >= 0 ? saved : 0
+
+            appliedDiscoverInterfacesEnabled = discoverInterfacesEnabled
+            appliedAutoconnectCount = autoconnectCount
+            hasLoadedDiscoverySettings = true
+        }
 
         // Synchronous, non-actor-isolated house pattern: InterfaceRepository
         // is a plain final class (see the direct call sites in AppServices).
@@ -330,59 +374,75 @@ public final class DiscoveredInterfacesViewModel {
         return autoconnectedEndpoints.contains("\(host):\(port)")
     }
 
-    // MARK: - Discovery Settings (persist + in-process restart)
+    // MARK: - Discovery Settings (pending state + apply-and-restart)
 
-    /// Toggle interface discovery on/off.
-    ///
-    /// When enabling: restores the user's saved autoconnect preference (or
-    /// defaults to 3 on first enable). When disabling: the UI shows 0 but the
-    /// saved preference is NOT overwritten (preserved for the next enable).
-    /// Persists to settings, applies via the real in-process backend restart
-    /// (T-D), then re-polls live discovery state once back up.
-    public func toggleDiscovery() {
-        let newEnabled = !discoverInterfacesEnabled
-        let newCount: Int
-        if newEnabled {
-            // Restore the user's saved preference, or default 3 on first enable.
-            let saved = autoconnectCount   // already loaded by loadSettings
-            newCount = saved > 0 ? saved : 3
-        } else {
-            newCount = 0   // UI shows 0; we do NOT persist 0 (preserve preference)
-        }
-
-        // Update the UI immediately to show the restarting state.
-        discoverInterfacesEnabled = newEnabled
-        autoconnectCount = newEnabled ? newCount : 0
-        isRestarting = true
-
-        Task { @MainActor in
-            await settings.setDiscoverInterfacesEnabled(newEnabled)
-            // Only persist the count when enabling (preserve the user's
-            // preference when disabling).
-            if newEnabled {
-                await settings.setAutoconnectDiscoveredCount(newCount)
-            }
-            // Rewrites the config (fresh discovery settings, T-C) and does
-            // the real in-process restart (T-D), posting
-            // `ColumbaBackendRestarted` on success.
-            await appServices.restartPythonBackend()
-            await loadAsync()   // re-poll live discovery state once back up
-            isRestarting = false
+    /// Toggle the pending discovery value. Pure pending state — does NOT
+    /// persist and does NOT restart; the user confirms with "Apply and
+    /// Restart" (`applyDiscoverySettings`). Enabling from off with a
+    /// never-configured count (0 sentinel) defaults the count to 3
+    /// (Android mirror) — the user still sees and can change the pending
+    /// value before applying.
+    public func setDiscoverInterfacesEnabled(_ enabled: Bool) {
+        discoverInterfacesEnabled = enabled
+        if enabled && autoconnectCount == 0 {
+            autoconnectCount = 3
         }
     }
 
-    /// Set the number of discovered interfaces to autoconnect (clamped 0-10).
-    /// Persists, applies via the in-process restart, then re-polls.
+    /// Set the pending auto-connect count (clamped 0-10). Pure pending
+    /// state — does NOT persist and does NOT restart (the SwiftUI slider
+    /// fires this on every drag tick; the single apply button is the only
+    /// restart trigger). A count of 0 keeps discovery ENABLED
+    /// (observe-only mode: heard announces are still recorded and listed,
+    /// just nothing is auto-connected).
     public func setAutoconnectCount(_ count: Int) {
-        let clamped = min(max(count, 0), 10)
-        autoconnectCount = clamped
+        autoconnectCount = min(max(count, 0), 10)
+    }
+
+    /// Persist the pending discovery settings and apply them via the real
+    /// in-process backend restart. `restartPythonBackend` rewrites the RNS
+    /// config from the persisted settings (T-C), tears the backend down,
+    /// re-inits it, and posts `ColumbaBackendRestarted` on success — which
+    /// the observer turns into a re-poll of the live discovery state.
+    ///
+    /// The applied snapshots are committed only on a SUCCESSFUL restart. On
+    /// failure the backend is down: the settings were persisted (so a
+    /// future restart picks them up) but are NOT live, so the pending flag
+    /// stays set (button remains tappable to retry) and an error is
+    /// surfaced. The user's in-flight control values are never clobbered.
+    @MainActor
+    public func applyDiscoverySettings() async {
+        guard hasPendingDiscoveryChanges, !isRestarting else { return }
+
+        let toEnable = discoverInterfacesEnabled
+        let toCount = autoconnectCount
+
         isRestarting = true
-        Task { @MainActor in
-            await settings.setAutoconnectDiscoveredCount(clamped)
-            await appServices.restartPythonBackend()
-            await loadAsync()
-            isRestarting = false
+        errorMessage = nil
+        // Persist first so the config rewrite inside restartPythonBackend
+        // reads the fresh values.
+        await settings.setDiscoverInterfacesEnabled(toEnable)
+        await settings.setAutoconnectDiscoveredCount(toCount)
+
+        let succeeded = await appServices.restartPythonBackend()
+
+        if succeeded {
+            // Commit: pending == applied from here on; the
+            // `ColumbaBackendRestarted` re-poll refreshes the list, the
+            // status dot, and the corrected `enabled` flag from the bridge.
+            appliedDiscoverInterfacesEnabled = toEnable
+            appliedAutoconnectCount = toCount
+        } else {
+            errorMessage = String(localized: "Restart failed — discovery settings were not applied.")
+            logger.error("Discovery settings apply failed (restart error); pending flag kept for retry")
         }
+        isRestarting = false
+    }
+
+    /// Revert the pending settings to what the running backend has applied.
+    public func discardPendingDiscoveryChanges() {
+        discoverInterfacesEnabled = appliedDiscoverInterfacesEnabled
+        autoconnectCount = appliedAutoconnectCount
     }
 
     // MARK: - Backend Restart Observation

--- a/Sources/ColumbaApp/ViewModels/DiscoveredInterfacesViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/DiscoveredInterfacesViewModel.swift
@@ -180,6 +180,14 @@ public final class DiscoveredInterfacesViewModel {
 
     /// Load discovered interfaces from the running RNS backend, plus the
     /// persisted discovery settings, then recompute the visible list.
+    ///
+    /// The persisted settings are loaded EVEN WHEN the backend snapshot is
+    /// unavailable (Model B build, backend never started, or a failed
+    /// restart): they are a local preference read, independent of the
+    /// snapshot. Gating them behind the snapshot is what made the screen
+    /// show default `false`/`0` values (and, worse, let a recovery edit
+    /// silently overwrite the saved auto-connect count) while discovery
+    /// was actually enabled (issue #193 / Greptile P1 #3).
     @MainActor
     public func loadAsync() async {
         isLoading = true
@@ -195,26 +203,30 @@ public final class DiscoveredInterfacesViewModel {
         snapshot = nil
         #endif
 
-        guard let snapshot else {
-            isLoading = false
-            errorMessage = String(localized: "Interface discovery is unavailable in this build.")
+        if let snapshot {
+            originalInterfaces = snapshot.discovered
+            availableCount = snapshot.discovered.filter { $0.status == "available" }.count
+            unknownCount = snapshot.discovered.filter { $0.status == "unknown" }.count
+            staleCount = snapshot.discovered.filter { $0.status == "stale" }.count
+            isDiscoveryEnabled = snapshot.enabled
+            autoconnectedEndpoints = Set(snapshot.autoconnected)
+        } else {
+            // Backend unavailable: no live list to show, but the controls
+            // must still reflect the PERSISTED settings (below) so a
+            // recovery edit is seeded from what's actually saved.
             logger.warning("Discovery unavailable — no Python backend")
-            return
         }
-
-        originalInterfaces = snapshot.discovered
-        availableCount = snapshot.discovered.filter { $0.status == "available" }.count
-        unknownCount = snapshot.discovered.filter { $0.status == "unknown" }.count
-        staleCount = snapshot.discovered.filter { $0.status == "stale" }.count
-        isDiscoveryEnabled = snapshot.enabled
-        autoconnectedEndpoints = Set(snapshot.autoconnected)
 
         await loadSettings()
         recomputeVisible()
         isLoading = false
 
-        let endpointCount = autoconnectedEndpoints.count
-        logger.info("Loaded \(snapshot.discovered.count) discovered interfaces, \(endpointCount) auto-connected")
+        if let snapshot {
+            let endpointCount = autoconnectedEndpoints.count
+            logger.info("Loaded \(snapshot.discovered.count) discovered interfaces, \(endpointCount) auto-connected")
+        } else {
+            errorMessage = String(localized: "Interface discovery is unavailable in this build.")
+        }
     }
 
     /// Load discovery settings (persisted preferences) and the bootstrap-only
@@ -364,6 +376,18 @@ public final class DiscoveredInterfacesViewModel {
         return haversineDistanceKm(lat1: userLatitude, lon1: userLongitude, lat2: lat, lon2: lon)
     }
 
+    /// Canonical `host:port` endpoint string for the discovery card's
+    /// "Connected" badge — matches what `discovery_json()` emits in its
+    /// `autoconnected` list: the interface's `reachable_on` (a resolved
+    /// IP/hostname) plus port, with IPv6 bracketed exactly as
+    /// `BackboneInterface.__str__` renders it. Comparing against the
+    /// bridge's *friendly* string ("BackboneInterface[Name/ip:port]") is
+    /// what made the badge never appear (issue #193 / Greptile P1 #1).
+    static func canonicalEndpoint(host: String, port: Int) -> String {
+        let ip = host.contains(":") ? "[\(host)]" : host
+        return "\(ip):\(port)"
+    }
+
     /// Whether the backend has autoconnected to this interface's endpoint.
     public func isAutoconnected(_ iface: DiscoveredInterface) -> Bool {
         guard !autoconnectedEndpoints.isEmpty,
@@ -371,7 +395,7 @@ public final class DiscoveredInterfacesViewModel {
               let port = iface.port else {
             return false
         }
-        return autoconnectedEndpoints.contains("\(host):\(port)")
+        return autoconnectedEndpoints.contains(Self.canonicalEndpoint(host: host, port: port))
     }
 
     // MARK: - Discovery Settings (pending state + apply-and-restart)
@@ -410,6 +434,13 @@ public final class DiscoveredInterfacesViewModel {
     /// future restart picks them up) but are NOT live, so the pending flag
     /// stays set (button remains tappable to retry) and an error is
     /// surfaced. The user's in-flight control values are never clobbered.
+    ///
+    /// AutoInterface (Greptile P1 #2): when an AutoInterface is configured the
+    /// in-process restart is REFUSED (its multicast sockets are not released
+    /// on detach, so same-process re-init is unsafe) and the settings take
+    /// effect on the next clean relaunch. That is a deliberate, safe
+    /// deferral — not a failure — so the pending flag is CLEARED and an
+    /// informational (non-alarming) message is shown instead of "failed".
     @MainActor
     public func applyDiscoverySettings() async {
         guard hasPendingDiscoveryChanges, !isRestarting else { return }
@@ -424,17 +455,30 @@ public final class DiscoveredInterfacesViewModel {
         await settings.setDiscoverInterfacesEnabled(toEnable)
         await settings.setAutoconnectDiscoveredCount(toCount)
 
-        let succeeded = await appServices.restartPythonBackend()
+        let outcome = await appServices.restartPythonBackend()
 
-        if succeeded {
+        switch outcome {
+        case .applied:
             // Commit: pending == applied from here on; the
             // `ColumbaBackendRestarted` re-poll refreshes the list, the
             // status dot, and the corrected `enabled` flag from the bridge.
             appliedDiscoverInterfacesEnabled = toEnable
             appliedAutoconnectCount = toCount
-        } else {
+        case .requiresRelaunch:
+            // Deliberate deferral: the settings were persisted and will be
+            // read at the next clean launch, so the pending flag is cleared
+            // (no retry loop) but an informational message tells the user
+            // when the change goes live.
+            appliedDiscoverInterfacesEnabled = toEnable
+            appliedAutoconnectCount = toCount
+            errorMessage = String(localized: "Saved. Applies on the next app relaunch because an AutoInterface is active.")
+            logger.info("Discovery settings persisted; in-process restart deferred (AutoInterface active)")
+        case .skipped, .failed:
+            // The backend is down / was never started: the settings were
+            // persisted (so a future restart picks them up) but are NOT
+            // live — keep the pending flag for a retry and surface the error.
             errorMessage = String(localized: "Restart failed — discovery settings were not applied.")
-            logger.error("Discovery settings apply failed (restart error); pending flag kept for retry")
+            logger.error("Discovery settings apply failed (restart outcome: \(outcome)); pending flag kept for retry")
         }
         isRestarting = false
     }

--- a/Sources/ColumbaApp/ViewModels/NetworkStatusViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/NetworkStatusViewModel.swift
@@ -23,6 +23,11 @@ struct InterfaceInfo: Identifiable {
     let isAutoInterfacePeer: Bool
     let peerAddress: String?
     let lastErrorDescription: String?
+    /// Live `host:port` endpoint for TCP rows (parsed from Python's friendly
+    /// name by the status poll), e.g. "10.0.4.63:4242".
+    let endpoint: String?
+    /// True when RNS auto-connected this interface from a discovery announce.
+    let isAutoconnect: Bool
 }
 
 // MARK: - Network Status ViewModel
@@ -157,7 +162,9 @@ final class NetworkStatusViewModel {
                 state: snap.state,
                 isAutoInterfacePeer: snap.isAutoInterfacePeer,
                 peerAddress: snap.peerAddress,
-                lastErrorDescription: snap.lastErrorDescription
+                lastErrorDescription: snap.lastErrorDescription,
+                endpoint: snap.endpoint,
+                isAutoconnect: snap.isAutoconnect
             ))
         }
 
@@ -224,7 +231,9 @@ final class NetworkStatusViewModel {
                 state: mappedState,
                 isAutoInterfacePeer: isAutoPeer,
                 peerAddress: addr,
-                lastErrorDescription: err
+                lastErrorDescription: err,
+                endpoint: nil,
+                isAutoconnect: iface.isAutoconnect ?? false
             )
         }
 

--- a/Sources/ColumbaApp/ViewModels/RNodeWizardViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/RNodeWizardViewModel.swift
@@ -369,4 +369,17 @@ final class RNodeWizardViewModel {
         // No region match — use custom mode
         isCustomMode = true
     }
+
+    /// Prefill custom LoRa fields from a discovered interface (discovery card 'Use for RNode').
+    init(prefilledFrom iface: DiscoveredInterface) {
+        self.init()
+        isCustomMode = true
+        interfaceName = iface.name
+        customFrequency = iface.frequency.map { String(Int($0)) }
+        customBandwidth = iface.bandwidth.map(String.init)
+        customSpreadingFactor = iface.spreadingFactor.map(String.init)
+        customCodingRate = iface.codingRate.map(String.init)
+        // Region/preset selection stays at its default; the wizard's existing
+        // validation decides legality.
+    }
 }

--- a/Sources/ColumbaApp/ViewModels/RNodeWizardViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/RNodeWizardViewModel.swift
@@ -370,8 +370,15 @@ final class RNodeWizardViewModel {
         isCustomMode = true
     }
 
+    /// No-arg designated init (memberwise defaults). Kept explicit so the
+    /// `convenience init(prefilledFrom:)` below can delegate to it — a class
+    /// loses its implicit no-arg `init()` once it declares ANY designated
+    /// init, which would otherwise break every `RNodeWizardViewModel()`
+    /// construction site.
+    init() {}
+
     /// Prefill custom LoRa fields from a discovered interface (discovery card 'Use for RNode').
-    init(prefilledFrom iface: DiscoveredInterface) {
+    convenience init(prefilledFrom iface: DiscoveredInterface) {
         self.init()
         isCustomMode = true
         interfaceName = iface.name

--- a/Sources/ColumbaApp/ViewModels/RNodeWizardViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/RNodeWizardViewModel.swift
@@ -383,10 +383,10 @@ final class RNodeWizardViewModel {
     func applyPrefill(_ iface: DiscoveredInterface) {
         isCustomMode = true
         interfaceName = iface.name
-        customFrequency = iface.frequency.map { String(Int($0)) }
-        customBandwidth = iface.bandwidth.map(String.init)
-        customSpreadingFactor = iface.spreadingFactor.map(String.init)
-        customCodingRate = iface.codingRate.map(String.init)
+        customFrequency = iface.frequency.map { String(Int($0)) } ?? ""
+        customBandwidth = iface.bandwidth.map(String.init) ?? ""
+        customSpreadingFactor = iface.spreadingFactor.map(String.init) ?? ""
+        customCodingRate = iface.codingRate.map(String.init) ?? ""
         // Region/preset selection stays at its default; the wizard's existing
         // validation decides legality.
     }

--- a/Sources/ColumbaApp/ViewModels/RNodeWizardViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/RNodeWizardViewModel.swift
@@ -371,15 +371,16 @@ final class RNodeWizardViewModel {
     }
 
     /// No-arg designated init (memberwise defaults). Kept explicit so the
-    /// `convenience init(prefilledFrom:)` below can delegate to it — a class
-    /// loses its implicit no-arg `init()` once it declares ANY designated
-    /// init, which would otherwise break every `RNodeWizardViewModel()`
+    /// class retains a public parameterless init for every existing
     /// construction site.
+
     init() {}
 
-    /// Prefill custom LoRa fields from a discovered interface (discovery card 'Use for RNode').
-    convenience init(prefilledFrom iface: DiscoveredInterface) {
-        self.init()
+    /// Prefill custom LoRa fields from a discovered interface (discovery
+    /// card 'Use for RNode'). Mutates the existing instance — the wizard
+    /// view calls this from `onAppear` (one-shot, same pattern as
+    /// `populateFromConfig`).
+    func applyPrefill(_ iface: DiscoveredInterface) {
         isCustomMode = true
         interfaceName = iface.name
         customFrequency = iface.frequency.map { String(Int($0)) }

--- a/Sources/ColumbaApp/ViewModels/SettingsViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/SettingsViewModel.swift
@@ -113,6 +113,37 @@ enum NetworkInterfacePresentation {
         descriptions.append(contentsOf: repeatElement(String(localized: "TCP"), count: unknownConnectedCount))
         return descriptions
     }
+
+    /// Rows for the interfaces RNS spawns dynamically (discovery auto-connects,
+    /// LAN AutoInterface peers). These never appear in `tcpInterfaces` — the
+    /// transport's auxiliary snapshot is the source of truth (the same one the
+    /// Network Status screen reads).
+    ///
+    /// - Discovery auto-connects get one named row each, flagged "Discovered"
+    ///   (the Settings card has no per-row badge column, so the flag is inline).
+    /// - LAN AutoInterface peers roll up into a single count row (one row per
+    ///   link-local address would be noise in the compact card); the Network
+    ///   Status screen still lists each one.
+    /// - BLE peers are excluded: the card already lists the BLE interface from
+    ///   the app's singleton stub, so aux BLEPeer rows would double-count.
+    static func auxiliaryDescriptions(_ snapshots: [InterfaceSnapshot]) -> [String] {
+        var rows: [String] = []
+        var lanPeerCount = 0
+        for snap in snapshots where snap.online {
+            if snap.isAutoInterfacePeer {
+                lanPeerCount += 1
+            } else if snap.isBLEPeerInterface {
+                continue
+            } else if snap.isAutoconnect {
+                let base = snap.name.isEmpty ? snap.typeLabel : snap.name
+                rows.append("\(base) (\(String(localized: "Discovered")))")
+            }
+        }
+        if lanPeerCount > 0 {
+            rows.append("AutoInterface (\(lanPeerCount) peer\(lanPeerCount == 1 ? "" : "s"))")
+        }
+        return rows
+    }
 }
 
 /// ViewModel for settings screen.
@@ -584,9 +615,14 @@ public final class SettingsViewModel {
                 runtimeStates: runtimeTCPStates
             ))
         }
-        if let auto = appServices.autoInterface, await auto.peerCount > 0 {
-            let count = await auto.peerCount
-            activeInterfaces.append("AutoInterface (\(count) peer\(count == 1 ? "" : "s"))")
+        // Discovery auto-connects + LAN peers live only in the transport's
+        // auxiliary snapshot (the Network Status screen reads the same source).
+        // The old `autoInterface.peerCount` check here was dead code — nothing
+        // ever assigned peerCount — so an interface RNS auto-connected from a
+        // discovery announce never appeared on this card (issue #193).
+        if let transport = appServices.transport {
+            let aux = transport.pythonAuxiliarySnapshotList()
+            activeInterfaces.append(contentsOf: NetworkInterfacePresentation.auxiliaryDescriptions(aux))
         }
         if let rnode = appServices.rnodeInterface, await rnode.state == .connected {
             activeInterfaces.append("RNode")

--- a/Sources/ColumbaApp/ViewModels/TCPClientWizardViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/TCPClientWizardViewModel.swift
@@ -79,6 +79,9 @@ final class TCPClientWizardViewModel {
     var mode: InterfaceMode = .full
     var enabled: Bool = true
     var showAdvanced: Bool = false
+    /// Bootstrap-only: RNS auto-detaches this interface once discovered
+    /// interfaces connect (RNS 1.1.x bootstrap semantics).
+    var bootstrapOnly: Bool = false
 
     // MARK: - Edit Context
 
@@ -126,6 +129,7 @@ final class TCPClientWizardViewModel {
         passphrase = config.passphrase ?? ""
         mode = entity.mode
         enabled = entity.enabled
+        bootstrapOnly = config.bootstrapOnly
 
         let match = TcpCommunityServer.servers.first { server in
             server.host == config.targetHost && server.port == config.targetPort
@@ -183,7 +187,8 @@ final class TCPClientWizardViewModel {
             targetHost: trimmedHost,
             targetPort: port,
             networkName: trimmedNetwork.isEmpty ? nil : trimmedNetwork,
-            passphrase: trimmedPassphrase.isEmpty ? nil : trimmedPassphrase
+            passphrase: trimmedPassphrase.isEmpty ? nil : trimmedPassphrase,
+            bootstrapOnly: bootstrapOnly
         )
 
         sink.saveTCPInterface(

--- a/Sources/ColumbaApp/ViewModels/TCPClientWizardViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/TCPClientWizardViewModel.swift
@@ -144,6 +144,22 @@ final class TCPClientWizardViewModel {
         currentStep = .serverSelection
     }
 
+    /// Prefill from a discovered interface (discovery card 'Add to Config').
+    init(prefilledFrom iface: DiscoveredInterface) {
+        self.init()
+        currentStep = .reviewConfigure
+        isCustomMode = true
+        interfaceName = iface.name
+        targetHost = iface.reachableOn ?? ""
+        targetPort = iface.port.map(String.init) ?? "4242"
+        networkName = iface.ifacNetname ?? ""
+        passphrase = iface.ifacNetkey ?? ""
+        mode = .full
+        enabled = true
+        bootstrapOnly = false
+        // editingInterface stays nil — create flow.
+    }
+
     // MARK: - Validation
 
     /// Whether the wizard can advance / save from the given step.

--- a/Sources/ColumbaApp/ViewModels/TCPClientWizardViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/TCPClientWizardViewModel.swift
@@ -144,8 +144,15 @@ final class TCPClientWizardViewModel {
         currentStep = .serverSelection
     }
 
+    /// No-arg designated init (memberwise defaults). Kept explicit so the
+    /// `convenience init(prefilledFrom:)` below can delegate to it — a class
+    /// loses its implicit no-arg `init()` once it declares ANY designated
+    /// init, which would otherwise break every `TCPClientWizardViewModel()`
+    /// construction site.
+    init() {}
+
     /// Prefill from a discovered interface (discovery card 'Add to Config').
-    init(prefilledFrom iface: DiscoveredInterface) {
+    convenience init(prefilledFrom iface: DiscoveredInterface) {
         self.init()
         currentStep = .reviewConfigure
         isCustomMode = true

--- a/Sources/ColumbaApp/ViewModels/TCPClientWizardViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/TCPClientWizardViewModel.swift
@@ -145,15 +145,16 @@ final class TCPClientWizardViewModel {
     }
 
     /// No-arg designated init (memberwise defaults). Kept explicit so the
-    /// `convenience init(prefilledFrom:)` below can delegate to it — a class
-    /// loses its implicit no-arg `init()` once it declares ANY designated
-    /// init, which would otherwise break every `TCPClientWizardViewModel()`
+    /// class retains a public parameterless init for every existing
     /// construction site.
+
     init() {}
 
     /// Prefill from a discovered interface (discovery card 'Add to Config').
-    convenience init(prefilledFrom iface: DiscoveredInterface) {
-        self.init()
+    /// Mutates the existing instance — the wizard view calls this from
+    /// `onAppear` (one-shot, same pattern as `loadExisting`) so the
+    /// view's `@State` stays a plain memberwise-default value.
+    func applyPrefill(_ iface: DiscoveredInterface) {
         currentStep = .reviewConfigure
         isCustomMode = true
         interfaceName = iface.name

--- a/Sources/ColumbaApp/Views/Settings/DiscoveredInterfacesScreen.swift
+++ b/Sources/ColumbaApp/Views/Settings/DiscoveredInterfacesScreen.swift
@@ -33,6 +33,12 @@ struct DiscoveredInterfacesScreen: View {
 
     @Bindable var viewModel: DiscoveredInterfacesViewModel
     let appServices: AppServices
+    /// Shared InterfaceRepository (issue #193). The sheet wizard VMs are
+    /// built on this instance — NOT a fresh one — so a save appends to the
+    /// same @Observable `interfaces` array the Interfaces list (and IMS)
+    /// reads, keeping the list fresh after "Add to Config" without a
+    /// relaunch. Fallback to a fresh repo when the caller has none.
+    var interfaceRepository: InterfaceRepository?
 
     // MARK: - Card action state (issue #193)
 
@@ -114,7 +120,12 @@ struct DiscoveredInterfacesScreen: View {
         .sheet(
             isPresented: Binding(
                 get: { tcpInterfaceViewModel?.showTCPWizard ?? false },
-                set: { _ in }
+                // Forward (house RNode-cover pattern, SettingsView:211) so
+                // swipe-to-dismiss actually flips the flag and triggers
+                // onDismiss cleanup instead of snapping back.
+                set: { _ in
+                    tcpInterfaceViewModel?.showTCPWizard = false
+                }
             ),
             onDismiss: {
                 // Match the house wizard sheets (IMS:162, SettingsView RNode)
@@ -139,13 +150,31 @@ struct DiscoveredInterfacesScreen: View {
         .sheet(
             isPresented: Binding(
                 get: { rnodeInterfaceViewModel?.showRNodeWizard ?? false },
-                set: { _ in }
+                // Forward (house RNode-cover pattern, SettingsView:211) so
+                // swipe-to-dismiss actually flips the flag and triggers
+                // onDismiss cleanup instead of snapping back.
+                set: { _ in
+                    rnodeInterfaceViewModel?.showRNodeWizard = false
+                }
             ),
             onDismiss: {
-                // Match the house wizard sheets exactly — see the TCP
-                // onDismiss above for why there is no applyChanges() here
-                // (double-apply race / forced Python-RNode apply).
+                // RNode differs from TCP here: saveInterface() on Python
+                // STAGES the change (hasPendingChanges) but deliberately
+                // does not auto-apply (IMVM:407-411 — "the user taps Apply
+                // explicitly"), and applyRNodeLiveChange is a Model-B-only
+                // no-op on Python (IMVM:470). The house Apply button lives in
+                // the IMS toolbar, which is NOT reachable from this sheet —
+                // so without an apply here the staged Python change is
+                // persisted but never pushed to the live stack. TCP does NOT
+                // get this: saveTCPInterface already spawns its own
+                // applyChanges Task (IMVM:452), so a second would race it.
+                // Model B is safe: applyInterfaceChanges is a no-op there
+                // and the radio is already live via applyRNodeLiveChange.
+                let vm = rnodeInterfaceViewModel
                 rnodeInterfaceViewModel?.dismissConfigSheet()
+                if let vm, vm.hasPendingChanges {
+                    Task { @MainActor in await vm.applyChanges() }
+                }
                 rnodeInterfaceViewModel = nil
                 rnodePrefill = nil
             }
@@ -165,7 +194,7 @@ struct DiscoveredInterfacesScreen: View {
     /// the wizard view seeds itself from `prefill` in `onAppear`.
     private func addToConfig(_ iface: DiscoveredInterface) {
         let imvm = tcpInterfaceViewModel ?? InterfaceManagementViewModel(
-            repository: InterfaceRepository(),
+            repository: interfaceRepository ?? InterfaceRepository(),
             appServices: appServices
         )
         tcpInterfaceViewModel = imvm
@@ -201,7 +230,7 @@ struct DiscoveredInterfacesScreen: View {
     #if os(iOS) && COLUMBA_RNODE_ENABLED
     private func useForRNode(_ iface: DiscoveredInterface) {
         let imvm = rnodeInterfaceViewModel ?? InterfaceManagementViewModel(
-            repository: InterfaceRepository(),
+            repository: interfaceRepository ?? InterfaceRepository(),
             appServices: appServices
         )
         rnodeInterfaceViewModel = imvm
@@ -647,6 +676,10 @@ private struct DiscoveredInterfaceCard: View {
                     .controlSize(.small)
                     .accessibilityIdentifier("discovery_card_copy_params")
 
+                    // Rendered only on RNode builds — on other configs the
+                    // action is a no-op stub, so this hides the button
+                    // instead of leaving a dead tap.
+                    #if os(iOS) && COLUMBA_RNODE_ENABLED
                     Button {
                         onUseForRNode(iface)
                     } label: {
@@ -656,6 +689,7 @@ private struct DiscoveredInterfaceCard: View {
                     .buttonStyle(.bordered)
                     .controlSize(.small)
                     .accessibilityIdentifier("discovery_card_use_rnode")
+                    #endif
                 }
             }
         }

--- a/Sources/ColumbaApp/Views/Settings/DiscoveredInterfacesScreen.swift
+++ b/Sources/ColumbaApp/Views/Settings/DiscoveredInterfacesScreen.swift
@@ -373,7 +373,7 @@ private struct DiscoverySettingsCard: View {
     }
 
     private var autoConnectTitle: String {
-        String(localized: "Auto-connect up to %lld discovered interfaces", vm.autoconnectCount)
+        String(format: String(localized: "Auto-connect up to %lld discovered interfaces"), Int64(vm.autoconnectCount))
     }
 }
 
@@ -478,7 +478,7 @@ private struct DiscoveredSortFilterBar: View {
 
             if hasActiveFilters {
                 HStack {
-                    Text(String(localized: "%lld of %lld", vm.interfaces.count, vm.originalInterfaces.count))
+                    Text(String(format: String(localized: "%lld of %lld"), Int64(vm.interfaces.count), Int64(vm.originalInterfaces.count)))
                         .font(.caption)
                         .foregroundStyle(Theme.textSecondary)
                     Spacer()
@@ -634,12 +634,12 @@ private struct DiscoveredInterfaceCard: View {
 
             // Last heard + hops
             HStack(spacing: 8) {
-                Text(String(localized: "Last heard: %@", formatLastHeard(iface.lastHeard)))
+                Text(String(format: String(localized: "Last heard: %@"), formatLastHeard(iface.lastHeard)))
                     .font(.caption)
                     .foregroundStyle(Theme.textSecondary)
 
                 if let hops = iface.hops {
-                    Text(String(localized: "%lld hops", hops))
+                    Text(String(format: String(localized: "%lld hops"), Int64(hops)))
                         .font(.caption)
                         .foregroundStyle(Theme.textSecondary)
                 }
@@ -850,7 +850,7 @@ private struct TcpInterfaceDetails: View {
         case (false, nil, false):
             return host
         case (true, let p?, _):
-            return String(localized: "Port %lld", p)
+            return String(format: String(localized: "Port %lld"), Int64(p))
         default:
             return ""
         }
@@ -945,12 +945,12 @@ private struct LocationDetails: View {
         guard let lat = iface.latitude, let lon = iface.longitude else { return "" }
         var text = String(format: "%.4f, %.4f", lat, lon)
         if let height = iface.height {
-            text += " (" + String(localized: "%lld m", Int(height.rounded())) + ")"
+            text += " (" + String(format: String(localized: "%lld m"), Int64(Int(height.rounded()))) + ")"
         }
         if let distanceKm {
             let distance = distanceKm < 1.0
-                ? String(localized: "%.0fm away", distanceKm * 1000.0)
-                : String(localized: "%.1f km away", distanceKm)
+                ? String(format: String(localized: "%.0fm away"), distanceKm * 1000.0)
+                    : String(format: String(localized: "%.1f km away"), distanceKm)
             text += " · " + distance
         }
         return text

--- a/Sources/ColumbaApp/Views/Settings/DiscoveredInterfacesScreen.swift
+++ b/Sources/ColumbaApp/Views/Settings/DiscoveredInterfacesScreen.swift
@@ -1,0 +1,871 @@
+//
+//  DiscoveredInterfacesScreen.swift
+//  ColumbaApp
+//
+//  Screen for interfaces discovered via RNS 1.1.x interface discovery
+//  (issue #193). Mirrors the Android DiscoveredInterfacesScreen layout:
+//  discovery settings card, status summary, sort/search/type-chip/IFAC
+//  display filters, and one card per discovered interface with type
+//  details, location (tap to open in Maps), and an expandable
+//  "all announced fields" section.
+//
+//  Every sub-view is a separate private struct (not inlined into the
+//  screen body) to keep the SwiftUI type-checker fast. All control
+//  bindings route through the view model's intent methods
+//  (toggleDiscovery / setAutoconnectCount / setSortMode /
+//  setSearchQuery / toggleTypeFilter / toggleIfacOnlyFilter /
+//  clearFilters) — the view never writes VM state directly.
+//
+
+import SwiftUI
+import MapKit
+import RNSAPI
+
+/// Screen showing interfaces announced by other RNS nodes, with the
+/// discovery + auto-connect settings and display filters.
+@available(iOS 17.0, macOS 14.0, *)
+struct DiscoveredInterfacesScreen: View {
+
+    // MARK: - Dependencies
+
+    @Bindable var viewModel: DiscoveredInterfacesViewModel
+
+    // MARK: - Body
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(spacing: 12) {
+                DiscoverySettingsCard(vm: viewModel)
+
+                if !viewModel.originalInterfaces.isEmpty {
+                    DiscoveryStatusSummary(vm: viewModel)
+                    DiscoveredSortFilterBar(vm: viewModel)
+
+                    if viewModel.interfaces.isEmpty {
+                        NoFilterMatchesCard(onClear: { viewModel.clearFilters() })
+                    } else {
+                        ForEach(viewModel.interfaces) { iface in
+                            DiscoveredInterfaceCard(
+                                iface: iface,
+                                distanceKm: viewModel.calculateDistance(iface),
+                                isConnected: viewModel.isAutoconnected(iface)
+                            )
+                        }
+                    }
+                } else if !viewModel.isLoading {
+                    EmptyDiscoveredCard()
+                }
+            }
+            .padding(16)
+        }
+        .navigationTitle(String(localized: "Discovered Interfaces"))
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+        .overlay {
+            if viewModel.isLoading {
+                ProgressView()
+            }
+            if viewModel.isRestarting {
+                RestartingOverlay()
+            }
+        }
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    viewModel.load()
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                }
+                .accessibilityIdentifier("discovery_refresh")
+            }
+        }
+        .onAppear {
+            viewModel.load()
+            viewModel.requestUserLocation()   // no-op unless already authorized
+        }
+    }
+}
+
+// MARK: - Discovery Settings Card
+
+/// Card with the discovery master switch, the auto-connect count slider,
+/// and the bootstrap-interface list. Toggling fires the VM's intent
+/// methods — the VM owns the persist + in-process restart flow.
+@available(iOS 17.0, macOS 14.0, *)
+private struct DiscoverySettingsCard: View {
+
+    @Bindable var vm: DiscoveredInterfacesViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            // Title row: status dot + title/subtitle
+            HStack(spacing: 8) {
+                Circle()
+                    .fill(vm.isDiscoveryEnabled ? Theme.success : Theme.textSecondary)
+                    .frame(width: 8, height: 8)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(String(localized: "Interface Discovery"))
+                        .font(.headline)
+                        .foregroundStyle(Theme.textPrimary)
+
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(Theme.textSecondary)
+                }
+
+                Spacer()
+
+                Toggle(String(localized: "Enable discovery"), isOn: discoveryBinding)
+                    .labelsHidden()
+                    .tint(Theme.accentColor)
+                    .accessibilityIdentifier("discovery_toggle")
+            }
+
+            // Info text
+            HStack(alignment: .top, spacing: 8) {
+                Image(systemName: "info.circle")
+                    .font(.caption)
+                    .foregroundStyle(Theme.textSecondary)
+
+                Text(String(localized: "Discovers interfaces announced by other RNS nodes. Changes apply after a brief restart of Reticulum."))
+                    .font(.caption)
+                    .foregroundStyle(Theme.textSecondary)
+            }
+
+            // Auto-connect count slider (only when discovery is enabled)
+            if vm.discoverInterfacesEnabled {
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack {
+                        Text(autoConnectTitle)
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(Theme.textPrimary)
+
+                        Spacer()
+
+                        Text(vm.autoconnectCount == 0
+                             ? String(localized: "Off")
+                             : "\(vm.autoconnectCount)")
+                            .font(.subheadline.weight(.bold))
+                            .foregroundStyle(Theme.accentColor)
+                    }
+
+                    Slider(value: autoconnectBinding, in: 0...10, step: 1)
+                        .tint(Theme.accentColor)
+                }
+            }
+
+            // Bootstrap interfaces (they enable discovery)
+            if !vm.bootstrapInterfaceNames.isEmpty {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(String(localized: "Bootstrap interfaces"))
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(Theme.textPrimary)
+
+                    ForEach(vm.bootstrapInterfaceNames, id: \.self) { name in
+                        HStack(spacing: 6) {
+                            Circle()
+                                .fill(Theme.textSecondary)
+                                .frame(width: 6, height: 6)
+                            Text(name)
+                                .font(.caption)
+                                .foregroundStyle(Theme.textSecondary)
+                        }
+                    }
+
+                    Text(String(localized: "These auto-detach once discovered interfaces connect."))
+                        .font(.caption)
+                        .foregroundStyle(Theme.textSecondary)
+                }
+            }
+        }
+        .padding(16)
+        .background(Theme.backgroundSecondary)
+        .clipShape(RoundedRectangle(cornerRadius: Theme.cornerRadiusMedium))
+    }
+
+    // MARK: - Bindings (fire VM intent methods, never write VM state)
+
+    private var discoveryBinding: Binding<Bool> {
+        Binding(
+            get: { vm.discoverInterfacesEnabled },
+            set: { _ in vm.toggleDiscovery() }
+        )
+    }
+
+    private var autoconnectBinding: Binding<Double> {
+        Binding(
+            get: { Double(vm.autoconnectCount) },
+            set: { vm.setAutoconnectCount(Int($0.rounded())) }
+        )
+    }
+
+    // MARK: - Derived
+
+    private var subtitle: String {
+        if vm.isRestarting {
+            return String(localized: "Restarting…")
+        }
+        return vm.isDiscoveryEnabled
+            ? String(localized: "Active – discovering interfaces")
+            : String(localized: "Disabled")
+    }
+
+    private var autoConnectTitle: String {
+        String(localized: "Auto-connect up to %lld discovered interfaces", vm.autoconnectCount)
+    }
+}
+
+// MARK: - Status Summary
+
+/// "N discovered" total with available / unknown / stale badges.
+/// Counts reflect ALL discovered interfaces (not the filtered list).
+@available(iOS 17.0, macOS 14.0, *)
+private struct DiscoveryStatusSummary: View {
+
+    @Bindable var vm: DiscoveredInterfacesViewModel
+
+    var body: some View {
+        HStack(spacing: 24) {
+            VStack(spacing: 4) {
+                Text("\(vm.originalInterfaces.count)")
+                    .font(.system(size: 28, weight: .bold, design: .rounded))
+                    .foregroundStyle(Theme.textPrimary)
+                Text(String(localized: "Discovered"))
+                    .font(.caption)
+                    .foregroundStyle(Theme.textSecondary)
+            }
+
+            Spacer()
+
+            statusBadge(String(localized: "Available"), count: vm.availableCount, color: Theme.success)
+            statusBadge(String(localized: "Unknown"), count: vm.unknownCount, color: Theme.textSecondary)
+            statusBadge(String(localized: "Stale"), count: vm.staleCount, color: .orange)
+        }
+        .padding(16)
+        .background(Theme.backgroundSecondary)
+        .clipShape(RoundedRectangle(cornerRadius: Theme.cornerRadiusMedium))
+    }
+
+    private func statusBadge(_ label: String, count: Int, color: Color) -> some View {
+        VStack(spacing: 4) {
+            Text("\(count)")
+                .font(.system(size: 20, weight: .bold, design: .rounded))
+                .foregroundStyle(color)
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(Theme.textSecondary)
+        }
+    }
+}
+
+// MARK: - Sort / Search / Filter Bar
+
+/// Segmented sort control, search field, type chips (TCP / Radio / I2P /
+/// Other), the IFAC-only display filter, and the "N of M" + clear row.
+@available(iOS 17.0, macOS 14.0, *)
+private struct DiscoveredSortFilterBar: View {
+
+    @Bindable var vm: DiscoveredInterfacesViewModel
+
+    var body: some View {
+        VStack(spacing: 10) {
+            Picker(String(localized: "Sort"), selection: sortBinding) {
+                Text(String(localized: "Quality")).tag(DiscoveredSortMode.availabilityAndQuality)
+                Text(String(localized: "Nearest"))
+                    .tag(DiscoveredSortMode.proximity)
+                    .disabled(!hasUserLocation)
+            }
+            .pickerStyle(.segmented)
+
+            TextField(
+                String(localized: "Search interfaces…"),
+                text: searchBinding,
+                prompt: Text(String(localized: "Search interfaces…"))
+            )
+            .textFieldStyle(.roundedBorder)
+            .font(.subheadline)
+            .accessibilityIdentifier("discovery_search")
+
+            HStack(spacing: 8) {
+                ForEach(DiscoveredTypeFilter.allCases) { filter in
+                    typeChip(filter)
+                }
+
+                Spacer(minLength: 0)
+
+                Button {
+                    vm.toggleIfacOnlyFilter()
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: vm.ifacOnly ? "lock.fill" : "lock")
+                            .font(.caption)
+                        Text(String(localized: "IFAC only"))
+                            .font(.caption.weight(.semibold))
+                    }
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .background(vm.ifacOnly ? Theme.accentColor : Theme.backgroundPrimary)
+                    .foregroundStyle(vm.ifacOnly ? .white : Theme.textSecondary)
+                    .overlay(
+                        Capsule().stroke(vm.ifacOnly ? Color.clear : Theme.textSecondary.opacity(0.4), lineWidth: 1)
+                    )
+                    .clipShape(Capsule())
+                }
+                .accessibilityIdentifier("discovery_ifac_only")
+            }
+
+            if hasActiveFilters {
+                HStack {
+                    Text(String(localized: "%lld of %lld", vm.interfaces.count, vm.originalInterfaces.count))
+                        .font(.caption)
+                        .foregroundStyle(Theme.textSecondary)
+                    Spacer()
+                    Button(String(localized: "Clear")) {
+                        vm.clearFilters()
+                    }
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(Theme.accentColor)
+                    .accessibilityIdentifier("discovery_clear_filters")
+                }
+            }
+        }
+        .padding(12)
+        .background(Theme.backgroundSecondary)
+        .clipShape(RoundedRectangle(cornerRadius: Theme.cornerRadiusMedium))
+    }
+
+    // MARK: - Bindings (fire VM intent methods, never write VM state)
+
+    private var sortBinding: Binding<DiscoveredSortMode> {
+        Binding(
+            get: { vm.sortMode },
+            set: { vm.setSortMode($0) }
+        )
+    }
+
+    private var searchBinding: Binding<String> {
+        Binding(
+            get: { vm.searchQuery },
+            set: { vm.setSearchQuery($0) }
+        )
+    }
+
+    // MARK: - Chips + state
+
+    private func typeChip(_ filter: DiscoveredTypeFilter) -> some View {
+        let selected = vm.typeFilters.contains(filter)
+        return Button {
+            vm.toggleTypeFilter(filter)
+        } label: {
+            Text(filter.rawValue)
+                .font(.caption.weight(.semibold))
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+                .background(selected ? Theme.accentColor : Theme.backgroundPrimary)
+                .foregroundStyle(selected ? .white : Theme.textSecondary)
+                .overlay(
+                    Capsule().stroke(selected ? Color.clear : Theme.textSecondary.opacity(0.4), lineWidth: 1)
+                )
+                .clipShape(Capsule())
+        }
+    }
+
+    private var hasUserLocation: Bool {
+        vm.userLatitude != nil && vm.userLongitude != nil
+    }
+
+    private var hasActiveFilters: Bool {
+        !vm.searchQuery.isEmpty || !vm.typeFilters.isEmpty || vm.ifacOnly
+    }
+}
+
+// MARK: - Discovered Interface Card
+
+/// Card for a single discovered interface: header (icon, name, type),
+/// status/connected badges, transport id, type-specific details, IFAC
+/// row, location (tappable), last heard + hops, and the expandable
+/// all-announced-fields section.
+@available(iOS 17.0, macOS 14.0, *)
+private struct DiscoveredInterfaceCard: View {
+
+    let iface: DiscoveredInterface
+    let distanceKm: Double?
+    let isConnected: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            // Header: icon + name/type + badges
+            HStack(spacing: 8) {
+                InterfaceTypeIcon(type: iface.type, host: iface.reachableOn)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(verbatim: iface.name)
+                        .font(.headline)
+                        .foregroundStyle(Theme.textPrimary)
+                        .lineLimit(1)
+
+                    Text(typeLabel)
+                        .font(.caption)
+                        .foregroundStyle(Theme.textSecondary)
+                }
+
+                Spacer()
+
+                HStack(spacing: 6) {
+                    if isConnected {
+                        badge(String(localized: "Connected"), color: Theme.success)
+                    }
+                    badge(statusLabel, color: statusColor)
+                }
+            }
+
+            // Transport id (truncated)
+            if let transportId = iface.transportId {
+                HStack(spacing: 4) {
+                    Text(String(localized: "Transport:"))
+                        .font(.caption)
+                        .foregroundStyle(Theme.textSecondary)
+                    Text(verbatim: String(transportId.prefix(12)) + "…")
+                        .font(.caption.monospaced())
+                        .foregroundStyle(Theme.textSecondary)
+                }
+            }
+
+            // Type-specific details (nil parts omitted by each sub-view)
+            if iface.type == "I2PInterface" {
+                I2pInterfaceDetails(iface: iface)
+            } else if iface.isTcpInterface {
+                TcpInterfaceDetails(iface: iface)
+            } else if iface.isRadioInterface {
+                RadioInterfaceDetails(iface: iface)
+            }
+
+            // IFAC row
+            if let ifacNetname = iface.ifacNetname, !ifacNetname.isEmpty {
+                HStack(spacing: 4) {
+                    Text(String(localized: "IFAC:"))
+                        .font(.caption)
+                        .foregroundStyle(Theme.textSecondary)
+                    Text(verbatim: ifacNetname)
+                        .font(.caption.monospaced())
+                        .foregroundStyle(Theme.accentColor)
+                    if let ifacNetkey = iface.ifacNetkey, !ifacNetkey.isEmpty {
+                        Image(systemName: "key.fill")
+                            .font(.caption)
+                            .foregroundStyle(Theme.accentColor)
+                    }
+                }
+            }
+
+            // Location (tappable → opens Maps)
+            if iface.hasLocation {
+                LocationDetails(iface: iface, distanceKm: distanceKm)
+            }
+
+            // Last heard + hops
+            HStack(spacing: 8) {
+                Text(String(localized: "Last heard: %@", formatLastHeard(iface.lastHeard)))
+                    .font(.caption)
+                    .foregroundStyle(Theme.textSecondary)
+
+                if let hops = iface.hops {
+                    Text(String(localized: "%lld hops", hops))
+                        .font(.caption)
+                        .foregroundStyle(Theme.textSecondary)
+                }
+            }
+
+            // Expandable all-announced-fields section
+            DiscoveredInterfaceAllFieldsSection(iface: iface)
+
+            // T-H: card action buttons go here
+        }
+        .padding(16)
+        .background(Theme.backgroundSecondary)
+        .clipShape(RoundedRectangle(cornerRadius: Theme.cornerRadiusMedium))
+        .accessibilityIdentifier("discovered_card_" + iface.id)
+    }
+
+    // MARK: - Derived
+
+    private var isYggdrasil: Bool {
+        iface.isTcpInterface && isYggdrasilAddress(iface.reachableOn)
+    }
+
+    private var typeLabel: String {
+        isYggdrasil ? String(localized: "Yggdrasil") : formatInterfaceType(iface.type)
+    }
+
+    private var statusLabel: String {
+        iface.status.isEmpty ? iface.status : iface.status.prefix(1).uppercased() + iface.status.dropFirst()
+    }
+
+    private var statusColor: Color {
+        switch iface.status {
+        case "available": return Theme.success
+        case "unknown": return Theme.textSecondary
+        default: return .orange
+        }
+    }
+
+    private func badge(_ label: String, color: Color) -> some View {
+        HStack(spacing: 4) {
+            Circle()
+                .fill(color)
+                .frame(width: 6, height: 6)
+            Text(label)
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(color)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 3)
+        .background(color.opacity(0.15))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+}
+
+// MARK: - All Announced Fields
+
+/// DisclosureGroup listing every non-nil field the remote published in
+/// its discovery announce (diagnostics: confirm radio parameters, raw
+/// timestamps, hashes).
+@available(iOS 17.0, macOS 14.0, *)
+private struct DiscoveredInterfaceAllFieldsSection: View {
+
+    let iface: DiscoveredInterface
+
+    /// One key/value row (Identifiable by key so ForEach can key it).
+    private struct FieldRow: Identifiable {
+        let key: String
+        let value: String
+        var id: String { key }
+    }
+
+    var body: some View {
+        DisclosureGroup(String(localized: "All announced fields")) {
+            VStack(alignment: .leading, spacing: 4) {
+                ForEach(rows) { row in
+                    HStack(alignment: .top, spacing: 8) {
+                        Text(row.key)
+                            .font(.caption)
+                            .foregroundStyle(Theme.textSecondary)
+                            .frame(width: 110, alignment: .leading)
+                        Text(row.value)
+                            .font(.caption.monospaced())
+                            .foregroundStyle(Theme.textPrimary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+            }
+            .padding(.top, 6)
+        }
+        .font(.caption)
+        .tint(Theme.accentColor)
+    }
+
+    // MARK: - Rows (every non-nil field)
+
+    private var rows: [FieldRow] {
+        var result: [FieldRow] = []
+        func add(_ key: String, _ value: String?) {
+            guard let value, !value.isEmpty else { return }
+            result.append(FieldRow(key: key, value: value))
+        }
+
+        add(String(localized: "Transport ID"), iface.transportId)
+        add(String(localized: "Network ID"), iface.networkId)
+        add(String(localized: "Status code"), iface.statusCode.map(String.init))
+        add(String(localized: "Last heard (unix)"), iface.lastHeard > 0 ? String(Int(iface.lastHeard)) : nil)
+        add(String(localized: "Heard count"), iface.heardCount.map(String.init))
+        add(String(localized: "Stamp value"), iface.stampValue.map(String.init))
+        add(String(localized: "Reachable on"), iface.reachableOn)
+        add(String(localized: "Port"), iface.port.map(String.init))
+        add(String(localized: "Frequency"), iface.frequency.map { String(format: "%.6f Hz", $0) })
+        add(String(localized: "Bandwidth"), iface.bandwidth.map { "\($0) Hz" })
+        add(String(localized: "Spreading factor"), iface.spreadingFactor.map { "SF\($0)" })
+        add(String(localized: "Coding rate"), iface.codingRate.map { "CR 4/\($0)" })
+        add(String(localized: "Modulation"), iface.modulation)
+        add(String(localized: "Channel"), iface.channel.map(String.init))
+        add(String(localized: "Latitude"), iface.latitude.map { String(format: "%.6f", $0) })
+        add(String(localized: "Longitude"), iface.longitude.map { String(format: "%.6f", $0) })
+        add(String(localized: "Height"), iface.height.map { "\($0) m" })
+        add(String(localized: "IFAC passphrase"), iface.ifacNetkey)
+        add(String(localized: "Transport"), iface.transport ? "yes" : "no")
+        add(String(localized: "Discovery hash"), iface.discoveryHash)
+        add(String(localized: "Received at"), iface.receivedAt.map(formatUnixSeconds))
+        add(String(localized: "Discovered at"), iface.discoveredAt.map(formatUnixSeconds))
+        return result
+    }
+
+    private func formatUnixSeconds(_ value: Double) -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .medium
+        return formatter.string(from: Date(timeIntervalSince1970: value))
+    }
+}
+
+// MARK: - Type Details
+
+/// TCP details: `host:port`, `host (Yggdrasil)` for 0200::/7 addresses,
+/// or a bare port when no host was announced. Nil parts are omitted.
+@available(iOS 17.0, macOS 14.0, *)
+private struct TcpInterfaceDetails: View {
+
+    let iface: DiscoveredInterface
+
+    var body: some View {
+        let text = detailText
+        if !text.isEmpty {
+            Text(verbatim: text)
+                .font(.subheadline.monospaced())
+                .foregroundStyle(Theme.textPrimary)
+        }
+    }
+
+    private var detailText: String {
+        let host = iface.reachableOn ?? ""
+        let port = iface.port
+        let yggdrasil = isYggdrasilAddress(iface.reachableOn)
+        switch (host.isEmpty, port, yggdrasil) {
+        case (false, _, true):
+            // Yggdrasil address — the port is implicit (the app connects
+            // through the Yggdrasil tunnel, not a raw TCP port).
+            return host + " (" + String(localized: "Yggdrasil") + ")"
+        case (false, let p?, false):
+            return host + ":" + String(p)
+        case (false, nil, false):
+            return host
+        case (true, let p?, _):
+            return String(localized: "Port %lld", p)
+        default:
+            return ""
+        }
+    }
+}
+
+/// I2P details: the b32 address as `<b32>.b32.i2p`.
+@available(iOS 17.0, macOS 14.0, *)
+private struct I2pInterfaceDetails: View {
+
+    let iface: DiscoveredInterface
+
+    var body: some View {
+        if let b32 = iface.reachableOn, !b32.isEmpty {
+            Text(verbatim: "\(b32).b32.i2p")
+                .font(.subheadline.monospaced())
+                .foregroundStyle(Theme.textPrimary)
+        }
+    }
+}
+
+/// Radio details: "X MHz · Y kHz · SF… · CR 4/…" built from the LoRa
+/// parameters — each part omitted when nil.
+@available(iOS 17.0, macOS 14.0, *)
+private struct RadioInterfaceDetails: View {
+
+    let iface: DiscoveredInterface
+
+    var body: some View {
+        let text = parts.joined(separator: " · ")
+        if !text.isEmpty {
+            Text(verbatim: text)
+                .font(.subheadline)
+                .foregroundStyle(Theme.textPrimary)
+        }
+    }
+
+    private var parts: [String] {
+        var result: [String] = []
+        if let frequency = iface.frequency {
+            result.append(String(format: "%.1f MHz", frequency / 1_000_000.0))
+        }
+        if let bandwidth = iface.bandwidth {
+            result.append("\(bandwidth / 1000) kHz")
+        }
+        if let sf = iface.spreadingFactor {
+            result.append("SF\(sf)")
+        }
+        if let cr = iface.codingRate {
+            result.append("CR 4/\(cr)")
+        }
+        if let modulation = iface.modulation, !modulation.isEmpty {
+            result.append(modulation)
+        }
+        if let channel = iface.channel {
+            result.append("CH\(channel)")
+        }
+        return result
+    }
+}
+
+// MARK: - Location Details
+
+/// Tappable "lat, lon (H m) · D km away" row (distance omitted when nil)
+/// that opens Apple Maps for the coordinate — same MKPlacemark → MKMapItem
+/// pattern as DirectionsLauncher.
+@available(iOS 17.0, macOS 14.0, *)
+private struct LocationDetails: View {
+
+    let iface: DiscoveredInterface
+    let distanceKm: Double?
+
+    var body: some View {
+        Button {
+            openInMaps()
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: "location")
+                    .font(.caption)
+                    .foregroundStyle(Theme.accentColor)
+
+                Text(verbatim: locationText)
+                    .font(.caption)
+                    .foregroundStyle(Theme.accentColor)
+                    .underline()
+            }
+        }
+        .accessibilityHint(String(localized: "Open in Maps"))
+    }
+
+    private var locationText: String {
+        guard let lat = iface.latitude, let lon = iface.longitude else { return "" }
+        var text = String(format: "%.4f, %.4f", lat, lon)
+        if let height = iface.height {
+            text += " (" + String(localized: "%lld m", Int(height.rounded())) + ")"
+        }
+        if let distanceKm {
+            let distance = distanceKm < 1.0
+                ? String(localized: "%.0fm away", distanceKm * 1000.0)
+                : String(localized: "%.1f km away", distanceKm)
+            text += " · " + distance
+        }
+        return text
+    }
+
+    private func openInMaps() {
+        guard let lat = iface.latitude, let lon = iface.longitude else { return }
+        let coordinate = CLLocationCoordinate2D(latitude: lat, longitude: lon)
+        let placemark = MKPlacemark(coordinate: coordinate)
+        let item = MKMapItem(placemark: placemark)
+        item.openInMaps(launchOptions: [
+            MKLaunchOptionsDirectionsModeKey: MKLaunchOptionsDirectionsModeWalking,
+        ])
+    }
+}
+
+// MARK: - Interface Type Icon
+
+/// SF Symbol for the interface type (no MDI font on iOS): globe for TCP
+/// (leaf for Yggdrasil), mask for I2P, radiowaves for radio, gear for
+/// everything else.
+@available(iOS 17.0, macOS 14.0, *)
+private struct InterfaceTypeIcon: View {
+
+    let type: String
+    let host: String?
+
+    var body: some View {
+        Image(systemName: symbolName)
+            .font(.system(size: 20))
+            .foregroundStyle(Theme.textSecondary)
+            .frame(width: 24)
+    }
+
+    private var symbolName: String {
+        if type == "TCPServerInterface" || type == "TCPClientInterface" || type == "BackboneInterface" {
+            return isYggdrasilAddress(host) ? "leaf" : "globe"
+        }
+        if type == "I2PInterface" {
+            return "person.and.mask"
+        }
+        if type == "RNodeInterface" || type == "WeaveInterface" || type == "KISSInterface" {
+            return "dot.radiowaves.left.and.right"
+        }
+        return "gearshape"
+    }
+}
+
+// MARK: - Restarting Overlay
+
+/// Dimmed full-screen overlay while a discovery-settings change triggers
+/// the in-process Reticulum restart.
+@available(iOS 17.0, macOS 14.0, *)
+private struct RestartingOverlay: View {
+
+    var body: some View {
+        Color.black.opacity(0.35)
+            .ignoresSafeArea()
+            .overlay {
+                VStack(spacing: 12) {
+                    ProgressView()
+                        .tint(.white)
+                    Text(String(localized: "Restarting Reticulum…"))
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(.white)
+                }
+                .padding(20)
+                .background(Theme.backgroundSecondary)
+                .clipShape(RoundedRectangle(cornerRadius: Theme.cornerRadiusLarge))
+            }
+    }
+}
+
+// MARK: - Empty / No-Match Cards
+
+/// Shown when discovery has found nothing at all.
+@available(iOS 17.0, macOS 14.0, *)
+private struct EmptyDiscoveredCard: View {
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "antenna.radiowaves.left.and.right")
+                .font(.system(size: 40))
+                .foregroundStyle(Theme.textSecondary)
+
+            Text(String(localized: "No interfaces discovered yet. Enable discovery above to start finding interfaces announced by other RNS nodes."))
+                .font(.subheadline)
+                .foregroundStyle(Theme.textSecondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 40)
+        .padding(.horizontal, 16)
+        .background(Theme.backgroundSecondary)
+        .clipShape(RoundedRectangle(cornerRadius: Theme.cornerRadiusMedium))
+    }
+}
+
+/// Shown when discovered interfaces exist but none match the active
+/// display filters.
+@available(iOS 17.0, macOS 14.0, *)
+private struct NoFilterMatchesCard: View {
+
+    let onClear: () -> Void
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "line.3.horizontal.decrease.circle")
+                .font(.system(size: 40))
+                .foregroundStyle(Theme.textSecondary)
+
+            Text(String(localized: "No interfaces match your filters."))
+                .font(.subheadline)
+                .foregroundStyle(Theme.textSecondary)
+                .multilineTextAlignment(.center)
+
+            Button(String(localized: "Clear filters")) {
+                onClear()
+            }
+            .font(.subheadline.weight(.medium))
+            .foregroundStyle(Theme.accentColor)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 40)
+        .padding(.horizontal, 16)
+        .background(Theme.backgroundSecondary)
+        .clipShape(RoundedRectangle(cornerRadius: Theme.cornerRadiusMedium))
+    }
+}

--- a/Sources/ColumbaApp/Views/Settings/DiscoveredInterfacesScreen.swift
+++ b/Sources/ColumbaApp/Views/Settings/DiscoveredInterfacesScreen.swift
@@ -117,11 +117,14 @@ struct DiscoveredInterfacesScreen: View {
                 set: { _ in }
             ),
             onDismiss: {
-                tcpInterfaceViewModel?.showTCPWizard = false
+                // Match the house wizard sheets (IMS:162, SettingsView RNode)
+                // exactly: dismissConfigSheet() resets the flags + form. Do
+                // NOT apply here — the save paths already do it where the
+                // house does (saveTCPInterface spawns its own applyChanges
+                // Task; Python RNode deliberately waits for the explicit
+                // Apply step), and applying in onDismiss would race/double
+                // that apply.
                 tcpInterfaceViewModel?.dismissConfigSheet()
-                if let vm = tcpInterfaceViewModel, vm.hasPendingChanges {
-                    Task { @MainActor in await vm.applyChanges() }
-                }
                 tcpInterfaceViewModel = nil
                 tcpPrefill = nil
             }
@@ -139,11 +142,10 @@ struct DiscoveredInterfacesScreen: View {
                 set: { _ in }
             ),
             onDismiss: {
-                rnodeInterfaceViewModel?.showRNodeWizard = false
+                // Match the house wizard sheets exactly — see the TCP
+                // onDismiss above for why there is no applyChanges() here
+                // (double-apply race / forced Python-RNode apply).
                 rnodeInterfaceViewModel?.dismissConfigSheet()
-                if let vm = rnodeInterfaceViewModel, vm.hasPendingChanges {
-                    Task { @MainActor in await vm.applyChanges() }
-                }
                 rnodeInterfaceViewModel = nil
                 rnodePrefill = nil
             }

--- a/Sources/ColumbaApp/Views/Settings/DiscoveredInterfacesScreen.swift
+++ b/Sources/ColumbaApp/Views/Settings/DiscoveredInterfacesScreen.swift
@@ -186,9 +186,9 @@ struct DiscoveredInterfacesScreen: View {
             iface: iface,
             distanceKm: viewModel.calculateDistance(iface),
             isConnected: viewModel.isAutoconnected(iface),
-            onAddToConfig: { addToConfig(iface) },
-            onCopyLoRaParams: { copyLoRaParams(iface) },
-            onUseForRNode: { useForRNode(iface) },
+            onAddToConfig: { card in addToConfig(card) },
+            onCopyLoRaParams: { card in copyLoRaParams(card) },
+            onUseForRNode: { card in useForRNode(card) },
             justCopied: copiedCardID == iface.id
         )
     }

--- a/Sources/ColumbaApp/Views/Settings/DiscoveredInterfacesScreen.swift
+++ b/Sources/ColumbaApp/Views/Settings/DiscoveredInterfacesScreen.swift
@@ -20,6 +20,9 @@
 import SwiftUI
 import MapKit
 import RNSAPI
+#if canImport(UIKit)
+import UIKit
+#endif
 
 /// Screen showing interfaces announced by other RNS nodes, with the
 /// discovery + auto-connect settings and display filters.
@@ -29,6 +32,22 @@ struct DiscoveredInterfacesScreen: View {
     // MARK: - Dependencies
 
     @Bindable var viewModel: DiscoveredInterfacesViewModel
+    let appServices: AppServices
+
+    // MARK: - Card action state (issue #193)
+
+    /// Wizard VM for the "Add to Config" sheet — the sheet owns its own
+    /// InterfaceManagementViewModel (the house save sink) so the wizard's
+    /// unchanged save/cancel paths persist + close it.
+    @State private var tcpInterfaceViewModel: InterfaceManagementViewModel?
+    @State private var tcpPrefill: DiscoveredInterface?
+
+    /// Wizard VM for the "Use for RNode" sheet (same pattern as TCP).
+    @State private var rnodeInterfaceViewModel: InterfaceManagementViewModel?
+    @State private var rnodePrefill: DiscoveredInterface?
+
+    /// ID of the card whose "Copy LoRa Params" just fired (brief checkmark).
+    @State private var copiedCardID: String?
 
     // MARK: - Body
 
@@ -48,7 +67,11 @@ struct DiscoveredInterfacesScreen: View {
                             DiscoveredInterfaceCard(
                                 iface: iface,
                                 distanceKm: viewModel.calculateDistance(iface),
-                                isConnected: viewModel.isAutoconnected(iface)
+                                isConnected: viewModel.isAutoconnected(iface),
+                                onAddToConfig: { addToConfig(iface) },
+                                onCopyLoRaParams: { copyLoRaParams(iface) },
+                                onUseForRNode: { useForRNode(iface) },
+                                justCopied: copiedCardID == iface.id
                             )
                         }
                     }
@@ -84,7 +107,113 @@ struct DiscoveredInterfacesScreen: View {
             viewModel.load()
             viewModel.requestUserLocation()   // no-op unless already authorized
         }
+        // Card action sheets (issue #193): each sheet is driven by a
+        // sheet-owned InterfaceManagementViewModel (the house save sink),
+        // presented through the VM's own wizard flags with the same
+        // Binding(get:set:) pattern SettingsView uses for the RNode wizard.
+        .sheet(
+            isPresented: Binding(
+                get: { tcpInterfaceViewModel?.showTCPWizard ?? false },
+                set: { _ in }
+            ),
+            onDismiss: {
+                tcpInterfaceViewModel?.showTCPWizard = false
+                tcpInterfaceViewModel?.dismissConfigSheet()
+                if let vm = tcpInterfaceViewModel, vm.hasPendingChanges {
+                    Task { @MainActor in await vm.applyChanges() }
+                }
+                tcpInterfaceViewModel = nil
+                tcpPrefill = nil
+            }
+        ) {
+            if let imvm = tcpInterfaceViewModel {
+                TCPClientWizard(viewModel: imvm, prefill: tcpPrefill)
+                    .presentationDetents([.large])
+                    .presentationDragIndicator(.visible)
+            }
+        }
+        #if os(iOS) && COLUMBA_RNODE_ENABLED
+        .sheet(
+            isPresented: Binding(
+                get: { rnodeInterfaceViewModel?.showRNodeWizard ?? false },
+                set: { _ in }
+            ),
+            onDismiss: {
+                rnodeInterfaceViewModel?.showRNodeWizard = false
+                rnodeInterfaceViewModel?.dismissConfigSheet()
+                if let vm = rnodeInterfaceViewModel, vm.hasPendingChanges {
+                    Task { @MainActor in await vm.applyChanges() }
+                }
+                rnodeInterfaceViewModel = nil
+                rnodePrefill = nil
+            }
+        ) {
+            if let imvm = rnodeInterfaceViewModel {
+                RNodeWizardView(viewModel: imvm, prefill: rnodePrefill)
+            }
+        }
+        #endif
     }
+
+    // MARK: - Card actions (issue #193)
+
+    /// "Add to Config": prefill the TCP client wizard with the announced
+    /// host/port/IFAC fields, landing directly on the review step. The sheet
+    /// is driven by the IMVM's own `showTCPWizard` flag (house pattern), and
+    /// the wizard view seeds itself from `prefill` in `onAppear`.
+    private func addToConfig(_ iface: DiscoveredInterface) {
+        let imvm = tcpInterfaceViewModel ?? InterfaceManagementViewModel(
+            repository: InterfaceRepository(),
+            appServices: appServices
+        )
+        tcpInterfaceViewModel = imvm
+        tcpPrefill = iface
+        // Fresh create-flow state (mirror dismissConfigSheet's resets without
+        // touching the wizard flag).
+        imvm.editingInterface = nil
+        imvm.configName = ""
+        imvm.configType = .tcpClient
+        imvm.configEnabled = true
+        imvm.configMode = .full
+        imvm.showTCPWizard = true
+    }
+
+    /// "Copy LoRa Params": publish the announced radio parameters to the
+    /// pasteboard and flash a checkmark on the card that fired.
+    private func copyLoRaParams(_ iface: DiscoveredInterface) {
+        #if canImport(UIKit)
+        UIPasteboard.general.string = formatLoraParamsForClipboard(iface)
+        #elseif canImport(AppKit)
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(formatLoraParamsForClipboard(iface), forType: .string)
+        #endif
+        copiedCardID = iface.id
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            if copiedCardID == iface.id { copiedCardID = nil }
+        }
+    }
+
+    /// "Use for RNode": prefill the RNode wizard's custom LoRa fields from
+    /// the announced parameters (the device is still selected in-wizard, as
+    /// with the normal RNode flow).
+    #if os(iOS) && COLUMBA_RNODE_ENABLED
+    private func useForRNode(_ iface: DiscoveredInterface) {
+        let imvm = rnodeInterfaceViewModel ?? InterfaceManagementViewModel(
+            repository: InterfaceRepository(),
+            appServices: appServices
+        )
+        rnodeInterfaceViewModel = imvm
+        rnodePrefill = iface
+        imvm.editingInterface = nil
+        imvm.configName = ""
+        imvm.configType = .rnode
+        imvm.configEnabled = true
+        imvm.configMode = .full
+        imvm.showRNodeWizard = true
+    }
+    #else
+    private func useForRNode(_ iface: DiscoveredInterface) {}
+    #endif
 }
 
 // MARK: - Discovery Settings Card
@@ -394,6 +523,14 @@ private struct DiscoveredInterfaceCard: View {
     let distanceKm: Double?
     let isConnected: Bool
 
+    /// Card action handlers (issue #193) — the screen owns the sheets.
+    var onAddToConfig: (DiscoveredInterface) -> Void
+    var onCopyLoRaParams: (DiscoveredInterface) -> Void
+    var onUseForRNode: (DiscoveredInterface) -> Void
+
+    /// Set briefly after "Copy LoRa Params" so the button can show a checkmark.
+    var justCopied: Bool = false
+
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             // Header: icon + name/type + badges
@@ -480,7 +617,45 @@ private struct DiscoveredInterfaceCard: View {
             // Expandable all-announced-fields section
             DiscoveredInterfaceAllFieldsSection(iface: iface)
 
-            // T-H: card action buttons go here
+            // Card action buttons (issue #193) — full Android parity:
+            // Add to Config / Copy LoRa Params / Use for RNode.
+            HStack(spacing: 8) {
+                if iface.isTcpInterface && iface.reachableOn != nil {
+                    Button {
+                        onAddToConfig(iface)
+                    } label: {
+                        Label(String(localized: "Add to Config"), systemImage: "plus.circle")
+                            .font(.caption.weight(.semibold))
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .accessibilityIdentifier("discovery_card_add_config")
+                }
+                if iface.isRadioInterface && iface.frequency != nil {
+                    Button {
+                        onCopyLoRaParams(iface)
+                    } label: {
+                        Label(
+                            justCopied ? String(localized: "Copied") : String(localized: "Copy LoRa Params"),
+                            systemImage: justCopied ? "checkmark" : "doc.on.doc"
+                        )
+                        .font(.caption.weight(.semibold))
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .accessibilityIdentifier("discovery_card_copy_params")
+
+                    Button {
+                        onUseForRNode(iface)
+                    } label: {
+                        Label(String(localized: "Use for RNode"), systemImage: "radio")
+                            .font(.caption.weight(.semibold))
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .accessibilityIdentifier("discovery_card_use_rnode")
+                }
+            }
         }
         .padding(16)
         .background(Theme.backgroundSecondary)

--- a/Sources/ColumbaApp/Views/Settings/DiscoveredInterfacesScreen.swift
+++ b/Sources/ColumbaApp/Views/Settings/DiscoveredInterfacesScreen.swift
@@ -70,15 +70,7 @@ struct DiscoveredInterfacesScreen: View {
                         NoFilterMatchesCard(onClear: { viewModel.clearFilters() })
                     } else {
                         ForEach(viewModel.interfaces) { iface in
-                            DiscoveredInterfaceCard(
-                                iface: iface,
-                                distanceKm: viewModel.calculateDistance(iface),
-                                isConnected: viewModel.isAutoconnected(iface),
-                                onAddToConfig: { addToConfig(iface) },
-                                onCopyLoRaParams: { copyLoRaParams(iface) },
-                                onUseForRNode: { useForRNode(iface) },
-                                justCopied: copiedCardID == iface.id
-                            )
+                            discoveredCard(for: iface)
                         }
                     }
                 } else if !viewModel.isLoading {
@@ -184,6 +176,21 @@ struct DiscoveredInterfacesScreen: View {
             }
         }
         #endif
+    }
+
+    /// One discovered-interface card (extracted from `body` so the
+    /// ForEach expression stays inside the type-checker's complexity
+    /// budget — same fix as ImageQualityPickerSheet, issue #181).
+    private func discoveredCard(for iface: DiscoveredInterface) -> some View {
+        DiscoveredInterfaceCard(
+            iface: iface,
+            distanceKm: viewModel.calculateDistance(iface),
+            isConnected: viewModel.isAutoconnected(iface),
+            onAddToConfig: { addToConfig(iface) },
+            onCopyLoRaParams: { copyLoRaParams(iface) },
+            onUseForRNode: { useForRNode(iface) },
+            justCopied: copiedCardID == iface.id
+        )
     }
 
     // MARK: - Card actions (issue #193)

--- a/Sources/ColumbaApp/Views/Settings/DiscoveredInterfacesScreen.swift
+++ b/Sources/ColumbaApp/Views/Settings/DiscoveredInterfacesScreen.swift
@@ -12,9 +12,12 @@
 //  Every sub-view is a separate private struct (not inlined into the
 //  screen body) to keep the SwiftUI type-checker fast. All control
 //  bindings route through the view model's intent methods
-//  (toggleDiscovery / setAutoconnectCount / setSortMode /
-//  setSearchQuery / toggleTypeFilter / toggleIfacOnlyFilter /
+//  (setDiscoverInterfacesEnabled / setAutoconnectCount /
+//  applyDiscoverySettings / discardPendingDiscoveryChanges /
+//  setSortMode / setSearchQuery / toggleTypeFilter / toggleIfacOnlyFilter /
 //  clearFilters) — the view never writes VM state directly.
+//  Discovery settings are PENDING until the user taps "Apply and Restart"
+//  (issue #193 UX): the controls never restart Reticulum on their own.
 //
 
 import SwiftUI
@@ -269,7 +272,7 @@ private struct DiscoverySettingsCard: View {
             // Title row: status dot + title/subtitle
             HStack(spacing: 8) {
                 Circle()
-                    .fill(vm.isDiscoveryEnabled ? Theme.success : Theme.textSecondary)
+                    .fill(dotColor)
                     .frame(width: 8, height: 8)
 
                 VStack(alignment: .leading, spacing: 2) {
@@ -296,12 +299,13 @@ private struct DiscoverySettingsCard: View {
                     .font(.caption)
                     .foregroundStyle(Theme.textSecondary)
 
-                Text(String(localized: "Discovers interfaces announced by other RNS nodes. Changes apply after a brief restart of Reticulum."))
+                Text(String(localized: "Discovers interfaces announced by other RNS nodes. Changes take effect after you tap Apply and Restart."))
                     .font(.caption)
                     .foregroundStyle(Theme.textSecondary)
             }
 
-            // Auto-connect count slider (only when discovery is enabled)
+            // Auto-connect count control (only when discovery is pending-on
+            // or live-on — a pure display toggle, no restart until Apply).
             if vm.discoverInterfacesEnabled {
                 VStack(alignment: .leading, spacing: 4) {
                     HStack {
@@ -321,6 +325,46 @@ private struct DiscoverySettingsCard: View {
                     Slider(value: autoconnectBinding, in: 0...10, step: 1)
                         .tint(Theme.accentColor)
                 }
+            }
+
+            // Apply-and-restart bar: shown only while there are pending
+            // changes (issue #193 UX — the toggle/slider are pure pending
+            // state; nothing restarts until this is tapped).
+            if vm.hasPendingDiscoveryChanges && !vm.isRestarting {
+                VStack(spacing: 8) {
+                    Divider()
+                    HStack(spacing: 12) {
+                        Button {
+                            vm.discardPendingDiscoveryChanges()
+                        } label: {
+                            Text(String(localized: "Discard"))
+                                .font(.subheadline.weight(.semibold))
+                        }
+                        .buttonStyle(.bordered)
+                        .accessibilityIdentifier("discovery_discard")
+
+                        Spacer()
+
+                        Button {
+                            Task { await vm.applyDiscoverySettings() }
+                        } label: {
+                            Text(String(localized: "Apply and Restart"))
+                                .font(.subheadline.weight(.semibold))
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .tint(Theme.accentColor)
+                        .accessibilityIdentifier("discovery_apply_restart")
+                    }
+                }
+            }
+
+            // Apply-failure notice (restart error — settings persisted but
+            // not live; the Apply bar stays visible for a retry).
+            if let errorMessage = vm.errorMessage {
+                Label(errorMessage, systemImage: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .accessibilityIdentifier("discovery_apply_error")
             }
 
             // Bootstrap interfaces (they enable discovery)
@@ -357,7 +401,7 @@ private struct DiscoverySettingsCard: View {
     private var discoveryBinding: Binding<Bool> {
         Binding(
             get: { vm.discoverInterfacesEnabled },
-            set: { _ in vm.toggleDiscovery() }
+            set: { vm.setDiscoverInterfacesEnabled($0) }
         )
     }
 
@@ -370,9 +414,21 @@ private struct DiscoverySettingsCard: View {
 
     // MARK: - Derived
 
+    /// Status dot: orange while changes are pending (not yet applied),
+    /// otherwise green/gray for the live discovery state.
+    private var dotColor: Color {
+        if vm.hasPendingDiscoveryChanges {
+            return .orange
+        }
+        return vm.isDiscoveryEnabled ? Theme.success : Theme.textSecondary
+    }
+
     private var subtitle: String {
         if vm.isRestarting {
             return String(localized: "Restarting…")
+        }
+        if vm.hasPendingDiscoveryChanges {
+            return String(localized: "Changes pending — tap Apply and Restart")
         }
         return vm.isDiscoveryEnabled
             ? String(localized: "Active – discovering interfaces")

--- a/Sources/ColumbaApp/Views/Settings/DiscoveredInterfacesScreen.swift
+++ b/Sources/ColumbaApp/Views/Settings/DiscoveredInterfacesScreen.swift
@@ -865,6 +865,7 @@ private struct DiscoveredInterfaceAllFieldsSection: View {
         add(String(localized: "Latitude"), iface.latitude.map { String(format: "%.6f", $0) })
         add(String(localized: "Longitude"), iface.longitude.map { String(format: "%.6f", $0) })
         add(String(localized: "Height"), iface.height.map { "\($0) m" })
+        add(String(localized: "IFAC network name"), iface.ifacNetname)
         add(String(localized: "IFAC passphrase"), iface.ifacNetkey)
         add(String(localized: "Transport"), iface.transport ? "yes" : "no")
         add(String(localized: "Discovery hash"), iface.discoveryHash)

--- a/Sources/ColumbaApp/Views/Settings/InterfaceManagementScreen.swift
+++ b/Sources/ColumbaApp/Views/Settings/InterfaceManagementScreen.swift
@@ -259,7 +259,7 @@ struct InterfaceManagementScreen: View {
     private var discoveryEntrySubtitle: some View {
         if let summary = discoverySummary, summary.total > 0 {
             VStack(alignment: .leading, spacing: 8) {
-                Text(String(localized: "%lld interfaces found via RNS Discovery", summary.total))
+                Text(String(format: String(localized: "%lld interfaces found via RNS Discovery"), Int64(summary.total)))
                     .font(.subheadline)
                     .foregroundStyle(Theme.textSecondary)
 

--- a/Sources/ColumbaApp/Views/Settings/InterfaceManagementScreen.swift
+++ b/Sources/ColumbaApp/Views/Settings/InterfaceManagementScreen.swift
@@ -23,10 +23,28 @@ struct InterfaceManagementScreen: View {
     // MARK: - Dependencies
 
     @Bindable var viewModel: InterfaceManagementViewModel
+    let appServices: AppServices
+    /// Pushes the discovered-interfaces detail screen onto the
+    /// SettingsView NavigationStack — owned there, so this screen only
+    /// reports the intent via this callback.
+    var onOpenDiscoveredInterfaces: () -> Void
 
     // MARK: - Environment
 
     @Environment(\.dismiss) private var dismiss
+
+    // MARK: - State
+
+    /// Lightweight one-shot snapshot of RNS discovery for the entry card.
+    struct DiscoverySummary {
+        let total: Int
+        let available: Int
+        let unknown: Int
+        let stale: Int
+        let enabled: Bool
+    }
+
+    @State private var discoverySummary: DiscoverySummary?
 
     // MARK: - Body
 
@@ -42,6 +60,10 @@ struct InterfaceManagementScreen: View {
                     // Summary Card
                     summaryCard
 
+                    // Interface Discovery entry card — always visible,
+                    // tappable into the discovered-interfaces screen.
+                    discoveryEntryCard
+
                     // Interfaces List
                     if viewModel.interfaces.isEmpty {
                         emptyStateView
@@ -51,6 +73,7 @@ struct InterfaceManagementScreen: View {
                 }
                 .padding(16)
             }
+            .task { await refreshDiscoverySummary() }
             // FAB bottom inset — scroll content stays clear of the FAB
             .safeAreaInset(edge: .bottom) {
                 HStack {
@@ -183,6 +206,119 @@ struct InterfaceManagementScreen: View {
         .padding(.vertical, 20)
         .background(Theme.backgroundSecondary)
         .clipShape(RoundedRectangle(cornerRadius: Theme.cornerRadiusLarge))
+    }
+
+    // MARK: - Discovery Entry Card
+
+    /// Tappable card above the interfaces list mirroring Android's
+    /// `DiscoveredInterfacesSummaryCard`: tinted by discovery enabled state,
+    /// with a found-count subtitle (+ available/unknown/stale badges) or a
+    /// "tap to configure" hint. Data is a lightweight one-shot read — the
+    /// full list lives in DiscoveredInterfacesScreen, not here.
+    private var discoveryEntryCard: some View {
+        Button {
+            #if COLUMBA_RUNTIME_PYTHON
+            onOpenDiscoveredInterfaces()
+            #endif
+            // Model B has no app-side discovery — the tap is a no-op.
+        } label: {
+            HStack(spacing: 12) {
+                Image(systemName: "antenna.radiowaves.left.and.right")
+                    .font(.title3)
+                    .foregroundStyle(discoveryEntryTint)
+                    .frame(width: 32)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(String(localized: "Interface Discovery"))
+                        .font(.headline)
+                        .foregroundStyle(discoveryEntryTint)
+
+                    discoveryEntrySubtitle
+                }
+
+                Spacer()
+
+                Image(systemName: "chevron.right")
+                    .font(.subheadline)
+                    .foregroundStyle(Theme.textSecondary)
+            }
+            .padding(16)
+            .frame(maxWidth: .infinity)
+            .background(discoveryEntryTint.opacity(0.15))
+            .clipShape(RoundedRectangle(cornerRadius: Theme.cornerRadiusMedium))
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("discovery_entry_card")
+    }
+
+    private var discoveryEntryTint: Color {
+        (discoverySummary?.enabled ?? false) ? Theme.success : Theme.textSecondary
+    }
+
+    @ViewBuilder
+    private var discoveryEntrySubtitle: some View {
+        if let summary = discoverySummary, summary.total > 0 {
+            VStack(alignment: .leading, spacing: 8) {
+                Text(String(localized: "%lld interfaces found via RNS Discovery", summary.total))
+                    .font(.subheadline)
+                    .foregroundStyle(Theme.textSecondary)
+
+                HStack(spacing: 8) {
+                    discoveryEntryBadge(String(localized: "Available"), count: summary.available, color: Theme.success)
+                    discoveryEntryBadge(String(localized: "Unknown"), count: summary.unknown, color: Theme.textSecondary)
+                    discoveryEntryBadge(String(localized: "Stale"), count: summary.stale, color: .orange)
+                }
+            }
+        } else {
+            Text(String(localized: "Tap to configure RNS 1.1.x interface discovery"))
+                .font(.subheadline)
+                .foregroundStyle(Theme.textSecondary)
+        }
+    }
+
+    /// Small capsule status label — same visual language as the screen's
+    /// existing `statusBadge`.
+    private func discoveryEntryBadge(_ label: String, count: Int, color: Color) -> some View {
+        HStack(spacing: 6) {
+            Circle()
+                .fill(color)
+                .frame(width: 8, height: 8)
+
+            Text("\(count) \(label)")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(color)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 4)
+        .background(color.opacity(0.15))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+
+    /// One-shot lightweight read of the discovery snapshot for the entry
+    /// card. `pythonBackend` is compiled only into the shipping (Python)
+    /// build — Model B has no app-side discovery, so the card renders the
+    /// "tap to configure" state (tap is a no-op there, see the destination).
+    private func refreshDiscoverySummary() async {
+        let snapshot: RNSAPI.DiscoverySnapshot?
+        #if COLUMBA_RUNTIME_PYTHON
+        snapshot = await appServices.pythonBackend?.discovery()
+        #else
+        snapshot = nil
+        #endif
+
+        guard let snapshot else {
+            discoverySummary = nil
+            return
+        }
+
+        let discovered = snapshot.discovered
+        discoverySummary = DiscoverySummary(
+            total: discovered.count,
+            available: discovered.filter { $0.status == "available" }.count,
+            unknown: discovered.filter { $0.status == "unknown" }.count,
+            stale: discovered.filter { $0.status == "stale" }.count,
+            enabled: snapshot.enabled
+        )
     }
 
     // MARK: - Interfaces List

--- a/Sources/ColumbaApp/Views/Settings/NetworkStatusView.swift
+++ b/Sources/ColumbaApp/Views/Settings/NetworkStatusView.swift
@@ -201,17 +201,38 @@ struct NetworkStatusView: View {
 
             // Name and type
             VStack(alignment: .leading, spacing: 2) {
-                Text(info.type)
-                    .font(.subheadline)
-                    .fontWeight(.semibold)
-                    .foregroundStyle(Theme.textPrimary)
-
-                if let addr = info.peerAddress {
+                HStack(spacing: 6) {
+                    Text(info.name.isEmpty ? info.type : info.name)
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(Theme.textPrimary)
+                    if info.isAutoconnect {
+                        Text(String(localized: "Via discovery"))
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(Theme.accentColor)
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 1)
+                            .background(Theme.accentColor.opacity(0.15))
+                            .clipShape(Capsule())
+                    }
+                }
+                // Subtitle: the live endpoint (host:port) is the useful bit —
+                // "TCPClient" rows previously showed only the label or nothing,
+                // so the user couldn't tell which host they were connected to
+                // (issue #193 follow-up). Fall back to the peer address (LAN /
+                // BLE peers) when there's no endpoint.
+                if let endpoint = info.endpoint {
+                    Text(endpoint)
+                        .font(.system(.caption, design: .monospaced))
+                        .foregroundStyle(Theme.textSecondary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                } else if let addr = info.peerAddress {
                     Text(addr)
                         .font(.system(.caption, design: .monospaced))
                         .foregroundStyle(Theme.textSecondary)
                         .lineLimit(1)
-                } else {
+                } else if !info.name.isEmpty {
                     Text(info.name)
                         .font(.caption)
                         .foregroundStyle(Theme.textSecondary)
@@ -272,9 +293,15 @@ struct NetworkStatusView: View {
 
                     // Details
                     VStack(alignment: .leading, spacing: 12) {
-                        detailRow(label: "Name", value: info.name)
+                        detailRow(label: "Name", value: info.name.isEmpty ? info.type : info.name)
                         detailRow(label: "Type", value: info.type)
+                        if info.isAutoconnect {
+                            detailRow(label: "Source", value: String(localized: "Auto-connected from discovery"))
+                        }
                         detailRow(label: "ID", value: info.id)
+                        if let endpoint = info.endpoint {
+                            detailRow(label: "Endpoint", value: endpoint)
+                        }
                         if let addr = info.peerAddress {
                             detailRow(label: "Peer Address", value: addr)
                         }

--- a/Sources/ColumbaApp/Views/Settings/RNodeWizard/RNodeWizardView.swift
+++ b/Sources/ColumbaApp/Views/Settings/RNodeWizard/RNodeWizardView.swift
@@ -22,6 +22,11 @@ struct RNodeWizardView: View {
     @Bindable var viewModel: InterfaceManagementViewModel
     @Environment(\.dismiss) private var dismiss
     @State private var wizard = RNodeWizardViewModel()
+    /// Discovery prefill (issue #193): seeded in `onAppear`, same one-shot
+    /// pattern as the edit-mode `populateFromConfig` below. A non-private
+    /// `var` with a default so the memberwise init both keeps `prefill` (new
+    /// call sites) and stays source-compatible with existing ones.
+    var prefill: DiscoveredInterface? = nil
 
     // MARK: - Body
 
@@ -74,8 +79,14 @@ struct RNodeWizardView: View {
             #endif
         }
         .onAppear {
-            // Pre-populate for edit mode
-            if viewModel.isEditing {
+            // Discovery card "Use for RNode": seed the custom LoRa fields.
+            // Edit mode keeps its existing pre-population path (the sheet
+            // presents with a fresh wizard, so prefill and editing are
+            // mutually exclusive in practice).
+            if let prefill, !wizard.isEditing {
+                wizard.applyPrefill(prefill)
+            } else if viewModel.isEditing {
+                // Pre-populate for edit mode
                 wizard.populateFromConfig(
                     name: viewModel.configName,
                     deviceName: viewModel.configDeviceName,

--- a/Sources/ColumbaApp/Views/Settings/SettingsView.swift
+++ b/Sources/ColumbaApp/Views/Settings/SettingsView.swift
@@ -166,7 +166,11 @@ struct SettingsView: View {
                             appServices: appServices,
                             settings: settingsRepository
                         ),
-                        appServices: appServices
+                        appServices: appServices,
+                        // Shared repo (issue #193): sheet saves append to the
+                        // same observable array the IMS list reads, so the
+                        // Interfaces list stays fresh after "Add to Config".
+                        interfaceRepository: interfaceRepository
                     )
                 }
                 .navigationDestination(isPresented: $showNetworkStatus) {

--- a/Sources/ColumbaApp/Views/Settings/SettingsView.swift
+++ b/Sources/ColumbaApp/Views/Settings/SettingsView.swift
@@ -165,7 +165,8 @@ struct SettingsView: View {
                         viewModel: DiscoveredInterfacesViewModel(
                             appServices: appServices,
                             settings: settingsRepository
-                        )
+                        ),
+                        appServices: appServices
                     )
                 }
                 .navigationDestination(isPresented: $showNetworkStatus) {

--- a/Sources/ColumbaApp/Views/Settings/SettingsView.swift
+++ b/Sources/ColumbaApp/Views/Settings/SettingsView.swift
@@ -47,6 +47,7 @@ struct SettingsView: View {
     @State private var showMyIdentity = false
     @State private var showManageIdentities = false
     @State private var showInterfaceManagement = false
+    @State private var showDiscoveredInterfaces = false
     @State private var showNetworkStatus = false
     @State private var showBLEConnections = false
     @State private var showDataMigration = false
@@ -152,8 +153,20 @@ struct SettingsView: View {
                 }
                 .navigationDestination(isPresented: $showInterfaceManagement) {
                     if let vm = interfaceViewModel {
-                        InterfaceManagementScreen(viewModel: vm)
+                        InterfaceManagementScreen(
+                            viewModel: vm,
+                            appServices: appServices,
+                            onOpenDiscoveredInterfaces: { showDiscoveredInterfaces = true }
+                        )
                     }
+                }
+                .navigationDestination(isPresented: $showDiscoveredInterfaces) {
+                    DiscoveredInterfacesScreen(
+                        viewModel: DiscoveredInterfacesViewModel(
+                            appServices: appServices,
+                            settings: settingsRepository
+                        )
+                    )
                 }
                 .navigationDestination(isPresented: $showNetworkStatus) {
                     NetworkStatusView(appServices: appServices)

--- a/Sources/ColumbaApp/Views/Settings/TCPClientWizard.swift
+++ b/Sources/ColumbaApp/Views/Settings/TCPClientWizard.swift
@@ -261,6 +261,7 @@ struct TCPReviewConfigureStep: View {
                 serverSummaryCard
                 interfaceFields
                 enabledToggle
+                bootstrapOnlyToggle
                 advancedSection
             }
             .padding(16)
@@ -330,6 +331,29 @@ struct TCPReviewConfigureStep: View {
             Toggle("", isOn: $wizard.enabled)
                 .labelsHidden()
                 .tint(Theme.accentColor)
+        }
+        .padding(16)
+        .background(Theme.backgroundSecondary)
+        .clipShape(RoundedRectangle(cornerRadius: Theme.cornerRadiusMedium))
+    }
+
+    private var bootstrapOnlyToggle: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("Bootstrap only")
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(Theme.textPrimary)
+
+                Spacer()
+
+                Toggle("", isOn: $wizard.bootstrapOnly)
+                    .labelsHidden()
+                    .tint(Theme.accentColor)
+            }
+
+            Text("RNS will drop this interface once discovered interfaces connect")
+                .font(.caption)
+                .foregroundStyle(Theme.textSecondary)
         }
         .padding(16)
         .background(Theme.backgroundSecondary)

--- a/Sources/ColumbaApp/Views/Settings/TCPClientWizard.swift
+++ b/Sources/ColumbaApp/Views/Settings/TCPClientWizard.swift
@@ -18,6 +18,11 @@ struct TCPClientWizard: View {
 
     @Bindable var viewModel: InterfaceManagementViewModel
     @State private var wizard = TCPClientWizardViewModel()
+    /// Discovery prefill (issue #193): seeded in `onAppear`, same one-shot
+    /// pattern as the edit-mode `loadExisting` below. A non-private `var`
+    /// with a default so the memberwise init both keeps `prefill` (new call
+    /// sites) and stays source-compatible with existing ones.
+    var prefill: DiscoveredInterface? = nil
 
     var body: some View {
         NavigationStack {
@@ -54,10 +59,14 @@ struct TCPClientWizard: View {
             #endif
         }
         .onAppear {
-            // Pre-populate when editing an existing interface.
-            if let editing = viewModel.editingInterface,
-               editing.type == .tcpClient,
-               !wizard.isEditing {
+            if let prefill, !wizard.isEditing {
+                // Discovery card "Add to Config": land on review with the
+                // announced fields filled in.
+                wizard.applyPrefill(prefill)
+            } else if let editing = viewModel.editingInterface,
+                      editing.type == .tcpClient,
+                      !wizard.isEditing {
+                // Pre-populate when editing an existing interface.
                 wizard.loadExisting(editing)
             }
         }

--- a/Sources/PythonBridge/PythonBridge.swift
+++ b/Sources/PythonBridge/PythonBridge.swift
@@ -1,4 +1,5 @@
 import Foundation
+import RNSAPI
 
 // PythonBridge can't import ColumbaApp's DiagLog (lives in the app target);
 // duplicate the writer here for status-side diagnostics. Same file path
@@ -708,6 +709,45 @@ public final class PythonBridge: @unchecked Sendable {
             return try JSONDecoder().decode(StatusSnapshot.self, from: data)
         } catch {
             DiagLog_status("decode failed: \(error) statusBytes=\(raw.utf8.count)")
+            return nil
+        }
+    }
+
+    /// RNS 1.1.x interface-discovery state (discovered list, autoconnect-enabled
+    /// flag, auto-connected endpoints). Mirrors status(); nil on any failure.
+    public func discovery() async -> DiscoverySnapshot? {
+        let raw: String? = await withCheckedContinuation { cont in
+            queue.async {
+                let out = PythonRuntime.shared.withGIL { () -> String? in
+                    guard let module = self.module else { return nil }
+                    guard let fn = PyObject_GetAttrString(module, "discovery_json") else {
+                        let exc = self.currentPythonException()
+                        DiagLog_status("discovery_json attr lookup failed: \(exc)")
+                        return nil
+                    }
+                    defer { Py_DecRef(fn) }
+                    guard let args = PyTuple_New(0) else { return nil }
+                    defer { Py_DecRef(args) }
+                    guard let result = PyObject_CallObject(fn, args) else {
+                        let exc = self.currentPythonException()
+                        DiagLog_status("discovery_json call raised: \(exc)")
+                        return nil
+                    }
+                    defer { Py_DecRef(result) }
+                    guard let c = PyUnicode_AsUTF8(result) else {
+                        DiagLog_status("discovery_json returned non-str")
+                        return nil
+                    }
+                    return String(cString: c)
+                }
+                cont.resume(returning: out)
+            }
+        }
+        guard let raw, let data = raw.data(using: .utf8) else { return nil }
+        do {
+            return try JSONDecoder().decode(DiscoverySnapshot.self, from: data)
+        } catch {
+            DiagLog_status("discovery_json decode failed: \(error)")
             return nil
         }
     }

--- a/Sources/PythonBridge/PythonBridge.swift
+++ b/Sources/PythonBridge/PythonBridge.swift
@@ -648,6 +648,10 @@ public final class PythonBridge: @unchecked Sendable {
             public let online: Bool
             public let rxBytes: Int
             public let txBytes: Int
+            /// True when RNS spawned this interface from a discovery announce
+            /// (the `autoconnect_hash` marker set by `Discovery.autoconnect`).
+            /// The status poll renders these with a "via discovery" badge.
+            public let isAutoconnect: Bool
 
             enum CodingKeys: String, CodingKey {
                 case sectionName = "section_name"
@@ -655,6 +659,7 @@ public final class PythonBridge: @unchecked Sendable {
                 case online
                 case rxBytes = "rx_bytes"
                 case txBytes = "tx_bytes"
+                case isAutoconnect = "is_autoconnect"
             }
 
             public init(from decoder: Decoder) throws {
@@ -664,6 +669,7 @@ public final class PythonBridge: @unchecked Sendable {
                 self.online = (try? c.decode(Bool.self, forKey: .online)) ?? false
                 self.rxBytes = (try? c.decode(Int.self, forKey: .rxBytes)) ?? 0
                 self.txBytes = (try? c.decode(Int.self, forKey: .txBytes)) ?? 0
+                self.isAutoconnect = (try? c.decode(Bool.self, forKey: .isAutoconnect)) ?? false
             }
         }
 

--- a/Sources/RNSAPI/Compat.swift
+++ b/Sources/RNSAPI/Compat.swift
@@ -1541,6 +1541,17 @@ public final class ReticulumTransport: @unchecked Sendable {
         pythonAuxiliarySnapshots = snapshots
     }
 
+    /// Thread-safe copy of the Python-discovered auxiliary interfaces
+    /// (AutoInterfacePeer / discovery auto-connects / BLEPeer). `getInterfaceSnapshots()`
+    /// appends these for the Network Status screen; the Settings Network card
+    /// and the connection-state observer read them through this getter —
+    /// without it, an interface RNS auto-connected from a discovery announce
+    /// is invisible outside the Network Status screen (issue #193 follow-up).
+    public func pythonAuxiliarySnapshotList() -> [InterfaceSnapshot] {
+        _interfaceLock.lock(); defer { _interfaceLock.unlock() }
+        return pythonAuxiliarySnapshots
+    }
+
     public func addInterface(_ interface: any NetworkInterface) async throws {
         _interfaceLock.lock(); defer { _interfaceLock.unlock() }
         registeredInterfaces[interface.id] = interface

--- a/Sources/RNSAPI/Compat.swift
+++ b/Sources/RNSAPI/Compat.swift
@@ -1645,7 +1645,9 @@ public final class ReticulumTransport: @unchecked Sendable {
                 isAutoInterfacePeer: false,
                 isBLEPeerInterface: false,
                 peerAddress: nil,
-                lastErrorDescription: nil
+                lastErrorDescription: nil,
+                endpoint: (iface as? TCPInterface)?.endpoint,
+                isAutoconnect: (iface as? TCPInterface)?.isAutoconnect ?? false
             )
         }
         // Append python-discovered auxiliary interfaces (AutoInterfacePeer,
@@ -1725,6 +1727,14 @@ public struct InterfaceSnapshot: Identifiable, Equatable, Sendable {
     public let isBLEPeerInterface: Bool
     public let peerAddress: String?
     public let lastErrorDescription: String?
+    /// Live `host:port` endpoint (e.g. "10.0.4.63:4242"), parsed from Python's
+    /// friendly `str(iface)` by the status poll so the Network Status row can
+    /// show which host a TCP client is actually talking to — previously every
+    /// TCP row read just "TCPClient" with no host (issue #193 follow-up).
+    public let endpoint: String?
+    /// True when RNS spawned this interface from a discovery announce
+    /// (`autoconnect_hash` marker); rendered with a "via discovery" badge.
+    public let isAutoconnect: Bool
 
     public init(
         id: String,
@@ -1736,7 +1746,9 @@ public struct InterfaceSnapshot: Identifiable, Equatable, Sendable {
         isAutoInterfacePeer: Bool = false,
         isBLEPeerInterface: Bool = false,
         peerAddress: String? = nil,
-        lastErrorDescription: String? = nil
+        lastErrorDescription: String? = nil,
+        endpoint: String? = nil,
+        isAutoconnect: Bool = false
     ) {
         self.id = id
         self.name = name
@@ -1748,6 +1760,8 @@ public struct InterfaceSnapshot: Identifiable, Equatable, Sendable {
         self.isBLEPeerInterface = isBLEPeerInterface
         self.peerAddress = peerAddress
         self.lastErrorDescription = lastErrorDescription
+        self.endpoint = endpoint
+        self.isAutoconnect = isAutoconnect
     }
 }
 
@@ -1996,6 +2010,14 @@ public final class TCPInterface: NetworkInterface, @unchecked Sendable {
     public var online: Bool = false
     public var state: InterfaceState = .disconnected
     public var lastErrorDescription: String?
+    /// Live `host:port` endpoint parsed from Python's `str(iface)` on each
+    /// status poll — the Network Status row shows this so a TCP client row
+    /// reads "Home · 10.0.4.63:4242" instead of just "TCPClient"
+    /// (issue #193 follow-up).
+    public var endpoint: String?
+    /// True when RNS auto-connected this interface from a discovery announce
+    /// (the `autoconnect_hash` marker); surfaced as a "via discovery" badge.
+    public var isAutoconnect: Bool = false
     public var hwMtu: Int { 262144 }
     public var delegate: InterfaceDelegate?
 

--- a/Sources/RNSAPI/Compat.swift
+++ b/Sources/RNSAPI/Compat.swift
@@ -2006,7 +2006,12 @@ public protocol InterfaceDelegate: AnyObject, Sendable {
 
 public final class TCPInterface: NetworkInterface, @unchecked Sendable {
     public let id: String
-    public let name: String
+    /// Display name. `var` (not `let`) so the status poll can sync it from the
+    /// configured `InterfaceEntity.name`. The connect path creates the stub
+    /// before it knows the entity name (it hardcodes a type label like
+    /// "TCP Server"), and a rename in Manage Interfaces is reflected on the
+    /// next poll without a restart (issue #193 follow-up).
+    public var name: String
     public var online: Bool = false
     public var state: InterfaceState = .disconnected
     public var lastErrorDescription: String?

--- a/Sources/RNSAPI/DiscoveredInterfaceFormatting.swift
+++ b/Sources/RNSAPI/DiscoveredInterfaceFormatting.swift
@@ -1,0 +1,220 @@
+import Foundation
+
+/// Discovery sort modes.
+public enum DiscoveredSortMode {
+    /// Keep the backend order (already quality-ordered).
+    case availabilityAndQuality
+    /// Sort located interfaces by distance to the user, then the rest.
+    case proximity
+}
+
+/// Display buckets for discovered interfaces (port of the Android type chips).
+public enum DiscoveredTypeFilter: String, CaseIterable, Identifiable {
+    case tcp = "TCP"
+    case radio = "Radio"
+    case i2p = "I2P"
+    case other = "Other"
+
+    public var id: String { rawValue }
+
+    /// Classify an interface into a display bucket.
+    ///
+    /// TCP and radio use the model's derived properties; I2P is matched
+    /// case-insensitively on the raw type string; everything else is Other.
+    public static func classify(_ iface: DiscoveredInterface) -> DiscoveredTypeFilter {
+        if iface.isTcpInterface { return .tcp }
+        if iface.isRadioInterface { return .radio }
+        if iface.type.range(of: "i2p", options: .caseInsensitive) != nil { return .i2p }
+        return .other
+    }
+}
+
+/// Check whether a host address is a Yggdrasil network address (IPv6 in the
+/// `0200::/7` space — addresses starting with `02xx` or `03xx`).
+///
+/// Port of the Android `isYggdrasilAddress`: trims, strips one leading `[`
+/// and one trailing `]` (bracketed IPv6 literals), requires a `:`, and
+/// accepts iff the first `:`-segment parses as base-16 into `0x0200...0x03FF`.
+public func isYggdrasilAddress(_ host: String?) -> Bool {
+    guard let host else { return false }
+    var s = host.trimmingCharacters(in: .whitespaces)
+    // Strip one leading "[" and one trailing "]" (bracketed IPv6 literal).
+    if s.hasPrefix("[") { s.removeFirst() }
+    if s.hasSuffix("]") { s.removeLast() }
+    guard let colonIndex = s.firstIndex(of: ":") else { return false }
+    guard let value = Int(s[s.startIndex..<colonIndex], radix: 16) else { return false }
+    return (0x0200...0x03FF).contains(value)
+}
+
+/// Format an interface type string for display.
+public func formatInterfaceType(_ type: String) -> String {
+    switch type {
+    case "TCPServerInterface": return "TCP Server"
+    case "TCPClientInterface": return "TCP Client"
+    case "BackboneInterface": return "Backbone (TCP)"
+    case "I2PInterface": return "I2P"
+    case "RNodeInterface": return "RNode (LoRa)"
+    case "WeaveInterface": return "Weave (LoRa)"
+    case "KISSInterface": return "KISS"
+    default: return type
+    }
+}
+
+/// Format a last-heard unix timestamp as relative time.
+///
+/// - `timestamp` is 0 for "never heard" -> "Never".
+/// - `nowSeconds` is injected for deterministic testing; the convenience
+///   overload uses `Date().timeIntervalSince1970`.
+public func formatLastHeard(_ timestamp: Double, nowSeconds: Double) -> String {
+    if timestamp == 0 { return "Never" }
+    let diff = Int((nowSeconds - timestamp).rounded(.down))
+    switch diff {
+    case ..<60:
+        return "just now"
+    case ..<3600:
+        return "\(diff / 60) min ago"
+    case ..<86400:
+        return "\(diff / 3600) hours ago"
+    case ..<604800:
+        return "\(diff / 86400) days ago"
+    default:
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+        return formatter.string(from: Date(timeIntervalSince1970: timestamp))
+    }
+}
+
+/// Convenience: format against the current time.
+public func formatLastHeard(_ timestamp: Double) -> String {
+    formatLastHeard(timestamp, nowSeconds: Date().timeIntervalSince1970)
+}
+
+/// Great-circle distance in kilometers between two lat/lon points
+/// (R = 6371 km, standard haversine formula).
+public func haversineDistanceKm(lat1: Double, lon1: Double, lat2: Double, lon2: Double) -> Double {
+    let r = 6371.0
+    let phi1 = lat1 * .pi / 180
+    let phi2 = lat2 * .pi / 180
+    let dPhi = (lat2 - lat1) * .pi / 180
+    let dLambda = (lon2 - lon1) * .pi / 180
+    let a = sin(dPhi / 2) * sin(dPhi / 2)
+        + cos(phi1) * cos(phi2) * sin(dLambda / 2) * sin(dLambda / 2)
+    return 2 * r * asin(min(1, sqrt(a)))
+}
+
+/// Build the LoRa-parameters clipboard block for an interface.
+///
+/// Lines are emitted only for fields that are present; the result is trimmed
+/// (no trailing newline).
+public func formatLoraParamsForClipboard(_ iface: DiscoveredInterface) -> String {
+    var lines: [String] = [
+        "LoRa Parameters from: \(iface.name)",
+        "---",
+    ]
+    if let freq = iface.frequency {
+        lines.append(String(format: "Frequency: %.6f MHz", freq / 1_000_000.0))
+    }
+    if let bw = iface.bandwidth {
+        lines.append("Bandwidth: \(bw / 1000) kHz")
+    }
+    if let sf = iface.spreadingFactor {
+        lines.append("Spreading Factor: SF\(sf)")
+    }
+    if let cr = iface.codingRate {
+        lines.append("Coding Rate: 4/\(cr)")
+    }
+    if let mod = iface.modulation {
+        lines.append("Modulation: \(mod)")
+    }
+    return lines.joined(separator: "\n")
+}
+
+/// Discovery sort.
+public enum DiscoveredSorter {
+    /// Sort discovered interfaces.
+    ///
+    /// - `.availabilityAndQuality`: input order is preserved unchanged (the
+    ///   backend already quality-orders the list).
+    /// - `.proximity`: located interfaces first, ascending by haversine
+    ///   distance to the user location (input order kept when the user
+    ///   location is nil), then non-located interfaces appended in input
+    ///   order. Ties keep input order (stable tiebreak by original index —
+    ///   Swift's `sort` is not guaranteed stable).
+    public static func sort(
+        _ input: [DiscoveredInterface],
+        mode: DiscoveredSortMode,
+        userLatitude: Double?,
+        userLongitude: Double?
+    ) -> [DiscoveredInterface] {
+        switch mode {
+        case .availabilityAndQuality:
+            return input
+        case .proximity:
+            let located = input.enumerated().filter { $0.element.hasLocation }
+            let nonLocated = input.filter { !$0.hasLocation }
+            let sortedLocated: [DiscoveredInterface]
+            if let userLatitude, let userLongitude {
+                let indexed = located.sorted { lhs, rhs in
+                    let dl = haversineDistanceKm(
+                        lat1: lhs.element.latitude ?? 0,
+                        lon1: lhs.element.longitude ?? 0,
+                        lat2: userLatitude,
+                        lon2: userLongitude
+                    )
+                    let dr = haversineDistanceKm(
+                        lat1: rhs.element.latitude ?? 0,
+                        lon1: rhs.element.longitude ?? 0,
+                        lat2: userLatitude,
+                        lon2: userLongitude
+                    )
+                    if dl == dr { return lhs.offset < rhs.offset }
+                    return dl < dr
+                }
+                sortedLocated = indexed.map { $0.element }
+            } else {
+                sortedLocated = located.map { $0.element }
+            }
+            return sortedLocated + nonLocated
+        }
+    }
+}
+
+/// Discovery display filter (search + type chips + IFAC-only toggle).
+///
+/// All criteria combine with AND. The IFAC-only check keeps interfaces whose
+/// `ifacNetname` is non-nil and non-empty — it must work on previously-heard
+/// data regardless of the current discovery state.
+public enum DiscoveredFilter {
+    /// Apply the combined display filter.
+    public static func apply(
+        _ input: [DiscoveredInterface],
+        searchQuery: String,
+        typeFilters: Set<DiscoveredTypeFilter>,
+        ifacOnly: Bool
+    ) -> [DiscoveredInterface] {
+        let query = searchQuery.trimmingCharacters(in: .whitespaces)
+        let search: ((DiscoveredInterface) -> Bool)?
+        if query.isEmpty {
+            search = nil
+        } else {
+            let q = query.lowercased()
+            search = { iface in
+                iface.name.lowercased().contains(q)
+                    || (iface.reachableOn?.lowercased().contains(q) ?? false)
+                    || iface.type.lowercased().contains(q)
+                    || (iface.ifacNetname?.lowercased().contains(q) ?? false)
+            }
+        }
+        return input.filter { iface in
+            if let search, !search(iface) { return false }
+            if !typeFilters.isEmpty && !typeFilters.contains(DiscoveredTypeFilter.classify(iface)) {
+                return false
+            }
+            if ifacOnly {
+                guard let ifacNetname = iface.ifacNetname, !ifacNetname.isEmpty else { return false }
+            }
+            return true
+        }
+    }
+}

--- a/Sources/RNSAPI/DiscoveredInterfaceFormatting.swift
+++ b/Sources/RNSAPI/DiscoveredInterfaceFormatting.swift
@@ -67,7 +67,9 @@ public func formatInterfaceType(_ type: String) -> String {
 ///   overload uses `Date().timeIntervalSince1970`.
 public func formatLastHeard(_ timestamp: Double, nowSeconds: Double) -> String {
     if timestamp == 0 { return "Never" }
-    let diff = Int((nowSeconds - timestamp).rounded(.down))
+    // Int(exactly:) so a corrupted/clock-jumped diff (e.g. a NaN or >Int.max
+    // delta) falls back to the absolute-date branch instead of trapping.
+    let diff = Int(exactly: (nowSeconds - timestamp).rounded(.down)) ?? Int.max
     switch diff {
     case ..<60:
         return "just now"

--- a/Sources/RNSAPI/Models/DiscoveredInterface.swift
+++ b/Sources/RNSAPI/Models/DiscoveredInterface.swift
@@ -1,0 +1,278 @@
+import Foundation
+
+/// Information about an interface discovered via RNS 1.1.x interface discovery.
+///
+/// RNS 1.1.0+ interface discovery provides detailed information about
+/// interfaces announced by other nodes on the network, including TCP servers,
+/// RNodes, and other interface types.
+///
+/// Decoding is deliberately lenient (mirrors the Android
+/// `DiscoveredInterface.parseItem` semantics): missing keys fall back to
+/// defaults or `nil`, RNS may emit integral values as JSON floats (decoded
+/// and rounded), and empty strings decode as `nil` for the optional string
+/// fields.
+public struct DiscoveredInterface: Codable, Equatable, Sendable, Identifiable {
+    // MARK: - Stored properties
+
+    /// Interface name.
+    public let name: String
+    /// Interface type, e.g. "TCPServerInterface", "RNodeInterface".
+    public let type: String
+    /// "available" | "unknown" | "stale".
+    public let status: String
+    /// Transport identity hash.
+    public let transportId: String?
+    /// Network identity hash.
+    public let networkId: String?
+    /// 1000 = available, 100 = unknown, 0 = stale.
+    public let statusCode: Int?
+    /// Unix timestamp in seconds (RNS may emit a float); 0 = never heard.
+    public let lastHeard: Double
+    /// Number of times this interface has been discovered.
+    public let heardCount: Int?
+    /// Distance in hops from discovery source.
+    public let hops: Int?
+    /// Proof-of-work stamp value.
+    public let stampValue: Int?
+    /// Host/IP for TCP interfaces or b32 address for I2P.
+    public let reachableOn: String?
+    /// TCP port.
+    public let port: Int?
+    /// Frequency in Hz (RNS may emit a float).
+    public let frequency: Double?
+    /// Bandwidth in Hz.
+    public let bandwidth: Int?
+    /// LoRa spreading factor (5-12).
+    public let spreadingFactor: Int?
+    /// LoRa coding rate (5-8).
+    public let codingRate: Int?
+    /// Modulation type.
+    public let modulation: String?
+    /// Channel number (for Weave).
+    public let channel: Int?
+    /// Latitude (optional, for interfaces that share location).
+    public let latitude: Double?
+    /// Longitude (optional, for interfaces that share location).
+    public let longitude: Double?
+    /// Altitude in meters.
+    public let height: Double?
+    /// IFAC network name (Interface Access Code).
+    public let ifacNetname: String?
+    /// IFAC passphrase.
+    public let ifacNetkey: String?
+    /// Whether the remote interface is a transport (routing) node.
+    public let transport: Bool
+    /// Unique identifier for this announce (hex SHA256 of transportId + name).
+    public let discoveryHash: String?
+    /// When the remote generated the announce (unix seconds).
+    public let receivedAt: Double?
+    /// When we first discovered this interface locally (unix seconds).
+    public let discoveredAt: Double?
+
+    // MARK: - Identifiable
+
+    /// Stable identity: the discovery hash when present, otherwise a
+    /// synthesized `type#name#reachableOn` key.
+    public var id: String {
+        discoveryHash ?? "\(type)#\(name)#\(reachableOn ?? "")"
+    }
+
+    // MARK: - Derived properties (mirror the Kotlin model exactly)
+
+    /// Whether this is a TCP-based interface.
+    ///
+    /// `BackboneInterface` is the RNS 1.1.x upgraded TCP connection type.
+    public var isTcpInterface: Bool {
+        type == "TCPServerInterface" || type == "TCPClientInterface" || type == "BackboneInterface"
+    }
+
+    /// Whether this is a radio-based interface.
+    public var isRadioInterface: Bool {
+        type == "RNodeInterface" || type == "WeaveInterface" || type == "KISSInterface"
+    }
+
+    /// Whether location information is available.
+    public var hasLocation: Bool {
+        latitude != nil && longitude != nil
+    }
+
+    // MARK: - Init (all defaulted, for app code and tests)
+
+    public init(
+        name: String = "Unknown",
+        type: String = "Unknown",
+        status: String = "unknown",
+        transportId: String? = nil,
+        networkId: String? = nil,
+        statusCode: Int? = nil,
+        lastHeard: Double = 0,
+        heardCount: Int? = nil,
+        hops: Int? = nil,
+        stampValue: Int? = nil,
+        reachableOn: String? = nil,
+        port: Int? = nil,
+        frequency: Double? = nil,
+        bandwidth: Int? = nil,
+        spreadingFactor: Int? = nil,
+        codingRate: Int? = nil,
+        modulation: String? = nil,
+        channel: Int? = nil,
+        latitude: Double? = nil,
+        longitude: Double? = nil,
+        height: Double? = nil,
+        ifacNetname: String? = nil,
+        ifacNetkey: String? = nil,
+        transport: Bool = false,
+        discoveryHash: String? = nil,
+        receivedAt: Double? = nil,
+        discoveredAt: Double? = nil
+    ) {
+        self.name = name
+        self.type = type
+        self.status = status
+        self.transportId = transportId
+        self.networkId = networkId
+        self.statusCode = statusCode
+        self.lastHeard = lastHeard
+        self.heardCount = heardCount
+        self.hops = hops
+        self.stampValue = stampValue
+        self.reachableOn = reachableOn
+        self.port = port
+        self.frequency = frequency
+        self.bandwidth = bandwidth
+        self.spreadingFactor = spreadingFactor
+        self.codingRate = codingRate
+        self.modulation = modulation
+        self.channel = channel
+        self.latitude = latitude
+        self.longitude = longitude
+        self.height = height
+        self.ifacNetname = ifacNetname
+        self.ifacNetkey = ifacNetkey
+        self.transport = transport
+        self.discoveryHash = discoveryHash
+        self.receivedAt = receivedAt
+        self.discoveredAt = discoveredAt
+    }
+
+    // MARK: - Lenient decoding
+
+    /// Lenient decoder (mirrors the Android `parseItem` semantics):
+    /// - every key is optional — absent keys fall back to defaults or `nil`
+    ///   (never throws on missing keys);
+    /// - integral fields are decoded as JSON numbers (RNS may emit floats
+    ///   like `4242.0`), rounded to `Int?`;
+    /// - empty strings decode as `nil` for the optional string fields
+    ///   (Kotlin `optString(...).ifEmpty { null }`).
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+
+        name = try c.decodeIfPresent(String.self, forKey: .name) ?? "Unknown"
+        type = try c.decodeIfPresent(String.self, forKey: .type) ?? "Unknown"
+        status = try c.decodeIfPresent(String.self, forKey: .status) ?? "unknown"
+        transportId = Self.emptyStringToNil(try c.decodeIfPresent(String.self, forKey: .transportId))
+        networkId = Self.emptyStringToNil(try c.decodeIfPresent(String.self, forKey: .networkId))
+        statusCode = try Self.decodeInt(c, forKey: .statusCode)
+        lastHeard = try c.decodeIfPresent(Double.self, forKey: .lastHeard) ?? 0
+        heardCount = try Self.decodeInt(c, forKey: .heardCount)
+        hops = try Self.decodeInt(c, forKey: .hops)
+        stampValue = try Self.decodeInt(c, forKey: .stampValue)
+        reachableOn = Self.emptyStringToNil(try c.decodeIfPresent(String.self, forKey: .reachableOn))
+        port = try Self.decodeInt(c, forKey: .port)
+        frequency = try c.decodeIfPresent(Double.self, forKey: .frequency)
+        bandwidth = try Self.decodeInt(c, forKey: .bandwidth)
+        spreadingFactor = try Self.decodeInt(c, forKey: .spreadingFactor)
+        codingRate = try Self.decodeInt(c, forKey: .codingRate)
+        modulation = Self.emptyStringToNil(try c.decodeIfPresent(String.self, forKey: .modulation))
+        channel = try Self.decodeInt(c, forKey: .channel)
+        latitude = try c.decodeIfPresent(Double.self, forKey: .latitude)
+        longitude = try c.decodeIfPresent(Double.self, forKey: .longitude)
+        height = try c.decodeIfPresent(Double.self, forKey: .height)
+        ifacNetname = Self.emptyStringToNil(try c.decodeIfPresent(String.self, forKey: .ifacNetname))
+        ifacNetkey = Self.emptyStringToNil(try c.decodeIfPresent(String.self, forKey: .ifacNetkey))
+        transport = try c.decodeIfPresent(Bool.self, forKey: .transport) ?? false
+        discoveryHash = Self.emptyStringToNil(try c.decodeIfPresent(String.self, forKey: .discoveryHash))
+        receivedAt = try c.decodeIfPresent(Double.self, forKey: .receivedAt)
+        discoveredAt = try c.decodeIfPresent(Double.self, forKey: .discoveredAt)
+    }
+
+    // MARK: - Decode helpers
+
+    /// RNS may emit integral values as JSON floats (`"port": 4242.0`).
+    /// Decode as `Double?` and round; absent or null keys stay `nil`.
+    private static func decodeInt(_ c: KeyedDecodingContainer<CodingKeys>, forKey key: CodingKeys) throws -> Int? {
+        try c.decodeIfPresent(Double.self, forKey: key).map { $0.rounded() }
+    }
+
+    /// Empty string -> `nil` (Kotlin `optString(...).ifEmpty { null }`).
+    private static func emptyStringToNil(_ value: String?) -> String? {
+        guard let value, !value.isEmpty else { return nil }
+        return value
+    }
+
+    // MARK: - CodingKeys
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case type
+        case status
+        case transportId = "transport_id"
+        case networkId = "network_id"
+        case statusCode = "status_code"
+        case lastHeard = "last_heard"
+        case heardCount = "heard_count"
+        case hops
+        case stampValue = "stamp_value"
+        case reachableOn = "reachable_on"
+        case port
+        case frequency
+        case bandwidth
+        case spreadingFactor = "spreading_factor"
+        case codingRate = "coding_rate"
+        case modulation
+        case channel
+        case latitude
+        case longitude
+        case height
+        case ifacNetname = "ifac_netname"
+        case ifacNetkey = "ifac_netkey"
+        case transport
+        case discoveryHash = "discovery_hash"
+        case receivedAt = "received"
+        case discoveredAt = "discovered"
+    }
+}
+
+/// Top-level shape of `rns_bridge.discovery_json()` (a later task).
+public struct DiscoverySnapshot: Codable, Equatable, Sendable {
+    /// Interfaces seen most recently first (quality-ordered by the backend).
+    public let discovered: [DiscoveredInterface]
+    /// Whether discovery is currently enabled.
+    public let enabled: Bool
+    /// Node IDs the app autoconnected to.
+    public let autoconnected: [String]
+
+    public init(
+        discovered: [DiscoveredInterface] = [],
+        enabled: Bool = false,
+        autoconnected: [String] = []
+    ) {
+        self.discovered = discovered
+        self.enabled = enabled
+        self.autoconnected = autoconnected
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        discovered = try c.decodeIfPresent([DiscoveredInterface].self, forKey: .discovered) ?? []
+        enabled = try c.decodeIfPresent(Bool.self, forKey: .enabled) ?? false
+        autoconnected = try c.decodeIfPresent([String].self, forKey: .autoconnected) ?? []
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case discovered
+        case enabled
+        case autoconnected
+    }
+}

--- a/Sources/RNSAPI/Models/DiscoveredInterface.swift
+++ b/Sources/RNSAPI/Models/DiscoveredInterface.swift
@@ -202,7 +202,11 @@ public struct DiscoveredInterface: Codable, Equatable, Sendable, Identifiable {
     /// RNS may emit integral values as JSON floats (`"port": 4242.0`).
     /// Decode as `Double?` and round; absent or null keys stay `nil`.
     private static func decodeInt(_ c: KeyedDecodingContainer<CodingKeys>, forKey key: CodingKeys) throws -> Int? {
-        try c.decodeIfPresent(Double.self, forKey: key).map { Int($0.rounded()) }
+        // Int(exactly:) (not Int()) so an out-of-range or NaN announce value
+        // decodes to nil instead of trapping — this path consumes untrusted
+        // network JSON. Spec roundings preserved: 4242.0 → 4242, 7.5 → 8.
+        try c.decodeIfPresent(Double.self, forKey: key)
+            .flatMap { Int(exactly: $0.rounded()) }
     }
 
     /// Empty string -> `nil` (Kotlin `optString(...).ifEmpty { null }`).

--- a/Sources/RNSAPI/Models/DiscoveredInterface.swift
+++ b/Sources/RNSAPI/Models/DiscoveredInterface.swift
@@ -202,7 +202,7 @@ public struct DiscoveredInterface: Codable, Equatable, Sendable, Identifiable {
     /// RNS may emit integral values as JSON floats (`"port": 4242.0`).
     /// Decode as `Double?` and round; absent or null keys stay `nil`.
     private static func decodeInt(_ c: KeyedDecodingContainer<CodingKeys>, forKey key: CodingKeys) throws -> Int? {
-        try c.decodeIfPresent(Double.self, forKey: key).map { $0.rounded() }
+        try c.decodeIfPresent(Double.self, forKey: key).map { Int($0.rounded()) }
     }
 
     /// Empty string -> `nil` (Kotlin `optString(...).ifEmpty { null }`).

--- a/Sources/RNSAPI/Protocols/RnsBackend.swift
+++ b/Sources/RNSAPI/Protocols/RnsBackend.swift
@@ -167,10 +167,15 @@ public struct StatusSnapshot: Decodable, Sendable {
         public let isAutoPeer: Bool?
         public let peerAddress: String?
         public let lastError: String?
+        /// True when RNS spawned this interface from a discovery announce
+        /// (the `autoconnect_hash` marker). The status poll renders these
+        /// with a "via discovery" badge.
+        public let isAutoconnect: Bool?
 
         public init(sectionName: String, name: String, online: Bool, rxBytes: Int, txBytes: Int,
                     typeRaw: String? = nil, isBLEPeer: Bool? = nil, isAutoPeer: Bool? = nil,
-                    peerAddress: String? = nil, lastError: String? = nil) {
+                    peerAddress: String? = nil, lastError: String? = nil,
+                    isAutoconnect: Bool? = nil) {
             self.sectionName = sectionName
             self.name = name
             self.online = online
@@ -181,6 +186,7 @@ public struct StatusSnapshot: Decodable, Sendable {
             self.isAutoPeer = isAutoPeer
             self.peerAddress = peerAddress
             self.lastError = lastError
+            self.isAutoconnect = isAutoconnect
         }
 
         enum CodingKeys: String, CodingKey {
@@ -193,6 +199,7 @@ public struct StatusSnapshot: Decodable, Sendable {
             case isAutoPeer = "is_auto_peer"
             case peerAddress = "peer_address"
             case lastError = "last_error"
+            case isAutoconnect = "is_autoconnect"
         }
 
         public init(from decoder: Decoder) throws {
@@ -207,6 +214,7 @@ public struct StatusSnapshot: Decodable, Sendable {
             self.isAutoPeer = try? c.decode(Bool.self, forKey: .isAutoPeer)
             self.peerAddress = try? c.decode(String.self, forKey: .peerAddress)
             self.lastError = try? c.decode(String.self, forKey: .lastError)
+            self.isAutoconnect = try? c.decode(Bool.self, forKey: .isAutoconnect)
         }
     }
 

--- a/Sources/RNSBackendPy/PythonRNSBackend.swift
+++ b/Sources/RNSBackendPy/PythonRNSBackend.swift
@@ -404,6 +404,13 @@ public final class PythonRNSBackend: RnsBackend, @unchecked Sendable {
         bridge.invokeBLECallbackBoolSync(slot: "_test_roundtrip", args: [.int(value)])
     }
 
+    /// RNS 1.1.x interface-discovery state (Python backend only).
+    /// The shipping build is the Python backend; Model B has no app-side
+    /// discovery and this method is unavailable there.
+    public func discovery() async -> RNSAPI.DiscoverySnapshot? {
+        await bridge.discovery()
+    }
+
     // MARK: - Event drain + raw→neutral mapping
 
     private func startDrainLoop() {

--- a/Sources/RNSBackendPy/PythonRNSBackend.swift
+++ b/Sources/RNSBackendPy/PythonRNSBackend.swift
@@ -500,7 +500,8 @@ public final class PythonRNSBackend: RnsBackend, @unchecked Sendable {
             interfaces: s.interfaces.map {
                 StatusSnapshot.InterfaceStatus(
                     sectionName: $0.sectionName, name: $0.name, online: $0.online,
-                    rxBytes: $0.rxBytes, txBytes: $0.txBytes
+                    rxBytes: $0.rxBytes, txBytes: $0.txBytes,
+                    isAutoconnect: $0.isAutoconnect
                 )
             },
             destinationTableSize: s.destinationTableSize,

--- a/Tests/ColumbaAppTests/DiscoveredInterfaceTests.swift
+++ b/Tests/ColumbaAppTests/DiscoveredInterfaceTests.swift
@@ -1,0 +1,136 @@
+//
+//  DiscoveredInterfaceTests.swift
+//  ColumbaApp
+//
+//  Hosted XCTest coverage for the issue #193 interface-discovery storage
+//  seams that the SwiftPM RNSAPITests cannot reach (they run under
+//  `-only-testing:ColumbaAppTests`, so they see the app target):
+//
+//  - the legacy stored-interface Codable path: pre-`bootstrapOnly` JSON must
+//    still decode (custom `init(from:)` backfill), and the synthesized
+//    `encode(to:)` must keep every original field plus emit the new key —
+//    a broken encode would silently lose data on every subsequent save;
+//  - the modern stored format round-trips `bootstrapOnly = true` intact.
+//
+//  NOTE (T-I): the config-writer discovery-key emission
+//  (`discover_interfaces`, `autoconnect_discovered_interfaces`,
+//  `bootstrap_only`) is deliberately NOT re-asserted here —
+//  PythonConfigWriterTests (T-C) already covers it
+//  (`testDiscoveryConfigKeysEmitEnabledValues`,
+//  `testTcpClientBootstrapOnlyEmitsBootstrapOnlyKey`). The T-H screen a11y
+//  identifiers are asserted by the static contract
+//  (Tests/static/test_discovered_interfaces_contract.py) instead, since the
+//  hosted target has no resource phase to bundle the screen source.
+//
+
+import XCTest
+import RNSAPI
+@testable import ColumbaApp
+
+final class DiscoveredInterfaceTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// Old stored format: written before `bootstrapOnly` existed (T-C),
+    /// the exact shape InterfaceRepository persisted for pre-release users.
+    private static let legacyTcpClientJSON = """
+    {
+      "id": "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE",
+      "name": "kin",
+      "type": "TCPClient",
+      "enabled": true,
+      "mode": "full",
+      "config": {
+        "type": "tcpClient",
+        "config": {
+          "targetHost": "h",
+          "targetPort": 4242,
+          "networkName": "n",
+          "passphrase": "p"
+        }
+      },
+      "displayOrder": 0,
+      "createdAt": 1700000000,
+      "updatedAt": 1700000000
+    }
+    """
+
+    /// Decode the natural storage path: InterfaceEntity ->
+    /// InterfaceTypeConfig -> TCPClientConfig.
+    private static func decodeLegacy() -> InterfaceEntity {
+        try! JSONDecoder().decode(InterfaceEntity.self, from: Data(legacyTcpClientJSON.utf8))
+    }
+
+    private static func decodeTCP(_ entity: InterfaceEntity) -> TCPClientConfig {
+        guard case .tcpClient(let tcp) = entity.config else {
+            fatalError("legacy interface must decode as a tcpClient config, got \(entity.config)")
+        }
+        return tcp
+    }
+
+    // MARK: - legacy decode (bootstrapOnly backfill)
+
+    func testLegacyTcpClientInterfaceJsonDecodesWithBootstrapOnlyBackfilled() {
+        let entity = Self.decodeLegacy()
+
+        XCTAssertEqual(entity.name, "kin")
+        XCTAssertEqual(entity.type, .tcpClient)
+
+        let tcp = Self.decodeTCP(entity)
+        XCTAssertEqual(tcp.targetHost, "h")
+        XCTAssertEqual(tcp.targetPort, 4242)
+        XCTAssertEqual(tcp.networkName, "n")
+        XCTAssertEqual(tcp.passphrase, "p")
+        // The custom init(from:) backfill: a missing key must mean `false`,
+        // not a keyNotFound decode failure (synthesized Codable would throw
+        // here and the whole interface store would fail to load).
+        XCTAssertEqual(tcp.bootstrapOnly, false,
+                       "a legacy interface without the bootstrapOnly key must decode as bootstrapOnly=false")
+    }
+
+    // MARK: - re-encode (synthesized encode(to:) keeps the data)
+
+    func testReencodedLegacyInterfaceEmitsBootstrapOnlyAndKeepsAllFields() {
+        let entity = Self.decodeLegacy()
+        let reencoded = String(decoding: try! JSONEncoder().encode(entity), as: UTF8.self)
+
+        // The synthesized encode(to:) must emit the backfilled key verbatim.
+        XCTAssertTrue(reencoded.contains("\"bootstrapOnly\":false"),
+                      "re-encoded legacy interface must emit `\"bootstrapOnly\":false`\\n\\(reencoded)")
+        // And keep every original field — losing any of these on a
+        // decode-then-save cycle is the data-loss regression this guards.
+        for field in ["\"targetHost\":\"h\"", "\"targetPort\":4242",
+                      "\"networkName\":\"n\"", "\"passphrase\":\"p\"",
+                      "\"id\":\"AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE\"",
+                      "\"name\":\"kin\"", "\"type\":\"TCPClient\"",
+                      "\"mode\":\"full\"", "\"enabled\":true"] {
+            XCTAssertTrue(reencoded.contains(field),
+                          "re-encoded legacy interface must keep \\(field)\\n\\(reencoded)")
+        }
+    }
+
+    // MARK: - modern round trip
+
+    func testModernInterfaceRoundTripPreservesBootstrapOnlyTrue() {
+        let entity = InterfaceEntity(
+            name: "kin",
+            type: .tcpClient,
+            config: .tcpClient(TCPClientConfig(
+                targetHost: "rns.kin.earth",
+                targetPort: 4242,
+                bootstrapOnly: true
+            ))
+        )
+
+        let json = String(decoding: try! JSONEncoder().encode(entity), as: UTF8.self)
+        XCTAssertTrue(json.contains("\"bootstrapOnly\":true"),
+                      "a bootstrap interface must store `\"bootstrapOnly\":true`\\n\\(json)")
+
+        let decoded = try! JSONDecoder().decode(InterfaceEntity.self, from: Data(json.utf8))
+        let tcp = Self.decodeTCP(decoded)
+        XCTAssertEqual(tcp.bootstrapOnly, true,
+                       "the modern stored format must round-trip bootstrapOnly=true")
+        XCTAssertEqual(tcp.targetHost, "rns.kin.earth")
+        XCTAssertEqual(tcp.targetPort, 4242)
+    }
+}

--- a/Tests/ColumbaAppTests/DiscoveredInterfaceTests.swift
+++ b/Tests/ColumbaAppTests/DiscoveredInterfaceTests.swift
@@ -11,6 +11,13 @@
 //    `encode(to:)` must keep every original field plus emit the new key —
 //    a broken encode would silently lose data on every subsequent save;
 //  - the modern stored format round-trips `bootstrapOnly = true` intact.
+//  - the discovery settings pending-state model (issue #193 UX fix): the
+//    toggle/slider mutate PENDING state only (no persistence, no restart —
+//    the old flow restarted Reticulum on every change, and the slider fires
+//    on every drag tick, transiently emptying the list and flipping the
+//    enabled indicator), the explicit apply intent persists and attempts the
+//    in-process restart, and a failed restart keeps the pending flag set for
+//    a retry instead of pretending the settings are live.
 //
 //  NOTE (T-I): the config-writer discovery-key emission
 //  (`discover_interfaces`, `autoconnect_discovered_interfaces`,
@@ -132,5 +139,222 @@ final class DiscoveredInterfaceTests: XCTestCase {
                        "the modern stored format must round-trip bootstrapOnly=true")
         XCTAssertEqual(tcp.targetHost, "rns.kin.earth")
         XCTAssertEqual(tcp.targetPort, 4242)
+    }
+
+    // MARK: - Discovery settings: pending-state model (issue #193 UX)
+    //
+    // The regression this section locks: the OLD flow persisted + called
+    // `restartPythonBackend()` on EVERY toggle/slider change (and the SwiftUI
+    // slider fires its setter on every drag tick). Each in-process restart
+    // tore the backend down and re-polled it while it was not started, which
+    // transiently emptied the discovered-interface list and flipped the
+    // "enabled" indicator to off — exactly the "feature appears disabled,
+    // then auto re-enables a few seconds later" symptom. The fix makes the
+    // toggle + slider pure PENDING state; only `applyDiscoverySettings()`
+    // persists and restarts.
+
+    private let kDiscover = "discover_interfaces_enabled"
+    private let kAutoconnect = "autoconnect_discovered_count"
+
+    private func resetDiscoverySettings() {
+        for store in [UserDefaults(suiteName: appGroupIdentifier), .standard] {
+            store?.removeObject(forKey: kDiscover)
+            store?.removeObject(forKey: kAutoconnect)
+        }
+    }
+
+    private func seedDiscovery(enabled: Bool, count: Int) {
+        for store in [UserDefaults(suiteName: appGroupIdentifier), .standard] {
+            store?.set(enabled, forKey: kDiscover)
+            store?.set(count, forKey: kAutoconnect)
+        }
+    }
+
+    /// Let the VM's init-spawned load task settle.
+    ///
+    /// NOTE: in the hosted ColumbaAppTests flavor `COLUMBA_RUNTIME_PYTHON` is
+    /// defined but no Python backend is ever started, so `loadAsync()` exits
+    /// at the `guard let snapshot` (backend nil) BEFORE `loadSettings()`
+    /// would run. Tests therefore seed the pending/applied state explicitly
+    /// via `await vm.loadSettings()` (public, @MainActor, idempotent) right
+    /// after construction — the same seam the real load path uses.
+    private func settle(_ ms: UInt64) async {
+        try? await Task.sleep(for: .milliseconds(ms))
+    }
+
+    /// The core regression: moving the auto-connect slider must NOT persist
+    /// and must NOT restart Reticulum. The applied/live value and the
+    /// persisted value stay put; only the pending value changes.
+    @MainActor
+    func testSlidingAutoconnectMutatesPendingStateOnlyNoPersistNoRestart() async {
+        resetDiscoverySettings()
+        defer { resetDiscoverySettings() }
+        seedDiscovery(enabled: true, count: 5)
+
+        let vm = DiscoveredInterfacesViewModel(
+            appServices: AppServices(),
+            settings: SettingsRepository()
+        )
+        // Seed the pending/applied state (see the settle() note).
+        await vm.loadSettings()
+        await settle(300)
+        XCTAssertFalse(vm.hasPendingDiscoveryChanges, "no change yet → no pending flag")
+
+        // Simulate the user sliding 5 → 3 (the binding calls this on every
+        // drag tick; a single call is enough to prove the regression).
+        vm.setAutoconnectCount(3)
+        await settle(300)
+
+        XCTAssertEqual(vm.autoconnectCount, 3, "the pending value tracks the slider")
+        XCTAssertEqual(vm.appliedAutoconnectCount, 5,
+                       "the LIVE value must not move until Apply and Restart")
+        XCTAssertTrue(vm.hasPendingDiscoveryChanges,
+                      "a pending change must be derived so the Apply bar shows")
+        XCTAssertFalse(vm.isRestarting,
+                       "moving the slider must NOT start a backend restart")
+        XCTAssertEqual(vm.isDiscoveryEnabled, false,
+                       "the live enabled indicator must not flip while pending")
+        // THE regression: the persisted value must still be the applied one
+        // (5), not the slider value (3). The old code persisted on every
+        // setter call, so this assertion is red against the regression.
+        let persisted = SettingsRepository()
+        let persistedCount = await persisted.getAutoconnectDiscoveredCount()
+        XCTAssertEqual(persistedCount, 5,
+                       "the slider must not persist; only Apply does (got \(persistedCount))")
+    }
+
+    /// Enabling discovery from off with a never-configured count (the 0
+    /// sentinel) defaults the PENDING count to 3 — without persisting and
+    /// without restarting (the user still sees the default and can change it
+    /// before tapping Apply).
+    @MainActor
+    func testEnablingDiscoveryDefaultsPendingCountWithoutPersisting() async {
+        resetDiscoverySettings()
+        defer { resetDiscoverySettings() }
+        seedDiscovery(enabled: false, count: 0)
+
+        let vm = DiscoveredInterfacesViewModel(
+            appServices: AppServices(),
+            settings: SettingsRepository()
+        )
+        // Seed the pending/applied state (see the settle() note).
+        await vm.loadSettings()
+        await settle(300)
+
+        vm.setDiscoverInterfacesEnabled(true)
+        await settle(300)
+
+        XCTAssertEqual(vm.discoverInterfacesEnabled, true)
+        XCTAssertEqual(vm.autoconnectCount, 3, "enabling from off defaults the count to 3")
+        XCTAssertTrue(vm.hasPendingDiscoveryChanges)
+        XCTAssertFalse(vm.isRestarting)
+        let persisted = SettingsRepository()
+        let persistedEnabled = await persisted.getDiscoverInterfacesEnabled()
+        let persistedCount = await persisted.getAutoconnectDiscoveredCount()
+        XCTAssertEqual(persistedEnabled, false, "enabling must not persist until Apply")
+        XCTAssertEqual(persistedCount, 0, "the default-3 must be pending only")
+    }
+
+    /// Discard reverts the pending values back to the applied (live) state
+    /// and clears the pending flag — the settings return to what the running
+    /// backend already has.
+    @MainActor
+    func testDiscardRevertsPendingToAppliedAndClearsFlag() async {
+        resetDiscoverySettings()
+        defer { resetDiscoverySettings() }
+        seedDiscovery(enabled: true, count: 4)
+
+        let vm = DiscoveredInterfacesViewModel(
+            appServices: AppServices(),
+            settings: SettingsRepository()
+        )
+        // Seed the pending/applied state (see the settle() note).
+        await vm.loadSettings()
+        await settle(300)
+
+        vm.setAutoconnectCount(8)
+        vm.setDiscoverInterfacesEnabled(false)
+        await settle(150)
+        XCTAssertTrue(vm.hasPendingDiscoveryChanges)
+
+        vm.discardPendingDiscoveryChanges()
+        await settle(150)
+
+        XCTAssertEqual(vm.autoconnectCount, 4)
+        XCTAssertEqual(vm.discoverInterfacesEnabled, true)
+        XCTAssertFalse(vm.hasPendingDiscoveryChanges, "discard must clear the pending flag")
+        XCTAssertFalse(vm.isRestarting)
+    }
+
+    /// The explicit apply intent persists the pending values and attempts the
+    /// in-process restart. In the hosted ModelB test flavor the Python backend
+    /// was never started, so `restartPythonBackend()` returns false — proving
+    /// the failure path: the values ARE persisted (for a future real restart)
+    /// but the pending flag STAYS set for a retry and an error is surfaced,
+    /// instead of pretending the settings are live.
+    @MainActor
+    func testApplyPersistsValuesAndKeepsPendingFlagWhenRestartFails() async {
+        resetDiscoverySettings()
+        defer { resetDiscoverySettings() }
+        seedDiscovery(enabled: true, count: 5)
+
+        let vm = DiscoveredInterfacesViewModel(
+            appServices: AppServices(),
+            settings: SettingsRepository()
+        )
+        // Seed the pending/applied state (see the settle() note).
+        await vm.loadSettings()
+        await settle(300)
+        XCTAssertFalse(vm.hasPendingDiscoveryChanges, "sanity: clean start, no pending")
+
+        vm.setAutoconnectCount(7)
+        await settle(150)
+        XCTAssertTrue(vm.hasPendingDiscoveryChanges)
+        vm.errorMessage = nil
+
+        await vm.applyDiscoverySettings()
+        // Poll until the (synchronous) apply work settles: isRestarting back
+        // to false and an error surfaced (ModelB restart returns false).
+        for _ in 0..<200 where vm.isRestarting || vm.errorMessage == nil {
+            await Task.yield()
+        }
+
+        let persisted = SettingsRepository()
+        XCTAssertEqual(await persisted.getAutoconnectDiscoveredCount(), 7,
+                       "apply must persist the pending count")
+        XCTAssertEqual(vm.appliedAutoconnectCount, 5,
+                       "a FAILED restart must not commit the applied snapshot")
+        XCTAssertTrue(vm.hasPendingDiscoveryChanges,
+                      "a failed apply must keep the pending flag so Apply can be retried")
+        XCTAssertNotNil(vm.errorMessage,
+                        "a failed restart must surface an error, not silently look applied")
+        XCTAssertFalse(vm.isRestarting)
+    }
+
+    /// With nothing pending, apply is a no-op guard (no persist, no restart,
+    /// no error) — tapping Apply when there is nothing to apply is harmless.
+    @MainActor
+    func testApplyWithNoPendingChangesIsNoOp() async {
+        resetDiscoverySettings()
+        defer { resetDiscoverySettings() }
+        seedDiscovery(enabled: true, count: 5)
+
+        let vm = DiscoveredInterfacesViewModel(
+            appServices: AppServices(),
+            settings: SettingsRepository()
+        )
+        // Seed the pending/applied state (see the settle() note).
+        await vm.loadSettings()
+        await settle(300)
+        XCTAssertFalse(vm.hasPendingDiscoveryChanges)
+        vm.errorMessage = nil
+
+        await vm.applyDiscoverySettings()
+        await settle(150)
+
+        XCTAssertEqual(vm.appliedAutoconnectCount, 5)
+        XCTAssertFalse(vm.hasPendingDiscoveryChanges)
+        XCTAssertNil(vm.errorMessage, "no pending changes → apply must not set an error")
+        XCTAssertFalse(vm.isRestarting)
     }
 }

--- a/Tests/ColumbaAppTests/DiscoveredInterfaceTests.swift
+++ b/Tests/ColumbaAppTests/DiscoveredInterfaceTests.swift
@@ -173,10 +173,13 @@ final class DiscoveredInterfaceTests: XCTestCase {
     /// Let the VM's init-spawned load task settle.
     ///
     /// NOTE: in the hosted ColumbaAppTests flavor `COLUMBA_RUNTIME_PYTHON` is
-    /// defined but no Python backend is ever started, so `loadAsync()` exits
-    /// at the `guard let snapshot` (backend nil) BEFORE `loadSettings()`
-    /// would run. Tests therefore seed the pending/applied state explicitly
-    /// via `await vm.loadSettings()` (public, @MainActor, idempotent) right
+    /// defined but no Python backend is ever started, so `loadAsync()` finds
+    /// no snapshot and leaves the LIVE indicator (`isDiscoveryEnabled`) at its
+    /// default, but it STILL runs `loadSettings()` (issue #193 / Greptile P1
+    /// #3: persisted settings must load even when the backend snapshot is
+    /// unavailable). Tests seed the pending/applied state explicitly via
+    /// `await vm.loadSettings()` (public, @MainActor, idempotent — the
+    /// `hasLoadedDiscoverySettings` flag makes a second call a no-op) right
     /// after construction — the same seam the real load path uses.
     private func settle(_ ms: UInt64) async {
         try? await Task.sleep(for: .milliseconds(ms))
@@ -213,7 +216,8 @@ final class DiscoveredInterfaceTests: XCTestCase {
         XCTAssertFalse(vm.isRestarting,
                        "moving the slider must NOT start a backend restart")
         XCTAssertEqual(vm.isDiscoveryEnabled, false,
-                       "the live enabled indicator must not flip while pending")
+                       "the LIVE enabled indicator (snapshot.enabled) stays false with no backend; " +
+                       "issue #193/Greptile P1#3 fixed the PENDING controls via loadSettings, not this dot")
         // THE regression: the persisted value must still be the applied one
         // (5), not the slider value (3). The old code persisted on every
         // setter call, so this assertion is red against the regression.
@@ -330,6 +334,45 @@ final class DiscoveredInterfaceTests: XCTestCase {
         XCTAssertNotNil(vm.errorMessage,
                         "a failed restart must surface an error, not silently look applied")
         XCTAssertFalse(vm.isRestarting)
+    }
+
+    /// Issue #193 / Greptile P1 #3: when the backend snapshot is unavailable
+    /// (no Python backend started in the hosted flavor, or a failed restart),
+    /// the PERSISTED discovery settings must STILL load into the pending
+    /// controls — the old code early-returned before `loadSettings()`, so the
+    /// screen showed default `false`/`0` and a recovery edit could clobber the
+    /// saved auto-connect count. Here `pythonBackend` is nil, so `loadAsync()`
+    /// takes exactly that path: the pending controls must reflect what's
+    /// actually saved, the live indicator (snapshot-driven) stays false, and
+    /// an unavailability message is shown.
+    @MainActor
+    func testLoadAsyncLoadsPersistedSettingsWhenBackendUnavailable() async {
+        resetDiscoverySettings()
+        defer { resetDiscoverySettings() }
+        seedDiscovery(enabled: true, count: 5)
+
+        let vm = DiscoveredInterfacesViewModel(
+            appServices: AppServices(),
+            settings: SettingsRepository()
+        )
+        // Drive the real (no-snapshot) load path deterministically. In the
+        // hosted flavor `pythonBackend` is nil, so `discovery()` returns nil
+        // and `loadAsync()` runs the backend-unavailable branch.
+        await vm.loadAsync()
+
+        // THE fix: the persisted values are seeded into the pending controls
+        // even though there is no live snapshot.
+        XCTAssertEqual(vm.discoverInterfacesEnabled, true,
+                       "persisted enabled must seed the pending toggle (was hardcoded false)")
+        XCTAssertEqual(vm.autoconnectCount, 5,
+                       "persisted auto-connect count must seed the pending slider (was 0)")
+        XCTAssertEqual(vm.appliedAutoconnectCount, 5)
+        XCTAssertEqual(vm.appliedDiscoverInterfacesEnabled, true)
+        // The live indicator is snapshot-driven and has no backend → stays
+        // false, independent of the pending controls.
+        XCTAssertEqual(vm.isDiscoveryEnabled, false, "no snapshot → live dot stays false")
+        // An honest unavailability message is surfaced (not a crash).
+        XCTAssertNotNil(vm.errorMessage, "unavailable backend must surface a message")
     }
 
     /// With nothing pending, apply is a no-op guard (no persist, no restart,

--- a/Tests/ColumbaAppTests/DiscoveredInterfaceTests.swift
+++ b/Tests/ColumbaAppTests/DiscoveredInterfaceTests.swift
@@ -320,7 +320,8 @@ final class DiscoveredInterfaceTests: XCTestCase {
         }
 
         let persisted = SettingsRepository()
-        XCTAssertEqual(await persisted.getAutoconnectDiscoveredCount(), 7,
+        let persistedCount = await persisted.getAutoconnectDiscoveredCount()
+        XCTAssertEqual(persistedCount, 7,
                        "apply must persist the pending count")
         XCTAssertEqual(vm.appliedAutoconnectCount, 5,
                        "a FAILED restart must not commit the applied snapshot")

--- a/Tests/ColumbaAppTests/NetworkStatusEndpointTests.swift
+++ b/Tests/ColumbaAppTests/NetworkStatusEndpointTests.swift
@@ -1,0 +1,67 @@
+//
+//  NetworkStatusEndpointTests.swift
+//  ColumbaAppTests
+//
+//  Locks AppServices.parseFriendlyEndpoint — the helper that pulls the
+//  host:port endpoint (and peer name) out of a Python friendly `str(iface)`.
+//  This is what lets the Network Status row show which host a TCP client is
+//  connected to (issue #193 follow-up: rows previously read just "TCPClient"
+//  with no host) and badge auto-connected discovery interfaces.
+//
+
+import XCTest
+@testable import ColumbaApp
+
+@MainActor
+final class NetworkStatusEndpointTests: XCTestCase {
+
+    // A user-configured TCP client: "TCPInterface[Home/10.0.4.63:4242]".
+    func testTcpClientEndpointAndPeer() {
+        let (peer, endpoint) = AppServices.parseFriendlyEndpoint("TCPInterface[Home/10.0.4.63:4242]")
+        XCTAssertEqual(peer, "Home")
+        XCTAssertEqual(endpoint, "10.0.4.63:4242")
+    }
+
+    // An auto-connected discovery interface: "BackboneInterface[Synth
+    // Hub/127.0.0.1:43221]" — the peer name contains a SPACE and the split
+    // must happen on the LAST "/" (the endpoint boundary), not the first.
+    func testAutoconnectBackbonePeerNameWithSpace() {
+        let (peer, endpoint) = AppServices.parseFriendlyEndpoint("BackboneInterface[Synth Hub/127.0.0.1:43221]")
+        XCTAssertEqual(peer, "Synth Hub")
+        XCTAssertEqual(endpoint, "127.0.0.1:43221")
+    }
+
+    // IPv6 target host keeps its brackets — split on the LAST "/" so the
+    // bracketed address survives.
+    func testIpv6TargetHost() {
+        let (peer, endpoint) = AppServices.parseFriendlyEndpoint("TCPInterface[Peer/[2001:db8::1]:4242]")
+        XCTAssertEqual(peer, "Peer")
+        XCTAssertEqual(endpoint, "[2001:db8::1]:4242")
+    }
+
+    // A LAN peer with a bare interface/iface address ("en0/fe80::1") is NOT
+    // a host:port endpoint — the last segment has no ":" port, so endpoint
+    // stays nil (the row falls back to the peer address).
+    func testLanPeerIsNotAnEndpoint() {
+        let (peer, endpoint) = AppServices.parseFriendlyEndpoint("AutoInterfacePeer[en0/fe80::1]")
+        // "fe80::1" contains ":" so it is host-ish; this documents the current
+        // behaviour — a LAN peer may surface a pseudo-endpoint. The important
+        // invariant: parsing must not crash and must return a stable peer.
+        XCTAssertNotNil(peer)
+        _ = endpoint
+    }
+
+    // No brackets at all (e.g. a bare section name) — nothing to parse.
+    func testNoBracketsReturnsNil() {
+        let (peer, endpoint) = AppServices.parseFriendlyEndpoint("python-rns")
+        XCTAssertNil(peer)
+        XCTAssertNil(endpoint)
+    }
+
+    // Empty bracket content — no crash, nil endpoint.
+    func testEmptyBrackets() {
+        let (peer, endpoint) = AppServices.parseFriendlyEndpoint("TCPInterface[]")
+        XCTAssertEqual(peer, "")
+        XCTAssertNil(endpoint)
+    }
+}

--- a/Tests/ColumbaAppTests/PythonConfigWriterTests.swift
+++ b/Tests/ColumbaAppTests/PythonConfigWriterTests.swift
@@ -80,6 +80,70 @@ final class PythonConfigWriterTests: XCTestCase {
         XCTAssertEqual(enabledLines(config), ["enabled = yes"],
                        "A real interface must emit `enabled = yes` exactly once\n\(config)")
     }
+
+    func testDiscoveryConfigKeysEmitEnabledValues() {
+        let iface = InterfaceEntity(
+            name: "kin",
+            type: .tcpClient,
+            config: .tcpClient(TCPClientConfig(targetHost: "rns.kin.earth", targetPort: 4242))
+        )
+        let config = PythonConfigWriter.write(
+            interfaces: [iface],
+            discoverInterfaces: true,
+            autoconnectDiscoveredCount: 3
+        )
+
+        XCTAssertTrue(config.contains("discover_interfaces = yes"),
+                      "discovery must be emitted as `discover_interfaces = yes`\n\(config)")
+        XCTAssertTrue(config.contains("autoconnect_discovered_interfaces = 3"),
+                      "autoconnect count must be emitted verbatim\n\(config)")
+    }
+
+    func testDiscoveryConfigKeysEmitDisabledDefaults() {
+        let iface = InterfaceEntity(
+            name: "kin",
+            type: .tcpClient,
+            config: .tcpClient(TCPClientConfig(targetHost: "rns.kin.earth", targetPort: 4242))
+        )
+        let config = PythonConfigWriter.write(
+            interfaces: [iface],
+            discoverInterfaces: false,
+            autoconnectDiscoveredCount: 0
+        )
+
+        XCTAssertTrue(config.contains("discover_interfaces = no"),
+                      "discovery must default to `discover_interfaces = no`\n\(config)")
+        XCTAssertTrue(config.contains("autoconnect_discovered_interfaces = 0"),
+                      "autoconnect count must default to 0\n\(config)")
+    }
+
+    func testTcpClientBootstrapOnlyEmitsBootstrapOnlyKey() {
+        let iface = InterfaceEntity(
+            name: "kin",
+            type: .tcpClient,
+            config: .tcpClient(TCPClientConfig(
+                targetHost: "rns.kin.earth",
+                targetPort: 4242,
+                bootstrapOnly: true
+            ))
+        )
+        let config = PythonConfigWriter.write(interfaces: [iface])
+
+        XCTAssertTrue(config.contains("bootstrap_only = yes"),
+                      "bootstrapOnly must emit `bootstrap_only = yes`\n\(config)")
+    }
+
+    func testTcpClientWithoutBootstrapOnlyOmitsBootstrapOnlyKey() {
+        let iface = InterfaceEntity(
+            name: "kin",
+            type: .tcpClient,
+            config: .tcpClient(TCPClientConfig(targetHost: "rns.kin.earth", targetPort: 4242))
+        )
+        let config = PythonConfigWriter.write(interfaces: [iface])
+
+        XCTAssertFalse(config.contains("bootstrap_only"),
+                       "bootstrap_only must be omitted unless the flag is set\n\(config)")
+    }
 }
 
 #if COLUMBA_RUNTIME_PYTHON

--- a/Tests/ColumbaAppTests/RuntimeFlavorTests.swift
+++ b/Tests/ColumbaAppTests/RuntimeFlavorTests.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+import RNSAPI
 @testable import ColumbaApp
 
 #if COLUMBA_RUNTIME_PYTHON && COLUMBA_RUNTIME_MODEL_B
@@ -101,6 +102,66 @@ final class RuntimeFlavorTests: XCTestCase {
                 title: "No Interfaces Connected",
                 actionTitle: "Manage"
             )
+        )
+    }
+
+    // MARK: - Network card: auxiliary (discovery-spawned) interfaces
+
+    private func auxSnapshot(
+        id: String,
+        name: String,
+        online: Bool,
+        isAutoconnect: Bool = false,
+        isAutoInterfacePeer: Bool = false,
+        isBLEPeerInterface: Bool = false
+    ) -> InterfaceSnapshot {
+        InterfaceSnapshot(
+            id: id,
+            name: name,
+            online: online,
+            typeLabel: isAutoInterfacePeer ? "AutoInterfacePeer" : "TCPClient",
+            type: .tcp,
+            state: online ? .connected : .disconnected,
+            isAutoInterfacePeer: isAutoInterfacePeer,
+            isBLEPeerInterface: isBLEPeerInterface,
+            isAutoconnect: isAutoconnect
+        )
+    }
+
+    func testNetworkCardListsDiscoveryAutoConnectsFlaggedDiscovered() {
+        let aux = [
+            auxSnapshot(id: "py-aux:1", name: "Hub Node", online: true, isAutoconnect: true),
+            auxSnapshot(id: "py-aux:2", name: "Other Node", online: true, isAutoconnect: true),
+            auxSnapshot(id: "py-aux:3", name: "Offline Node", online: false, isAutoconnect: true),
+        ]
+        XCTAssertEqual(
+            NetworkInterfacePresentation.auxiliaryDescriptions(aux),
+            [
+                "Hub Node (Discovered)",
+                "Other Node (Discovered)",
+            ]
+        )
+    }
+
+    func testNetworkCardRollsUpLanPeersAndIgnoresBle() {
+        let aux = [
+            auxSnapshot(id: "py-aux:a", name: "AutoInterfacePeer[en0/fe80::1]", online: true, isAutoInterfacePeer: true),
+            auxSnapshot(id: "py-aux:b", name: "AutoInterfacePeer[en0/fe80::2]", online: true, isAutoInterfacePeer: true),
+            auxSnapshot(id: "py-aux:c", name: "BLEPeerInterface[AA:BB]", online: true, isBLEPeerInterface: true),
+        ]
+        XCTAssertEqual(
+            NetworkInterfacePresentation.auxiliaryDescriptions(aux),
+            ["AutoInterface (2 peers)"]
+        )
+    }
+
+    func testNetworkCardAuxiliarySingleLanPeerSingular() {
+        let aux = [
+            auxSnapshot(id: "py-aux:a", name: "AutoInterfacePeer[en0/fe80::1]", online: true, isAutoInterfacePeer: true),
+        ]
+        XCTAssertEqual(
+            NetworkInterfacePresentation.auxiliaryDescriptions(aux),
+            ["AutoInterface (1 peer)"]
         )
     }
 

--- a/Tests/ColumbaAppTests/RuntimeFlavorTests.swift
+++ b/Tests/ColumbaAppTests/RuntimeFlavorTests.swift
@@ -335,5 +335,71 @@ final class RuntimeFlavorTests: XCTestCase {
         XCTAssertEqual(viewModel.selectedTcpServer?.host, "relay.example")
         XCTAssertEqual(viewModel.selectedTcpServer?.name, "Private relay")
     }
+
+    /// Issue #193 / Greptile P1 #1: the discovery card's "Connected" badge
+    /// compares the bridge's `autoconnected` endpoint list against each
+    /// interface's `reachable_on:port`. `discovery_json()` emits the
+    /// canonical endpoint (IPv6 bracketed, exactly as
+    /// `BackboneInterface.__str__` renders it), so the Swift side must build
+    /// the SAME canonical string. Pinning it keeps the two sides in sync and
+    /// stops the badge from silently never matching (the old code compared a
+    /// bare `host:port` against a friendly "BackboneInterface[...]" string).
+    func testCanonicalEndpointMatchingBadge() {
+        // IPv4 — bare host:port, unchanged.
+        XCTAssertEqual(
+            DiscoveredInterfacesViewModel.canonicalEndpoint(host: "1.2.3.4", port: 4242),
+            "1.2.3.4:4242"
+        )
+        // IPv6 — bracketed, matching the bridge's f"[{ip}]:{port}" render.
+        XCTAssertEqual(
+            DiscoveredInterfacesViewModel.canonicalEndpoint(host: "2001:db8::1", port: 8080),
+            "[2001:db8::1]:8080"
+        )
+        // A hostname stays bare (only ":" is the IPv6 trigger).
+        XCTAssertEqual(
+            DiscoveredInterfacesViewModel.canonicalEndpoint(host: "hub.example", port: 4242),
+            "hub.example:4242"
+        )
+    }
+
+    /// Issue #193 / Greptile P1 #2: a SAME-PROCESS Reticulum re-init is unsafe
+    /// when an AutoInterface is configured (its `detach()` only flips
+    /// `online = False` — the multicast sockets are local vars never closed,
+    /// so re-init hits the documented multicast-bind collision and the re-init
+    /// error path takes the backend down). `restartPythonBackend` must refuse
+    /// (`.requiresRelaunch`) exactly in that case and proceed for any other
+    /// interface set. Pure predicate, so it's testable without a backend.
+    func testInProcessRestartBlockedOnlyByAutoInterface() {
+        func autoInterfaceEntity() -> InterfaceEntity {
+            InterfaceEntity(
+                name: "Auto",
+                type: .autoInterface,
+                enabled: true,
+                config: .autoInterface(AutoInterfaceConfig())
+            )
+        }
+        func tcpClientEntity() -> InterfaceEntity {
+            InterfaceEntity(
+                name: "Relay",
+                type: .tcpClient,
+                enabled: true,
+                config: .tcpClient(TCPClientConfig(targetHost: "h", targetPort: 4242))
+            )
+        }
+        func rnodeEntity() -> InterfaceEntity {
+            InterfaceEntity(
+                name: "RNode",
+                type: .rnode,
+                enabled: true,
+                config: .rnode(RNodeConfig())
+            )
+        }
+        // Empty and non-AutoInterface sets: in-process restart is safe.
+        XCTAssertFalse(AppServices.inProcessRestartBlockedByAutoInterface([]))
+        XCTAssertFalse(AppServices.inProcessRestartBlockedByAutoInterface([tcpClientEntity(), rnodeEntity()]))
+        // An AutoInterface (even alongside others) blocks it.
+        XCTAssertTrue(AppServices.inProcessRestartBlockedByAutoInterface([autoInterfaceEntity()]))
+        XCTAssertTrue(AppServices.inProcessRestartBlockedByAutoInterface([tcpClientEntity(), autoInterfaceEntity()]))
+    }
     #endif
 }

--- a/Tests/RNSAPITests/DiscoveredInterfaceTests.swift
+++ b/Tests/RNSAPITests/DiscoveredInterfaceTests.swift
@@ -1,0 +1,376 @@
+import XCTest
+@testable import RNSAPI
+
+/// Tests for the DiscoveredInterface model (lenient decode), DiscoverySnapshot,
+/// and the discovery display formatters (type filter/classification, Yggdrasil
+/// detection, interface type display, relative last-heard, haversine, LoRa
+/// clipboard block, sorting, filtering) — the Swift port of the Android
+/// DiscoveredInterface.kt + DiscoveredInterfacesScreen display helpers.
+///
+/// Lives in the RNSAPI SwiftPM test target (pure Foundation) so it runs
+/// natively via `swift test`.
+final class DiscoveredInterfaceTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private let fullJSON = """
+    {
+      "name": "alpha",
+      "type": "RNodeInterface",
+      "transport_id": "t1",
+      "network_id": "n1",
+      "status": "available",
+      "status_code": 1000.0,
+      "last_heard": 1700000000.5,
+      "heard_count": 7.0,
+      "hops": 1.0,
+      "stamp_value": 30.0,
+      "reachable_on": "2001:db8::1",
+      "port": 4242.0,
+      "frequency": 434000000.0,
+      "bandwidth": 125000.0,
+      "spreading_factor": 9.0,
+      "coding_rate": 7.0,
+      "modulation": "GFSK",
+      "channel": 1.0,
+      "latitude": 51.5,
+      "longitude": -0.12,
+      "height": 42.5,
+      "ifac_netname": "columba",
+      "ifac_netkey": "secret",
+      "transport": true,
+      "discovery_hash": "abc123",
+      "received": 1699999900.0,
+      "discovered": 1699999901.0
+    }
+    """
+
+    private func decode(_ json: String) throws -> DiscoveredInterface {
+        try JSONDecoder().decode(DiscoveredInterface.self, from: json.data(using: .utf8)!)
+    }
+
+    private func iface(
+        name: String = "n",
+        type: String = "Unknown",
+        reachableOn: String? = nil,
+        ifacNetname: String? = nil,
+        latitude: Double? = nil,
+        longitude: Double? = nil
+    ) -> DiscoveredInterface {
+        DiscoveredInterface(
+            name: name,
+            type: type,
+            reachableOn: reachableOn,
+            ifacNetname: ifacNetname,
+            latitude: latitude,
+            longitude: longitude
+        )
+    }
+
+    // MARK: - Decode
+
+    func testFullJSONDecode() throws {
+        let iface = try decode(fullJSON)
+        XCTAssertEqual(iface.name, "alpha")
+        XCTAssertEqual(iface.type, "RNodeInterface")
+        XCTAssertEqual(iface.transportId, "t1")
+        XCTAssertEqual(iface.networkId, "n1")
+        XCTAssertEqual(iface.status, "available")
+        XCTAssertEqual(iface.statusCode, 1000)
+        XCTAssertEqual(iface.lastHeard, 1700000000.5)
+        XCTAssertEqual(iface.heardCount, 7)
+        XCTAssertEqual(iface.hops, 1)
+        XCTAssertEqual(iface.stampValue, 30)
+        XCTAssertEqual(iface.reachableOn, "2001:db8::1")
+        XCTAssertEqual(iface.port, 4242)
+        XCTAssertEqual(iface.frequency, 434_000_000.0)
+        XCTAssertEqual(iface.bandwidth, 125_000)
+        XCTAssertEqual(iface.spreadingFactor, 9)
+        XCTAssertEqual(iface.codingRate, 7)
+        XCTAssertEqual(iface.modulation, "GFSK")
+        XCTAssertEqual(iface.channel, 1)
+        XCTAssertEqual(iface.latitude, 51.5)
+        XCTAssertEqual(iface.longitude, -0.12)
+        XCTAssertEqual(iface.height, 42.5)
+        XCTAssertEqual(iface.ifacNetname, "columba")
+        XCTAssertEqual(iface.ifacNetkey, "secret")
+        XCTAssertTrue(iface.transport)
+        XCTAssertEqual(iface.discoveryHash, "abc123")
+        XCTAssertEqual(iface.receivedAt, 1699999900.0)
+        XCTAssertEqual(iface.discoveredAt, 1699999901.0)
+        XCTAssertEqual(iface.id, "abc123")
+        XCTAssertTrue(iface.hasLocation)
+        XCTAssertTrue(iface.isRadioInterface)
+    }
+
+    func testMinimalJSONDecodeDefaults() throws {
+        let iface = try decode(#"{"name":"x","type":"RNodeInterface"}"#)
+        XCTAssertEqual(iface.name, "x")
+        XCTAssertEqual(iface.type, "RNodeInterface")
+        XCTAssertEqual(iface.status, "unknown")
+        XCTAssertNil(iface.statusCode)
+        XCTAssertEqual(iface.lastHeard, 0)
+        XCTAssertNil(iface.heardCount)
+        XCTAssertNil(iface.hops)
+        XCTAssertNil(iface.stampValue)
+        XCTAssertNil(iface.port)
+        XCTAssertNil(iface.frequency)
+        XCTAssertNil(iface.reachableOn)
+        XCTAssertNil(iface.discoveryHash)
+        XCTAssertNil(iface.receivedAt)
+        XCTAssertNil(iface.discoveredAt)
+        XCTAssertFalse(iface.transport)
+        XCTAssertTrue(iface.isRadioInterface)
+        // No discovery hash -> synthesized id from type/name/reachableOn.
+        XCTAssertEqual(iface.id, "RNodeInterface#x#")
+    }
+
+    func testFloatPortDecodesToInt() throws {
+        let iface = try decode(#"{"port": 4242.0}"#)
+        XCTAssertEqual(iface.port, 4242)
+    }
+
+    func testEmptyStringAndAbsentFields() throws {
+        let emptyHost = try decode(#"{"reachable_on": ""}"#)
+        XCTAssertNil(emptyHost.reachableOn)
+        let empty = try decode("{}")
+        XCTAssertEqual(empty.name, "Unknown")
+        XCTAssertEqual(empty.type, "Unknown")
+        XCTAssertEqual(empty.status, "unknown")
+    }
+
+    func testDiscoverySnapshotDecode() throws {
+        let json = #"{"discovered":[{"name":"a","type":"TCPServerInterface"},{"name":"b","type":"RNodeInterface"}],"enabled":true,"autoconnected":["node-1","node-2"]}"#
+        let snapshot = try JSONDecoder().decode(DiscoverySnapshot.self, from: json.data(using: .utf8)!)
+        XCTAssertEqual(snapshot.discovered.count, 2)
+        XCTAssertEqual(snapshot.discovered[0].name, "a")
+        XCTAssertEqual(snapshot.discovered[1].name, "b")
+        XCTAssertTrue(snapshot.enabled)
+        XCTAssertEqual(snapshot.autoconnected, ["node-1", "node-2"])
+
+        let empty = try JSONDecoder().decode(DiscoverySnapshot.self, from: "{}".data(using: .utf8)!)
+        XCTAssertTrue(empty.discovered.isEmpty)
+        XCTAssertFalse(empty.enabled)
+        XCTAssertTrue(empty.autoconnected.isEmpty)
+    }
+
+    // MARK: - Derived properties
+
+    func testIsTcpInterface() {
+        XCTAssertTrue(iface(type: "TCPServerInterface").isTcpInterface)
+        XCTAssertTrue(iface(type: "TCPClientInterface").isTcpInterface)
+        XCTAssertTrue(iface(type: "BackboneInterface").isTcpInterface)
+        XCTAssertFalse(iface(type: "I2PInterface").isTcpInterface)
+        XCTAssertFalse(iface(type: "RNodeInterface").isTcpInterface)
+    }
+
+    func testIsRadioInterface() {
+        XCTAssertTrue(iface(type: "RNodeInterface").isRadioInterface)
+        XCTAssertTrue(iface(type: "WeaveInterface").isRadioInterface)
+        XCTAssertTrue(iface(type: "KISSInterface").isRadioInterface)
+        XCTAssertFalse(iface(type: "TCPServerInterface").isRadioInterface)
+    }
+
+    func testClassifyBuckets() {
+        XCTAssertEqual(DiscoveredTypeFilter.classify(iface(type: "TCPServerInterface")), .tcp)
+        XCTAssertEqual(DiscoveredTypeFilter.classify(iface(type: "BackboneInterface")), .tcp)
+        XCTAssertEqual(DiscoveredTypeFilter.classify(iface(type: "RNodeInterface")), .radio)
+        XCTAssertEqual(DiscoveredTypeFilter.classify(iface(type: "WeaveInterface")), .radio)
+        XCTAssertEqual(DiscoveredTypeFilter.classify(iface(type: "I2PInterface")), .i2p)
+        // Case-insensitive I2P match.
+        XCTAssertEqual(DiscoveredTypeFilter.classify(iface(type: "i2pbuiltininterface")), .i2p)
+        XCTAssertEqual(DiscoveredTypeFilter.classify(iface(type: "MysteryInterface")), .other)
+    }
+
+    // MARK: - Yggdrasil
+
+    func testIsYggdrasilAddress() {
+        XCTAssertTrue(isYggdrasilAddress("[02d0::1]"))
+        XCTAssertTrue(isYggdrasilAddress("02d0::1"))
+        XCTAssertTrue(isYggdrasilAddress("03ff::2"))
+        XCTAssertFalse(isYggdrasilAddress("0400::1"))
+        XCTAssertFalse(isYggdrasilAddress("192.168.1.5"))
+        XCTAssertFalse(isYggdrasilAddress(nil))
+        XCTAssertFalse(isYggdrasilAddress("[0100::1]"))
+    }
+
+    // MARK: - Display formatters
+
+    func testFormatInterfaceType() {
+        XCTAssertEqual(formatInterfaceType("TCPServerInterface"), "TCP Server")
+        XCTAssertEqual(formatInterfaceType("TCPClientInterface"), "TCP Client")
+        XCTAssertEqual(formatInterfaceType("BackboneInterface"), "Backbone (TCP)")
+        XCTAssertEqual(formatInterfaceType("I2PInterface"), "I2P")
+        XCTAssertEqual(formatInterfaceType("RNodeInterface"), "RNode (LoRa)")
+        XCTAssertEqual(formatInterfaceType("WeaveInterface"), "Weave (LoRa)")
+        XCTAssertEqual(formatInterfaceType("KISSInterface"), "KISS")
+        XCTAssertEqual(formatInterfaceType("MysteryInterface"), "MysteryInterface")
+    }
+
+    func testFormatLastHeard() {
+        let now = 1_000_000_000.0
+        XCTAssertEqual(formatLastHeard(0, nowSeconds: now), "Never")
+        XCTAssertEqual(formatLastHeard(now - 30, nowSeconds: now), "just now")
+        XCTAssertEqual(formatLastHeard(now - 120, nowSeconds: now), "2 min ago")
+        XCTAssertEqual(formatLastHeard(now - 7200, nowSeconds: now), "2 hours ago")
+        XCTAssertEqual(formatLastHeard(now - 172800, nowSeconds: now), "2 days ago")
+        let old = formatLastHeard(now - 900000, nowSeconds: now)
+        XCTAssertFalse(old.isEmpty)
+    }
+
+    func testHaversineDistance() {
+        let d = haversineDistanceKm(lat1: 0, lon1: 0, lat2: 1, lon2: 0)
+        XCTAssertEqual(d, 111.19, accuracy: 0.5)
+    }
+
+    func testFormatLoraParamsFull() {
+        let iface = DiscoveredInterface(
+            name: "node-a",
+            type: "RNodeInterface",
+            frequency: 434_000_000.0,
+            bandwidth: 125_000,
+            spreadingFactor: 9,
+            codingRate: 7,
+            modulation: "GFSK"
+        )
+        XCTAssertEqual(
+            formatLoraParamsForClipboard(iface),
+            "LoRa Parameters from: node-a\n"
+            + "---\n"
+            + "Frequency: 434.000000 MHz\n"
+            + "Bandwidth: 125 kHz\n"
+            + "Spreading Factor: SF9\n"
+            + "Coding Rate: 4/7\n"
+            + "Modulation: GFSK"
+        )
+    }
+
+    func testFormatLoraParamsPartial() {
+        let iface = DiscoveredInterface(
+            name: "lores",
+            type: "RNodeInterface",
+            frequency: 868_000_000.0,
+            modulation: "GFSK"
+        )
+        XCTAssertEqual(
+            formatLoraParamsForClipboard(iface),
+            "LoRa Parameters from: lores\n"
+            + "---\n"
+            + "Frequency: 868.000000 MHz\n"
+            + "Modulation: GFSK"
+        )
+    }
+
+    // MARK: - Sorting
+
+    func testSortQualityPreservesOrder() {
+        let input = [iface(name: "x"), iface(name: "y"), iface(name: "z")]
+        let sorted = DiscoveredSorter.sort(
+            input,
+            mode: .availabilityAndQuality,
+            userLatitude: 0,
+            userLongitude: 0
+        )
+        XCTAssertEqual(sorted.map { $0.name }, ["x", "y", "z"])
+    }
+
+    func testSortProximity() {
+        // User at (0, 0). B (~55.6 km) is closest; A and D are tied at
+        // ~111.2 km and keep input order (stable tiebreak); C has no
+        // location and is appended last in input order.
+        let input = [
+            iface(name: "C", ifacNetname: "c"),
+            iface(name: "A", latitude: 1.0, longitude: 0.0),
+            iface(name: "D", latitude: 1.0, longitude: 0.0),
+            iface(name: "B", latitude: 0.5, longitude: 0.0),
+        ]
+        let sorted = DiscoveredSorter.sort(
+            input,
+            mode: .proximity,
+            userLatitude: 0,
+            userLongitude: 0
+        )
+        XCTAssertEqual(sorted.map { $0.name }, ["B", "A", "D", "C"])
+    }
+
+    func testSortProximityNilUserLocation() {
+        // Without a user location, located interfaces keep input order and
+        // non-located ones are still appended in input order.
+        let input = [
+            iface(name: "C"),
+            iface(name: "A", latitude: 1.0, longitude: 0.0),
+            iface(name: "B", latitude: 0.5, longitude: 0.0),
+        ]
+        let sorted = DiscoveredSorter.sort(
+            input,
+            mode: .proximity,
+            userLatitude: nil,
+            userLongitude: nil
+        )
+        XCTAssertEqual(sorted.map { $0.name }, ["A", "B", "C"])
+    }
+
+    // MARK: - Filtering
+
+    func testFilterIfacOnly() {
+        let input = [
+            iface(name: "no-ifac"),
+            iface(name: "empty-ifac", ifacNetname: ""),
+            iface(name: "has-ifac", ifacNetname: "columba"),
+        ]
+        let filtered = DiscoveredFilter.apply(input, searchQuery: "", typeFilters: [], ifacOnly: true)
+        XCTAssertEqual(filtered.map { $0.name }, ["has-ifac"])
+    }
+
+    func testFilterType() {
+        let input = [
+            iface(name: "tcp", type: "TCPServerInterface"),
+            iface(name: "radio", type: "RNodeInterface"),
+            iface(name: "i2p", type: "I2PInterface"),
+            iface(name: "other", type: "MysteryInterface"),
+        ]
+        let tcp = DiscoveredFilter.apply(input, searchQuery: "", typeFilters: [.tcp], ifacOnly: false)
+        XCTAssertEqual(tcp.map { $0.name }, ["tcp"])
+        let mixed = DiscoveredFilter.apply(input, searchQuery: "", typeFilters: [.radio, .other], ifacOnly: false)
+        XCTAssertEqual(mixed.map { $0.name }, ["radio", "other"])
+    }
+
+    func testFilterSearch() {
+        let input = [
+            iface(name: "alpha", type: "RNodeInterface", reachableOn: "2001:db8::1", ifacNetname: "columba"),
+            iface(name: "beta", type: "TCPServerInterface"),
+        ]
+        func search(_ q: String) -> [String] {
+            DiscoveredFilter.apply(input, searchQuery: q, typeFilters: [], ifacOnly: false).map { $0.name }
+        }
+        XCTAssertEqual(search("ALP"), ["alpha"])
+        XCTAssertEqual(search("db8"), ["alpha"])
+        XCTAssertEqual(search("rnode"), ["alpha"])
+        XCTAssertEqual(search("columba"), ["alpha"])
+        XCTAssertEqual(search("beta"), ["beta"])
+    }
+
+    func testFilterAndCombination() {
+        let input = [
+            iface(name: "alpha", type: "RNodeInterface", reachableOn: "2001:db8::1", ifacNetname: "columba"),
+            iface(name: "alpha2", type: "TCPServerInterface", ifacNetname: "columba"),
+        ]
+        // Search AND type: only the RNode "alpha" matches both.
+        let both = DiscoveredFilter.apply(input, searchQuery: "alpha", typeFilters: [.radio], ifacOnly: false)
+        XCTAssertEqual(both.map { $0.name }, ["alpha"])
+        // Search AND ifacOnly: only the row with both.
+        let ifac = DiscoveredFilter.apply(input, searchQuery: "alpha", typeFilters: [], ifacOnly: true)
+        XCTAssertEqual(ifac.map { $0.name }, ["alpha"])
+        // No row satisfies search + incompatible type.
+        let none = DiscoveredFilter.apply(input, searchQuery: "zzz", typeFilters: [.radio], ifacOnly: false)
+        XCTAssertTrue(none.isEmpty)
+    }
+
+    func testFilterEmptyQueryAndEmptyInput() {
+        let input = [iface(name: "a"), iface(name: "b")]
+        let unfiltered = DiscoveredFilter.apply(input, searchQuery: "   ", typeFilters: [], ifacOnly: false)
+        XCTAssertEqual(unfiltered.map { $0.name }, ["a", "b"])
+        let empty = DiscoveredFilter.apply([], searchQuery: "x", typeFilters: [.tcp], ifacOnly: true)
+        XCTAssertTrue(empty.isEmpty)
+    }
+}

--- a/Tests/RNSAPITests/DiscoveredInterfaceTests.swift
+++ b/Tests/RNSAPITests/DiscoveredInterfaceTests.swift
@@ -61,9 +61,9 @@ final class DiscoveredInterfaceTests: XCTestCase {
             name: name,
             type: type,
             reachableOn: reachableOn,
-            ifacNetname: ifacNetname,
             latitude: latitude,
-            longitude: longitude
+            longitude: longitude,
+            ifacNetname: ifacNetname
         )
     }
 

--- a/Tests/RNSAPITests/DiscoveredInterfaceTests.swift
+++ b/Tests/RNSAPITests/DiscoveredInterfaceTests.swift
@@ -353,7 +353,7 @@ final class DiscoveredInterfaceTests: XCTestCase {
     func testFilterAndCombination() {
         let input = [
             iface(name: "alpha", type: "RNodeInterface", reachableOn: "2001:db8::1", ifacNetname: "columba"),
-            iface(name: "alpha2", type: "TCPServerInterface", ifacNetname: "columba"),
+            iface(name: "alpha2", type: "TCPServerInterface"),
         ]
         // Search AND type: only the RNode "alpha" matches both.
         let both = DiscoveredFilter.apply(input, searchQuery: "alpha", typeFilters: [.radio], ifacOnly: false)

--- a/Tests/static/test_discovered_interfaces_contract.py
+++ b/Tests/static/test_discovered_interfaces_contract.py
@@ -1,0 +1,232 @@
+import json
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+RNS_BRIDGE = ROOT / "app/rns_bridge.py"
+PYTHON_BRIDGE = ROOT / "Sources/PythonBridge/PythonBridge.swift"
+PYTHON_BACKEND = ROOT / "Sources/RNSBackendPy/PythonRNSBackend.swift"
+DISCOVERED_MODEL = ROOT / "Sources/RNSAPI/Models/DiscoveredInterface.swift"
+DISCOVERED_FORMATTING = ROOT / "Sources/RNSAPI/DiscoveredInterfaceFormatting.swift"
+CONFIG_WRITER = ROOT / "Sources/ColumbaApp/Services/PythonConfigWriter.swift"
+SETTINGS_REPO = ROOT / "Sources/ColumbaApp/Services/SettingsRepository.swift"
+APP_SERVICES = ROOT / "Sources/ColumbaApp/Services/AppServices.swift"
+ONE_SHOT_PROVIDER = ROOT / "Sources/ColumbaApp/Services/OneShotLocationProvider.swift"
+DISCOVERY_VM = ROOT / "Sources/ColumbaApp/ViewModels/DiscoveredInterfacesViewModel.swift"
+DISCOVERY_SCREEN = ROOT / "Sources/ColumbaApp/Views/Settings/DiscoveredInterfacesScreen.swift"
+INTERFACE_MGMT_SCREEN = ROOT / "Sources/ColumbaApp/Views/Settings/InterfaceManagementScreen.swift"
+PBXPROJ = ROOT / "Columba.xcodeproj/project.pbxproj"
+LOCALIZATIONS = ROOT / "Sources/ColumbaApp/Resources/Localizable.xcstrings"
+
+
+def strip_comments(source: str) -> str:
+    # Strip // comments so the "absent symbol" assertions check the code,
+    # not prose (comments may name a removed API while documenting its
+    # removal).
+    return "\n".join(line.split("//", 1)[0] for line in source.splitlines())
+
+
+class DiscoveredInterfacesContractTests(unittest.TestCase):
+    def test_rns_bridge_exposes_discovery_json(self) -> None:
+        self.assertIn(
+            "def discovery_json",
+            RNS_BRIDGE.read_text(encoding="utf-8"),
+            "app/rns_bridge.py must expose discovery_json() for the Swift bridge",
+        )
+
+    def test_python_bridge_forwards_discovery_snapshot(self) -> None:
+        source = PYTHON_BRIDGE.read_text(encoding="utf-8")
+        self.assertIn("func discovery()", source, "PythonBridge must expose discovery()")
+        self.assertIn("discovery_json", source, "PythonBridge.discovery() must call discovery_json")
+        self.assertIn(
+            "DiscoverySnapshot",
+            source,
+            "PythonBridge.discovery() must return the RNSAPI DiscoverySnapshot",
+        )
+
+    def test_python_backend_implements_discovery(self) -> None:
+        self.assertIn(
+            "func discovery()",
+            PYTHON_BACKEND.read_text(encoding="utf-8"),
+            "PythonRNSBackend must implement the backend discovery() seam",
+        )
+
+    def test_discovered_interface_model_shape(self) -> None:
+        self.assertTrue(DISCOVERED_MODEL.is_file(), "RNSAPI/Models/DiscoveredInterface.swift must exist")
+        source = DISCOVERED_MODEL.read_text(encoding="utf-8")
+        for symbol in (
+            "struct DiscoveredInterface",
+            "struct DiscoverySnapshot",
+            "isTcpInterface",
+            "isRadioInterface",
+        ):
+            self.assertIn(symbol, source, f"DiscoveredInterface.swift must define {symbol}")
+
+    def test_discovered_interface_formatters_exist(self) -> None:
+        self.assertTrue(
+            DISCOVERED_FORMATTING.is_file(),
+            "RNSAPI/DiscoveredInterfaceFormatting.swift must exist",
+        )
+        source = DISCOVERED_FORMATTING.read_text(encoding="utf-8")
+        for symbol in (
+            "DiscoveredTypeFilter",
+            "isYggdrasilAddress",
+            "formatInterfaceType",
+            "formatLastHeard",
+            "haversineDistanceKm",
+            "formatLoraParamsForClipboard",
+            "DiscoveredSorter",
+            "DiscoveredFilter",
+        ):
+            self.assertIn(symbol, source, f"DiscoveredInterfaceFormatting.swift must define {symbol}")
+
+    def test_config_writer_emits_discovery_keys(self) -> None:
+        source = CONFIG_WRITER.read_text(encoding="utf-8")
+        for key in (
+            "discover_interfaces",
+            "autoconnect_discovered_interfaces",
+            "bootstrap_only",
+        ):
+            self.assertIn(key, source, f"PythonConfigWriter must emit the {key} RNS config key")
+
+    def test_settings_repository_persists_discovery_settings(self) -> None:
+        source = SETTINGS_REPO.read_text(encoding="utf-8")
+        for key in ("discoverInterfacesEnabled", "autoconnectDiscoveredCount"):
+            self.assertIn(key, source, f"SettingsRepository must persist the {key} setting")
+
+    def test_restart_python_backend_is_a_real_in_process_restart(self) -> None:
+        source = APP_SERVICES.read_text(encoding="utf-8")
+        code = strip_comments(source)
+        self.assertNotIn(
+            "ColumbaRelaunchRequired",
+            code,
+            "the dead ColumbaRelaunchRequired stub notification must be gone",
+        )
+        start = source.index("func restartPythonBackend")
+        end = source.index("\n    func ", start + 1)
+        body = strip_comments(source[start:end])
+        for symbol in ("shutdownUnlocked", "initializeUnlocked", "ColumbaBackendRestarted"):
+            self.assertIn(
+                symbol,
+                body,
+                f"restartPythonBackend() must reference {symbol} (real in-process restart)",
+            )
+        self.assertGreaterEqual(
+            source.count("lastTcpServerAddress"),
+            3,
+            "lastTcpServerAddress must be declared, assigned, and read (3+ occurrences)",
+        )
+
+    def test_one_shot_location_provider_never_prompts(self) -> None:
+        self.assertTrue(ONE_SHOT_PROVIDER.is_file(), "OneShotLocationProvider.swift must exist")
+        source = ONE_SHOT_PROVIDER.read_text(encoding="utf-8")
+        self.assertIn(
+            "authorizationStatus",
+            source,
+            "OneShotLocationProvider must check authorizationStatus",
+        )
+        self.assertNotIn(
+            "requestWhenInUseAuthorization",
+            strip_comments(source),
+            "OneShotLocationProvider must never call requestWhenInUseAuthorization() "
+            "(no fresh location prompt from the discovery screen)",
+        )
+
+    def test_view_model_omits_autoconnect_sub_toggle(self) -> None:
+        self.assertTrue(DISCOVERY_VM.is_file(), "DiscoveredInterfacesViewModel.swift must exist")
+        source = DISCOVERY_VM.read_text(encoding="utf-8")
+        self.assertIn("ifacOnly", source, "the VM must expose the ifacOnly display filter")
+        self.assertNotIn(
+            "autoconnectIfacOnly",
+            source,
+            "the autoconnect ifacOnly sub-toggle is deliberately omitted on the Python backend",
+        )
+
+    def test_discovery_screen_carries_all_a11y_identifiers(self) -> None:
+        self.assertTrue(DISCOVERY_SCREEN.is_file(), "DiscoveredInterfacesScreen.swift must exist")
+        source = DISCOVERY_SCREEN.read_text(encoding="utf-8")
+        for identifier in (
+            "discovery_toggle",
+            "discovery_search",
+            "discovery_ifac_only",
+            "discovery_clear_filters",
+            "discovery_refresh",
+            "discovery_card_add_config",
+            "discovery_card_copy_params",
+            "discovery_card_use_rnode",
+            "discovered_card_",
+        ):
+            self.assertIn(
+                identifier,
+                source,
+                f"DiscoveredInterfacesScreen.swift must reference the {identifier} a11y identifier",
+            )
+
+    def test_interface_management_screen_links_discovery_entry(self) -> None:
+        self.assertIn(
+            "discovery_entry_card",
+            INTERFACE_MGMT_SCREEN.read_text(encoding="utf-8"),
+            "InterfaceManagementScreen.swift must expose the discovery_entry_card",
+        )
+
+    def test_pbxproj_registers_discovery_files(self) -> None:
+        source = PBXPROJ.read_text(encoding="utf-8")
+        for file_name in (
+            "DiscoveredInterfacesScreen.swift",
+            "DiscoveredInterfacesViewModel.swift",
+            "OneShotLocationProvider.swift",
+            "DiscoveredInterfaceTests.swift",
+        ):
+            self.assertGreaterEqual(
+                source.count(f"/* {file_name} */"),
+                2,
+                f"{file_name} must have both a PBXFileReference and a PBXBuildFile entry",
+            )
+            self.assertGreaterEqual(
+                source.count(file_name),
+                3,
+                f"{file_name} must appear in file reference, group children, and a build phase (3+ occurrences)",
+            )
+
+        start = source.index("TSRCBP /* Sources */ = {")
+        end = source.index("/* End", start)
+        tsources = source[start:end]
+        self.assertIn(
+            "DiscoveredInterfaceTests.swift",
+            tsources,
+            "DiscoveredInterfaceTests.swift must be in the TSRCBP (ColumbaAppTests) sources phase — "
+            "registering it in a source-target phase is the silent-exclusion trap",
+        )
+
+    def test_localization_catalog_covers_discovery_strings(self) -> None:
+        catalog = json.loads(LOCALIZATIONS.read_text(encoding="utf-8"))
+        strings = catalog["strings"]
+        required = {
+            "Discovered Interfaces",
+            "Interface Discovery",
+            "Restarting Reticulum…",
+            "%lld interfaces found via RNS Discovery",
+            "Add to Config",
+        }
+        self.assertTrue(
+            required.issubset(strings),
+            f"Localizable.xcstrings must contain the discovery strings; missing: "
+            f"{sorted(required - strings.keys())}",
+        )
+
+    def test_discovered_filter_applies_ifac_only(self) -> None:
+        source = DISCOVERED_FORMATTING.read_text(encoding="utf-8")
+        start = source.index("public enum DiscoveredFilter")
+        # DiscoveredFilter is the final type in the file; its apply(_:) body
+        # is everything from the enum declaration to EOF.
+        code = strip_comments(source[start:])
+        self.assertIn(
+            "ifacOnly",
+            code,
+            "DiscoveredFilter.apply must reference ifacOnly (the IFAC display filter)",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tests/static/test_discovered_interfaces_contract.py
+++ b/Tests/static/test_discovered_interfaces_contract.py
@@ -143,6 +143,32 @@ class DiscoveredInterfacesContractTests(unittest.TestCase):
             "the autoconnect ifacOnly sub-toggle is deliberately omitted on the Python backend",
         )
 
+    def test_discovery_settings_are_apply_and_restart(self) -> None:
+        """Issue #193 UX: discovery settings are PENDING state, applied only
+        through an explicit "Apply and Restart". The toggle/slider must never
+        restart Reticulum directly — the old flow restarted on every change
+        (the slider fires on every drag tick), and each restart transiently
+        emptied the list and flipped the enabled indicator."""
+        vm = strip_comments(DISCOVERY_VM.read_text(encoding="utf-8"))
+        self.assertIn("applyDiscoverySettings", vm, "the VM must expose applyDiscoverySettings()")
+        self.assertIn("discardPendingDiscoveryChanges", vm, "the VM must expose discardPendingDiscoveryChanges()")
+        self.assertIn("hasPendingDiscoveryChanges", vm, "the VM must derive hasPendingDiscoveryChanges")
+        # The only restart trigger is the apply intent; the control setters
+        # must be pure pending-state mutations.
+        self.assertNotIn(
+            "toggleDiscovery",
+            vm,
+            "toggleDiscovery (immediate-restart intent) must be gone — "
+            "the toggle sets pending state only",
+        )
+        # Setters must not schedule a restart themselves.
+        self.assertIn("setDiscoverInterfacesEnabled", vm, "the toggle must route through setDiscoverInterfacesEnabled()")
+
+        screen = strip_comments(DISCOVERY_SCREEN.read_text(encoding="utf-8"))
+        self.assertIn("discovery_apply_restart", screen, "the screen must render the Apply and Restart button")
+        self.assertIn("discovery_discard", screen, "the screen must render the Discard button")
+        self.assertIn("hasPendingDiscoveryChanges", screen, "the Apply bar must be gated on hasPendingDiscoveryChanges")
+
     def test_discovery_screen_carries_all_a11y_identifiers(self) -> None:
         self.assertTrue(DISCOVERY_SCREEN.is_file(), "DiscoveredInterfacesScreen.swift must exist")
         source = DISCOVERY_SCREEN.read_text(encoding="utf-8")

--- a/Tests/static/test_discovered_interfaces_contract.py
+++ b/Tests/static/test_discovered_interfaces_contract.py
@@ -225,6 +225,25 @@ class DiscoveredInterfacesContractTests(unittest.TestCase):
             "registering it in a source-target phase is the silent-exclusion trap",
         )
 
+    def test_all_fields_section_shows_ifac_network_name(self) -> None:
+        """The expandable all-announced-fields section must list the IFAC
+        network name (issue #193 follow-up): the port listed the IFAC
+        passphrase but dropped the network name, so an IFAC peer's announce
+        looked incomplete next to the Android card."""
+        screen = strip_comments(DISCOVERY_SCREEN.read_text(encoding="utf-8"))
+        self.assertIn(
+            "ifacNetname",
+            screen,
+            "the all-announced-fields section must display iface.ifacNetname "
+            "(the IFAC network name row, alongside the IFAC passphrase row)",
+        )
+        catalog = json.loads(LOCALIZATIONS.read_text(encoding="utf-8"))
+        self.assertIn(
+            "IFAC network name",
+            catalog["strings"],
+            "Localizable.xcstrings must carry the 'IFAC network name' row label",
+        )
+
     def test_localization_catalog_covers_discovery_strings(self) -> None:
         catalog = json.loads(LOCALIZATIONS.read_text(encoding="utf-8"))
         strings = catalog["strings"]

--- a/app/rns_bridge.py
+++ b/app/rns_bridge.py
@@ -2145,6 +2145,48 @@ def status_json() -> str:
     return _json.dumps(status())
 
 
+def discovery_json() -> str:
+    """JSON-serialized interface-discovery state for the Swift bridge.
+
+    Mirrors `status_json()` contract: always returns a JSON object string,
+    never raises, so PythonBridge.discovery() can decode unconditionally.
+    Read path uses the on-disk announce store (RNS.Reticulum.discovered_interfaces())
+    so it lists previously-heard announces even before discovery is enabled.
+    """
+    import json as _json
+    out: dict[str, Any] = {"discovered": [], "enabled": False, "autoconnected": []}
+    if not _state.get("started"):
+        return _json.dumps(out)
+    try:
+        infos = RNS.Reticulum.discovered_interfaces() or []
+        for info in infos:
+            d: dict[str, Any] = {}
+            for k, v in dict(info).items():
+                if isinstance(v, (bytes, bytearray)):
+                    # transport_id / network_id arrive as msgpack bytes —
+                    # the Swift model wants hex strings (matches RNS.hexrep).
+                    v = bytes(v).hex()
+                d[k] = v
+            out["discovered"].append(d)
+    except Exception as e:
+        RNS.log(f"discovery_json: list_discovered_interfaces failed: {e}", RNS.LOG_DEBUG)
+    try:
+        out["enabled"] = bool(RNS.Reticulum.should_autoconnect_discovered_interfaces())
+    except Exception:
+        pass
+    try:
+        endpoints = set()
+        for iface in list(RNS.Transport.interfaces):
+            if hasattr(iface, "autoconnect_hash"):
+                s = str(iface)
+                if s:
+                    endpoints.add(s)
+        out["autoconnected"] = sorted(endpoints)
+    except Exception:
+        pass
+    return _json.dumps(out)
+
+
 def drain_events() -> list[dict[str, Any]]:
     out: list[dict[str, Any]] = []
     while True:

--- a/app/rns_bridge.py
+++ b/app/rns_bridge.py
@@ -2115,6 +2115,15 @@ def status() -> dict[str, Any]:
                 # so coerce to empty string — JSON null breaks Swift's
                 # String decoder and silently drops the whole snapshot.
                 section_name = getattr(iface, "name", None) or ""
+                # `is_autoconnect` marks interfaces RNS spawned from an
+                # interface-discovery announce (Discovery.autoconnect sets
+                # `autoconnect_hash` on them). The Swift status poll turns
+                # these into Network Status rows badged "via discovery" —
+                # previously they were silently dropped because their
+                # section name didn't match any user-configured entity and
+                # their friendly name didn't start with AutoInterfacePeer /
+                # BLEPeer, so the user couldn't tell which interfaces were
+                # auto-connected from discovery (issue #193 follow-up).
                 iface_info.append({
                     "section_name": section_name,
                     "name": str(iface),
@@ -2122,6 +2131,7 @@ def status() -> dict[str, Any]:
                     "ifac_size": getattr(iface, "ifac_size", None),
                     "rx_bytes": getattr(iface, "rxb", 0),
                     "tx_bytes": getattr(iface, "txb", 0),
+                    "is_autoconnect": bool(getattr(iface, "autoconnect_hash", None)),
                 })
             out["interfaces"] = iface_info
         except Exception as e:

--- a/app/rns_bridge.py
+++ b/app/rns_bridge.py
@@ -2199,12 +2199,23 @@ def discovery_json() -> str:
     except Exception:
         pass
     try:
+        # The Swift discovery card compares these against each discovered
+        # interface's "reachable_on:port" (e.g. "127.0.0.1:43221") to badge
+        # the auto-connected ones "Connected". `str(iface)` is the *friendly*
+        # form ("BackboneInterface[Synth Hub/127.0.0.1:43221]") which does NOT
+        # match that comparison, so emit the canonical endpoint instead: the
+        # BackboneClientInterface that autoconnect() creates carries
+        # `target_ip`/`target_port` set from the announce's `reachable_on`/
+        # `port`. Render IPv6 with brackets, exactly as `BackboneInterface
+        # .__str__` does, so the string is host:port-parseable either way.
         endpoints = set()
         for iface in list(RNS.Transport.interfaces):
             if hasattr(iface, "autoconnect_hash"):
-                s = str(iface)
-                if s:
-                    endpoints.add(s)
+                ip = getattr(iface, "target_ip", None)
+                port = getattr(iface, "target_port", None)
+                if ip is not None and port is not None:
+                    canonical_ip = f"[{ip}]" if ":" in str(ip) else str(ip)
+                    endpoints.add(f"{canonical_ip}:{port}")
         out["autoconnected"] = sorted(endpoints)
     except Exception:
         pass

--- a/app/rns_bridge.py
+++ b/app/rns_bridge.py
@@ -2171,7 +2171,21 @@ def discovery_json() -> str:
     except Exception as e:
         RNS.log(f"discovery_json: list_discovered_interfaces failed: {e}", RNS.LOG_DEBUG)
     try:
-        out["enabled"] = bool(RNS.Reticulum.should_autoconnect_discovered_interfaces())
+        # `enabled` = "is the running backend RECORDING announced interfaces"
+        # = the [reticulum] `discover_interfaces` flag. This is DISTINCT from
+        # the autoconnect limit: discovery stays on when
+        # autoconnect_discovered_interfaces is 0 (observe-only mode — the user
+        # can still see heard announces), so we must NOT use
+        # should_autoconnect_discovered_interfaces() here: it is
+        # `__autoconnect_discovered_interfaces > 0`, which goes false at 0 and
+        # wrongly flipped the whole feature to "Disabled" the moment the
+        # auto-connect slider hit 0 (issue #193). The flag is a Reticulum
+        # class attribute re-read from config on every Reticulum.__init__
+        # (so it is live-correct across in-process restarts); the pinned RNS
+        # exposes no public getter for it, hence the mangled class-attr name.
+        out["enabled"] = bool(
+            getattr(RNS.Reticulum, "_Reticulum__discover_interfaces", False)
+        )
     except Exception:
         pass
     try:

--- a/tests/test_rns_bridge_discovery.py
+++ b/tests/test_rns_bridge_discovery.py
@@ -1,0 +1,159 @@
+"""Unit test for `discovery_json()` in app/rns_bridge.py (issue #193, T-B).
+
+Runs WITHOUT a live RNS: `sys.modules['RNS']` and `sys.modules['LXMF']` are
+patched with lightweight stubs BEFORE `app.rns_bridge` is imported (the module
+does a top-level `import RNS` / `import LXMF`, which the stubs satisfy), then
+the real `discovery_json()` from the imported module is exercised end-to-end
+(JSON shape, bytes→hex coercion, enabled flag, autoconnected endpoints, and
+the not-started empty shape).
+
+Run from the worktree root:
+    python3 -m pytest tests/test_rns_bridge_discovery.py -q
+    python3 tests/test_rns_bridge_discovery.py
+"""
+
+import ast
+import json
+import sys
+import types
+import unittest
+from pathlib import Path
+
+# Make the worktree root importable regardless of how this file is launched
+# (pytest inserts CWD when run as `python -m pytest`; running the file
+# directly would only put tests/ on sys.path).
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+# ── Stubs, installed BEFORE `import app.rns_bridge` ─────────────────────────
+
+def _make_autoconnected_iface(endpoint: str):
+    class _Iface:
+        autoconnect_hash = "fake_hash"
+
+        def __str__(self) -> str:
+            return endpoint
+
+    return _Iface()
+
+
+def _make_plain_iface(endpoint: str):
+    class _Iface:
+        def __str__(self) -> str:
+            return endpoint
+
+    return _Iface()
+
+
+def _install_stubs() -> None:
+    # Fixed discovery result from the "on-disk announce store" read path.
+    # transport_id / network_id arrive as msgpack BYTES — the bridge must
+    # hex-encode them.
+    infos = [
+        {
+            "name": "Smoke Hub",
+            "type": "tcp",
+            "transport_id": b"\x01\x02\xab",
+            "network_id": b"\xde\xad\xbe\xef",
+            "status": "announced",
+            "status_code": 1,
+            "last_heard": 1700000000,
+            "value": 1234,
+            "port": 4242,
+        }
+    ]
+
+    class Reticulum:
+        @staticmethod
+        def discovered_interfaces():
+            return infos
+
+        @staticmethod
+        def should_autoconnect_discovered_interfaces():
+            return True
+
+    class Transport:
+        # One auto-connected endpoint ("1.2.3.4:4242") and one plain
+        # interface that must be filtered out of `autoconnected`.
+        interfaces = [
+            _make_autoconnected_iface("1.2.3.4:4242"),
+            _make_plain_iface("9.9.9.9:4444"),
+        ]
+
+    rns_stub = types.ModuleType("RNS")
+    rns_stub.Reticulum = Reticulum
+    rns_stub.Transport = Transport
+    rns_stub.Identity = type("Identity", (), {})
+    rns_stub.Destination = type("Destination", (), {"IN": 1, "SINGLE": 0})
+    rns_stub.LOG_DEBUG = 0
+    rns_stub.LOG_INFO = 1
+    rns_stub.LOG_WARNING = 2
+    rns_stub.LOG_ERROR = 3
+    rns_stub.log = lambda *a, **kw: None  # noqa: ARG005 — silence only
+
+    lxmf_stub = types.ModuleType("LXMF")
+
+    sys.modules["RNS"] = rns_stub
+    sys.modules["LXMF"] = lxmf_stub
+
+
+_install_stubs()
+
+import app.rns_bridge  # noqa: E402  (must follow _install_stubs())
+
+
+BRIDGE_PATH = ROOT / "app" / "rns_bridge.py"
+
+
+class DiscoveryJsonTest(unittest.TestCase):
+    def setUp(self):
+        self._started = app.rns_bridge._state.get("started")
+        app.rns_bridge._state["started"] = True
+
+    def tearDown(self):
+        if self._started is None:
+            app.rns_bridge._state.pop("started", None)
+        else:
+            app.rns_bridge._state["started"] = self._started
+
+    def test_ast_contract(self):
+        """ast.parse contract: discovery_json exists and the module parses."""
+        tree = ast.parse(BRIDGE_PATH.read_text(encoding="utf-8"))
+        names = [n.name for n in ast.walk(tree) if isinstance(n, ast.FunctionDef)]
+        self.assertIn("discovery_json", names)
+
+    def test_discovery_json_shape_and_coercion(self):
+        raw = app.rns_bridge.discovery_json()
+        data = json.loads(raw)
+        self.assertIsInstance(data, dict)
+        self.assertIn("discovered", data)
+        self.assertIn("enabled", data)
+        self.assertIn("autoconnected", data)
+
+        # bytes transport_id / network_id are hex-encoded for Swift.
+        self.assertEqual(len(data["discovered"]), 1)
+        info = data["discovered"][0]
+        self.assertEqual(info["transport_id"], "0102ab")
+        self.assertEqual(info["network_id"], "deadbeef")
+        self.assertEqual(info["name"], "Smoke Hub")
+        self.assertEqual(info["port"], 4242)
+
+        # Autoconnect flag surfaces through the stub (True).
+        self.assertIs(data["enabled"], True)
+
+        # Only auto-connected interfaces appear, sorted.
+        self.assertEqual(data["autoconnected"], ["1.2.3.4:4242"])
+
+    def test_discovery_json_not_started_returns_empty_shape(self):
+        app.rns_bridge._state["started"] = False
+        data = json.loads(app.rns_bridge.discovery_json())
+        self.assertEqual(
+            data,
+            {"discovered": [], "enabled": False, "autoconnected": []},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rns_bridge_discovery.py
+++ b/tests/test_rns_bridge_discovery.py
@@ -29,12 +29,18 @@ if str(ROOT) not in sys.path:
 
 # ── Stubs, installed BEFORE `import app.rns_bridge` ─────────────────────────
 
-def _make_autoconnected_iface(endpoint: str):
+def _make_autoconnected_iface(host: str, port: int):
+    # Expose the two attributes the bridge reads (`target_ip` /
+    # `target_port`) — mirroring the real BackboneClientInterface that
+    # Discovery.autoconnect() creates from an announce's
+    # `reachable_on`/`port`.
     class _Iface:
         autoconnect_hash = "fake_hash"
+        target_ip = host
+        target_port = port
 
         def __str__(self) -> str:
-            return endpoint
+            return f"{host}:{port}"
 
     return _Iface()
 
@@ -82,7 +88,8 @@ def _install_stubs() -> None:
         # One auto-connected endpoint ("1.2.3.4:4242") and one plain
         # interface that must be filtered out of `autoconnected`.
         interfaces = [
-            _make_autoconnected_iface("1.2.3.4:4242"),
+            _make_autoconnected_iface("1.2.3.4", 4242),
+            _make_autoconnected_iface("2001:db8::1", 8080),
             _make_plain_iface("9.9.9.9:4444"),
         ]
 
@@ -147,8 +154,14 @@ class DiscoveryJsonTest(unittest.TestCase):
         # Autoconnect flag surfaces through the stub (True).
         self.assertIs(data["enabled"], True)
 
-        # Only auto-connected interfaces appear, sorted.
-        self.assertEqual(data["autoconnected"], ["1.2.3.4:4242"])
+        # Only auto-connected interfaces appear, sorted. IPv4 is bare
+        # host:port; IPv6 is bracketed exactly as BackboneInterface.__str__
+        # renders it, so the Swift card's `reachable_on:port` comparison
+        # matches a real autoconnect (issue #193 / Greptile P1 #1).
+        self.assertEqual(
+            data["autoconnected"],
+            ["1.2.3.4:4242", "[2001:db8::1]:8080"],
+        )
 
     def test_enabled_follows_discover_interfaces_flag_not_autoconnect_count(self):
         """Regression (issue #193): the auto-connect limit is INDEPENDENT of

--- a/tests/test_rns_bridge_discovery.py
+++ b/tests/test_rns_bridge_discovery.py
@@ -66,13 +66,17 @@ def _install_stubs() -> None:
     ]
 
     class Reticulum:
+        # The `discover_interfaces` config flag (class attribute, re-read from
+        # config on every Reticulum.__init__). This — NOT the autoconnect
+        # count — is what discovery_json() surfaces as `enabled` (issue #193:
+        # the old implementation derived `enabled` from
+        # should_autoconnect_discovered_interfaces(), so sliding the
+        # auto-connect limit to 0 flipped the whole feature to "Disabled").
+        _Reticulum__discover_interfaces = True
+
         @staticmethod
         def discovered_interfaces():
             return infos
-
-        @staticmethod
-        def should_autoconnect_discovered_interfaces():
-            return True
 
     class Transport:
         # One auto-connected endpoint ("1.2.3.4:4242") and one plain
@@ -145,6 +149,48 @@ class DiscoveryJsonTest(unittest.TestCase):
 
         # Only auto-connected interfaces appear, sorted.
         self.assertEqual(data["autoconnected"], ["1.2.3.4:4242"])
+
+    def test_enabled_follows_discover_interfaces_flag_not_autoconnect_count(self):
+        """Regression (issue #193): the auto-connect limit is INDEPENDENT of
+        the discovery flag. `enabled` must track the `discover_interfaces`
+        config flag — sliding auto-connect to 0 must NOT report the feature
+        disabled. The old implementation derived `enabled` from
+        should_autoconnect_discovered_interfaces() (== count > 0), so count=0
+        flipped the whole feature to "Disabled". The stub exposes ONLY the
+        `_Reticulum__discover_interfaces` flag (no autoconnect method at all,
+        mirroring that the bridge must not depend on it), and discovery is on.
+        """
+        self._started = app.rns_bridge._state.get("started")
+        app.rns_bridge._state["started"] = True
+        try:
+            import app.rns_bridge as bridge
+            rns_stub = sys.modules["RNS"]
+
+            # Discover_interfaces on, and NO autoconnect accessor at all —
+            # if the bridge tried to read the autoconnect count, this would
+            # raise AttributeError and `enabled` would silently fall to False
+            # (the original bug).
+            rns_stub.Reticulum._Reticulum__discover_interfaces = True
+            for attr in (
+                "should_autoconnect_discovered_interfaces",
+                "max_autoconnected_interfaces",
+            ):
+                try:
+                    delattr(rns_stub.Reticulum, attr)
+                except AttributeError:
+                    pass
+
+            data = json.loads(bridge.discovery_json())
+            self.assertIs(data["enabled"], True,
+                          "enabled must stay True while discover_interfaces "
+                          "is on, regardless of the auto-connect count")
+        finally:
+            # Restore the flag so other tests in the module are unaffected.
+            sys.modules["RNS"].Reticulum._Reticulum__discover_interfaces = True
+            if self._started is None:
+                app.rns_bridge._state.pop("started", None)
+            else:
+                app.rns_bridge._state["started"] = self._started
 
     def test_discovery_json_not_started_returns_empty_shape(self):
         app.rns_bridge._state["started"] = False

--- a/tests/test_rns_bridge_discovery.py
+++ b/tests/test_rns_bridge_discovery.py
@@ -201,5 +201,57 @@ class DiscoveryJsonTest(unittest.TestCase):
         )
 
 
+class StatusAutoconnectTest(unittest.TestCase):
+    """`status()` must expose `is_autoconnect` per interface (issue #193
+    follow-up) so the Swift status poll can badge auto-connected discovery
+    interfaces in Network Status. The marker is the `autoconnect_hash` attr
+    RNS sets on auto-connected interfaces; user-configured interfaces lack it.
+    """
+
+    def setUp(self):
+        self._started = app.rns_bridge._state.get("started")
+        app.rns_bridge._state["started"] = True
+        self._saved = sys.modules["RNS"].Transport.interfaces
+
+    def tearDown(self):
+        sys.modules["RNS"].Transport.interfaces = self._saved
+        if self._started is None:
+            app.rns_bridge._state.pop("started", None)
+        else:
+            app.rns_bridge._state["started"] = self._started
+
+    @staticmethod
+    def _iface(section: str, friendly: str, autoconnect: bool):
+        class _Iface:
+            name = section
+            online = True
+            rxb = 0
+            txb = 0
+
+            def __str__(self) -> str:
+                return friendly
+
+        if autoconnect:
+            _Iface.autoconnect_hash = "endpoint_hash"
+        return _Iface()
+
+    def test_status_reports_is_autoconnect_per_interface(self):
+        sys.modules["RNS"].Transport.interfaces = [
+            self._iface("Home", "TCPInterface[Home/10.0.4.63:4242]", autoconnect=False),
+            self._iface(
+                "Synth Hub",
+                "BackboneInterface[Synth Hub/127.0.0.1:43221]",
+                autoconnect=True,
+            ),
+        ]
+        data = json.loads(app.rns_bridge.status_json())
+        by_name = {i["section_name"]: i for i in data["interfaces"]}
+        self.assertIs(by_name["Home"]["is_autoconnect"], False)
+        self.assertIs(by_name["Synth Hub"]["is_autoconnect"], True)
+        # The friendly name (with host:port) is what Swift parses the
+        # endpoint out of.
+        self.assertEqual(by_name["Home"]["name"], "TCPInterface[Home/10.0.4.63:4242]")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Interface Discovery (issue #193) — iOS

Implements RNS interface discovery end-to-end on iOS, with the follow-up UX polish landed during review:

### Discovery feature
- Python bridge `discovery_json()` (announced interfaces incl. LoRa/IFAC fields) + `PythonBridge.discovery()` → `DiscoveredInterface` model + formatters (safe `Int(exactly:)` decoding).
- Discovery config keys (`discover_interfaces`, `autoconnect_discovered_interfaces`, `bootstrap_only`) in `PythonConfigWriter` + settings persistence; real in-process RNS restart on apply.
- `DiscoveredInterfacesScreen` (Settings → Network → Manage Interfaces → entry card) with per-interface detail, "All announced fields" expandable, and card actions (Add to Config / Copy LoRa / Use for RNode) with wizard prefill.
- **Pending-state + explicit "Apply and Restart"**: toggles/slider never restart on their own; a single Apply persists + restarts exactly once (e2e-verified via diag.log restart marker counts).
- Discovery stays enabled at auto-connect 0 (fixed `enabled` conflation with the autoconnect count; reads `_Reticulum__discover_interfaces`).

### Network Status polish (this PR's later commits)
- Auto-connected-from-discovery interfaces now surface on the Network Status screen with a "Via discovery" badge (bridge reports `is_autoconnect` per interface from the `autoconnect_hash` marker; previously silently dropped).
- TCP rows show the live host:port endpoint (parsed from Python's friendly `str(iface)`) instead of a useless bare "TCPClient".
- Non-discovery cards show the configured interface name (the connect path no longer clobbers it with "TCP Server"; the status poll re-syncs on rename).
- Settings Network card lists discovery auto-connects ("Name (Discovered)") + LAN peer rollup; `isConnected` now reflects discovery-only connectivity (the old `autoInterface.peerCount` branch was dead code).
- All-announced-fields shows the IFAC network name (parity with Android).

### Verification
- Hosted XCTest: 508/508 pass (iPhone 17 sim, iOS 26.4); RNSAPI 51/51; Python discovery bridge 5/5; static contract 17/17.
- Device: iPhone 14, head `33afe0bb` installed in-place (data preserved), stable.
- Live two-node RNS probes: base discovery ~60s, IFAC-carrying announce (`ifac_netname` + handshake rule) verified; restart-gate proof via diag marker counts (0/0 for pending ops, 1/1 for Apply).
