### PR TITLE
deps(ios): bump RNS pin to 1.5.2 + surface operator LXMF contact

### DIFF
--- a/Sources/ColumbaApp/Resources/Localizable.xcstrings
+++ b/Sources/ColumbaApp/Resources/Localizable.xcstrings
@@ -2944,6 +2944,26 @@
           }
         }
       }
+    },
+    "Contact": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contact"
+          }
+        }
+      }
+    },
+    "Contact:": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contact:"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Sources/ColumbaApp/Views/Settings/DiscoveredInterfacesScreen.swift
+++ b/Sources/ColumbaApp/Views/Settings/DiscoveredInterfacesScreen.swift
@@ -690,6 +690,21 @@ private struct DiscoveredInterfaceCard: View {
                 }
             }
 
+            // Contact row (operator LXMF address, RNS 1.5.0+)
+            if let contact = iface.operatorLxmfAddress, !contact.isEmpty {
+                HStack(spacing: 4) {
+                    Image(systemName: "envelope.fill")
+                        .font(.caption2)
+                        .foregroundStyle(Theme.accentColor)
+                    Text(String(localized: "Contact:"))
+                        .font(.caption)
+                        .foregroundStyle(Theme.textSecondary)
+                    Text(verbatim: contact)
+                        .font(.caption.monospaced())
+                        .foregroundStyle(Theme.accentColor)
+                }
+            }
+
             // Location (tappable → opens Maps)
             if iface.hasLocation {
                 LocationDetails(iface: iface, distanceKm: distanceKm)
@@ -867,6 +882,7 @@ private struct DiscoveredInterfaceAllFieldsSection: View {
         add(String(localized: "Height"), iface.height.map { "\($0) m" })
         add(String(localized: "IFAC network name"), iface.ifacNetname)
         add(String(localized: "IFAC passphrase"), iface.ifacNetkey)
+        add(String(localized: "Contact"), iface.operatorLxmfAddress)
         add(String(localized: "Transport"), iface.transport ? "yes" : "no")
         add(String(localized: "Discovery hash"), iface.discoveryHash)
         add(String(localized: "Received at"), iface.receivedAt.map(formatUnixSeconds))

--- a/Sources/ColumbaApp/Views/Settings/DiscoveredInterfacesScreen.swift
+++ b/Sources/ColumbaApp/Views/Settings/DiscoveredInterfacesScreen.swift
@@ -699,7 +699,9 @@ private struct DiscoveredInterfaceCard: View {
                     Text(String(localized: "Contact:"))
                         .font(.caption)
                         .foregroundStyle(Theme.textSecondary)
-                    Text(verbatim: contact)
+                    // Truncated like the transport ID row above — the full
+                    // address stays available in the detail section.
+                    Text(verbatim: String(contact.prefix(12)) + "…")
                         .font(.caption.monospaced())
                         .foregroundStyle(Theme.accentColor)
                 }

--- a/Sources/RNSAPI/Models/DiscoveredInterface.swift
+++ b/Sources/RNSAPI/Models/DiscoveredInterface.swift
@@ -60,6 +60,8 @@ public struct DiscoveredInterface: Codable, Equatable, Sendable, Identifiable {
     public let ifacNetname: String?
     /// IFAC passphrase.
     public let ifacNetkey: String?
+    /// Operator LXMF address (RNS 1.5.0+ contact field; 32-hex, nil if absent).
+    public let operatorLxmfAddress: String?
     /// Whether the remote interface is a transport (routing) node.
     public let transport: Bool
     /// Unique identifier for this announce (hex SHA256 of transportId + name).
@@ -122,6 +124,7 @@ public struct DiscoveredInterface: Codable, Equatable, Sendable, Identifiable {
         height: Double? = nil,
         ifacNetname: String? = nil,
         ifacNetkey: String? = nil,
+        operatorLxmfAddress: String? = nil,
         transport: Bool = false,
         discoveryHash: String? = nil,
         receivedAt: Double? = nil,
@@ -150,6 +153,7 @@ public struct DiscoveredInterface: Codable, Equatable, Sendable, Identifiable {
         self.height = height
         self.ifacNetname = ifacNetname
         self.ifacNetkey = ifacNetkey
+        self.operatorLxmfAddress = operatorLxmfAddress
         self.transport = transport
         self.discoveryHash = discoveryHash
         self.receivedAt = receivedAt
@@ -191,6 +195,7 @@ public struct DiscoveredInterface: Codable, Equatable, Sendable, Identifiable {
         height = try c.decodeIfPresent(Double.self, forKey: .height)
         ifacNetname = Self.emptyStringToNil(try c.decodeIfPresent(String.self, forKey: .ifacNetname))
         ifacNetkey = Self.emptyStringToNil(try c.decodeIfPresent(String.self, forKey: .ifacNetkey))
+        operatorLxmfAddress = Self.emptyStringToNil(try c.decodeIfPresent(String.self, forKey: .operatorLxmfAddress))
         transport = try c.decodeIfPresent(Bool.self, forKey: .transport) ?? false
         discoveryHash = Self.emptyStringToNil(try c.decodeIfPresent(String.self, forKey: .discoveryHash))
         receivedAt = try c.decodeIfPresent(Double.self, forKey: .receivedAt)
@@ -241,6 +246,7 @@ public struct DiscoveredInterface: Codable, Equatable, Sendable, Identifiable {
         case height
         case ifacNetname = "ifac_netname"
         case ifacNetkey = "ifac_netkey"
+        case operatorLxmfAddress = "operator_lxmf_address"
         case transport
         case discoveryHash = "discovery_hash"
         case receivedAt = "received"

--- a/Sources/RNSBackendPy/PythonRNSBackend.swift
+++ b/Sources/RNSBackendPy/PythonRNSBackend.swift
@@ -70,7 +70,7 @@ public final class PythonRNSBackend: RnsBackend, @unchecked Sendable {
     public var capabilities: BackendCapabilities {
         BackendCapabilities(
             backendId: .pythonEmbedded,
-            versions: .init(reticulum: "1.3.1", lxmf: "0.9.9", lxst: nil, bleReticulum: "0.2.2"),
+            versions: .init(reticulum: "1.5.2", lxmf: "1.1.0", lxst: nil, bleReticulum: "0.2.2"),
             interfaces: .init(hotReloadInterfaces: true),
             telemetry: .init(
                 collectorHostMode: .unsupported,

--- a/Tests/RNSAPITests/DiscoveredInterfaceTests.swift
+++ b/Tests/RNSAPITests/DiscoveredInterfaceTests.swift
@@ -38,6 +38,7 @@ final class DiscoveredInterfaceTests: XCTestCase {
       "height": 42.5,
       "ifac_netname": "columba",
       "ifac_netkey": "secret",
+      "operator_lxmf_address": "0102030405060708091011121314151617181920212223242526272829303132",
       "transport": true,
       "discovery_hash": "abc123",
       "received": 1699999900.0,
@@ -69,6 +70,27 @@ final class DiscoveredInterfaceTests: XCTestCase {
 
     // MARK: - Decode
 
+    func testOperatorLxmfAddressDecode() throws {
+        // Present: 32-hex contact field (RNS 1.5.0+ discovery contact).
+        let withContact = try decode("""
+        {"name":"x","type":"TCPServerInterface","operator_lxmf_address":"0102030405060708091011121314151617181920212223242526272829303132"}
+        """)
+        XCTAssertEqual(withContact.operatorLxmfAddress, "0102030405060708091011121314151617181920212223242526272829303132")
+
+        // Absent (pre-1.5.0 announces / operators who don't set it): nil, no
+        // decode failure — this key did not exist before RNS 1.5.0.
+        let withoutContact = try decode("""
+        {"name":"y","type":"TCPServerInterface"}
+        """)
+        XCTAssertNil(withoutContact.operatorLxmfAddress)
+
+        // Empty string decodes as nil (mirrors the other optional string fields).
+        let emptyContact = try decode("""
+        {"name":"z","type":"TCPServerInterface","operator_lxmf_address":""}
+        """)
+        XCTAssertNil(emptyContact.operatorLxmfAddress)
+    }
+
     func testFullJSONDecode() throws {
         let iface = try decode(fullJSON)
         XCTAssertEqual(iface.name, "alpha")
@@ -94,6 +116,7 @@ final class DiscoveredInterfaceTests: XCTestCase {
         XCTAssertEqual(iface.height, 42.5)
         XCTAssertEqual(iface.ifacNetname, "columba")
         XCTAssertEqual(iface.ifacNetkey, "secret")
+        XCTAssertEqual(iface.operatorLxmfAddress, "0102030405060708091011121314151617181920212223242526272829303132")
         XCTAssertTrue(iface.transport)
         XCTAssertEqual(iface.discoveryHash, "abc123")
         XCTAssertEqual(iface.receivedAt, 1699999900.0)

--- a/Tests/static/test_ios_stamp_runtime_hardening.py
+++ b/Tests/static/test_ios_stamp_runtime_hardening.py
@@ -18,7 +18,7 @@ ROOT = Path(__file__).resolve().parents[2]
 FETCH = ROOT / "support" / "fetch-wheels.sh"
 BRIDGE = ROOT / "app" / "rns_bridge.py"
 STAMP = ROOT / "Sources" / "SwiftBLEBridge" / "StampGenerator.swift"
-RNS_SHA = "5b3a6ee4f25e2925cf84d4a2b108e6a708fbd395"
+RNS_SHA = "754654fe8cbca180c784e9274d033cb3ce229312"
 LXMF_SHA = "8912186e48b482a76bf04e2ac4b6c8940991aecc"
 
 

--- a/support/fetch-wheels.sh
+++ b/support/fetch-wheels.sh
@@ -44,7 +44,7 @@ PIP_PYTHON="$PIP_VENV/bin/python"
 #   RETICULUM_LOCAL=~/repos/Reticulum support/fetch-wheels.sh
 # Otherwise the pinned GitHub commit is used — a local checkout is never picked
 # up implicitly.
-RETICULUM_REF="${RETICULUM_REF:-5b3a6ee4f25e2925cf84d4a2b108e6a708fbd395}"
+RETICULUM_REF="${RETICULUM_REF:-754654fe8cbca180c784e9274d033cb3ce229312}"
 if [ -n "${RETICULUM_LOCAL:-}" ]; then
     echo "==> RETICULUM_LOCAL set — using local Reticulum checkout: $RETICULUM_LOCAL"
     RNS_SPEC="$RETICULUM_LOCAL"


### PR DESCRIPTION
Bumps the RNS wheel pin to the 1.5.2-based fork branch and surfaces the new
operator LXMF contact field in interface discovery.

## What changed
- `support/fetch-wheels.sh`: `RETICULUM_REF` → `754654fe…` (branch
  `patches/columba-ios-1.5.2` = upstream 1.5.2 tag + the six embedded-runtime
  hardening patches rebased cleanly on top).
- `PythonRNSBackend.swift`: advertised RNS version label `1.3.1` → `1.5.2`
  (cosmetic, no in-app reader).
- `Tests/static/test_ios_stamp_runtime_hardening.py`: SHA pin updated to the
  new head.
- **LXMf contact (RNS 1.5.0+):** `DiscoveredInterface.operatorLxmfAddress`
  (lenient decode; absent/empty → nil), a compact-card "Contact:" row and a
  detail "Contact" field row in `DiscoveredInterfacesScreen`, `Localizable`
  entries, and a decode regression in `RNSAPITests/DiscoveredInterfaceTests`.
  This is display-only — the app emits no discoverable interface, so it only
  shows contacts other operators announce.

The bridge `discovery_json()` already passes announce info keys through, so no
`rns_bridge.py` change is needed for the contact field.

## Verification (real execution)
- Mac worktree `fetch-wheels.sh`: produced `rns-1.5.2@754654fe`,
  `lxmf-1.1.0@8912186e`, `ble_reticulum-0.2.2@07d94130`; provenance validator
  passed; 0 symlinks.
- Built bundle ships `rns-1.5.2.dist-info`, `__version__ = "1.5.2"`, deployed
  `Discovery.py` has the `operator_lxmf_address` field.
- `ColumbaAppTests` on iPhone 17 sim: **512/512, 0 failures** (was 511 before
  the LXMf decode test).
- `RNSAPITests.DiscoveredInterfaceTests` via `swift test`: 23/23 (incl. new
  LXMf present/absent/empty decode).
- Sim in-process restart smoke on 1.5.2: toggle discovery → Apply & Restart →
  `config written → in-process restart complete`, stack back up
  (`interfaces=rnsd-interop-intero:1`, Delivery/Telephony announces),
  `discover_interfaces = yes` took effect, no errors/Traceback. This exercises
  the 1.5.2 singleton stop→start cycle — the main regression risk of the bump.
- AutoInterface guard path is unit-covered (`RuntimeFlavorTests` 398–402) and
  short-circuits before RNS teardown, so it adds no RNS-bump coverage.
- Device build + install + restart smoke running (see post-PR update).

## Notes
- The `.requiresRelaunch` guard (added in #196 / `8085fca9`) still refuses
  in-process restart when an AutoInterface is configured. Its premise —
  "AutoInterface.detach() doesn't release multicast sockets" — no longer holds
  on this 1.5.2 wheel (detach() now closes sockets and joins threads). Removing
  that guard is a separate behavior change and is deliberately **out of scope**
  here (kept to the minimum bump). Tracked as follow-up.