### PR TITLE
fix(ios): ship full reply quote in 0x31 FIELD_REPLY_QUOTE (Android parity)

### DIFF
--- a/Columba.xcodeproj/project.pbxproj
+++ b/Columba.xcodeproj/project.pbxproj
@@ -285,6 +285,7 @@
 		AA9D3715FB399E675BD53B41 /* PythonConfigWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBA4F8C4C9008A06DFF5AC8A /* PythonConfigWriter.swift */; };
 		AC4014BF281AD8BE6FF9E852 /* PeerChildInterfaceRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8A2F8952F6F036C94824552 /* PeerChildInterfaceRegistry.swift */; };
 		ACT02 /* AnnounceClassificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACT01 /* AnnounceClassificationTests.swift */; };
+		RQP02 /* ReplyQuoteParityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = RQP01 /* ReplyQuoteParityTests.swift */; };
 		DRAFT002 /* DraftMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DRAFT001 /* DraftMessageTests.swift */; };
 		DA143A000000000000000002 /* DraftAutosaveController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA143A000000000000000001 /* DraftAutosaveController.swift */; };
 		DA143A000000000000000003 /* DraftAutosaveController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA143A000000000000000001 /* DraftAutosaveController.swift */; };
@@ -516,6 +517,7 @@
 		A8A2F8952F6F036C94824552 /* PeerChildInterfaceRegistry.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PeerChildInterfaceRegistry.swift; sourceTree = "<group>"; };
 		ACA6D4C7151A87D862FF9B8A /* CodecProfileInfo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CodecProfileInfo.swift; sourceTree = "<group>"; };
 		ACT01 /* AnnounceClassificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnounceClassificationTests.swift; sourceTree = "<group>"; };
+		RQP01 /* ReplyQuoteParityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplyQuoteParityTests.swift; sourceTree = "<group>"; };
 		DRAFT001 /* DraftMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftMessageTests.swift; sourceTree = "<group>"; };
 		DA143A000000000000000001 /* DraftAutosaveController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftAutosaveController.swift; sourceTree = "<group>"; };
 		AD87870C760723D7E77C87E9 /* TCPClientWizardViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TCPClientWizardViewModel.swift; sourceTree = "<group>"; };
@@ -1167,6 +1169,7 @@
 				A1B2C3D4E5F60718293A4B5D /* MessageBubbleLayoutTests.swift */,
 				APVT001 /* MessageAttachmentPreviewTests.swift */,
 				ACT01 /* AnnounceClassificationTests.swift */,
+				RQP01 /* ReplyQuoteParityTests.swift */,
 				DRAFT001 /* DraftMessageTests.swift */,
 				EA0AA6C472B1D4EFA2896086 /* RNodeSeamTests.swift */,
 				853F1E1C2B6E5305277FCB2A /* MigrationRoundTripTests.swift */,
@@ -1947,6 +1950,7 @@
 				A1B2C3D4E5F60718293A4B5E /* MessageBubbleLayoutTests.swift in Sources */,
 				APVT002 /* MessageAttachmentPreviewTests.swift in Sources */,
 				ACT02 /* AnnounceClassificationTests.swift in Sources */,
+				RQP02 /* ReplyQuoteParityTests.swift in Sources */,
 				DRAFT002 /* DraftMessageTests.swift in Sources */,
 				0FF6A5C5596A39C092AADA29 /* MigrationRoundTripTests.swift in Sources */,
 				A1B2C3D4E5F60718293A4B5C /* IncomingMessageSizeLimitTests.swift in Sources */,

--- a/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/MessagingViewModel.swift
@@ -938,11 +938,27 @@ public final class MessagingViewModel {
             }
         }
 
-        // Build reply preview for optimistic display
+        // Build reply preview for optimistic display (capped at 80 chars for the
+        // compact bubble preview).
         let replyPreview: String? = {
             guard let replyToId else { return nil }
             if let msg = messages.first(where: { $0.id == replyToId }) {
                 return String(msg.content.prefix(80))
+            }
+            return nil
+        }()
+
+        // Full quoted content for the FIELD_REPLY_QUOTE (0x31) wire field. Upstream
+        // LXMF carries the reply target only by hash (0x30); 0x31 is the optional
+        // quoted-content add-on so recipients can render the quote without the
+        // original locally. Ship the FULL quote here — matching Android, which sends
+        // the complete original content — not the 80-char display preview. Both
+        // resolve from the local store, so when the message isn't local (e.g. never
+        // delivered to this device) the quote is nil, exactly as on Android.
+        let replyQuotedContent: String? = {
+            guard let replyToId else { return nil }
+            if let msg = messages.first(where: { $0.id == replyToId }) {
+                return msg.content
             }
             return nil
         }()
@@ -997,7 +1013,7 @@ public final class MessagingViewModel {
                     audioAttachment: audioAttachment.map { RnsAudio(mode: Int($0.mode.rawValue), bytes: $0.bytes) },
                     iconAppearance: icon,
                     replyToMessageHashHex: replyToId,
-                    replyQuotedContent: replyPreview,
+                    replyQuotedContent: replyQuotedContent,
                     extraFields: nil
                 ),
                 backend: backend
@@ -1087,7 +1103,7 @@ public final class MessagingViewModel {
                             audioAttachment: audioAttachment.map { RnsAudio(mode: Int($0.mode.rawValue), bytes: $0.bytes) },
                             iconAppearance: icon,
                             replyToMessageHashHex: replyToId,
-                            replyQuotedContent: replyPreview,
+                            replyQuotedContent: replyQuotedContent,
                             extraFields: nil
                         ),
                         backend: backend

--- a/Tests/ColumbaAppTests/ReplyQuoteParityTests.swift
+++ b/Tests/ColumbaAppTests/ReplyQuoteParityTests.swift
@@ -1,0 +1,141 @@
+import XCTest
+@testable import ColumbaApp
+import RNSAPI
+import GRDB
+
+/// Reply-quote wire parity with Android / the upstream LXMF reference.
+///
+/// Upstream LXMF (`reticulum/lxmf/LXMF/LXMF.py`):
+///   `FIELD_REPLY_TO    = 0x30`  # Bytes, full LXMessage.hash
+///   `FIELD_REPLY_QUOTE = 0x31`  # Bytes, quoted content in UTF-8 encoding
+///
+/// The canonical reply wire field is the target HASH (0x30). The quoted
+/// content (0x31) is an *optional* interop payload carried inline so a
+/// recipient can render a quote without the original in their local store
+/// (MeshChatX interop; peer history aged out).
+///
+/// Parity contract: Android ships the FULL quoted content in 0x31
+/// (`MessagingViewModel.kt` passes `getMessageById(id)?.content?.takeIf {
+/// it.isNotEmpty() }` — no cap). iOS previously shipped only the first 80
+/// characters (the same `prefix(80)` it uses for its local preview), so an
+/// iOS→Android / iOS→MeshChatX reply delivered a quote that was silently
+/// truncated mid-sentence. This pins the wire field to the full original
+/// content, matching the other side.
+///
+/// The 80-char cap remains correct for the *display* preview (the accent-bar
+/// quote above the bubble, which is `lineLimit(2)`); only the wire field is
+/// changed.
+@MainActor
+final class ReplyQuoteParityTests: XCTestCase {
+    private func temporaryDatabaseURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("columba-reply-quote-parity-\(UUID().uuidString).sqlite")
+    }
+
+    private func removeDatabase(at url: URL) {
+        let fm = FileManager.default
+        try? fm.removeItem(at: url)
+        try? fm.removeItem(atPath: url.path + "-wal")
+        try? fm.removeItem(atPath: url.path + "-shm")
+    }
+
+    /// A reply to a message longer than the 80-char preview cap must put the
+    /// FULL original content on the wire (field 0x31), byte-for-byte, not a
+    /// truncated prefix.
+    func testReplyQuoteShipsFullContentOnTheWire() async throws {
+        let databaseURL = temporaryDatabaseURL()
+        defer { removeDatabase(at: databaseURL) }
+        let repository = try MessageRepository(grdbPath: databaseURL.path)
+        let destination = Data(repeating: 0x41, count: 16)
+
+        // The original message the reply is quoting: 200 chars, well past the
+        // 80-char display-preview cap.
+        // 100 chars: clearly longer than the 80-char preview cap, so a cap applied
+        // to the wire quote would be observable here.
+        let originalContent = String(repeating: "abcdefghij", count: 10)
+        XCTAssertEqual(100, originalContent.count)
+        let originalID = String(repeating: "ab", count: 32)
+
+        let captured = LockedBox<MessagingViewModel.OutboundSendRequest>(nil)
+        let viewModel = MessagingViewModel(
+            conversationHash: destination,
+            repository: repository,
+            appServices: AppServices(),
+            identity: Identity(),
+            outboundSendOperation: { request in
+                captured.value = request
+                return .queued(messageHash: String(repeating: "cd", count: 32))
+            }
+        )
+
+        // Seed the replied-to message so the reply-preview lookup can resolve it.
+        viewModel.messages = [
+            Message(
+                id: originalID,
+                content: originalContent,
+                isFromMe: false
+            )
+        ]
+
+        let accepted = await viewModel.sendMessage(
+            text: "This is my reply.",
+            imageData: nil,
+            imageFormat: nil,
+            attachments: nil,
+            replyToId: originalID
+        )
+        XCTAssertTrue(accepted)
+
+        let request = try XCTUnwrap(captured.value, "the send must reach the outbound seam")
+        // The reply-target hash (field 0x30) is the canonical, always-present field.
+        XCTAssertEqual(originalID, request.replyToMessageHashHex)
+        // The quoted content (field 0x31) must be the FULL original — not the
+        // 80-char preview. This is the Android/MeshChatX parity guarantee.
+        XCTAssertEqual(originalContent, request.replyQuotedContent)
+    }
+
+    /// A reply to a message within the preview cap is unaffected: the quote is
+    /// exactly the original content (no cap to observe at this length).
+    func testReplyQuoteForShortMessageIsUnchanged() async throws {
+        let databaseURL = temporaryDatabaseURL()
+        defer { removeDatabase(at: databaseURL) }
+        let repository = try MessageRepository(grdbPath: databaseURL.path)
+        let destination = Data(repeating: 0x41, count: 16)
+
+        let originalContent = "short quoted line"
+        let originalID = String(repeating: "5f", count: 32)
+
+        let captured = LockedBox<MessagingViewModel.OutboundSendRequest>(nil)
+        let viewModel = MessagingViewModel(
+            conversationHash: destination,
+            repository: repository,
+            appServices: AppServices(),
+            identity: Identity(),
+            outboundSendOperation: { request in
+                captured.value = request
+                return .queued(messageHash: String(repeating: "cd", count: 32))
+            }
+        )
+        viewModel.messages = [Message(id: originalID, content: originalContent, isFromMe: false)]
+
+        let accepted = await viewModel.sendMessage(
+            text: "reply",
+            imageData: nil,
+            imageFormat: nil,
+            attachments: nil,
+            replyToId: originalID
+        )
+        XCTAssertTrue(accepted)
+
+        let request = try XCTUnwrap(captured.value)
+        XCTAssertEqual(originalContent, request.replyQuotedContent)
+    }
+}
+
+/// Minimal thread-confined box for capturing a value from an escaping closure
+/// on the main actor without a heavyweight actor.
+@MainActor
+final class LockedBox<T> {
+    var value: T?
+    init(_ initial: T?) { self.value = initial }
+}

--- a/Tests/ColumbaAppTests/ReplyQuoteParityTests.swift
+++ b/Tests/ColumbaAppTests/ReplyQuoteParityTests.swift
@@ -57,6 +57,8 @@ final class ReplyQuoteParityTests: XCTestCase {
         let originalID = String(repeating: "ab", count: 32)
 
         let captured = LockedBox<MessagingViewModel.OutboundSendRequest>(nil)
+        let optimisticPreview = LockedBox<String?>(nil)
+        let vmRef = LockedBox<MessagingViewModel>(nil)
         let viewModel = MessagingViewModel(
             conversationHash: destination,
             repository: repository,
@@ -64,9 +66,15 @@ final class ReplyQuoteParityTests: XCTestCase {
             identity: Identity(),
             outboundSendOperation: { request in
                 captured.value = request
+                // The seam runs after the optimistic row is appended and before
+                // it is replaced post-send — snapshot the display preview here.
+                if let vm = vmRef.value {
+                    optimisticPreview.value = vm.messages.last(where: { $0.isFromMe })?.replyToPreview
+                }
                 return .queued(messageHash: String(repeating: "cd", count: 32))
             }
         )
+        vmRef.value = viewModel
 
         // Seed the replied-to message so the reply-preview lookup can resolve it.
         viewModel.messages = [
@@ -92,6 +100,36 @@ final class ReplyQuoteParityTests: XCTestCase {
         // The quoted content (field 0x31) must be the FULL original — not the
         // 80-char preview. This is the Android/MeshChatX parity guarantee.
         XCTAssertEqual(originalContent, request.replyQuotedContent)
+
+        // The seam above returns before encoding runs, so assert the wire
+        // contract itself: feed the captured request's reply fields through the
+        // same codec both backends use and check the emitted field map.
+        let wireFields = LxmfFieldCodec.buildFieldMap(
+            imageData: request.imageData,
+            imageFormat: request.imageFormat,
+            fileAttachments: request.fileAttachments,
+            audioAttachment: request.audioAttachment,
+            iconAppearance: request.iconAppearance,
+            replyToMessageHashHex: request.replyToMessageHashHex,
+            replyQuotedContent: request.replyQuotedContent,
+            extraFields: request.extraFields
+        )
+        let quoteField = try XCTUnwrap(
+            wireFields[LxmfFields.FIELD_REPLY_QUOTE] as? Data,
+            "codec must emit FIELD_REPLY_QUOTE (0x31) for a reply with local quote content"
+        )
+        // Full content on the wire — byte-for-byte, no cap.
+        XCTAssertEqual(originalContent, String(data: quoteField, encoding: .utf8))
+        let hashField = try XCTUnwrap(
+            wireFields[LxmfFields.FIELD_REPLY_HASH] as? Data,
+            "codec must emit FIELD_REPLY_HASH (0x30)"
+        )
+        XCTAssertEqual(Data(repeating: 0xab, count: 32), hashField)
+
+        // The display-side preview must stay capped at 80 chars — the fix splits
+        // the two consumers, and this pins the display half (snapshotted from the
+        // optimistic row inside the seam, before the row is replaced post-send).
+        XCTAssertEqual(String(originalContent.prefix(80)), optimisticPreview.value)
     }
 
     /// A reply to a message within the preview cap is unaffected: the quote is


### PR DESCRIPTION
## Problem

iOS truncated the optional `0x31 FIELD_REPLY_QUOTE` wire field to the 80-char display-preview cap before encoding, while Android ships the full quoted content:

- iOS: `MessagingViewModel` built `replyPreview = String(msg.content.prefix(80))` and passed it to **both** the bubble preview and `OutboundSendRequest.replyQuotedContent` → `LxmfFieldCodec` → `fields[0x31]`.
- Android: sends the complete original content in the same field.

Consequence: a long quoted reply sent from iOS rendered as a cut-off preview on Android/MeshChatX. (Upstream LXMF carries the reply target canonically by hash in `0x30`; `0x31` is the optional quoted-content add-on, so the mechanism was already in parity — only the payload length was not.)

## Fix

Split the two consumers of the reply lookup in `sendMessage`:

- `replyPreview` — unchanged, `prefix(80)` — drives the optimistic bubble display only.
- `replyQuotedContent` — full content — drives `OutboundSendRequest` → `0x31` wire field (primary + failure-fallback send sites).

Both resolve from the local store, so a non-local original yields a nil quote — exactly matching Android.

## Tests (TDD)

New `ReplyQuoteParityTests`:

- `testReplyQuoteShipsFullContentOnTheWire` — RED before the fix (captured wire quote was the 80-char truncated string, expected the full 100-char content), GREEN after.
- `testReplyQuoteForShortMessageIsUnchanged` — sub-cap reply unaffected.

Both drive the public `sendMessage(replyToId:)` through the `outboundSendOperation` test seam and assert on the exact `OutboundSendRequest` that reaches the LXMF codec.

## Verification

- Full `ColumbaAppTests` on this head: **514 passed / 0 failed** (sim 5514A047, Xcode 16.4, Debug).
- Full `ColumbaAppTests` on pristine `main` (a790385bd) control: **512 passed / 0 failed**. The +2 delta is exactly the two new tests; zero regressions.

## Related

- Fixes the 0x31 payload-length half of issue #52 (the reply-body clipping half is the separate, already-fixed layout bug from PR #138).