### PR TITLE
feat(ios): reliable Local Network prompt + carrier re-adopt for Auto Discovery

### DIFF
--- a/Columba.xcodeproj/project.pbxproj
+++ b/Columba.xcodeproj/project.pbxproj
@@ -45,6 +45,8 @@
 		C01110CA1100000000000003 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = C01110CA1100000000000001 /* Localizable.xcstrings */; };
 		0229B2C848210EE825D13B8E /* PythonBLECallbackBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF4DCA18506B96230721ACC /* PythonBLECallbackBridge.swift */; };
 		024 /* AppServices.swift in Sources */ = {isa = PBXBuildFile; fileRef = F024 /* AppServices.swift */; };
+		LNP001 /* LocalNetworkProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = LNP002 /* LocalNetworkProbe.swift */; };
+		LNP003 /* LocalNetworkProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = LNP002 /* LocalNetworkProbe.swift */; };
 		025 /* MessageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = F025 /* MessageRepository.swift */; };
 		CHF004 /* CallHistoryFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = CHF003 /* CallHistoryFormatting.swift */; };
 		CHM002 /* CallHistoryModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = CHM001 /* CallHistoryModels.swift */; };
@@ -589,6 +591,7 @@
 		C01110CA1100000000000001 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		F023 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F024 /* AppServices.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppServices.swift; sourceTree = "<group>"; };
+		LNP002 /* LocalNetworkProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalNetworkProbe.swift; sourceTree = "<group>"; };
 		F025 /* MessageRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageRepository.swift; sourceTree = "<group>"; };
 		CHF003 /* CallHistoryFormatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallHistoryFormatting.swift; sourceTree = "<group>"; };
 		CHM001 /* CallHistoryModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallHistoryModels.swift; sourceTree = "<group>"; };
@@ -1109,6 +1112,7 @@
 			children = (
 				BGPSYNCREF001 /* BackgroundPropagationSync.swift */,
 				F024 /* AppServices.swift */,
+				LNP002 /* LocalNetworkProbe.swift */,
 				E284643CB4F95B1B3DBA965B /* OneShotLocationProvider.swift */,
 				BKF002 /* BackendFactory.swift */,
 				F025 /* MessageRepository.swift */,
@@ -1823,6 +1827,7 @@
 				021 /* MapView.swift in Sources */,
 				048 /* MapLibreMapView.swift in Sources */,
 				024 /* AppServices.swift in Sources */,
+				LNP003 /* LocalNetworkProbe.swift in Sources */,
 				A4EA60E22E1A3A65C6AFA5E7 /* OneShotLocationProvider.swift in Sources */,
 				099A0C66CE2C1444E52912D0 /* DiscoveredInterfacesViewModel.swift in Sources */,
 				BKF001 /* BackendFactory.swift in Sources */,

--- a/Sources/ColumbaApp/Resources/Info.plist
+++ b/Sources/ColumbaApp/Resources/Info.plist
@@ -41,6 +41,12 @@
 	<key>NSBonjourServices</key>
 	<array>
 		<string>_reticulum._tcp</string>
+		<!-- Probe-only type for the Local Network permission trigger
+		     (LocalNetworkProbe.swift). Not a real protocol service: the probe
+		     browses + briefly publishes this type to make iOS reliably raise
+		     the Local Network prompt and to detect a grant/denial. Declaring
+		     it here is what makes the prompt actually fire. -->
+		<string>_columba-lnp._tcp</string>
 	</array>
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>Columba uses the local network for peer-to-peer communication with nearby Reticulum devices.</string>

--- a/Sources/ColumbaApp/Resources/Localizable.xcstrings
+++ b/Sources/ColumbaApp/Resources/Localizable.xcstrings
@@ -1,3010 +1,3010 @@
 {
-    "sourceLanguage": "en",
-    "strings": {
-        "Common causes include an unavailable route, an offline recipient, or a delivery timeout. Check your interfaces and try again.": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Common causes include an unavailable route, an offline recipient, or a delivery timeout. Check your interfaces and try again."
-                    }
-                }
-            }
-        },
-        "Message delivery failed": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Message delivery failed"
-                    }
-                }
-            }
-        },
-        "No delivery confirmation": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "No delivery confirmation"
-                    }
-                }
-            }
-        },
-        "No relay is selected. Select a relay in Message Delivery and Retrieval, then try again.": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "No relay is selected. Select a relay in Message Delivery and Retrieval, then try again."
-                    }
-                }
-            }
-        },
-        "Shows delivery failure details": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Shows delivery failure details"
-                    }
-                }
-            }
-        },
-        "No active interface": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "No active interface"
-                    }
-                }
-            }
-        },
-        "Interfaces:": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Interfaces:"
-                    }
-                }
-            }
-        },
-        "TCP": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "TCP"
-                    }
-                }
-            }
-        },
-        "TCP Server": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "TCP Server"
-                    }
-                }
-            }
-        },
-        "Tap to configure RNS 1.1.x interface discovery": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Tap to configure RNS 1.1.x interface discovery"
-                    }
-                }
-            }
-        },
-        "Manage": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Manage"
-                    }
-                }
-            }
-        },
-        "Manage Interfaces": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Manage Interfaces"
-                    }
-                }
-            }
-        },
-        "No Interfaces Connected": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "No Interfaces Connected"
-                    }
-                }
-            }
-        },
-        "Opens network interface settings": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Opens network interface settings"
-                    }
-                }
-            }
-        },
-        "A relay helps your device reach Reticulum peers over the internet. It transports encrypted Reticulum traffic — it does not create an account or hold your identity. We've selected a recommended default.": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "A relay helps your device reach Reticulum peers over the internet. It transports encrypted Reticulum traffic — it does not create an account or hold your identity. We've selected a recommended default."
-                    }
-                }
-            }
-        },
-        "Allow Columba to alert you after it receives:": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Allow Columba to alert you after it receives:"
-                    }
-                }
-            }
-        },
-        "Allow notifications to stay informed": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Allow notifications to stay informed"
-                    }
-                }
-            }
-        },
-        "Another Columba user can scan this public contact code to add you. It does not contain your private identity keys.": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Another Columba user can scan this public contact code to add you. It does not contain your private identity keys."
-                    }
-                }
-            }
-        },
-        "Apple devices only, no Wi-Fi needed": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Apple devices only, no Wi-Fi needed"
-                    }
-                }
-            }
-        },
-        "BLE": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "BLE"
-                    }
-                }
-            }
-        },
-        "Back": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Back"
-                    }
-                }
-            }
-        },
-        "Background Delivery": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Background Delivery"
-                    }
-                }
-            }
-        },
-        "Backup Contents": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Backup Contents"
-                    }
-                }
-            }
-        },
-        "Bluetooth": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Bluetooth"
-                    }
-                }
-            }
-        },
-        "Bluetooth LE": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Bluetooth LE"
-                    }
-                }
-            }
-        },
-        "Bluetooth access is requested only if you select Bluetooth LE. RNode access is requested later during radio setup.": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Bluetooth access is requested only if you select Bluetooth LE. RNode access is requested later during radio setup."
-                    }
-                }
-            }
-        },
-        "Cancel": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Cancel"
-                    }
-                }
-            }
-        },
-        "Choose a Display Name": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Choose a Display Name"
-                    }
-                }
-            }
-        },
-        "Choose a relay": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Choose a relay"
-                    }
-                }
-            }
-        },
-        "Close": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Close"
-                    }
-                }
-            }
-        },
-        "Columba creates a private cryptographic identity on your device. You control it — and can protect it with an encrypted backup.": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Columba creates a private cryptographic identity on your device. You control it — and can protect it with an encrypted backup."
-                    }
-                }
-            }
-        },
-        "Columba generates the private cryptographic identity. This name does not need to be unique, and you can change it anytime.": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Columba generates the private cryptographic identity. This name does not need to be unique, and you can change it anytime."
-                    }
-                }
-            }
-        },
-        "Columba uses Apple's VPN system to keep its own network component available in the background. It is not a commercial VPN service.": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Columba uses Apple's VPN system to keep its own network component available in the background. It is not a commercial VPN service."
-                    }
-                }
-            }
-        },
-        "Configure in Settings after setup": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Configure in Settings after setup"
-                    }
-                }
-            }
-        },
-        "Connect directly to nearby Columba devices": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Connect directly to nearby Columba devices"
-                    }
-                }
-            }
-        },
-        "Connect directly with nearby Apple devices": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Connect directly with nearby Apple devices"
-                    }
-                }
-            }
-        },
-        "Continue": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Continue"
-                    }
-                }
-            }
-        },
-        "Decrypt": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Decrypt"
-                    }
-                }
-            }
-        },
-        "Disabled": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Disabled"
-                    }
-                }
-            }
-        },
-        "Done": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Done"
-                    }
-                }
-            }
-        },
-        "Enable": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Enable"
-                    }
-                }
-            }
-        },
-        "Enable Background Delivery": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Enable Background Delivery"
-                    }
-                }
-            }
-        },
-        "Enabled": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Enabled"
-                    }
-                }
-            }
-        },
-        "Enter Backup Password": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Enter Backup Password"
-                    }
-                }
-            }
-        },
-        "Existing identities and messages will not be duplicated. Conversation details and app settings may be updated from this backup.": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Existing identities and messages will not be duplicated. Conversation details and app settings may be updated from this backup."
-                    }
-                }
-            }
-        },
-        "Generating identity...": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Generating identity..."
-                    }
-                }
-            }
-        },
-        "Get Started": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Get Started"
-                    }
-                }
-            }
-        },
-        "How will you connect?": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "How will you connect?"
-                    }
-                }
-            }
-        },
-        "Incorrect password. Please try again.": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Incorrect password. Please try again."
-                    }
-                }
-            }
-        },
-        "Internet Relay": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Internet Relay"
-                    }
-                }
-            }
-        },
-        "Internet relay": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Internet relay"
-                    }
-                }
-            }
-        },
-        "Internet, local, Bluetooth, and radio connections": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Internet, local, Bluetooth, and radio connections"
-                    }
-                }
-            }
-        },
-        "Local Wi-Fi": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Local Wi-Fi"
-                    }
-                }
-            }
-        },
-        "Long-range mesh via RNode hardware": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Long-range mesh via RNode hardware"
-                    }
-                }
-            }
-        },
-        "Message Alerts": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Message Alerts"
-                    }
-                }
-            }
-        },
-        "Nearby": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Nearby"
-                    }
-                }
-            }
-        },
-        "New messages": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "New messages"
-                    }
-                }
-            }
-        },
-        "No Wi-Fi required; iOS will request Bluetooth access": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "No Wi-Fi required; iOS will request Bluetooth access"
-                    }
-                }
-            }
-        },
-        "No active identity is available.": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "No active identity is available."
-                    }
-                }
-            }
-        },
-        "No central account or sign-up": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "No central account or sign-up"
-                    }
-                }
-            }
-        },
-        "No internet required; iOS may request Local Network access": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "No internet required; iOS may request Local Network access"
-                    }
-                }
-            }
-        },
-        "No phone number or email": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "No phone number or email"
-                    }
-                }
-            }
-        },
-        "Notification permission does not keep Columba connected in the background. You can change access anytime in iOS Settings.": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Notification permission does not keep Columba connected in the background. You can change access anytime in iOS Settings."
-                    }
-                }
-            }
-        },
-        "Notifications": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Notifications"
-                    }
-                }
-            }
-        },
-        "OK": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "OK"
-                    }
-                }
-            }
-        },
-        "Optional network and Bluetooth events": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Optional network and Bluetooth events"
-                    }
-                }
-            }
-        },
-        "Other Public Relays": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Other Public Relays"
-                    }
-                }
-            }
-        },
-        "Please try again.": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Please try again."
-                    }
-                }
-            }
-        },
-        "Private messaging without a central account": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Private messaging without a central account"
-                    }
-                }
-            }
-        },
-        "RNode": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "RNode"
-                    }
-                }
-            }
-        },
-        "RNode Radio": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "RNode Radio"
-                    }
-                }
-            }
-        },
-        "Reach Reticulum devices on the same network": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Reach Reticulum devices on the same network"
-                    }
-                }
-            }
-        },
-        "Reach Reticulum peers through a public relay": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Reach Reticulum peers through a public relay"
-                    }
-                }
-            }
-        },
-        "Reading backup...": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Reading backup..."
-                    }
-                }
-            }
-        },
-        "Recommended Relays": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Recommended Relays"
-                    }
-                }
-            }
-        },
-        "Recommended for getting started; requires internet": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Recommended for getting started; requires internet"
-                    }
-                }
-            }
-        },
-        "Relay server": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Relay server"
-                    }
-                }
-            }
-        },
-        "Reopen onboarding without deleting your identity or messages.": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Reopen onboarding without deleting your identity or messages."
-                    }
-                }
-            }
-        },
-        "Restore Backup": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Restore Backup"
-                    }
-                }
-            }
-        },
-        "Restore Complete!": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Restore Complete!"
-                    }
-                }
-            }
-        },
-        "Restore Data": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Restore Data"
-                    }
-                }
-            }
-        },
-        "Restore from backup": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Restore from backup"
-                    }
-                }
-            }
-        },
-        "Review Setup Guide": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Review Setup Guide"
-                    }
-                }
-            }
-        },
-        "Select Server": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Select Server"
-                    }
-                }
-            }
-        },
-        "Select Text": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Select Text"
-                    }
-                }
-            }
-        },
-        "Select a relay before using propagation": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Select a relay before using propagation"
-                    }
-                }
-            }
-        },
-        "Select at least one connection method to continue.": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Select at least one connection method to continue."
-                    }
-                }
-            }
-        },
-        "Select one or more. You can change these later.": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Select one or more. You can change these later."
-                    }
-                }
-            }
-        },
-        "Share Your Identity": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Share Your Identity"
-                    }
-                }
-            }
-        },
-        "Share your QR code with another Columba user, then create an encrypted backup from Settings.": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Share your QR code with another Columba user, then create an encrypted backup from Settings."
-                    }
-                }
-            }
-        },
-        "Show QR Code": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Show QR Code"
-                    }
-                }
-            }
-        },
-        "Show alerts for received messages and events": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Show alerts for received messages and events"
-                    }
-                }
-            }
-        },
-        "The indicator means iOS has an active network extension. It stays visible while Background Delivery is enabled.": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "The indicator means iOS has an active network extension. It stays visible while Background Delivery is enabled."
-                    }
-                }
-            }
-        },
-        "The indicator means iOS has an active network extension. It stays visible while Background Transport is enabled.": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "The indicator means iOS has an active network extension. It stays visible while Background Transport is enabled."
-                    }
-                }
-            }
-        },
-        "This backup is encrypted. Enter the password used when creating it.": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "This backup is encrypted. Enter the password used when creating it."
-                    }
-                }
-            }
-        },
-        "This is the changeable name other people will see.": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "This is the changeable name other people will see."
-                    }
-                }
-            }
-        },
-        "Try Again": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Try Again"
-                    }
-                }
-            }
-        },
-        "Unable to Open Setup": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Unable to Open Setup"
-                    }
-                }
-            }
-        },
-        "Use Defaults": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Use Defaults"
-                    }
-                }
-            }
-        },
-        "VPN": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "VPN"
-                    }
-                }
-            }
-        },
-        "Welcome to Columba": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Welcome to Columba"
-                    }
-                }
-            }
-        },
-        "While this is on, iOS shows a VPN indicator.": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "While this is on, iOS shows a VPN indicator."
-                    }
-                }
-            }
-        },
-        "Wi-Fi": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Wi-Fi"
-                    }
-                }
-            }
-        },
-        "You can choose another relay later in Settings.": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "You can choose another relay later in Settings."
-                    }
-                }
-            }
-        },
-        "You're all set!": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "You're all set!"
-                    }
-                }
-            }
-        },
-        "iOS Notifications": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "iOS Notifications"
-                    }
-                }
-            }
-        },
-        "iOS uses its VPN system to let Columba's network component continue running when the app is not open. Only traffic from Columba and Reticulum uses this component; your other apps and web traffic are not routed through Columba.": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "iOS uses its VPN system to let Columba's network component continue running when the app is not open. Only traffic from Columba and Reticulum uses this component; your other apps and web traffic are not routed through Columba."
-                    }
-                }
-            }
-        },
-        "iOS will ask you to allow the configuration and will show a VPN indicator while Background Delivery is enabled. Delivery still depends on available Reticulum connections.": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "iOS will ask you to allow the configuration and will show a VPN indicator while Background Delivery is enabled. Delivery still depends on available Reticulum connections."
-                    }
-                }
-            }
-        },
-        "Your Display Name": {
-            "comment": "Read-only heading shown while reviewing an existing setup."
-        },
-        "Current relay": {
-            "comment": "Read-only heading for the relay shown during setup review."
-        },
-        "This is the relay currently configured for Columba. You can change it later in Settings.": {
-            "comment": "Explains that setup review does not edit the relay."
-        },
-        "Current connections": {
-            "comment": "Read-only heading for connection methods shown during setup review."
-        },
-        "This setup review is read-only. Change connection methods in Settings.": {
-            "comment": "Explains where connection methods can be edited."
-        },
-        "Setup Guide Reviewed": {
-            "comment": "Heading after completing a read-only setup review."
-        },
-        "iOS Notification Permission": {
-            "comment": "Label for the operating-system notification authorization status."
-        },
-        "Allowed": {
-            "comment": "Status indicating an iOS permission is allowed."
-        },
-        "Not Allowed": {
-            "comment": "Status indicating an iOS permission is not allowed."
-        },
-        "Text Size": {
-            "comment": "Conversation action and picker title for changing primary message-body text size."
-        },
-        "Preview message text": {
-            "comment": "Sample message shown in the conversation text-size picker."
-        },
-        "Message text size": {
-            "comment": "VoiceOver label for the conversation message text-size slider."
-        },
-        "Minimum text size": {
-            "comment": "VoiceOver label for the small endpoint in the message text-size range."
-        },
-        "Maximum text size": {
-            "comment": "VoiceOver label for the large endpoint in the message text-size range."
-        },
-        "%lld percent": {
-            "comment": "VoiceOver value announcing the selected message text-size percentage."
-        },
-        "Image attachment": {
-            "comment": "VoiceOver label for an image attached to a chat message."
-        },
-        "File attachment: %@": {
-            "comment": "VoiceOver label for a file attached to a chat message. The placeholder is the sender-provided display name."
-        },
-        "Opens attachment preview": {
-            "comment": "VoiceOver hint for tappable image and file attachment controls."
-        },
-        "Unable to Open Attachment": {
-            "comment": "Error alert title when a message attachment cannot be prepared for preview."
-        },
-        "The attachment could not be prepared for preview.": {
-            "comment": "Privacy-safe error text shown when temporary attachment export fails."
-        },
-        "Type a message...": {
-            "comment": "Placeholder and VoiceOver label for the message composer.",
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Type a message..."
-                    }
-                }
-            }
-        },
-        "Enter Key Sends Message": {
-            "comment": "Settings toggle controlling whether the on-screen keyboard Enter key sends the current message.",
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Enter Key Sends Message"
-                    }
-                }
-            }
-        },
-        "Messaging": {
-            "comment": "Title of the settings card containing message composition preferences.",
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Messaging"
-                    }
-                }
-            }
-        },
-        "Press Enter to send. Turn this off when you want Enter to insert new lines.": {
-            "comment": "Explanation shown when the message composer Enter key sends messages.",
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Press Enter to send. Turn this off when you want Enter to insert new lines."
-                    }
-                }
-            }
-        },
-        "Press Enter to insert a new line. Use the send button to send the message.": {
-            "comment": "Explanation shown when the message composer Enter key inserts a line break.",
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Press Enter to insert a new line. Use the send button to send the message."
-                    }
-                }
-            }
-        },
-        "Messages from contacts only": {
-            "comment": "Label for the privacy control that rejects messages from unknown senders.",
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Messages from contacts only"
-                    }
-                }
-            }
-        },
-        "Only contacts can message you. Messages from unknown senders are silently discarded.": {
-            "comment": "Privacy explanation shown when messages from unknown senders are blocked.",
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Only contacts can message you. Messages from unknown senders are silently discarded."
-                    }
-                }
-            }
-        },
-        "Anyone can send you messages, including unknown senders.": {
-            "comment": "Privacy explanation shown when messages from unknown senders are allowed.",
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Anyone can send you messages, including unknown senders."
-                    }
-                }
-            }
-        },
-        "Announce to Network": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Announce to Network"
-                    }
-                }
-            }
-        },
-        "Announced": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Announced"
-                    }
-                }
-            }
-        },
-        "Broadcasts your identity so nearby peers can discover you": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Broadcasts your identity so nearby peers can discover you"
-                    }
-                }
-            }
-        },
-        "Send Announce": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Send Announce"
-                    }
-                }
-            }
-        },
-        "Pending send": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Pending send"
-                    }
-                }
-            }
-        },
-        "Sending to relay": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Sending to relay"
-                    }
-                }
-            }
-        },
-        "Stored on relay": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Stored on relay"
-                    }
-                }
-            }
-        },
-        "Pending": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Pending"
-                    }
-                }
-            }
-        },
-        "Queued locally; no transport confirmation yet": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Queued locally; no transport confirmation yet"
-                    }
-                }
-            }
-        },
-        "Sending to Relay": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Sending to Relay"
-                    }
-                }
-            }
-        },
-        "Submitting through the selected relay": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Submitting through the selected relay"
-                    }
-                }
-            }
-        },
-        "Stored on Relay": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Stored on Relay"
-                    }
-                }
-            }
-        },
-        "Relay accepted the message; recipient delivery is not confirmed": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Relay accepted the message; recipient delivery is not confirmed"
-                    }
-                }
-            }
-        },
-        "Submitting to the selected relay": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Submitting to the selected relay"
-                    }
-                }
-            }
-        },
-        "Stored by relay; awaiting recipient delivery": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Stored by relay; awaiting recipient delivery"
-                    }
-                }
-            }
-        },
-        "Recipient delivery confirmed through relay": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Recipient delivery confirmed through relay"
-                    }
-                }
-            }
-        },
-        "Relay delivery attempt failed": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Relay delivery attempt failed"
-                    }
-                }
-            }
-        },
-        "Relay method selected; relay acceptance is unconfirmed": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Relay method selected; relay acceptance is unconfirmed"
-                    }
-                }
-            }
-        },
-        "Message was queued, but its local state could not be saved. Do not retry until its delivery outcome is known.": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Message was queued, but its local state could not be saved. Do not retry until its delivery outcome is known."
-                    }
-                }
-            }
-        },
-        "Relay submission was queued, but its local state could not be saved. Do not retry until its delivery outcome is known.": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Relay submission was queued, but its local state could not be saved. Do not retry until its delivery outcome is known."
-                    }
-                }
-            }
-        },
-        "north": {
-            "comment": "Compass direction shown next to a peer pin distance in the map contact sheet."
-        },
-        "northeast": {
-            "comment": "Compass direction shown next to a peer pin distance in the map contact sheet."
-        },
-        "east": {
-            "comment": "Compass direction shown next to a peer pin distance in the map contact sheet."
-        },
-        "southeast": {
-            "comment": "Compass direction shown next to a peer pin distance in the map contact sheet."
-        },
-        "south": {
-            "comment": "Compass direction shown next to a peer pin distance in the map contact sheet."
-        },
-        "southwest": {
-            "comment": "Compass direction shown next to a peer pin distance in the map contact sheet."
-        },
-        "west": {
-            "comment": "Compass direction shown next to a peer pin distance in the map contact sheet."
-        },
-        "northwest": {
-            "comment": "Compass direction shown next to a peer pin distance in the map contact sheet."
-        },
-        "Location unknown": {
-            "comment": "Distance line in the map contact sheet when the user has not granted or is not yet providing a location."
-        },
-        "Updated just now": {
-            "comment": "Relative last-update line for a peer location that arrived in the last few seconds."
-        },
-        "Updated %llds ago": {
-            "comment": "Relative last-update line, seconds. %lld is the whole-second count."
-        },
-        "Updated %lldm ago": {
-            "comment": "Relative last-update line, minutes. %lld is the whole-minute count."
-        },
-        "Updated %lldh ago": {
-            "comment": "Relative last-update line, hours. %lld is the whole-hour count."
-        },
-        "Updated %lldd ago": {
-            "comment": "Relative last-update line, days. %lld is the whole-day count."
-        },
-        "Stale": {
-            "comment": "Badge on the profile icon in the map contact sheet when the peer location is outside the freshness window."
-        },
-        "Directions": {
-            "comment": "Action button label in the map peer contact sheet."
-        },
-        "Message": {
-            "comment": "Action button label in the map peer contact sheet; routes to the peer chat."
-        },
-        "Remove from map": {
-            "comment": "Action button label in the map peer contact sheet; hides this peer until it reports again."
-        },
-        "Open Directions in:": {
-            "comment": "Title of the confirmation dialog choosing the directions app when both Apple Maps and Google Maps are available."
-        },
-        "Apple Maps": {
-            "comment": "Name of the Apple Maps option in the directions chooser."
-        },
-        "Google Maps": {
-            "comment": "Name of the Google Maps option in the directions chooser."
-        },
-        "Select Voice Message Quality": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Select Voice Message Quality"
-                    }
-                }
-            }
-        },
-        "Choose the recording format and bandwidth": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Choose the recording format and bandwidth"
-                    }
-                }
-            }
-        },
-        "Record": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Record"
-                    }
-                }
-            }
-        },
-        "Codec2 1200": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Codec2 1200"
-                    }
-                }
-            }
-        },
-        "Very low bandwidth voice": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Very low bandwidth voice"
-                    }
-                }
-            }
-        },
-        "Codec2 2400": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Codec2 2400"
-                    }
-                }
-            }
-        },
-        "Low bandwidth voice": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Low bandwidth voice"
-                    }
-                }
-            }
-        },
-        "Codec2 3200": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Codec2 3200"
-                    }
-                }
-            }
-        },
-        "Clearer speech at low bandwidth": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Clearer speech at low bandwidth"
-                    }
-                }
-            }
-        },
-        "Medium Quality": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Medium Quality"
-                    }
-                }
-            }
-        },
-        "Opus 8 kbps mono - good balance of quality and bandwidth": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Opus 8 kbps mono - good balance of quality and bandwidth"
-                    }
-                }
-            }
-        },
-        "High Quality": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "High Quality"
-                    }
-                }
-            }
-        },
-        "Opus 16 kbps mono - higher fidelity audio": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Opus 16 kbps mono - higher fidelity audio"
-                    }
-                }
-            }
-        },
-        "Maximum Quality": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Maximum Quality"
-                    }
-                }
-            }
-        },
-        "Opus 32 kbps stereo - best audio, requires more bandwidth": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Opus 32 kbps stereo - best audio, requires more bandwidth"
-                    }
-                }
-            }
-        },
-        "Voice": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Voice"
-                    }
-                }
-            }
-        },
-        "Record a voice message": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Record a voice message"
-                    }
-                }
-            }
-        },
-        "Voice message": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Voice message"
-                    }
-                }
-            }
-        },
-        "Start recording": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Start recording"
-                    }
-                }
-            }
-        },
-        "Stop recording": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Stop recording"
-                    }
-                }
-            }
-        },
-        "Cancel recording": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Cancel recording"
-                    }
-                }
-            }
-        },
-        "Remove recording": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Remove recording"
-                    }
-                }
-            }
-        },
-        "Microphone permission is required to record a voice message.": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Microphone permission is required to record a voice message."
-                    }
-                }
-            }
-        },
-        "Voice messages are not supported on this device.": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Voice messages are not supported on this device."
-                    }
-                }
-            }
-        },
-        "Recording": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Recording"
-                    }
-                }
-            }
-        },
-        "Finalizing": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Finalizing"
-                    }
-                }
-            }
-        },
-        "Selected voice message": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Selected voice message"
-                    }
-                }
-            }
-        },
-        "Recording error: %@": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Recording error: %@"
-                    }
-                }
-            }
-        },
-        "Ready to record a voice message": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Ready to record a voice message"
-                    }
-                }
-            }
-        },
-        "Grant microphone access": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Grant microphone access"
-                    }
-                }
-            }
-        },
-        "Microphone access is disabled. Enable it in app settings.": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Microphone access is disabled. Enable it in app settings."
-                    }
-                }
-            }
-        },
-        "Open settings": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Open settings"
-                    }
-                }
-            }
-        },
-        "Voice recording is unavailable during a call.": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Voice recording is unavailable during a call."
-                    }
-                }
-            }
-        },
-        "Play voice message": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Play voice message"
-                    }
-                }
-            }
-        },
-        "Pause voice message": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Pause voice message"
-                    }
-                }
-            }
-        },
-        "Loading voice message": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Loading voice message"
-                    }
-                }
-            }
-        },
-        "Voice message unavailable": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Voice message unavailable"
-                    }
-                }
-            }
-        },
-        "Unsupported voice message": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Unsupported voice message"
-                    }
-                }
-            }
-        },
-        "%@ of %@": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "%@ of %@"
-                    }
-                }
-            }
-        },
-        "Unable to play voice message": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Unable to play voice message"
-                    }
-                }
-            }
-        },
-        "Voice message recording produced no audio.": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Voice message recording produced no audio."
-                    }
-                }
-            }
-        },
-        "Text": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Text"
-                    }
-                }
-            }
-        },
-        "Clear history": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Clear history"
-                    }
-                }
-            }
-        },
-        "No Calls Yet": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "No Calls Yet"
-                    }
-                }
-            }
-        },
-        "Incoming and outgoing voice calls will appear here.": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Incoming and outgoing voice calls will appear here."
-                    }
-                }
-            }
-        },
-        "Call Details": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Call Details"
-                    }
-                }
-            }
-        },
-        "Direction": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Direction"
-                    }
-                }
-            }
-        },
-        "Outcome": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Outcome"
-                    }
-                }
-            }
-        },
-        "Quality profile": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Quality profile"
-                    }
-                }
-            }
-        },
-        "Attempted": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Attempted"
-                    }
-                }
-            }
-        },
-        "Ringing": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Ringing"
-                    }
-                }
-            }
-        },
-        "Connected": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Connected"
-                    }
-                }
-            }
-        },
-        "Ended": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Ended"
-                    }
-                }
-            }
-        },
-        "Duration": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Duration"
-                    }
-                }
-            }
-        },
-        "Local identity": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Local identity"
-                    }
-                }
-            }
-        },
-        "Remote identity": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Remote identity"
-                    }
-                }
-            }
-        },
-        "Call again": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Call again"
-                    }
-                }
-            }
-        },
-        "Missed": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Missed"
-                    }
-                }
-            }
-        },
-        "Declined": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Declined"
-                    }
-                }
-            }
-        },
-        "Rejected": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Rejected"
-                    }
-                }
-            }
-        },
-        "Busy": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Busy"
-                    }
-                }
-            }
-        },
-        "Cancelled": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Cancelled"
-                    }
-                }
-            }
-        },
-        "Not connected": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Not connected"
-                    }
-                }
-            }
-        },
-        "Failed": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Failed"
-                    }
-                }
-            }
-        },
-        "Interrupted": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Interrupted"
-                    }
-                }
-            }
-        },
-        "In progress": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "In progress"
-                    }
-                }
-            }
-        },
-        "Recovering call status": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Recovering call status"
-                    }
-                }
-            }
-        },
-        "Search calls": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Search calls"
-                    }
-                }
-            }
-        },
-        "Couldn't Load Call History": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Couldn't Load Call History"
-                    }
-                }
-            }
-        },
-        "Retry": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Retry"
-                    }
-                }
-            }
-        },
-        "No Calls Found": {
-            "extractionState": "manual",
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "No Calls Found"
-                    }
-                }
-            }
-        },
-        "Discovered Interfaces": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Discovered Interfaces"
-                    }
-                }
-            }
-        },
-        "Interface Discovery": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Interface Discovery"
-                    }
-                }
-            }
-        },
-        "Enable discovery": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Enable discovery"
-                    }
-                }
-            }
-        },
-        "Discovery enabled - no interfaces found yet": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Discovery enabled - no interfaces found yet"
-                    }
-                }
-            }
-        },
-        "Off": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Off"
-                    }
-                }
-            }
-        },
-        "Bootstrap interfaces": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Bootstrap interfaces"
-                    }
-                }
-            }
-        },
-        "These auto-detach once discovered interfaces connect.": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "These auto-detach once discovered interfaces connect."
-                    }
-                }
-            }
-        },
-        "Restarting…": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Restarting…"
-                    }
-                }
-            }
-        },
-        "Active – discovering interfaces": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Active – discovering interfaces"
-                    }
-                }
-            }
-        },
-        "Auto-connect up to %lld discovered interfaces": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Auto-connect up to %lld discovered interfaces"
-                    }
-                }
-            }
-        },
-        "Discovered": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Discovered"
-                    }
-                }
-            }
-        },
-        "Available": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Available"
-                    }
-                }
-            }
-        },
-        "Unknown": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Unknown"
-                    }
-                }
-            }
-        },
-        "Sort": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Sort"
-                    }
-                }
-            }
-        },
-        "Quality": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Quality"
-                    }
-                }
-            }
-        },
-        "Nearest": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Nearest"
-                    }
-                }
-            }
-        },
-        "Search interfaces…": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Search interfaces…"
-                    }
-                }
-            }
-        },
-        "IFAC only": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "IFAC only"
-                    }
-                }
-            }
-        },
-        "%lld of %lld": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "%lld of %lld"
-                    }
-                }
-            }
-        },
-        "Clear": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Clear"
-                    }
-                }
-            }
-        },
-        "Transport:": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Transport:"
-                    }
-                }
-            }
-        },
-        "IFAC:": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "IFAC:"
-                    }
-                }
-            }
-        },
-        "Last heard: %@": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Last heard: %@"
-                    }
-                }
-            }
-        },
-        "%lld hops": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "%lld hops"
-                    }
-                }
-            }
-        },
-        "Yggdrasil": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Yggdrasil"
-                    }
-                }
-            }
-        },
-        "All announced fields": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "All announced fields"
-                    }
-                }
-            }
-        },
-        "Transport ID": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Transport ID"
-                    }
-                }
-            }
-        },
-        "Network ID": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Network ID"
-                    }
-                }
-            }
-        },
-        "Status code": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Status code"
-                    }
-                }
-            }
-        },
-        "Last heard (unix)": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Last heard (unix)"
-                    }
-                }
-            }
-        },
-        "Heard count": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Heard count"
-                    }
-                }
-            }
-        },
-        "Stamp value": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Stamp value"
-                    }
-                }
-            }
-        },
-        "Reachable on": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Reachable on"
-                    }
-                }
-            }
-        },
-        "Port": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Port"
-                    }
-                }
-            }
-        },
-        "Frequency": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Frequency"
-                    }
-                }
-            }
-        },
-        "Bandwidth": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Bandwidth"
-                    }
-                }
-            }
-        },
-        "Spreading factor": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Spreading factor"
-                    }
-                }
-            }
-        },
-        "Coding rate": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Coding rate"
-                    }
-                }
-            }
-        },
-        "Modulation": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Modulation"
-                    }
-                }
-            }
-        },
-        "Channel": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Channel"
-                    }
-                }
-            }
-        },
-        "Latitude": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Latitude"
-                    }
-                }
-            }
-        },
-        "Longitude": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Longitude"
-                    }
-                }
-            }
-        },
-        "Height": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Height"
-                    }
-                }
-            }
-        },
-        "IFAC passphrase": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "IFAC passphrase"
-                    }
-                }
-            }
-        },
-        "Transport": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Transport"
-                    }
-                }
-            }
-        },
-        "Discovery hash": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Discovery hash"
-                    }
-                }
-            }
-        },
-        "Received at": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Received at"
-                    }
-                }
-            }
-        },
-        "Discovered at": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Discovered at"
-                    }
-                }
-            }
-        },
-        "Port %lld": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Port %lld"
-                    }
-                }
-            }
-        },
-        "Open in Maps": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Open in Maps"
-                    }
-                }
-            }
-        },
-        "%lld m": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "%lld m"
-                    }
-                }
-            }
-        },
-        "%lld interfaces found via RNS Discovery": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "%lld interfaces found via RNS Discovery"
-                    }
-                }
-            }
-        },
-        "%.0fm away": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "%.0fm away"
-                    }
-                }
-            }
-        },
-        "%.1f km away": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "%.1f km away"
-                    }
-                }
-            }
-        },
-        "Restarting Reticulum…": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Restarting Reticulum…"
-                    }
-                }
-            }
-        },
-        "No interfaces discovered yet. Enable discovery above to start finding interfaces announced by other RNS nodes.": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "No interfaces discovered yet. Enable discovery above to start finding interfaces announced by other RNS nodes."
-                    }
-                }
-            }
-        },
-        "No interfaces match your filters.": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "No interfaces match your filters."
-                    }
-                }
-            }
-        },
-        "Clear filters": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Clear filters"
-                    }
-                }
-            }
-        },
-        "Add to Config": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Add to Config"
-                    }
-                }
-            }
-        },
-        "Copy LoRa Params": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Copy LoRa Params"
-                    }
-                }
-            }
-        },
-        "Use for RNode": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Use for RNode"
-                    }
-                }
-            }
-        },
-        "Copied": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Copied"
-                    }
-                }
-            }
-        },
-        "Restart failed — discovery settings were not applied.": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Restart failed — discovery settings were not applied."
-                    }
-                }
-            }
-        },
-        "Discovers interfaces announced by other RNS nodes. Changes take effect after you tap Apply and Restart.": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Discovers interfaces announced by other RNS nodes. Changes take effect after you tap Apply and Restart."
-                    }
-                }
-            }
-        },
-        "Changes pending — tap Apply and Restart": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Changes pending — tap Apply and Restart"
-                    }
-                }
-            }
-        },
-        "Apply and Restart": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Apply and Restart"
-                    }
-                }
-            }
-        },
-        "Discard": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Discard"
-                    }
-                }
-            }
-        },
-        "IFAC network name": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "IFAC network name"
-                    }
-                }
-            }
-        },
-        "Via discovery": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Via discovery"
-                    }
-                }
-            }
-        },
-        "Auto-connected from discovery": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Auto-connected from discovery"
-                    }
-                }
-            }
-        },
-        "Endpoint": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Endpoint"
-                    }
-                }
-            }
-        },
-        "Source": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Source"
-                    }
-                }
-            }
-        },
-        "Saved. Applies on the next app relaunch because an AutoInterface is active.": {
-            "extractionState": "manual",
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Saved. Applies on the next app relaunch because an AutoInterface is active."
-                    }
-                }
-            }
-        },
-        "Interface discovery is unavailable in this build.": {
-            "extractionState": "manual",
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Interface discovery is unavailable in this build."
-                    }
-                }
-            }
-        },
-        "Contact": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Contact"
-                    }
-                }
-            }
-        },
-        "Contact:": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Contact:"
-                    }
-                }
-            }
-        },
-        "Local Network access is off": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Local Network access is off"
-                    }
-                }
-            }
-        },
-        "Columba can't find nearby peers until Local Network access is allowed. This setting can be changed in iOS Settings.": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Columba can't find nearby peers until Local Network access is allowed. This setting can be changed in iOS Settings."
-                    }
-                }
-            }
-        },
-        "Waiting for a network connection": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Waiting for a network connection"
-                    }
-                }
-            }
-        },
-        "Auto Discovery is ready and will connect as soon as a Wi-Fi or cellular connection is available.": {
-            "localizations": {
-                "en": {
-                    "stringUnit": {
-                        "state": "translated",
-                        "value": "Auto Discovery is ready and will connect as soon as a Wi-Fi or cellular connection is available."
-                    }
-                }
-            }
+  "sourceLanguage": "en",
+  "strings": {
+    "Local Network access is off": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Local Network access is off"
+          }
         }
+      }
     },
-    "version": "1.0"
+    "Columba can't find nearby peers until Local Network access is allowed. This setting can be changed in iOS Settings.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Columba can't find nearby peers until Local Network access is allowed. This setting can be changed in iOS Settings."
+          }
+        }
+      }
+    },
+    "Waiting for a network connection": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Waiting for a network connection"
+          }
+        }
+      }
+    },
+    "Auto Discovery is ready and will connect as soon as a Wi-Fi or cellular connection is available.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto Discovery is ready and will connect as soon as a Wi-Fi or cellular connection is available."
+          }
+        }
+      }
+    },
+    "Common causes include an unavailable route, an offline recipient, or a delivery timeout. Check your interfaces and try again.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Common causes include an unavailable route, an offline recipient, or a delivery timeout. Check your interfaces and try again."
+          }
+        }
+      }
+    },
+    "Message delivery failed": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Message delivery failed"
+          }
+        }
+      }
+    },
+    "No delivery confirmation": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No delivery confirmation"
+          }
+        }
+      }
+    },
+    "No relay is selected. Select a relay in Message Delivery and Retrieval, then try again.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No relay is selected. Select a relay in Message Delivery and Retrieval, then try again."
+          }
+        }
+      }
+    },
+    "Shows delivery failure details": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shows delivery failure details"
+          }
+        }
+      }
+    },
+    "No active interface": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No active interface"
+          }
+        }
+      }
+    },
+    "Interfaces:": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Interfaces:"
+          }
+        }
+      }
+    },
+    "TCP": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "TCP"
+          }
+        }
+      }
+    },
+    "TCP Server": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "TCP Server"
+          }
+        }
+      }
+    },
+    "Tap to configure RNS 1.1.x interface discovery": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap to configure RNS 1.1.x interface discovery"
+          }
+        }
+      }
+    },
+    "Manage": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manage"
+          }
+        }
+      }
+    },
+    "Manage Interfaces": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manage Interfaces"
+          }
+        }
+      }
+    },
+    "No Interfaces Connected": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Interfaces Connected"
+          }
+        }
+      }
+    },
+    "Opens network interface settings": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opens network interface settings"
+          }
+        }
+      }
+    },
+    "A relay helps your device reach Reticulum peers over the internet. It transports encrypted Reticulum traffic — it does not create an account or hold your identity. We've selected a recommended default.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A relay helps your device reach Reticulum peers over the internet. It transports encrypted Reticulum traffic — it does not create an account or hold your identity. We've selected a recommended default."
+          }
+        }
+      }
+    },
+    "Allow Columba to alert you after it receives:": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow Columba to alert you after it receives:"
+          }
+        }
+      }
+    },
+    "Allow notifications to stay informed": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow notifications to stay informed"
+          }
+        }
+      }
+    },
+    "Another Columba user can scan this public contact code to add you. It does not contain your private identity keys.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Another Columba user can scan this public contact code to add you. It does not contain your private identity keys."
+          }
+        }
+      }
+    },
+    "Apple devices only, no Wi-Fi needed": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apple devices only, no Wi-Fi needed"
+          }
+        }
+      }
+    },
+    "BLE": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BLE"
+          }
+        }
+      }
+    },
+    "Back": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Back"
+          }
+        }
+      }
+    },
+    "Background Delivery": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Background Delivery"
+          }
+        }
+      }
+    },
+    "Backup Contents": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Backup Contents"
+          }
+        }
+      }
+    },
+    "Bluetooth": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bluetooth"
+          }
+        }
+      }
+    },
+    "Bluetooth LE": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bluetooth LE"
+          }
+        }
+      }
+    },
+    "Bluetooth access is requested only if you select Bluetooth LE. RNode access is requested later during radio setup.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bluetooth access is requested only if you select Bluetooth LE. RNode access is requested later during radio setup."
+          }
+        }
+      }
+    },
+    "Cancel": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
+          }
+        }
+      }
+    },
+    "Choose a Display Name": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose a Display Name"
+          }
+        }
+      }
+    },
+    "Choose a relay": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose a relay"
+          }
+        }
+      }
+    },
+    "Close": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        }
+      }
+    },
+    "Columba creates a private cryptographic identity on your device. You control it — and can protect it with an encrypted backup.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Columba creates a private cryptographic identity on your device. You control it — and can protect it with an encrypted backup."
+          }
+        }
+      }
+    },
+    "Columba generates the private cryptographic identity. This name does not need to be unique, and you can change it anytime.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Columba generates the private cryptographic identity. This name does not need to be unique, and you can change it anytime."
+          }
+        }
+      }
+    },
+    "Columba uses Apple's VPN system to keep its own network component available in the background. It is not a commercial VPN service.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Columba uses Apple's VPN system to keep its own network component available in the background. It is not a commercial VPN service."
+          }
+        }
+      }
+    },
+    "Configure in Settings after setup": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configure in Settings after setup"
+          }
+        }
+      }
+    },
+    "Connect directly to nearby Columba devices": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connect directly to nearby Columba devices"
+          }
+        }
+      }
+    },
+    "Connect directly with nearby Apple devices": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connect directly with nearby Apple devices"
+          }
+        }
+      }
+    },
+    "Continue": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continue"
+          }
+        }
+      }
+    },
+    "Decrypt": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Decrypt"
+          }
+        }
+      }
+    },
+    "Disabled": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disabled"
+          }
+        }
+      }
+    },
+    "Done": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Done"
+          }
+        }
+      }
+    },
+    "Enable": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable"
+          }
+        }
+      }
+    },
+    "Enable Background Delivery": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable Background Delivery"
+          }
+        }
+      }
+    },
+    "Enabled": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enabled"
+          }
+        }
+      }
+    },
+    "Enter Backup Password": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter Backup Password"
+          }
+        }
+      }
+    },
+    "Existing identities and messages will not be duplicated. Conversation details and app settings may be updated from this backup.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Existing identities and messages will not be duplicated. Conversation details and app settings may be updated from this backup."
+          }
+        }
+      }
+    },
+    "Generating identity...": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Generating identity..."
+          }
+        }
+      }
+    },
+    "Get Started": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Get Started"
+          }
+        }
+      }
+    },
+    "How will you connect?": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "How will you connect?"
+          }
+        }
+      }
+    },
+    "Incorrect password. Please try again.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Incorrect password. Please try again."
+          }
+        }
+      }
+    },
+    "Internet Relay": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Internet Relay"
+          }
+        }
+      }
+    },
+    "Internet relay": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Internet relay"
+          }
+        }
+      }
+    },
+    "Internet, local, Bluetooth, and radio connections": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Internet, local, Bluetooth, and radio connections"
+          }
+        }
+      }
+    },
+    "Local Wi-Fi": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Local Wi-Fi"
+          }
+        }
+      }
+    },
+    "Long-range mesh via RNode hardware": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Long-range mesh via RNode hardware"
+          }
+        }
+      }
+    },
+    "Message Alerts": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Message Alerts"
+          }
+        }
+      }
+    },
+    "Nearby": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nearby"
+          }
+        }
+      }
+    },
+    "New messages": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New messages"
+          }
+        }
+      }
+    },
+    "No Wi-Fi required; iOS will request Bluetooth access": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Wi-Fi required; iOS will request Bluetooth access"
+          }
+        }
+      }
+    },
+    "No active identity is available.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No active identity is available."
+          }
+        }
+      }
+    },
+    "No central account or sign-up": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No central account or sign-up"
+          }
+        }
+      }
+    },
+    "No internet required; iOS may request Local Network access": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No internet required; iOS may request Local Network access"
+          }
+        }
+      }
+    },
+    "No phone number or email": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No phone number or email"
+          }
+        }
+      }
+    },
+    "Notification permission does not keep Columba connected in the background. You can change access anytime in iOS Settings.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notification permission does not keep Columba connected in the background. You can change access anytime in iOS Settings."
+          }
+        }
+      }
+    },
+    "Notifications": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notifications"
+          }
+        }
+      }
+    },
+    "OK": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        }
+      }
+    },
+    "Optional network and Bluetooth events": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Optional network and Bluetooth events"
+          }
+        }
+      }
+    },
+    "Other Public Relays": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Other Public Relays"
+          }
+        }
+      }
+    },
+    "Please try again.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Please try again."
+          }
+        }
+      }
+    },
+    "Private messaging without a central account": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Private messaging without a central account"
+          }
+        }
+      }
+    },
+    "RNode": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RNode"
+          }
+        }
+      }
+    },
+    "RNode Radio": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RNode Radio"
+          }
+        }
+      }
+    },
+    "Reach Reticulum devices on the same network": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reach Reticulum devices on the same network"
+          }
+        }
+      }
+    },
+    "Reach Reticulum peers through a public relay": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reach Reticulum peers through a public relay"
+          }
+        }
+      }
+    },
+    "Reading backup...": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reading backup..."
+          }
+        }
+      }
+    },
+    "Recommended Relays": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recommended Relays"
+          }
+        }
+      }
+    },
+    "Recommended for getting started; requires internet": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recommended for getting started; requires internet"
+          }
+        }
+      }
+    },
+    "Relay server": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relay server"
+          }
+        }
+      }
+    },
+    "Reopen onboarding without deleting your identity or messages.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reopen onboarding without deleting your identity or messages."
+          }
+        }
+      }
+    },
+    "Restore Backup": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restore Backup"
+          }
+        }
+      }
+    },
+    "Restore Complete!": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restore Complete!"
+          }
+        }
+      }
+    },
+    "Restore Data": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restore Data"
+          }
+        }
+      }
+    },
+    "Restore from backup": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restore from backup"
+          }
+        }
+      }
+    },
+    "Review Setup Guide": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Review Setup Guide"
+          }
+        }
+      }
+    },
+    "Select Server": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select Server"
+          }
+        }
+      }
+    },
+    "Select Text": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select Text"
+          }
+        }
+      }
+    },
+    "Select a relay before using propagation": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select a relay before using propagation"
+          }
+        }
+      }
+    },
+    "Select at least one connection method to continue.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select at least one connection method to continue."
+          }
+        }
+      }
+    },
+    "Select one or more. You can change these later.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select one or more. You can change these later."
+          }
+        }
+      }
+    },
+    "Share Your Identity": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share Your Identity"
+          }
+        }
+      }
+    },
+    "Share your QR code with another Columba user, then create an encrypted backup from Settings.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share your QR code with another Columba user, then create an encrypted backup from Settings."
+          }
+        }
+      }
+    },
+    "Show QR Code": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show QR Code"
+          }
+        }
+      }
+    },
+    "Show alerts for received messages and events": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show alerts for received messages and events"
+          }
+        }
+      }
+    },
+    "The indicator means iOS has an active network extension. It stays visible while Background Delivery is enabled.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The indicator means iOS has an active network extension. It stays visible while Background Delivery is enabled."
+          }
+        }
+      }
+    },
+    "The indicator means iOS has an active network extension. It stays visible while Background Transport is enabled.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The indicator means iOS has an active network extension. It stays visible while Background Transport is enabled."
+          }
+        }
+      }
+    },
+    "This backup is encrypted. Enter the password used when creating it.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This backup is encrypted. Enter the password used when creating it."
+          }
+        }
+      }
+    },
+    "This is the changeable name other people will see.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This is the changeable name other people will see."
+          }
+        }
+      }
+    },
+    "Try Again": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Try Again"
+          }
+        }
+      }
+    },
+    "Unable to Open Setup": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to Open Setup"
+          }
+        }
+      }
+    },
+    "Use Defaults": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use Defaults"
+          }
+        }
+      }
+    },
+    "VPN": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "VPN"
+          }
+        }
+      }
+    },
+    "Welcome to Columba": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Welcome to Columba"
+          }
+        }
+      }
+    },
+    "While this is on, iOS shows a VPN indicator.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "While this is on, iOS shows a VPN indicator."
+          }
+        }
+      }
+    },
+    "Wi-Fi": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wi-Fi"
+          }
+        }
+      }
+    },
+    "You can choose another relay later in Settings.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You can choose another relay later in Settings."
+          }
+        }
+      }
+    },
+    "You're all set!": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You're all set!"
+          }
+        }
+      }
+    },
+    "iOS Notifications": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iOS Notifications"
+          }
+        }
+      }
+    },
+    "iOS uses its VPN system to let Columba's network component continue running when the app is not open. Only traffic from Columba and Reticulum uses this component; your other apps and web traffic are not routed through Columba.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iOS uses its VPN system to let Columba's network component continue running when the app is not open. Only traffic from Columba and Reticulum uses this component; your other apps and web traffic are not routed through Columba."
+          }
+        }
+      }
+    },
+    "iOS will ask you to allow the configuration and will show a VPN indicator while Background Delivery is enabled. Delivery still depends on available Reticulum connections.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iOS will ask you to allow the configuration and will show a VPN indicator while Background Delivery is enabled. Delivery still depends on available Reticulum connections."
+          }
+        }
+      }
+    },
+    "Your Display Name": {
+      "comment": "Read-only heading shown while reviewing an existing setup."
+    },
+    "Current relay": {
+      "comment": "Read-only heading for the relay shown during setup review."
+    },
+    "This is the relay currently configured for Columba. You can change it later in Settings.": {
+      "comment": "Explains that setup review does not edit the relay."
+    },
+    "Current connections": {
+      "comment": "Read-only heading for connection methods shown during setup review."
+    },
+    "This setup review is read-only. Change connection methods in Settings.": {
+      "comment": "Explains where connection methods can be edited."
+    },
+    "Setup Guide Reviewed": {
+      "comment": "Heading after completing a read-only setup review."
+    },
+    "iOS Notification Permission": {
+      "comment": "Label for the operating-system notification authorization status."
+    },
+    "Allowed": {
+      "comment": "Status indicating an iOS permission is allowed."
+    },
+    "Not Allowed": {
+      "comment": "Status indicating an iOS permission is not allowed."
+    },
+    "Text Size": {
+      "comment": "Conversation action and picker title for changing primary message-body text size."
+    },
+    "Preview message text": {
+      "comment": "Sample message shown in the conversation text-size picker."
+    },
+    "Message text size": {
+      "comment": "VoiceOver label for the conversation message text-size slider."
+    },
+    "Minimum text size": {
+      "comment": "VoiceOver label for the small endpoint in the message text-size range."
+    },
+    "Maximum text size": {
+      "comment": "VoiceOver label for the large endpoint in the message text-size range."
+    },
+    "%lld percent": {
+      "comment": "VoiceOver value announcing the selected message text-size percentage."
+    },
+    "Image attachment": {
+      "comment": "VoiceOver label for an image attached to a chat message."
+    },
+    "File attachment: %@": {
+      "comment": "VoiceOver label for a file attached to a chat message. The placeholder is the sender-provided display name."
+    },
+    "Opens attachment preview": {
+      "comment": "VoiceOver hint for tappable image and file attachment controls."
+    },
+    "Unable to Open Attachment": {
+      "comment": "Error alert title when a message attachment cannot be prepared for preview."
+    },
+    "The attachment could not be prepared for preview.": {
+      "comment": "Privacy-safe error text shown when temporary attachment export fails."
+    },
+    "Type a message...": {
+      "comment": "Placeholder and VoiceOver label for the message composer.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Type a message..."
+          }
+        }
+      }
+    },
+    "Enter Key Sends Message": {
+      "comment": "Settings toggle controlling whether the on-screen keyboard Enter key sends the current message.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter Key Sends Message"
+          }
+        }
+      }
+    },
+    "Messaging": {
+      "comment": "Title of the settings card containing message composition preferences.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Messaging"
+          }
+        }
+      }
+    },
+    "Press Enter to send. Turn this off when you want Enter to insert new lines.": {
+      "comment": "Explanation shown when the message composer Enter key sends messages.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Press Enter to send. Turn this off when you want Enter to insert new lines."
+          }
+        }
+      }
+    },
+    "Press Enter to insert a new line. Use the send button to send the message.": {
+      "comment": "Explanation shown when the message composer Enter key inserts a line break.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Press Enter to insert a new line. Use the send button to send the message."
+          }
+        }
+      }
+    },
+    "Messages from contacts only": {
+      "comment": "Label for the privacy control that rejects messages from unknown senders.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Messages from contacts only"
+          }
+        }
+      }
+    },
+    "Only contacts can message you. Messages from unknown senders are silently discarded.": {
+      "comment": "Privacy explanation shown when messages from unknown senders are blocked.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Only contacts can message you. Messages from unknown senders are silently discarded."
+          }
+        }
+      }
+    },
+    "Anyone can send you messages, including unknown senders.": {
+      "comment": "Privacy explanation shown when messages from unknown senders are allowed.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anyone can send you messages, including unknown senders."
+          }
+        }
+      }
+    },
+    "Announce to Network": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Announce to Network"
+          }
+        }
+      }
+    },
+    "Announced": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Announced"
+          }
+        }
+      }
+    },
+    "Broadcasts your identity so nearby peers can discover you": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Broadcasts your identity so nearby peers can discover you"
+          }
+        }
+      }
+    },
+    "Send Announce": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Send Announce"
+          }
+        }
+      }
+    },
+    "Pending send": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pending send"
+          }
+        }
+      }
+    },
+    "Sending to relay": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sending to relay"
+          }
+        }
+      }
+    },
+    "Stored on relay": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stored on relay"
+          }
+        }
+      }
+    },
+    "Pending": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pending"
+          }
+        }
+      }
+    },
+    "Queued locally; no transport confirmation yet": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Queued locally; no transport confirmation yet"
+          }
+        }
+      }
+    },
+    "Sending to Relay": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sending to Relay"
+          }
+        }
+      }
+    },
+    "Submitting through the selected relay": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Submitting through the selected relay"
+          }
+        }
+      }
+    },
+    "Stored on Relay": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stored on Relay"
+          }
+        }
+      }
+    },
+    "Relay accepted the message; recipient delivery is not confirmed": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relay accepted the message; recipient delivery is not confirmed"
+          }
+        }
+      }
+    },
+    "Submitting to the selected relay": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Submitting to the selected relay"
+          }
+        }
+      }
+    },
+    "Stored by relay; awaiting recipient delivery": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stored by relay; awaiting recipient delivery"
+          }
+        }
+      }
+    },
+    "Recipient delivery confirmed through relay": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recipient delivery confirmed through relay"
+          }
+        }
+      }
+    },
+    "Relay delivery attempt failed": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relay delivery attempt failed"
+          }
+        }
+      }
+    },
+    "Relay method selected; relay acceptance is unconfirmed": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relay method selected; relay acceptance is unconfirmed"
+          }
+        }
+      }
+    },
+    "Message was queued, but its local state could not be saved. Do not retry until its delivery outcome is known.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Message was queued, but its local state could not be saved. Do not retry until its delivery outcome is known."
+          }
+        }
+      }
+    },
+    "Relay submission was queued, but its local state could not be saved. Do not retry until its delivery outcome is known.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relay submission was queued, but its local state could not be saved. Do not retry until its delivery outcome is known."
+          }
+        }
+      }
+    },
+    "north": {
+      "comment": "Compass direction shown next to a peer pin distance in the map contact sheet."
+    },
+    "northeast": {
+      "comment": "Compass direction shown next to a peer pin distance in the map contact sheet."
+    },
+    "east": {
+      "comment": "Compass direction shown next to a peer pin distance in the map contact sheet."
+    },
+    "southeast": {
+      "comment": "Compass direction shown next to a peer pin distance in the map contact sheet."
+    },
+    "south": {
+      "comment": "Compass direction shown next to a peer pin distance in the map contact sheet."
+    },
+    "southwest": {
+      "comment": "Compass direction shown next to a peer pin distance in the map contact sheet."
+    },
+    "west": {
+      "comment": "Compass direction shown next to a peer pin distance in the map contact sheet."
+    },
+    "northwest": {
+      "comment": "Compass direction shown next to a peer pin distance in the map contact sheet."
+    },
+    "Location unknown": {
+      "comment": "Distance line in the map contact sheet when the user has not granted or is not yet providing a location."
+    },
+    "Updated just now": {
+      "comment": "Relative last-update line for a peer location that arrived in the last few seconds."
+    },
+    "Updated %llds ago": {
+      "comment": "Relative last-update line, seconds. %lld is the whole-second count."
+    },
+    "Updated %lldm ago": {
+      "comment": "Relative last-update line, minutes. %lld is the whole-minute count."
+    },
+    "Updated %lldh ago": {
+      "comment": "Relative last-update line, hours. %lld is the whole-hour count."
+    },
+    "Updated %lldd ago": {
+      "comment": "Relative last-update line, days. %lld is the whole-day count."
+    },
+    "Stale": {
+      "comment": "Badge on the profile icon in the map contact sheet when the peer location is outside the freshness window."
+    },
+    "Directions": {
+      "comment": "Action button label in the map peer contact sheet."
+    },
+    "Message": {
+      "comment": "Action button label in the map peer contact sheet; routes to the peer chat."
+    },
+    "Remove from map": {
+      "comment": "Action button label in the map peer contact sheet; hides this peer until it reports again."
+    },
+    "Open Directions in:": {
+      "comment": "Title of the confirmation dialog choosing the directions app when both Apple Maps and Google Maps are available."
+    },
+    "Apple Maps": {
+      "comment": "Name of the Apple Maps option in the directions chooser."
+    },
+    "Google Maps": {
+      "comment": "Name of the Google Maps option in the directions chooser."
+    },
+    "Select Voice Message Quality": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select Voice Message Quality"
+          }
+        }
+      }
+    },
+    "Choose the recording format and bandwidth": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose the recording format and bandwidth"
+          }
+        }
+      }
+    },
+    "Record": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Record"
+          }
+        }
+      }
+    },
+    "Codec2 1200": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codec2 1200"
+          }
+        }
+      }
+    },
+    "Very low bandwidth voice": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Very low bandwidth voice"
+          }
+        }
+      }
+    },
+    "Codec2 2400": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codec2 2400"
+          }
+        }
+      }
+    },
+    "Low bandwidth voice": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Low bandwidth voice"
+          }
+        }
+      }
+    },
+    "Codec2 3200": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codec2 3200"
+          }
+        }
+      }
+    },
+    "Clearer speech at low bandwidth": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clearer speech at low bandwidth"
+          }
+        }
+      }
+    },
+    "Medium Quality": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Medium Quality"
+          }
+        }
+      }
+    },
+    "Opus 8 kbps mono - good balance of quality and bandwidth": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opus 8 kbps mono - good balance of quality and bandwidth"
+          }
+        }
+      }
+    },
+    "High Quality": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "High Quality"
+          }
+        }
+      }
+    },
+    "Opus 16 kbps mono - higher fidelity audio": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opus 16 kbps mono - higher fidelity audio"
+          }
+        }
+      }
+    },
+    "Maximum Quality": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maximum Quality"
+          }
+        }
+      }
+    },
+    "Opus 32 kbps stereo - best audio, requires more bandwidth": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opus 32 kbps stereo - best audio, requires more bandwidth"
+          }
+        }
+      }
+    },
+    "Voice": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voice"
+          }
+        }
+      }
+    },
+    "Record a voice message": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Record a voice message"
+          }
+        }
+      }
+    },
+    "Voice message": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voice message"
+          }
+        }
+      }
+    },
+    "Start recording": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start recording"
+          }
+        }
+      }
+    },
+    "Stop recording": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stop recording"
+          }
+        }
+      }
+    },
+    "Cancel recording": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel recording"
+          }
+        }
+      }
+    },
+    "Remove recording": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove recording"
+          }
+        }
+      }
+    },
+    "Microphone permission is required to record a voice message.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Microphone permission is required to record a voice message."
+          }
+        }
+      }
+    },
+    "Voice messages are not supported on this device.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voice messages are not supported on this device."
+          }
+        }
+      }
+    },
+    "Recording": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recording"
+          }
+        }
+      }
+    },
+    "Finalizing": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finalizing"
+          }
+        }
+      }
+    },
+    "Selected voice message": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selected voice message"
+          }
+        }
+      }
+    },
+    "Recording error: %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recording error: %@"
+          }
+        }
+      }
+    },
+    "Ready to record a voice message": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ready to record a voice message"
+          }
+        }
+      }
+    },
+    "Grant microphone access": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grant microphone access"
+          }
+        }
+      }
+    },
+    "Microphone access is disabled. Enable it in app settings.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Microphone access is disabled. Enable it in app settings."
+          }
+        }
+      }
+    },
+    "Open settings": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open settings"
+          }
+        }
+      }
+    },
+    "Voice recording is unavailable during a call.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voice recording is unavailable during a call."
+          }
+        }
+      }
+    },
+    "Play voice message": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Play voice message"
+          }
+        }
+      }
+    },
+    "Pause voice message": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pause voice message"
+          }
+        }
+      }
+    },
+    "Loading voice message": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading voice message"
+          }
+        }
+      }
+    },
+    "Voice message unavailable": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voice message unavailable"
+          }
+        }
+      }
+    },
+    "Unsupported voice message": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unsupported voice message"
+          }
+        }
+      }
+    },
+    "%@ of %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ of %@"
+          }
+        }
+      }
+    },
+    "Unable to play voice message": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to play voice message"
+          }
+        }
+      }
+    },
+    "Voice message recording produced no audio.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voice message recording produced no audio."
+          }
+        }
+      }
+    },
+    "Text": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Text"
+          }
+        }
+      }
+    },
+    "Clear history": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear history"
+          }
+        }
+      }
+    },
+    "No Calls Yet": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Calls Yet"
+          }
+        }
+      }
+    },
+    "Incoming and outgoing voice calls will appear here.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Incoming and outgoing voice calls will appear here."
+          }
+        }
+      }
+    },
+    "Call Details": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Call Details"
+          }
+        }
+      }
+    },
+    "Direction": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Direction"
+          }
+        }
+      }
+    },
+    "Outcome": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Outcome"
+          }
+        }
+      }
+    },
+    "Quality profile": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quality profile"
+          }
+        }
+      }
+    },
+    "Attempted": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attempted"
+          }
+        }
+      }
+    },
+    "Ringing": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ringing"
+          }
+        }
+      }
+    },
+    "Connected": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connected"
+          }
+        }
+      }
+    },
+    "Ended": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ended"
+          }
+        }
+      }
+    },
+    "Duration": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duration"
+          }
+        }
+      }
+    },
+    "Local identity": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Local identity"
+          }
+        }
+      }
+    },
+    "Remote identity": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remote identity"
+          }
+        }
+      }
+    },
+    "Call again": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Call again"
+          }
+        }
+      }
+    },
+    "Missed": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Missed"
+          }
+        }
+      }
+    },
+    "Declined": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Declined"
+          }
+        }
+      }
+    },
+    "Rejected": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rejected"
+          }
+        }
+      }
+    },
+    "Busy": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Busy"
+          }
+        }
+      }
+    },
+    "Cancelled": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelled"
+          }
+        }
+      }
+    },
+    "Not connected": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not connected"
+          }
+        }
+      }
+    },
+    "Failed": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed"
+          }
+        }
+      }
+    },
+    "Interrupted": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Interrupted"
+          }
+        }
+      }
+    },
+    "In progress": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "In progress"
+          }
+        }
+      }
+    },
+    "Recovering call status": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recovering call status"
+          }
+        }
+      }
+    },
+    "Search calls": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search calls"
+          }
+        }
+      }
+    },
+    "Couldn't Load Call History": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't Load Call History"
+          }
+        }
+      }
+    },
+    "Retry": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retry"
+          }
+        }
+      }
+    },
+    "No Calls Found": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Calls Found"
+          }
+        }
+      }
+    },
+    "Discovered Interfaces": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Discovered Interfaces"
+          }
+        }
+      }
+    },
+    "Interface Discovery": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Interface Discovery"
+          }
+        }
+      }
+    },
+    "Enable discovery": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable discovery"
+          }
+        }
+      }
+    },
+    "Discovery enabled - no interfaces found yet": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Discovery enabled - no interfaces found yet"
+          }
+        }
+      }
+    },
+    "Off": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Off"
+          }
+        }
+      }
+    },
+    "Bootstrap interfaces": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bootstrap interfaces"
+          }
+        }
+      }
+    },
+    "These auto-detach once discovered interfaces connect.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "These auto-detach once discovered interfaces connect."
+          }
+        }
+      }
+    },
+    "Restarting…": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restarting…"
+          }
+        }
+      }
+    },
+    "Active – discovering interfaces": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Active – discovering interfaces"
+          }
+        }
+      }
+    },
+    "Auto-connect up to %lld discovered interfaces": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto-connect up to %lld discovered interfaces"
+          }
+        }
+      }
+    },
+    "Discovered": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Discovered"
+          }
+        }
+      }
+    },
+    "Available": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Available"
+          }
+        }
+      }
+    },
+    "Unknown": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown"
+          }
+        }
+      }
+    },
+    "Sort": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sort"
+          }
+        }
+      }
+    },
+    "Quality": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quality"
+          }
+        }
+      }
+    },
+    "Nearest": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nearest"
+          }
+        }
+      }
+    },
+    "Search interfaces…": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search interfaces…"
+          }
+        }
+      }
+    },
+    "IFAC only": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IFAC only"
+          }
+        }
+      }
+    },
+    "%lld of %lld": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld of %lld"
+          }
+        }
+      }
+    },
+    "Clear": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear"
+          }
+        }
+      }
+    },
+    "Transport:": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transport:"
+          }
+        }
+      }
+    },
+    "IFAC:": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IFAC:"
+          }
+        }
+      }
+    },
+    "Last heard: %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last heard: %@"
+          }
+        }
+      }
+    },
+    "%lld hops": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld hops"
+          }
+        }
+      }
+    },
+    "Yggdrasil": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yggdrasil"
+          }
+        }
+      }
+    },
+    "All announced fields": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "All announced fields"
+          }
+        }
+      }
+    },
+    "Transport ID": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transport ID"
+          }
+        }
+      }
+    },
+    "Network ID": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Network ID"
+          }
+        }
+      }
+    },
+    "Status code": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Status code"
+          }
+        }
+      }
+    },
+    "Last heard (unix)": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last heard (unix)"
+          }
+        }
+      }
+    },
+    "Heard count": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Heard count"
+          }
+        }
+      }
+    },
+    "Stamp value": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stamp value"
+          }
+        }
+      }
+    },
+    "Reachable on": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reachable on"
+          }
+        }
+      }
+    },
+    "Port": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Port"
+          }
+        }
+      }
+    },
+    "Frequency": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Frequency"
+          }
+        }
+      }
+    },
+    "Bandwidth": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bandwidth"
+          }
+        }
+      }
+    },
+    "Spreading factor": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spreading factor"
+          }
+        }
+      }
+    },
+    "Coding rate": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coding rate"
+          }
+        }
+      }
+    },
+    "Modulation": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modulation"
+          }
+        }
+      }
+    },
+    "Channel": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Channel"
+          }
+        }
+      }
+    },
+    "Latitude": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Latitude"
+          }
+        }
+      }
+    },
+    "Longitude": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Longitude"
+          }
+        }
+      }
+    },
+    "Height": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Height"
+          }
+        }
+      }
+    },
+    "IFAC passphrase": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IFAC passphrase"
+          }
+        }
+      }
+    },
+    "Transport": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transport"
+          }
+        }
+      }
+    },
+    "Discovery hash": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Discovery hash"
+          }
+        }
+      }
+    },
+    "Received at": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Received at"
+          }
+        }
+      }
+    },
+    "Discovered at": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Discovered at"
+          }
+        }
+      }
+    },
+    "Port %lld": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Port %lld"
+          }
+        }
+      }
+    },
+    "Open in Maps": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open in Maps"
+          }
+        }
+      }
+    },
+    "%lld m": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld m"
+          }
+        }
+      }
+    },
+    "%lld interfaces found via RNS Discovery": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld interfaces found via RNS Discovery"
+          }
+        }
+      }
+    },
+    "%.0fm away": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%.0fm away"
+          }
+        }
+      }
+    },
+    "%.1f km away": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%.1f km away"
+          }
+        }
+      }
+    },
+    "Restarting Reticulum…": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restarting Reticulum…"
+          }
+        }
+      }
+    },
+    "No interfaces discovered yet. Enable discovery above to start finding interfaces announced by other RNS nodes.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No interfaces discovered yet. Enable discovery above to start finding interfaces announced by other RNS nodes."
+          }
+        }
+      }
+    },
+    "No interfaces match your filters.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No interfaces match your filters."
+          }
+        }
+      }
+    },
+    "Clear filters": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear filters"
+          }
+        }
+      }
+    },
+    "Add to Config": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add to Config"
+          }
+        }
+      }
+    },
+    "Copy LoRa Params": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy LoRa Params"
+          }
+        }
+      }
+    },
+    "Use for RNode": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use for RNode"
+          }
+        }
+      }
+    },
+    "Copied": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copied"
+          }
+        }
+      }
+    },
+    "Restart failed — discovery settings were not applied.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restart failed — discovery settings were not applied."
+          }
+        }
+      }
+    },
+    "Discovers interfaces announced by other RNS nodes. Changes take effect after you tap Apply and Restart.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Discovers interfaces announced by other RNS nodes. Changes take effect after you tap Apply and Restart."
+          }
+        }
+      }
+    },
+    "Changes pending — tap Apply and Restart": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Changes pending — tap Apply and Restart"
+          }
+        }
+      }
+    },
+    "Apply and Restart": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apply and Restart"
+          }
+        }
+      }
+    },
+    "Discard": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Discard"
+          }
+        }
+      }
+    },
+    "IFAC network name": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IFAC network name"
+          }
+        }
+      }
+    },
+    "Via discovery": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Via discovery"
+          }
+        }
+      }
+    },
+    "Auto-connected from discovery": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto-connected from discovery"
+          }
+        }
+      }
+    },
+    "Endpoint": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Endpoint"
+          }
+        }
+      }
+    },
+    "Source": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Source"
+          }
+        }
+      }
+    },
+    "Saved. Applies on the next app relaunch because an AutoInterface is active.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Saved. Applies on the next app relaunch because an AutoInterface is active."
+          }
+        }
+      }
+    },
+    "Interface discovery is unavailable in this build.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Interface discovery is unavailable in this build."
+          }
+        }
+      }
+    },
+    "Contact": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contact"
+          }
+        }
+      }
+    },
+    "Contact:": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contact:"
+          }
+        }
+      }
+    }
+  },
+  "version": "1.0"
 }

--- a/Sources/ColumbaApp/Resources/Localizable.xcstrings
+++ b/Sources/ColumbaApp/Resources/Localizable.xcstrings
@@ -1,2970 +1,3010 @@
 {
-  "sourceLanguage": "en",
-  "strings": {
-    "Common causes include an unavailable route, an offline recipient, or a delivery timeout. Check your interfaces and try again.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Common causes include an unavailable route, an offline recipient, or a delivery timeout. Check your interfaces and try again."
-          }
-        }
-      }
-    },
-    "Message delivery failed": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Message delivery failed"
-          }
-        }
-      }
-    },
-    "No delivery confirmation": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No delivery confirmation"
-          }
-        }
-      }
-    },
-    "No relay is selected. Select a relay in Message Delivery and Retrieval, then try again.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No relay is selected. Select a relay in Message Delivery and Retrieval, then try again."
-          }
-        }
-      }
-    },
-    "Shows delivery failure details": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shows delivery failure details"
-          }
-        }
-      }
-    },
-    "No active interface": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No active interface"
-          }
-        }
-      }
-    },
-    "Interfaces:": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Interfaces:"
-          }
-        }
-      }
-    },
-    "TCP": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "TCP"
-          }
-        }
-      }
-    },
-    "TCP Server": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "TCP Server"
-          }
-        }
-      }
-    },
-    "Tap to configure RNS 1.1.x interface discovery": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tap to configure RNS 1.1.x interface discovery"
-          }
-        }
-      }
-    },
-    "Manage": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Manage"
-          }
-        }
-      }
-    },
-    "Manage Interfaces": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Manage Interfaces"
-          }
-        }
-      }
-    },
-    "No Interfaces Connected": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No Interfaces Connected"
-          }
-        }
-      }
-    },
-    "Opens network interface settings": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Opens network interface settings"
-          }
-        }
-      }
-    },
-    "A relay helps your device reach Reticulum peers over the internet. It transports encrypted Reticulum traffic — it does not create an account or hold your identity. We've selected a recommended default.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A relay helps your device reach Reticulum peers over the internet. It transports encrypted Reticulum traffic — it does not create an account or hold your identity. We've selected a recommended default."
-          }
-        }
-      }
-    },
-    "Allow Columba to alert you after it receives:": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Allow Columba to alert you after it receives:"
-          }
-        }
-      }
-    },
-    "Allow notifications to stay informed": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Allow notifications to stay informed"
-          }
-        }
-      }
-    },
-    "Another Columba user can scan this public contact code to add you. It does not contain your private identity keys.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Another Columba user can scan this public contact code to add you. It does not contain your private identity keys."
-          }
-        }
-      }
-    },
-    "Apple devices only, no Wi-Fi needed": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Apple devices only, no Wi-Fi needed"
-          }
-        }
-      }
-    },
-    "BLE": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "BLE"
-          }
-        }
-      }
-    },
-    "Back": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Back"
-          }
-        }
-      }
-    },
-    "Background Delivery": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Background Delivery"
-          }
-        }
-      }
-    },
-    "Backup Contents": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Backup Contents"
-          }
-        }
-      }
-    },
-    "Bluetooth": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bluetooth"
-          }
-        }
-      }
-    },
-    "Bluetooth LE": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bluetooth LE"
-          }
-        }
-      }
-    },
-    "Bluetooth access is requested only if you select Bluetooth LE. RNode access is requested later during radio setup.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bluetooth access is requested only if you select Bluetooth LE. RNode access is requested later during radio setup."
-          }
-        }
-      }
-    },
-    "Cancel": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel"
-          }
-        }
-      }
-    },
-    "Choose a Display Name": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Choose a Display Name"
-          }
-        }
-      }
-    },
-    "Choose a relay": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Choose a relay"
-          }
-        }
-      }
-    },
-    "Close": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Close"
-          }
-        }
-      }
-    },
-    "Columba creates a private cryptographic identity on your device. You control it — and can protect it with an encrypted backup.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Columba creates a private cryptographic identity on your device. You control it — and can protect it with an encrypted backup."
-          }
-        }
-      }
-    },
-    "Columba generates the private cryptographic identity. This name does not need to be unique, and you can change it anytime.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Columba generates the private cryptographic identity. This name does not need to be unique, and you can change it anytime."
-          }
-        }
-      }
-    },
-    "Columba uses Apple's VPN system to keep its own network component available in the background. It is not a commercial VPN service.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Columba uses Apple's VPN system to keep its own network component available in the background. It is not a commercial VPN service."
-          }
-        }
-      }
-    },
-    "Configure in Settings after setup": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Configure in Settings after setup"
-          }
-        }
-      }
-    },
-    "Connect directly to nearby Columba devices": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connect directly to nearby Columba devices"
-          }
-        }
-      }
-    },
-    "Connect directly with nearby Apple devices": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connect directly with nearby Apple devices"
-          }
-        }
-      }
-    },
-    "Continue": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Continue"
-          }
-        }
-      }
-    },
-    "Decrypt": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Decrypt"
-          }
-        }
-      }
-    },
-    "Disabled": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Disabled"
-          }
-        }
-      }
-    },
-    "Done": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Done"
-          }
-        }
-      }
-    },
-    "Enable": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enable"
-          }
-        }
-      }
-    },
-    "Enable Background Delivery": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enable Background Delivery"
-          }
-        }
-      }
-    },
-    "Enabled": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enabled"
-          }
-        }
-      }
-    },
-    "Enter Backup Password": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enter Backup Password"
-          }
-        }
-      }
-    },
-    "Existing identities and messages will not be duplicated. Conversation details and app settings may be updated from this backup.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Existing identities and messages will not be duplicated. Conversation details and app settings may be updated from this backup."
-          }
-        }
-      }
-    },
-    "Generating identity...": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Generating identity..."
-          }
-        }
-      }
-    },
-    "Get Started": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Get Started"
-          }
-        }
-      }
-    },
-    "How will you connect?": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "How will you connect?"
-          }
-        }
-      }
-    },
-    "Incorrect password. Please try again.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Incorrect password. Please try again."
-          }
-        }
-      }
-    },
-    "Internet Relay": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Internet Relay"
-          }
-        }
-      }
-    },
-    "Internet relay": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Internet relay"
-          }
-        }
-      }
-    },
-    "Internet, local, Bluetooth, and radio connections": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Internet, local, Bluetooth, and radio connections"
-          }
-        }
-      }
-    },
-    "Local Wi-Fi": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Local Wi-Fi"
-          }
-        }
-      }
-    },
-    "Long-range mesh via RNode hardware": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Long-range mesh via RNode hardware"
-          }
-        }
-      }
-    },
-    "Message Alerts": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Message Alerts"
-          }
-        }
-      }
-    },
-    "Nearby": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nearby"
-          }
-        }
-      }
-    },
-    "New messages": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "New messages"
-          }
-        }
-      }
-    },
-    "No Wi-Fi required; iOS will request Bluetooth access": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No Wi-Fi required; iOS will request Bluetooth access"
-          }
-        }
-      }
-    },
-    "No active identity is available.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No active identity is available."
-          }
-        }
-      }
-    },
-    "No central account or sign-up": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No central account or sign-up"
-          }
-        }
-      }
-    },
-    "No internet required; iOS may request Local Network access": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No internet required; iOS may request Local Network access"
-          }
-        }
-      }
-    },
-    "No phone number or email": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No phone number or email"
-          }
-        }
-      }
-    },
-    "Notification permission does not keep Columba connected in the background. You can change access anytime in iOS Settings.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Notification permission does not keep Columba connected in the background. You can change access anytime in iOS Settings."
-          }
-        }
-      }
-    },
-    "Notifications": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Notifications"
-          }
-        }
-      }
-    },
-    "OK": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "OK"
-          }
-        }
-      }
-    },
-    "Optional network and Bluetooth events": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Optional network and Bluetooth events"
-          }
-        }
-      }
-    },
-    "Other Public Relays": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Other Public Relays"
-          }
-        }
-      }
-    },
-    "Please try again.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Please try again."
-          }
-        }
-      }
-    },
-    "Private messaging without a central account": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Private messaging without a central account"
-          }
-        }
-      }
-    },
-    "RNode": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "RNode"
-          }
-        }
-      }
-    },
-    "RNode Radio": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "RNode Radio"
-          }
-        }
-      }
-    },
-    "Reach Reticulum devices on the same network": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reach Reticulum devices on the same network"
-          }
-        }
-      }
-    },
-    "Reach Reticulum peers through a public relay": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reach Reticulum peers through a public relay"
-          }
-        }
-      }
-    },
-    "Reading backup...": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reading backup..."
-          }
-        }
-      }
-    },
-    "Recommended Relays": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recommended Relays"
-          }
-        }
-      }
-    },
-    "Recommended for getting started; requires internet": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recommended for getting started; requires internet"
-          }
-        }
-      }
-    },
-    "Relay server": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Relay server"
-          }
-        }
-      }
-    },
-    "Reopen onboarding without deleting your identity or messages.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reopen onboarding without deleting your identity or messages."
-          }
-        }
-      }
-    },
-    "Restore Backup": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restore Backup"
-          }
-        }
-      }
-    },
-    "Restore Complete!": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restore Complete!"
-          }
-        }
-      }
-    },
-    "Restore Data": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restore Data"
-          }
-        }
-      }
-    },
-    "Restore from backup": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restore from backup"
-          }
-        }
-      }
-    },
-    "Review Setup Guide": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Review Setup Guide"
-          }
-        }
-      }
-    },
-    "Select Server": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Select Server"
-          }
-        }
-      }
-    },
-    "Select Text": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Select Text"
-          }
-        }
-      }
-    },
-    "Select a relay before using propagation": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Select a relay before using propagation"
-          }
-        }
-      }
-    },
-    "Select at least one connection method to continue.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Select at least one connection method to continue."
-          }
-        }
-      }
-    },
-    "Select one or more. You can change these later.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Select one or more. You can change these later."
-          }
-        }
-      }
-    },
-    "Share Your Identity": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Share Your Identity"
-          }
-        }
-      }
-    },
-    "Share your QR code with another Columba user, then create an encrypted backup from Settings.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Share your QR code with another Columba user, then create an encrypted backup from Settings."
-          }
-        }
-      }
-    },
-    "Show QR Code": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Show QR Code"
-          }
-        }
-      }
-    },
-    "Show alerts for received messages and events": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Show alerts for received messages and events"
-          }
-        }
-      }
-    },
-    "The indicator means iOS has an active network extension. It stays visible while Background Delivery is enabled.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The indicator means iOS has an active network extension. It stays visible while Background Delivery is enabled."
-          }
-        }
-      }
-    },
-    "The indicator means iOS has an active network extension. It stays visible while Background Transport is enabled.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The indicator means iOS has an active network extension. It stays visible while Background Transport is enabled."
-          }
-        }
-      }
-    },
-    "This backup is encrypted. Enter the password used when creating it.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This backup is encrypted. Enter the password used when creating it."
-          }
-        }
-      }
-    },
-    "This is the changeable name other people will see.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This is the changeable name other people will see."
-          }
-        }
-      }
-    },
-    "Try Again": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Try Again"
-          }
-        }
-      }
-    },
-    "Unable to Open Setup": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unable to Open Setup"
-          }
-        }
-      }
-    },
-    "Use Defaults": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Use Defaults"
-          }
-        }
-      }
-    },
-    "VPN": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "VPN"
-          }
-        }
-      }
-    },
-    "Welcome to Columba": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Welcome to Columba"
-          }
-        }
-      }
-    },
-    "While this is on, iOS shows a VPN indicator.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "While this is on, iOS shows a VPN indicator."
-          }
-        }
-      }
-    },
-    "Wi-Fi": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wi-Fi"
-          }
-        }
-      }
-    },
-    "You can choose another relay later in Settings.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "You can choose another relay later in Settings."
-          }
-        }
-      }
-    },
-    "You're all set!": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "You're all set!"
-          }
-        }
-      }
-    },
-    "iOS Notifications": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "iOS Notifications"
-          }
-        }
-      }
-    },
-    "iOS uses its VPN system to let Columba's network component continue running when the app is not open. Only traffic from Columba and Reticulum uses this component; your other apps and web traffic are not routed through Columba.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "iOS uses its VPN system to let Columba's network component continue running when the app is not open. Only traffic from Columba and Reticulum uses this component; your other apps and web traffic are not routed through Columba."
-          }
-        }
-      }
-    },
-    "iOS will ask you to allow the configuration and will show a VPN indicator while Background Delivery is enabled. Delivery still depends on available Reticulum connections.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "iOS will ask you to allow the configuration and will show a VPN indicator while Background Delivery is enabled. Delivery still depends on available Reticulum connections."
-          }
-        }
-      }
-    },
-    "Your Display Name": {
-      "comment": "Read-only heading shown while reviewing an existing setup."
-    },
-    "Current relay": {
-      "comment": "Read-only heading for the relay shown during setup review."
-    },
-    "This is the relay currently configured for Columba. You can change it later in Settings.": {
-      "comment": "Explains that setup review does not edit the relay."
-    },
-    "Current connections": {
-      "comment": "Read-only heading for connection methods shown during setup review."
-    },
-    "This setup review is read-only. Change connection methods in Settings.": {
-      "comment": "Explains where connection methods can be edited."
-    },
-    "Setup Guide Reviewed": {
-      "comment": "Heading after completing a read-only setup review."
-    },
-    "iOS Notification Permission": {
-      "comment": "Label for the operating-system notification authorization status."
-    },
-    "Allowed": {
-      "comment": "Status indicating an iOS permission is allowed."
-    },
-    "Not Allowed": {
-      "comment": "Status indicating an iOS permission is not allowed."
-    },
-    "Text Size": {
-      "comment": "Conversation action and picker title for changing primary message-body text size."
-    },
-    "Preview message text": {
-      "comment": "Sample message shown in the conversation text-size picker."
-    },
-    "Message text size": {
-      "comment": "VoiceOver label for the conversation message text-size slider."
-    },
-    "Minimum text size": {
-      "comment": "VoiceOver label for the small endpoint in the message text-size range."
-    },
-    "Maximum text size": {
-      "comment": "VoiceOver label for the large endpoint in the message text-size range."
-    },
-    "%lld percent": {
-      "comment": "VoiceOver value announcing the selected message text-size percentage."
-    },
-    "Image attachment": {
-      "comment": "VoiceOver label for an image attached to a chat message."
-    },
-    "File attachment: %@": {
-      "comment": "VoiceOver label for a file attached to a chat message. The placeholder is the sender-provided display name."
-    },
-    "Opens attachment preview": {
-      "comment": "VoiceOver hint for tappable image and file attachment controls."
-    },
-    "Unable to Open Attachment": {
-      "comment": "Error alert title when a message attachment cannot be prepared for preview."
-    },
-    "The attachment could not be prepared for preview.": {
-      "comment": "Privacy-safe error text shown when temporary attachment export fails."
-    },
-    "Type a message...": {
-      "comment": "Placeholder and VoiceOver label for the message composer.",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Type a message..."
-          }
-        }
-      }
-    },
-    "Enter Key Sends Message": {
-      "comment": "Settings toggle controlling whether the on-screen keyboard Enter key sends the current message.",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enter Key Sends Message"
-          }
-        }
-      }
-    },
-    "Messaging": {
-      "comment": "Title of the settings card containing message composition preferences.",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Messaging"
-          }
-        }
-      }
-    },
-    "Press Enter to send. Turn this off when you want Enter to insert new lines.": {
-      "comment": "Explanation shown when the message composer Enter key sends messages.",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Press Enter to send. Turn this off when you want Enter to insert new lines."
-          }
-        }
-      }
-    },
-    "Press Enter to insert a new line. Use the send button to send the message.": {
-      "comment": "Explanation shown when the message composer Enter key inserts a line break.",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Press Enter to insert a new line. Use the send button to send the message."
-          }
-        }
-      }
-    },
-    "Messages from contacts only": {
-      "comment": "Label for the privacy control that rejects messages from unknown senders.",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Messages from contacts only"
-          }
-        }
-      }
-    },
-    "Only contacts can message you. Messages from unknown senders are silently discarded.": {
-      "comment": "Privacy explanation shown when messages from unknown senders are blocked.",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Only contacts can message you. Messages from unknown senders are silently discarded."
-          }
-        }
-      }
-    },
-    "Anyone can send you messages, including unknown senders.": {
-      "comment": "Privacy explanation shown when messages from unknown senders are allowed.",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Anyone can send you messages, including unknown senders."
-          }
-        }
-      }
-    },
-    "Announce to Network": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Announce to Network"
-          }
-        }
-      }
-    },
-    "Announced": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Announced"
-          }
-        }
-      }
-    },
-    "Broadcasts your identity so nearby peers can discover you": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Broadcasts your identity so nearby peers can discover you"
-          }
-        }
-      }
-    },
-    "Send Announce": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Send Announce"
-          }
-        }
-      }
-    },
-    "Pending send": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pending send"
-          }
-        }
-      }
-    },
-    "Sending to relay": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sending to relay"
-          }
-        }
-      }
-    },
-    "Stored on relay": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stored on relay"
-          }
-        }
-      }
-    },
-    "Pending": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pending"
-          }
-        }
-      }
-    },
-    "Queued locally; no transport confirmation yet": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Queued locally; no transport confirmation yet"
-          }
-        }
-      }
-    },
-    "Sending to Relay": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sending to Relay"
-          }
-        }
-      }
-    },
-    "Submitting through the selected relay": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Submitting through the selected relay"
-          }
-        }
-      }
-    },
-    "Stored on Relay": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stored on Relay"
-          }
-        }
-      }
-    },
-    "Relay accepted the message; recipient delivery is not confirmed": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Relay accepted the message; recipient delivery is not confirmed"
-          }
-        }
-      }
-    },
-    "Submitting to the selected relay": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Submitting to the selected relay"
-          }
-        }
-      }
-    },
-    "Stored by relay; awaiting recipient delivery": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stored by relay; awaiting recipient delivery"
-          }
-        }
-      }
-    },
-    "Recipient delivery confirmed through relay": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recipient delivery confirmed through relay"
-          }
-        }
-      }
-    },
-    "Relay delivery attempt failed": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Relay delivery attempt failed"
-          }
-        }
-      }
-    },
-    "Relay method selected; relay acceptance is unconfirmed": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Relay method selected; relay acceptance is unconfirmed"
-          }
-        }
-      }
-    },
-    "Message was queued, but its local state could not be saved. Do not retry until its delivery outcome is known.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Message was queued, but its local state could not be saved. Do not retry until its delivery outcome is known."
-          }
-        }
-      }
-    },
-    "Relay submission was queued, but its local state could not be saved. Do not retry until its delivery outcome is known.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Relay submission was queued, but its local state could not be saved. Do not retry until its delivery outcome is known."
-          }
-        }
-      }
-    },
-    "north": {
-      "comment": "Compass direction shown next to a peer pin distance in the map contact sheet."
-    },
-    "northeast": {
-      "comment": "Compass direction shown next to a peer pin distance in the map contact sheet."
-    },
-    "east": {
-      "comment": "Compass direction shown next to a peer pin distance in the map contact sheet."
-    },
-    "southeast": {
-      "comment": "Compass direction shown next to a peer pin distance in the map contact sheet."
-    },
-    "south": {
-      "comment": "Compass direction shown next to a peer pin distance in the map contact sheet."
-    },
-    "southwest": {
-      "comment": "Compass direction shown next to a peer pin distance in the map contact sheet."
-    },
-    "west": {
-      "comment": "Compass direction shown next to a peer pin distance in the map contact sheet."
-    },
-    "northwest": {
-      "comment": "Compass direction shown next to a peer pin distance in the map contact sheet."
-    },
-    "Location unknown": {
-      "comment": "Distance line in the map contact sheet when the user has not granted or is not yet providing a location."
-    },
-    "Updated just now": {
-      "comment": "Relative last-update line for a peer location that arrived in the last few seconds."
-    },
-    "Updated %llds ago": {
-      "comment": "Relative last-update line, seconds. %lld is the whole-second count."
-    },
-    "Updated %lldm ago": {
-      "comment": "Relative last-update line, minutes. %lld is the whole-minute count."
-    },
-    "Updated %lldh ago": {
-      "comment": "Relative last-update line, hours. %lld is the whole-hour count."
-    },
-    "Updated %lldd ago": {
-      "comment": "Relative last-update line, days. %lld is the whole-day count."
-    },
-    "Stale": {
-      "comment": "Badge on the profile icon in the map contact sheet when the peer location is outside the freshness window."
-    },
-    "Directions": {
-      "comment": "Action button label in the map peer contact sheet."
-    },
-    "Message": {
-      "comment": "Action button label in the map peer contact sheet; routes to the peer chat."
-    },
-    "Remove from map": {
-      "comment": "Action button label in the map peer contact sheet; hides this peer until it reports again."
-    },
-    "Open Directions in:": {
-      "comment": "Title of the confirmation dialog choosing the directions app when both Apple Maps and Google Maps are available."
-    },
-    "Apple Maps": {
-      "comment": "Name of the Apple Maps option in the directions chooser."
-    },
-    "Google Maps": {
-      "comment": "Name of the Google Maps option in the directions chooser."
-    },
-    "Select Voice Message Quality": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Select Voice Message Quality"
-          }
-        }
-      }
-    },
-    "Choose the recording format and bandwidth": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Choose the recording format and bandwidth"
-          }
-        }
-      }
-    },
-    "Record": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Record"
-          }
-        }
-      }
-    },
-    "Codec2 1200": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Codec2 1200"
-          }
-        }
-      }
-    },
-    "Very low bandwidth voice": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Very low bandwidth voice"
-          }
-        }
-      }
-    },
-    "Codec2 2400": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Codec2 2400"
-          }
-        }
-      }
-    },
-    "Low bandwidth voice": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Low bandwidth voice"
-          }
-        }
-      }
-    },
-    "Codec2 3200": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Codec2 3200"
-          }
-        }
-      }
-    },
-    "Clearer speech at low bandwidth": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Clearer speech at low bandwidth"
-          }
-        }
-      }
-    },
-    "Medium Quality": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Medium Quality"
-          }
-        }
-      }
-    },
-    "Opus 8 kbps mono - good balance of quality and bandwidth": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Opus 8 kbps mono - good balance of quality and bandwidth"
-          }
-        }
-      }
-    },
-    "High Quality": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "High Quality"
-          }
-        }
-      }
-    },
-    "Opus 16 kbps mono - higher fidelity audio": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Opus 16 kbps mono - higher fidelity audio"
-          }
-        }
-      }
-    },
-    "Maximum Quality": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Maximum Quality"
-          }
-        }
-      }
-    },
-    "Opus 32 kbps stereo - best audio, requires more bandwidth": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Opus 32 kbps stereo - best audio, requires more bandwidth"
-          }
-        }
-      }
-    },
-    "Voice": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voice"
-          }
-        }
-      }
-    },
-    "Record a voice message": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Record a voice message"
-          }
-        }
-      }
-    },
-    "Voice message": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voice message"
-          }
-        }
-      }
-    },
-    "Start recording": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Start recording"
-          }
-        }
-      }
-    },
-    "Stop recording": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stop recording"
-          }
-        }
-      }
-    },
-    "Cancel recording": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel recording"
-          }
-        }
-      }
-    },
-    "Remove recording": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Remove recording"
-          }
-        }
-      }
-    },
-    "Microphone permission is required to record a voice message.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Microphone permission is required to record a voice message."
-          }
-        }
-      }
-    },
-    "Voice messages are not supported on this device.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voice messages are not supported on this device."
-          }
-        }
-      }
-    },
-    "Recording": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recording"
-          }
-        }
-      }
-    },
-    "Finalizing": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Finalizing"
-          }
-        }
-      }
-    },
-    "Selected voice message": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Selected voice message"
-          }
-        }
-      }
-    },
-    "Recording error: %@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recording error: %@"
-          }
-        }
-      }
-    },
-    "Ready to record a voice message": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ready to record a voice message"
-          }
-        }
-      }
-    },
-    "Grant microphone access": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Grant microphone access"
-          }
-        }
-      }
-    },
-    "Microphone access is disabled. Enable it in app settings.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Microphone access is disabled. Enable it in app settings."
-          }
-        }
-      }
-    },
-    "Open settings": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Open settings"
-          }
-        }
-      }
-    },
-    "Voice recording is unavailable during a call.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voice recording is unavailable during a call."
-          }
-        }
-      }
-    },
-    "Play voice message": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Play voice message"
-          }
-        }
-      }
-    },
-    "Pause voice message": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pause voice message"
-          }
-        }
-      }
-    },
-    "Loading voice message": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Loading voice message"
-          }
-        }
-      }
-    },
-    "Voice message unavailable": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voice message unavailable"
-          }
-        }
-      }
-    },
-    "Unsupported voice message": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unsupported voice message"
-          }
-        }
-      }
-    },
-    "%@ of %@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ of %@"
-          }
-        }
-      }
-    },
-    "Unable to play voice message": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unable to play voice message"
-          }
-        }
-      }
-    },
-    "Voice message recording produced no audio.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voice message recording produced no audio."
-          }
-        }
-      }
-    },
-    "Text": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Text"
-          }
-        }
-      }
-    },
-    "Clear history": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Clear history"
-          }
-        }
-      }
-    },
-    "No Calls Yet": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No Calls Yet"
-          }
-        }
-      }
-    },
-    "Incoming and outgoing voice calls will appear here.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Incoming and outgoing voice calls will appear here."
-          }
-        }
-      }
-    },
-    "Call Details": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Call Details"
-          }
-        }
-      }
-    },
-    "Direction": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Direction"
-          }
-        }
-      }
-    },
-    "Outcome": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Outcome"
-          }
-        }
-      }
-    },
-    "Quality profile": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Quality profile"
-          }
-        }
-      }
-    },
-    "Attempted": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Attempted"
-          }
-        }
-      }
-    },
-    "Ringing": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ringing"
-          }
-        }
-      }
-    },
-    "Connected": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connected"
-          }
-        }
-      }
-    },
-    "Ended": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ended"
-          }
-        }
-      }
-    },
-    "Duration": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Duration"
-          }
-        }
-      }
-    },
-    "Local identity": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Local identity"
-          }
-        }
-      }
-    },
-    "Remote identity": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Remote identity"
-          }
-        }
-      }
-    },
-    "Call again": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Call again"
-          }
-        }
-      }
-    },
-    "Missed": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Missed"
-          }
-        }
-      }
-    },
-    "Declined": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Declined"
-          }
-        }
-      }
-    },
-    "Rejected": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rejected"
-          }
-        }
-      }
-    },
-    "Busy": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Busy"
-          }
-        }
-      }
-    },
-    "Cancelled": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancelled"
-          }
-        }
-      }
-    },
-    "Not connected": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Not connected"
-          }
-        }
-      }
-    },
-    "Failed": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed"
-          }
-        }
-      }
-    },
-    "Interrupted": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Interrupted"
-          }
-        }
-      }
-    },
-    "In progress": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "In progress"
-          }
-        }
-      }
-    },
-    "Recovering call status": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recovering call status"
-          }
-        }
-      }
-    },
-    "Search calls": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Search calls"
-          }
-        }
-      }
-    },
-    "Couldn't Load Call History": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't Load Call History"
-          }
-        }
-      }
-    },
-    "Retry": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retry"
-          }
-        }
-      }
-    },
-    "No Calls Found": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No Calls Found"
-          }
-        }
-      }
-    },
-    "Discovered Interfaces": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Discovered Interfaces"
-          }
-        }
-      }
-    },
-    "Interface Discovery": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Interface Discovery"
-          }
-        }
-      }
-    },
-    "Enable discovery": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enable discovery"
-          }
-        }
-      }
-    },
-    "Discovery enabled - no interfaces found yet": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Discovery enabled - no interfaces found yet"
-          }
-        }
-      }
-    },
-    "Off": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Off"
-          }
-        }
-      }
-    },
-    "Bootstrap interfaces": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bootstrap interfaces"
-          }
-        }
-      }
-    },
-    "These auto-detach once discovered interfaces connect.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "These auto-detach once discovered interfaces connect."
-          }
-        }
-      }
-    },
-    "Restarting…": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restarting…"
-          }
-        }
-      }
-    },
-    "Active – discovering interfaces": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Active – discovering interfaces"
-          }
-        }
-      }
-    },
-    "Auto-connect up to %lld discovered interfaces": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Auto-connect up to %lld discovered interfaces"
-          }
-        }
-      }
-    },
-    "Discovered": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Discovered"
-          }
-        }
-      }
-    },
-    "Available": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Available"
-          }
-        }
-      }
-    },
-    "Unknown": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unknown"
-          }
-        }
-      }
-    },
-    "Sort": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sort"
-          }
-        }
-      }
-    },
-    "Quality": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Quality"
-          }
-        }
-      }
-    },
-    "Nearest": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nearest"
-          }
-        }
-      }
-    },
-    "Search interfaces…": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Search interfaces…"
-          }
-        }
-      }
-    },
-    "IFAC only": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "IFAC only"
-          }
-        }
-      }
-    },
-    "%lld of %lld": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld of %lld"
-          }
-        }
-      }
-    },
-    "Clear": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Clear"
-          }
-        }
-      }
-    },
-    "Transport:": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Transport:"
-          }
-        }
-      }
-    },
-    "IFAC:": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "IFAC:"
-          }
-        }
-      }
-    },
-    "Last heard: %@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Last heard: %@"
-          }
-        }
-      }
-    },
-    "%lld hops": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld hops"
-          }
-        }
-      }
-    },
-    "Yggdrasil": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Yggdrasil"
-          }
-        }
-      }
-    },
-    "All announced fields": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "All announced fields"
-          }
-        }
-      }
-    },
-    "Transport ID": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Transport ID"
-          }
-        }
-      }
-    },
-    "Network ID": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Network ID"
-          }
-        }
-      }
-    },
-    "Status code": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Status code"
-          }
-        }
-      }
-    },
-    "Last heard (unix)": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Last heard (unix)"
-          }
-        }
-      }
-    },
-    "Heard count": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Heard count"
-          }
-        }
-      }
-    },
-    "Stamp value": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stamp value"
-          }
-        }
-      }
-    },
-    "Reachable on": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reachable on"
-          }
-        }
-      }
-    },
-    "Port": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Port"
-          }
-        }
-      }
-    },
-    "Frequency": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Frequency"
-          }
-        }
-      }
-    },
-    "Bandwidth": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bandwidth"
-          }
-        }
-      }
-    },
-    "Spreading factor": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Spreading factor"
-          }
-        }
-      }
-    },
-    "Coding rate": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Coding rate"
-          }
-        }
-      }
-    },
-    "Modulation": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Modulation"
-          }
-        }
-      }
-    },
-    "Channel": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Channel"
-          }
-        }
-      }
-    },
-    "Latitude": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Latitude"
-          }
-        }
-      }
-    },
-    "Longitude": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Longitude"
-          }
-        }
-      }
-    },
-    "Height": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Height"
-          }
-        }
-      }
-    },
-    "IFAC passphrase": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "IFAC passphrase"
-          }
-        }
-      }
-    },
-    "Transport": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Transport"
-          }
-        }
-      }
-    },
-    "Discovery hash": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Discovery hash"
-          }
-        }
-      }
-    },
-    "Received at": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Received at"
-          }
-        }
-      }
-    },
-    "Discovered at": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Discovered at"
-          }
-        }
-      }
-    },
-    "Port %lld": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Port %lld"
-          }
-        }
-      }
-    },
-    "Open in Maps": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Open in Maps"
-          }
-        }
-      }
-    },
-    "%lld m": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld m"
-          }
-        }
-      }
-    },
-    "%lld interfaces found via RNS Discovery": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld interfaces found via RNS Discovery"
-          }
-        }
-      }
-    },
-    "%.0fm away": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%.0fm away"
-          }
-        }
-      }
-    },
-    "%.1f km away": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%.1f km away"
-          }
-        }
-      }
-    },
-    "Restarting Reticulum…": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restarting Reticulum…"
-          }
-        }
-      }
-    },
-    "No interfaces discovered yet. Enable discovery above to start finding interfaces announced by other RNS nodes.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No interfaces discovered yet. Enable discovery above to start finding interfaces announced by other RNS nodes."
-          }
-        }
-      }
-    },
-    "No interfaces match your filters.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No interfaces match your filters."
-          }
-        }
-      }
-    },
-    "Clear filters": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Clear filters"
-          }
-        }
-      }
-    },
-    "Add to Config": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Add to Config"
-          }
-        }
-      }
-    },
-    "Copy LoRa Params": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copy LoRa Params"
-          }
-        }
-      }
-    },
-    "Use for RNode": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Use for RNode"
-          }
-        }
-      }
-    },
-    "Copied": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copied"
-          }
-        }
-      }
-    },
-    "Restart failed — discovery settings were not applied.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restart failed — discovery settings were not applied."
-          }
-        }
-      }
-    },
-    "Discovers interfaces announced by other RNS nodes. Changes take effect after you tap Apply and Restart.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Discovers interfaces announced by other RNS nodes. Changes take effect after you tap Apply and Restart."
-          }
-        }
-      }
-    },
-    "Changes pending — tap Apply and Restart": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Changes pending — tap Apply and Restart"
-          }
-        }
-      }
-    },
-    "Apply and Restart": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Apply and Restart"
-          }
-        }
-      }
-    },
-    "Discard": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Discard"
-          }
-        }
-      }
-    },
-    "IFAC network name": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "IFAC network name"
-          }
-        }
-      }
-    },
-    "Via discovery": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Via discovery"
-          }
-        }
-      }
-    },
-    "Auto-connected from discovery": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Auto-connected from discovery"
-          }
-        }
-      }
-    },
-    "Endpoint": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Endpoint"
-          }
-        }
-      }
-    },
-    "Source": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Source"
-          }
-        }
-      }
-    },
-    "Saved. Applies on the next app relaunch because an AutoInterface is active.": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Saved. Applies on the next app relaunch because an AutoInterface is active."
-          }
-        }
-      }
-    },
-    "Interface discovery is unavailable in this build.": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Interface discovery is unavailable in this build."
-          }
-        }
-      }
-    },
-    "Contact": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Contact"
-          }
-        }
-      }
-    },
-    "Contact:": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Contact:"
-          }
-        }
-      }
-    }
-  },
-  "version": "1.0"
+    "sourceLanguage": "en",
+    "strings": {
+        "Common causes include an unavailable route, an offline recipient, or a delivery timeout. Check your interfaces and try again.": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Common causes include an unavailable route, an offline recipient, or a delivery timeout. Check your interfaces and try again."
+                    }
+                }
+            }
+        },
+        "Message delivery failed": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Message delivery failed"
+                    }
+                }
+            }
+        },
+        "No delivery confirmation": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "No delivery confirmation"
+                    }
+                }
+            }
+        },
+        "No relay is selected. Select a relay in Message Delivery and Retrieval, then try again.": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "No relay is selected. Select a relay in Message Delivery and Retrieval, then try again."
+                    }
+                }
+            }
+        },
+        "Shows delivery failure details": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Shows delivery failure details"
+                    }
+                }
+            }
+        },
+        "No active interface": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "No active interface"
+                    }
+                }
+            }
+        },
+        "Interfaces:": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Interfaces:"
+                    }
+                }
+            }
+        },
+        "TCP": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "TCP"
+                    }
+                }
+            }
+        },
+        "TCP Server": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "TCP Server"
+                    }
+                }
+            }
+        },
+        "Tap to configure RNS 1.1.x interface discovery": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Tap to configure RNS 1.1.x interface discovery"
+                    }
+                }
+            }
+        },
+        "Manage": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Manage"
+                    }
+                }
+            }
+        },
+        "Manage Interfaces": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Manage Interfaces"
+                    }
+                }
+            }
+        },
+        "No Interfaces Connected": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "No Interfaces Connected"
+                    }
+                }
+            }
+        },
+        "Opens network interface settings": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Opens network interface settings"
+                    }
+                }
+            }
+        },
+        "A relay helps your device reach Reticulum peers over the internet. It transports encrypted Reticulum traffic — it does not create an account or hold your identity. We've selected a recommended default.": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "A relay helps your device reach Reticulum peers over the internet. It transports encrypted Reticulum traffic — it does not create an account or hold your identity. We've selected a recommended default."
+                    }
+                }
+            }
+        },
+        "Allow Columba to alert you after it receives:": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Allow Columba to alert you after it receives:"
+                    }
+                }
+            }
+        },
+        "Allow notifications to stay informed": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Allow notifications to stay informed"
+                    }
+                }
+            }
+        },
+        "Another Columba user can scan this public contact code to add you. It does not contain your private identity keys.": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Another Columba user can scan this public contact code to add you. It does not contain your private identity keys."
+                    }
+                }
+            }
+        },
+        "Apple devices only, no Wi-Fi needed": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Apple devices only, no Wi-Fi needed"
+                    }
+                }
+            }
+        },
+        "BLE": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "BLE"
+                    }
+                }
+            }
+        },
+        "Back": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Back"
+                    }
+                }
+            }
+        },
+        "Background Delivery": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Background Delivery"
+                    }
+                }
+            }
+        },
+        "Backup Contents": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Backup Contents"
+                    }
+                }
+            }
+        },
+        "Bluetooth": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Bluetooth"
+                    }
+                }
+            }
+        },
+        "Bluetooth LE": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Bluetooth LE"
+                    }
+                }
+            }
+        },
+        "Bluetooth access is requested only if you select Bluetooth LE. RNode access is requested later during radio setup.": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Bluetooth access is requested only if you select Bluetooth LE. RNode access is requested later during radio setup."
+                    }
+                }
+            }
+        },
+        "Cancel": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Cancel"
+                    }
+                }
+            }
+        },
+        "Choose a Display Name": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Choose a Display Name"
+                    }
+                }
+            }
+        },
+        "Choose a relay": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Choose a relay"
+                    }
+                }
+            }
+        },
+        "Close": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Close"
+                    }
+                }
+            }
+        },
+        "Columba creates a private cryptographic identity on your device. You control it — and can protect it with an encrypted backup.": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Columba creates a private cryptographic identity on your device. You control it — and can protect it with an encrypted backup."
+                    }
+                }
+            }
+        },
+        "Columba generates the private cryptographic identity. This name does not need to be unique, and you can change it anytime.": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Columba generates the private cryptographic identity. This name does not need to be unique, and you can change it anytime."
+                    }
+                }
+            }
+        },
+        "Columba uses Apple's VPN system to keep its own network component available in the background. It is not a commercial VPN service.": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Columba uses Apple's VPN system to keep its own network component available in the background. It is not a commercial VPN service."
+                    }
+                }
+            }
+        },
+        "Configure in Settings after setup": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Configure in Settings after setup"
+                    }
+                }
+            }
+        },
+        "Connect directly to nearby Columba devices": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Connect directly to nearby Columba devices"
+                    }
+                }
+            }
+        },
+        "Connect directly with nearby Apple devices": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Connect directly with nearby Apple devices"
+                    }
+                }
+            }
+        },
+        "Continue": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Continue"
+                    }
+                }
+            }
+        },
+        "Decrypt": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Decrypt"
+                    }
+                }
+            }
+        },
+        "Disabled": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Disabled"
+                    }
+                }
+            }
+        },
+        "Done": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Done"
+                    }
+                }
+            }
+        },
+        "Enable": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Enable"
+                    }
+                }
+            }
+        },
+        "Enable Background Delivery": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Enable Background Delivery"
+                    }
+                }
+            }
+        },
+        "Enabled": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Enabled"
+                    }
+                }
+            }
+        },
+        "Enter Backup Password": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Enter Backup Password"
+                    }
+                }
+            }
+        },
+        "Existing identities and messages will not be duplicated. Conversation details and app settings may be updated from this backup.": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Existing identities and messages will not be duplicated. Conversation details and app settings may be updated from this backup."
+                    }
+                }
+            }
+        },
+        "Generating identity...": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Generating identity..."
+                    }
+                }
+            }
+        },
+        "Get Started": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Get Started"
+                    }
+                }
+            }
+        },
+        "How will you connect?": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "How will you connect?"
+                    }
+                }
+            }
+        },
+        "Incorrect password. Please try again.": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Incorrect password. Please try again."
+                    }
+                }
+            }
+        },
+        "Internet Relay": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Internet Relay"
+                    }
+                }
+            }
+        },
+        "Internet relay": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Internet relay"
+                    }
+                }
+            }
+        },
+        "Internet, local, Bluetooth, and radio connections": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Internet, local, Bluetooth, and radio connections"
+                    }
+                }
+            }
+        },
+        "Local Wi-Fi": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Local Wi-Fi"
+                    }
+                }
+            }
+        },
+        "Long-range mesh via RNode hardware": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Long-range mesh via RNode hardware"
+                    }
+                }
+            }
+        },
+        "Message Alerts": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Message Alerts"
+                    }
+                }
+            }
+        },
+        "Nearby": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Nearby"
+                    }
+                }
+            }
+        },
+        "New messages": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "New messages"
+                    }
+                }
+            }
+        },
+        "No Wi-Fi required; iOS will request Bluetooth access": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "No Wi-Fi required; iOS will request Bluetooth access"
+                    }
+                }
+            }
+        },
+        "No active identity is available.": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "No active identity is available."
+                    }
+                }
+            }
+        },
+        "No central account or sign-up": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "No central account or sign-up"
+                    }
+                }
+            }
+        },
+        "No internet required; iOS may request Local Network access": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "No internet required; iOS may request Local Network access"
+                    }
+                }
+            }
+        },
+        "No phone number or email": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "No phone number or email"
+                    }
+                }
+            }
+        },
+        "Notification permission does not keep Columba connected in the background. You can change access anytime in iOS Settings.": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Notification permission does not keep Columba connected in the background. You can change access anytime in iOS Settings."
+                    }
+                }
+            }
+        },
+        "Notifications": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Notifications"
+                    }
+                }
+            }
+        },
+        "OK": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "OK"
+                    }
+                }
+            }
+        },
+        "Optional network and Bluetooth events": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Optional network and Bluetooth events"
+                    }
+                }
+            }
+        },
+        "Other Public Relays": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Other Public Relays"
+                    }
+                }
+            }
+        },
+        "Please try again.": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Please try again."
+                    }
+                }
+            }
+        },
+        "Private messaging without a central account": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Private messaging without a central account"
+                    }
+                }
+            }
+        },
+        "RNode": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "RNode"
+                    }
+                }
+            }
+        },
+        "RNode Radio": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "RNode Radio"
+                    }
+                }
+            }
+        },
+        "Reach Reticulum devices on the same network": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Reach Reticulum devices on the same network"
+                    }
+                }
+            }
+        },
+        "Reach Reticulum peers through a public relay": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Reach Reticulum peers through a public relay"
+                    }
+                }
+            }
+        },
+        "Reading backup...": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Reading backup..."
+                    }
+                }
+            }
+        },
+        "Recommended Relays": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Recommended Relays"
+                    }
+                }
+            }
+        },
+        "Recommended for getting started; requires internet": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Recommended for getting started; requires internet"
+                    }
+                }
+            }
+        },
+        "Relay server": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Relay server"
+                    }
+                }
+            }
+        },
+        "Reopen onboarding without deleting your identity or messages.": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Reopen onboarding without deleting your identity or messages."
+                    }
+                }
+            }
+        },
+        "Restore Backup": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Restore Backup"
+                    }
+                }
+            }
+        },
+        "Restore Complete!": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Restore Complete!"
+                    }
+                }
+            }
+        },
+        "Restore Data": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Restore Data"
+                    }
+                }
+            }
+        },
+        "Restore from backup": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Restore from backup"
+                    }
+                }
+            }
+        },
+        "Review Setup Guide": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Review Setup Guide"
+                    }
+                }
+            }
+        },
+        "Select Server": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Select Server"
+                    }
+                }
+            }
+        },
+        "Select Text": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Select Text"
+                    }
+                }
+            }
+        },
+        "Select a relay before using propagation": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Select a relay before using propagation"
+                    }
+                }
+            }
+        },
+        "Select at least one connection method to continue.": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Select at least one connection method to continue."
+                    }
+                }
+            }
+        },
+        "Select one or more. You can change these later.": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Select one or more. You can change these later."
+                    }
+                }
+            }
+        },
+        "Share Your Identity": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Share Your Identity"
+                    }
+                }
+            }
+        },
+        "Share your QR code with another Columba user, then create an encrypted backup from Settings.": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Share your QR code with another Columba user, then create an encrypted backup from Settings."
+                    }
+                }
+            }
+        },
+        "Show QR Code": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Show QR Code"
+                    }
+                }
+            }
+        },
+        "Show alerts for received messages and events": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Show alerts for received messages and events"
+                    }
+                }
+            }
+        },
+        "The indicator means iOS has an active network extension. It stays visible while Background Delivery is enabled.": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "The indicator means iOS has an active network extension. It stays visible while Background Delivery is enabled."
+                    }
+                }
+            }
+        },
+        "The indicator means iOS has an active network extension. It stays visible while Background Transport is enabled.": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "The indicator means iOS has an active network extension. It stays visible while Background Transport is enabled."
+                    }
+                }
+            }
+        },
+        "This backup is encrypted. Enter the password used when creating it.": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "This backup is encrypted. Enter the password used when creating it."
+                    }
+                }
+            }
+        },
+        "This is the changeable name other people will see.": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "This is the changeable name other people will see."
+                    }
+                }
+            }
+        },
+        "Try Again": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Try Again"
+                    }
+                }
+            }
+        },
+        "Unable to Open Setup": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Unable to Open Setup"
+                    }
+                }
+            }
+        },
+        "Use Defaults": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Use Defaults"
+                    }
+                }
+            }
+        },
+        "VPN": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "VPN"
+                    }
+                }
+            }
+        },
+        "Welcome to Columba": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Welcome to Columba"
+                    }
+                }
+            }
+        },
+        "While this is on, iOS shows a VPN indicator.": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "While this is on, iOS shows a VPN indicator."
+                    }
+                }
+            }
+        },
+        "Wi-Fi": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Wi-Fi"
+                    }
+                }
+            }
+        },
+        "You can choose another relay later in Settings.": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "You can choose another relay later in Settings."
+                    }
+                }
+            }
+        },
+        "You're all set!": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "You're all set!"
+                    }
+                }
+            }
+        },
+        "iOS Notifications": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "iOS Notifications"
+                    }
+                }
+            }
+        },
+        "iOS uses its VPN system to let Columba's network component continue running when the app is not open. Only traffic from Columba and Reticulum uses this component; your other apps and web traffic are not routed through Columba.": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "iOS uses its VPN system to let Columba's network component continue running when the app is not open. Only traffic from Columba and Reticulum uses this component; your other apps and web traffic are not routed through Columba."
+                    }
+                }
+            }
+        },
+        "iOS will ask you to allow the configuration and will show a VPN indicator while Background Delivery is enabled. Delivery still depends on available Reticulum connections.": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "iOS will ask you to allow the configuration and will show a VPN indicator while Background Delivery is enabled. Delivery still depends on available Reticulum connections."
+                    }
+                }
+            }
+        },
+        "Your Display Name": {
+            "comment": "Read-only heading shown while reviewing an existing setup."
+        },
+        "Current relay": {
+            "comment": "Read-only heading for the relay shown during setup review."
+        },
+        "This is the relay currently configured for Columba. You can change it later in Settings.": {
+            "comment": "Explains that setup review does not edit the relay."
+        },
+        "Current connections": {
+            "comment": "Read-only heading for connection methods shown during setup review."
+        },
+        "This setup review is read-only. Change connection methods in Settings.": {
+            "comment": "Explains where connection methods can be edited."
+        },
+        "Setup Guide Reviewed": {
+            "comment": "Heading after completing a read-only setup review."
+        },
+        "iOS Notification Permission": {
+            "comment": "Label for the operating-system notification authorization status."
+        },
+        "Allowed": {
+            "comment": "Status indicating an iOS permission is allowed."
+        },
+        "Not Allowed": {
+            "comment": "Status indicating an iOS permission is not allowed."
+        },
+        "Text Size": {
+            "comment": "Conversation action and picker title for changing primary message-body text size."
+        },
+        "Preview message text": {
+            "comment": "Sample message shown in the conversation text-size picker."
+        },
+        "Message text size": {
+            "comment": "VoiceOver label for the conversation message text-size slider."
+        },
+        "Minimum text size": {
+            "comment": "VoiceOver label for the small endpoint in the message text-size range."
+        },
+        "Maximum text size": {
+            "comment": "VoiceOver label for the large endpoint in the message text-size range."
+        },
+        "%lld percent": {
+            "comment": "VoiceOver value announcing the selected message text-size percentage."
+        },
+        "Image attachment": {
+            "comment": "VoiceOver label for an image attached to a chat message."
+        },
+        "File attachment: %@": {
+            "comment": "VoiceOver label for a file attached to a chat message. The placeholder is the sender-provided display name."
+        },
+        "Opens attachment preview": {
+            "comment": "VoiceOver hint for tappable image and file attachment controls."
+        },
+        "Unable to Open Attachment": {
+            "comment": "Error alert title when a message attachment cannot be prepared for preview."
+        },
+        "The attachment could not be prepared for preview.": {
+            "comment": "Privacy-safe error text shown when temporary attachment export fails."
+        },
+        "Type a message...": {
+            "comment": "Placeholder and VoiceOver label for the message composer.",
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Type a message..."
+                    }
+                }
+            }
+        },
+        "Enter Key Sends Message": {
+            "comment": "Settings toggle controlling whether the on-screen keyboard Enter key sends the current message.",
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Enter Key Sends Message"
+                    }
+                }
+            }
+        },
+        "Messaging": {
+            "comment": "Title of the settings card containing message composition preferences.",
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Messaging"
+                    }
+                }
+            }
+        },
+        "Press Enter to send. Turn this off when you want Enter to insert new lines.": {
+            "comment": "Explanation shown when the message composer Enter key sends messages.",
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Press Enter to send. Turn this off when you want Enter to insert new lines."
+                    }
+                }
+            }
+        },
+        "Press Enter to insert a new line. Use the send button to send the message.": {
+            "comment": "Explanation shown when the message composer Enter key inserts a line break.",
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Press Enter to insert a new line. Use the send button to send the message."
+                    }
+                }
+            }
+        },
+        "Messages from contacts only": {
+            "comment": "Label for the privacy control that rejects messages from unknown senders.",
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Messages from contacts only"
+                    }
+                }
+            }
+        },
+        "Only contacts can message you. Messages from unknown senders are silently discarded.": {
+            "comment": "Privacy explanation shown when messages from unknown senders are blocked.",
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Only contacts can message you. Messages from unknown senders are silently discarded."
+                    }
+                }
+            }
+        },
+        "Anyone can send you messages, including unknown senders.": {
+            "comment": "Privacy explanation shown when messages from unknown senders are allowed.",
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Anyone can send you messages, including unknown senders."
+                    }
+                }
+            }
+        },
+        "Announce to Network": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Announce to Network"
+                    }
+                }
+            }
+        },
+        "Announced": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Announced"
+                    }
+                }
+            }
+        },
+        "Broadcasts your identity so nearby peers can discover you": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Broadcasts your identity so nearby peers can discover you"
+                    }
+                }
+            }
+        },
+        "Send Announce": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Send Announce"
+                    }
+                }
+            }
+        },
+        "Pending send": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Pending send"
+                    }
+                }
+            }
+        },
+        "Sending to relay": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Sending to relay"
+                    }
+                }
+            }
+        },
+        "Stored on relay": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Stored on relay"
+                    }
+                }
+            }
+        },
+        "Pending": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Pending"
+                    }
+                }
+            }
+        },
+        "Queued locally; no transport confirmation yet": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Queued locally; no transport confirmation yet"
+                    }
+                }
+            }
+        },
+        "Sending to Relay": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Sending to Relay"
+                    }
+                }
+            }
+        },
+        "Submitting through the selected relay": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Submitting through the selected relay"
+                    }
+                }
+            }
+        },
+        "Stored on Relay": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Stored on Relay"
+                    }
+                }
+            }
+        },
+        "Relay accepted the message; recipient delivery is not confirmed": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Relay accepted the message; recipient delivery is not confirmed"
+                    }
+                }
+            }
+        },
+        "Submitting to the selected relay": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Submitting to the selected relay"
+                    }
+                }
+            }
+        },
+        "Stored by relay; awaiting recipient delivery": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Stored by relay; awaiting recipient delivery"
+                    }
+                }
+            }
+        },
+        "Recipient delivery confirmed through relay": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Recipient delivery confirmed through relay"
+                    }
+                }
+            }
+        },
+        "Relay delivery attempt failed": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Relay delivery attempt failed"
+                    }
+                }
+            }
+        },
+        "Relay method selected; relay acceptance is unconfirmed": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Relay method selected; relay acceptance is unconfirmed"
+                    }
+                }
+            }
+        },
+        "Message was queued, but its local state could not be saved. Do not retry until its delivery outcome is known.": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Message was queued, but its local state could not be saved. Do not retry until its delivery outcome is known."
+                    }
+                }
+            }
+        },
+        "Relay submission was queued, but its local state could not be saved. Do not retry until its delivery outcome is known.": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Relay submission was queued, but its local state could not be saved. Do not retry until its delivery outcome is known."
+                    }
+                }
+            }
+        },
+        "north": {
+            "comment": "Compass direction shown next to a peer pin distance in the map contact sheet."
+        },
+        "northeast": {
+            "comment": "Compass direction shown next to a peer pin distance in the map contact sheet."
+        },
+        "east": {
+            "comment": "Compass direction shown next to a peer pin distance in the map contact sheet."
+        },
+        "southeast": {
+            "comment": "Compass direction shown next to a peer pin distance in the map contact sheet."
+        },
+        "south": {
+            "comment": "Compass direction shown next to a peer pin distance in the map contact sheet."
+        },
+        "southwest": {
+            "comment": "Compass direction shown next to a peer pin distance in the map contact sheet."
+        },
+        "west": {
+            "comment": "Compass direction shown next to a peer pin distance in the map contact sheet."
+        },
+        "northwest": {
+            "comment": "Compass direction shown next to a peer pin distance in the map contact sheet."
+        },
+        "Location unknown": {
+            "comment": "Distance line in the map contact sheet when the user has not granted or is not yet providing a location."
+        },
+        "Updated just now": {
+            "comment": "Relative last-update line for a peer location that arrived in the last few seconds."
+        },
+        "Updated %llds ago": {
+            "comment": "Relative last-update line, seconds. %lld is the whole-second count."
+        },
+        "Updated %lldm ago": {
+            "comment": "Relative last-update line, minutes. %lld is the whole-minute count."
+        },
+        "Updated %lldh ago": {
+            "comment": "Relative last-update line, hours. %lld is the whole-hour count."
+        },
+        "Updated %lldd ago": {
+            "comment": "Relative last-update line, days. %lld is the whole-day count."
+        },
+        "Stale": {
+            "comment": "Badge on the profile icon in the map contact sheet when the peer location is outside the freshness window."
+        },
+        "Directions": {
+            "comment": "Action button label in the map peer contact sheet."
+        },
+        "Message": {
+            "comment": "Action button label in the map peer contact sheet; routes to the peer chat."
+        },
+        "Remove from map": {
+            "comment": "Action button label in the map peer contact sheet; hides this peer until it reports again."
+        },
+        "Open Directions in:": {
+            "comment": "Title of the confirmation dialog choosing the directions app when both Apple Maps and Google Maps are available."
+        },
+        "Apple Maps": {
+            "comment": "Name of the Apple Maps option in the directions chooser."
+        },
+        "Google Maps": {
+            "comment": "Name of the Google Maps option in the directions chooser."
+        },
+        "Select Voice Message Quality": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Select Voice Message Quality"
+                    }
+                }
+            }
+        },
+        "Choose the recording format and bandwidth": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Choose the recording format and bandwidth"
+                    }
+                }
+            }
+        },
+        "Record": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Record"
+                    }
+                }
+            }
+        },
+        "Codec2 1200": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Codec2 1200"
+                    }
+                }
+            }
+        },
+        "Very low bandwidth voice": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Very low bandwidth voice"
+                    }
+                }
+            }
+        },
+        "Codec2 2400": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Codec2 2400"
+                    }
+                }
+            }
+        },
+        "Low bandwidth voice": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Low bandwidth voice"
+                    }
+                }
+            }
+        },
+        "Codec2 3200": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Codec2 3200"
+                    }
+                }
+            }
+        },
+        "Clearer speech at low bandwidth": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Clearer speech at low bandwidth"
+                    }
+                }
+            }
+        },
+        "Medium Quality": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Medium Quality"
+                    }
+                }
+            }
+        },
+        "Opus 8 kbps mono - good balance of quality and bandwidth": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Opus 8 kbps mono - good balance of quality and bandwidth"
+                    }
+                }
+            }
+        },
+        "High Quality": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "High Quality"
+                    }
+                }
+            }
+        },
+        "Opus 16 kbps mono - higher fidelity audio": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Opus 16 kbps mono - higher fidelity audio"
+                    }
+                }
+            }
+        },
+        "Maximum Quality": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Maximum Quality"
+                    }
+                }
+            }
+        },
+        "Opus 32 kbps stereo - best audio, requires more bandwidth": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Opus 32 kbps stereo - best audio, requires more bandwidth"
+                    }
+                }
+            }
+        },
+        "Voice": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Voice"
+                    }
+                }
+            }
+        },
+        "Record a voice message": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Record a voice message"
+                    }
+                }
+            }
+        },
+        "Voice message": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Voice message"
+                    }
+                }
+            }
+        },
+        "Start recording": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Start recording"
+                    }
+                }
+            }
+        },
+        "Stop recording": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Stop recording"
+                    }
+                }
+            }
+        },
+        "Cancel recording": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Cancel recording"
+                    }
+                }
+            }
+        },
+        "Remove recording": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Remove recording"
+                    }
+                }
+            }
+        },
+        "Microphone permission is required to record a voice message.": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Microphone permission is required to record a voice message."
+                    }
+                }
+            }
+        },
+        "Voice messages are not supported on this device.": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Voice messages are not supported on this device."
+                    }
+                }
+            }
+        },
+        "Recording": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Recording"
+                    }
+                }
+            }
+        },
+        "Finalizing": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Finalizing"
+                    }
+                }
+            }
+        },
+        "Selected voice message": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Selected voice message"
+                    }
+                }
+            }
+        },
+        "Recording error: %@": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Recording error: %@"
+                    }
+                }
+            }
+        },
+        "Ready to record a voice message": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Ready to record a voice message"
+                    }
+                }
+            }
+        },
+        "Grant microphone access": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Grant microphone access"
+                    }
+                }
+            }
+        },
+        "Microphone access is disabled. Enable it in app settings.": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Microphone access is disabled. Enable it in app settings."
+                    }
+                }
+            }
+        },
+        "Open settings": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Open settings"
+                    }
+                }
+            }
+        },
+        "Voice recording is unavailable during a call.": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Voice recording is unavailable during a call."
+                    }
+                }
+            }
+        },
+        "Play voice message": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Play voice message"
+                    }
+                }
+            }
+        },
+        "Pause voice message": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Pause voice message"
+                    }
+                }
+            }
+        },
+        "Loading voice message": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Loading voice message"
+                    }
+                }
+            }
+        },
+        "Voice message unavailable": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Voice message unavailable"
+                    }
+                }
+            }
+        },
+        "Unsupported voice message": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Unsupported voice message"
+                    }
+                }
+            }
+        },
+        "%@ of %@": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "%@ of %@"
+                    }
+                }
+            }
+        },
+        "Unable to play voice message": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Unable to play voice message"
+                    }
+                }
+            }
+        },
+        "Voice message recording produced no audio.": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Voice message recording produced no audio."
+                    }
+                }
+            }
+        },
+        "Text": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Text"
+                    }
+                }
+            }
+        },
+        "Clear history": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Clear history"
+                    }
+                }
+            }
+        },
+        "No Calls Yet": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "No Calls Yet"
+                    }
+                }
+            }
+        },
+        "Incoming and outgoing voice calls will appear here.": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Incoming and outgoing voice calls will appear here."
+                    }
+                }
+            }
+        },
+        "Call Details": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Call Details"
+                    }
+                }
+            }
+        },
+        "Direction": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Direction"
+                    }
+                }
+            }
+        },
+        "Outcome": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Outcome"
+                    }
+                }
+            }
+        },
+        "Quality profile": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Quality profile"
+                    }
+                }
+            }
+        },
+        "Attempted": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Attempted"
+                    }
+                }
+            }
+        },
+        "Ringing": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Ringing"
+                    }
+                }
+            }
+        },
+        "Connected": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Connected"
+                    }
+                }
+            }
+        },
+        "Ended": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Ended"
+                    }
+                }
+            }
+        },
+        "Duration": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Duration"
+                    }
+                }
+            }
+        },
+        "Local identity": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Local identity"
+                    }
+                }
+            }
+        },
+        "Remote identity": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Remote identity"
+                    }
+                }
+            }
+        },
+        "Call again": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Call again"
+                    }
+                }
+            }
+        },
+        "Missed": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Missed"
+                    }
+                }
+            }
+        },
+        "Declined": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Declined"
+                    }
+                }
+            }
+        },
+        "Rejected": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Rejected"
+                    }
+                }
+            }
+        },
+        "Busy": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Busy"
+                    }
+                }
+            }
+        },
+        "Cancelled": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Cancelled"
+                    }
+                }
+            }
+        },
+        "Not connected": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Not connected"
+                    }
+                }
+            }
+        },
+        "Failed": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Failed"
+                    }
+                }
+            }
+        },
+        "Interrupted": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Interrupted"
+                    }
+                }
+            }
+        },
+        "In progress": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "In progress"
+                    }
+                }
+            }
+        },
+        "Recovering call status": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Recovering call status"
+                    }
+                }
+            }
+        },
+        "Search calls": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Search calls"
+                    }
+                }
+            }
+        },
+        "Couldn't Load Call History": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Couldn't Load Call History"
+                    }
+                }
+            }
+        },
+        "Retry": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Retry"
+                    }
+                }
+            }
+        },
+        "No Calls Found": {
+            "extractionState": "manual",
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "No Calls Found"
+                    }
+                }
+            }
+        },
+        "Discovered Interfaces": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Discovered Interfaces"
+                    }
+                }
+            }
+        },
+        "Interface Discovery": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Interface Discovery"
+                    }
+                }
+            }
+        },
+        "Enable discovery": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Enable discovery"
+                    }
+                }
+            }
+        },
+        "Discovery enabled - no interfaces found yet": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Discovery enabled - no interfaces found yet"
+                    }
+                }
+            }
+        },
+        "Off": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Off"
+                    }
+                }
+            }
+        },
+        "Bootstrap interfaces": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Bootstrap interfaces"
+                    }
+                }
+            }
+        },
+        "These auto-detach once discovered interfaces connect.": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "These auto-detach once discovered interfaces connect."
+                    }
+                }
+            }
+        },
+        "Restarting…": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Restarting…"
+                    }
+                }
+            }
+        },
+        "Active – discovering interfaces": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Active – discovering interfaces"
+                    }
+                }
+            }
+        },
+        "Auto-connect up to %lld discovered interfaces": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Auto-connect up to %lld discovered interfaces"
+                    }
+                }
+            }
+        },
+        "Discovered": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Discovered"
+                    }
+                }
+            }
+        },
+        "Available": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Available"
+                    }
+                }
+            }
+        },
+        "Unknown": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Unknown"
+                    }
+                }
+            }
+        },
+        "Sort": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Sort"
+                    }
+                }
+            }
+        },
+        "Quality": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Quality"
+                    }
+                }
+            }
+        },
+        "Nearest": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Nearest"
+                    }
+                }
+            }
+        },
+        "Search interfaces…": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Search interfaces…"
+                    }
+                }
+            }
+        },
+        "IFAC only": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "IFAC only"
+                    }
+                }
+            }
+        },
+        "%lld of %lld": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "%lld of %lld"
+                    }
+                }
+            }
+        },
+        "Clear": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Clear"
+                    }
+                }
+            }
+        },
+        "Transport:": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Transport:"
+                    }
+                }
+            }
+        },
+        "IFAC:": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "IFAC:"
+                    }
+                }
+            }
+        },
+        "Last heard: %@": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Last heard: %@"
+                    }
+                }
+            }
+        },
+        "%lld hops": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "%lld hops"
+                    }
+                }
+            }
+        },
+        "Yggdrasil": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Yggdrasil"
+                    }
+                }
+            }
+        },
+        "All announced fields": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "All announced fields"
+                    }
+                }
+            }
+        },
+        "Transport ID": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Transport ID"
+                    }
+                }
+            }
+        },
+        "Network ID": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Network ID"
+                    }
+                }
+            }
+        },
+        "Status code": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Status code"
+                    }
+                }
+            }
+        },
+        "Last heard (unix)": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Last heard (unix)"
+                    }
+                }
+            }
+        },
+        "Heard count": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Heard count"
+                    }
+                }
+            }
+        },
+        "Stamp value": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Stamp value"
+                    }
+                }
+            }
+        },
+        "Reachable on": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Reachable on"
+                    }
+                }
+            }
+        },
+        "Port": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Port"
+                    }
+                }
+            }
+        },
+        "Frequency": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Frequency"
+                    }
+                }
+            }
+        },
+        "Bandwidth": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Bandwidth"
+                    }
+                }
+            }
+        },
+        "Spreading factor": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Spreading factor"
+                    }
+                }
+            }
+        },
+        "Coding rate": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Coding rate"
+                    }
+                }
+            }
+        },
+        "Modulation": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Modulation"
+                    }
+                }
+            }
+        },
+        "Channel": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Channel"
+                    }
+                }
+            }
+        },
+        "Latitude": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Latitude"
+                    }
+                }
+            }
+        },
+        "Longitude": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Longitude"
+                    }
+                }
+            }
+        },
+        "Height": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Height"
+                    }
+                }
+            }
+        },
+        "IFAC passphrase": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "IFAC passphrase"
+                    }
+                }
+            }
+        },
+        "Transport": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Transport"
+                    }
+                }
+            }
+        },
+        "Discovery hash": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Discovery hash"
+                    }
+                }
+            }
+        },
+        "Received at": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Received at"
+                    }
+                }
+            }
+        },
+        "Discovered at": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Discovered at"
+                    }
+                }
+            }
+        },
+        "Port %lld": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Port %lld"
+                    }
+                }
+            }
+        },
+        "Open in Maps": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Open in Maps"
+                    }
+                }
+            }
+        },
+        "%lld m": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "%lld m"
+                    }
+                }
+            }
+        },
+        "%lld interfaces found via RNS Discovery": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "%lld interfaces found via RNS Discovery"
+                    }
+                }
+            }
+        },
+        "%.0fm away": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "%.0fm away"
+                    }
+                }
+            }
+        },
+        "%.1f km away": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "%.1f km away"
+                    }
+                }
+            }
+        },
+        "Restarting Reticulum…": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Restarting Reticulum…"
+                    }
+                }
+            }
+        },
+        "No interfaces discovered yet. Enable discovery above to start finding interfaces announced by other RNS nodes.": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "No interfaces discovered yet. Enable discovery above to start finding interfaces announced by other RNS nodes."
+                    }
+                }
+            }
+        },
+        "No interfaces match your filters.": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "No interfaces match your filters."
+                    }
+                }
+            }
+        },
+        "Clear filters": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Clear filters"
+                    }
+                }
+            }
+        },
+        "Add to Config": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Add to Config"
+                    }
+                }
+            }
+        },
+        "Copy LoRa Params": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Copy LoRa Params"
+                    }
+                }
+            }
+        },
+        "Use for RNode": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Use for RNode"
+                    }
+                }
+            }
+        },
+        "Copied": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Copied"
+                    }
+                }
+            }
+        },
+        "Restart failed — discovery settings were not applied.": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Restart failed — discovery settings were not applied."
+                    }
+                }
+            }
+        },
+        "Discovers interfaces announced by other RNS nodes. Changes take effect after you tap Apply and Restart.": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Discovers interfaces announced by other RNS nodes. Changes take effect after you tap Apply and Restart."
+                    }
+                }
+            }
+        },
+        "Changes pending — tap Apply and Restart": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Changes pending — tap Apply and Restart"
+                    }
+                }
+            }
+        },
+        "Apply and Restart": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Apply and Restart"
+                    }
+                }
+            }
+        },
+        "Discard": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Discard"
+                    }
+                }
+            }
+        },
+        "IFAC network name": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "IFAC network name"
+                    }
+                }
+            }
+        },
+        "Via discovery": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Via discovery"
+                    }
+                }
+            }
+        },
+        "Auto-connected from discovery": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Auto-connected from discovery"
+                    }
+                }
+            }
+        },
+        "Endpoint": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Endpoint"
+                    }
+                }
+            }
+        },
+        "Source": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Source"
+                    }
+                }
+            }
+        },
+        "Saved. Applies on the next app relaunch because an AutoInterface is active.": {
+            "extractionState": "manual",
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Saved. Applies on the next app relaunch because an AutoInterface is active."
+                    }
+                }
+            }
+        },
+        "Interface discovery is unavailable in this build.": {
+            "extractionState": "manual",
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Interface discovery is unavailable in this build."
+                    }
+                }
+            }
+        },
+        "Contact": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Contact"
+                    }
+                }
+            }
+        },
+        "Contact:": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Contact:"
+                    }
+                }
+            }
+        },
+        "Local Network access is off": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Local Network access is off"
+                    }
+                }
+            }
+        },
+        "Columba can't find nearby peers until Local Network access is allowed. This setting can be changed in iOS Settings.": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Columba can't find nearby peers until Local Network access is allowed. This setting can be changed in iOS Settings."
+                    }
+                }
+            }
+        },
+        "Waiting for a network connection": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Waiting for a network connection"
+                    }
+                }
+            }
+        },
+        "Auto Discovery is ready and will connect as soon as a Wi-Fi or cellular connection is available.": {
+            "localizations": {
+                "en": {
+                    "stringUnit": {
+                        "state": "translated",
+                        "value": "Auto Discovery is ready and will connect as soon as a Wi-Fi or cellular connection is available."
+                    }
+                }
+            }
+        }
+    },
+    "version": "1.0"
 }

--- a/Sources/ColumbaApp/Services/AppServices.swift
+++ b/Sources/ColumbaApp/Services/AppServices.swift
@@ -14,6 +14,9 @@ import RNSAPI
 import LXSTSwift
 import SwiftBLEBridge
 import CryptoKit
+#if canImport(Network)
+import Network
+#endif
 #if canImport(UIKit)
 import UIKit
 #endif
@@ -640,11 +643,53 @@ public final class AppServices {
     /// launch-time snapshot — that was the source of the stale-status bug).
     private var pythonInterfaceEntities: [String: InterfaceEntity] = [:]
 
-/// Periodic poller that mirrors Python's RNS.Transport interface state
+    /// Periodic poller that mirrors Python's RNS.Transport interface state
     /// into the Compat TCPInterface stubs so the existing
     /// NetworkStatusView / InterfaceManagementScreen show correct
     /// connected/disconnected badges. Cancelled in `shutdown()`.
     private var pythonStatusPollTask: Task<Void, Never>?
+
+    // MARK: - Local Network coordinator (Option C)
+    //
+    // The AutoInterface (raw IPv6 link-local multicast, discovery-only) needs
+    // two things the stock RNS stack does not provide on iOS:
+    //   1. A RELIABLE trigger for the Local Network permission prompt. A raw
+    //      multicast join can fail to raise the prompt at all, leaving the
+    //      interface silently dead. The probe (LocalNetworkProbe) forces the
+    //      prompt via a declared Bonjour type.
+    //   2. A CARRIER RE-ADOPT. RNS AutoInterface scans system interfaces once,
+    //      in its constructor. If link-local IPv6 is not ready at cold start
+    //      (0 adopted) it logs "could not autoconfigure", sets receives=False,
+    //      and never re-scans - dead until relaunch. We detect the 0-adopted
+    //      state (via the Python `adopted_count`) and re-adopt on the first
+    //      carrier change (NWPathMonitor).
+    //
+    // Both are Python-backend-only: the Model B node runs in the NE, which
+    // already owns its socket lifecycle and does not use this path.
+    #if COLUMBA_RUNTIME_PYTHON
+    /// Task that runs the one-shot Local Network permission probe for this
+    /// backend start (cancelled on shutdown). Kept so a backend restart can
+    /// cancel a stale probe mid-flight.
+    private var localNetworkProbeTask: Task<Void, Never>?
+    /// Set once the probe has run for this backend start. We probe at most
+    /// once per backend start: re-probing a denial re-shows nothing (the user's
+    /// Open-Settings action is the recovery), and a prior grant makes a second
+    /// probe redundant.
+    private var localNetworkProbeRan = false
+    /// Guards the re-adopt against concurrent evaluation (the status poll and a
+    /// re-adopt can both fire). A re-adopt is a hot-remove + hot-add, so it must
+    /// never run twice for the same dead interface.
+    private var autoReadoptInFlight = false
+    private var lastReadoptAttempt = Date.distantPast
+    private let reAdoptCooldown: TimeInterval = 30
+    /// Public Local Network health state for the UI warning. nil = not yet
+    /// evaluated (no AutoInterface, or the coordinator has not run).
+    public private(set) var localNetworkState: LocalNetworkHealthState?
+    /// Live adopted-interface count for the enabled AutoInterface (from the
+    /// Python `adopted_count`); -1 until the first snapshot. The UI warning
+    /// keys off this (0 = dead), not `online` (which is True either way).
+    public private(set) var autoAdoptedCount: Int = -1
+    #endif
 
     /// Last interface snapshot key we logged, so the poll only logs
     /// changes (not every 2s tick).
@@ -1754,6 +1799,14 @@ public final class AppServices {
             DiagLog.log("[RNS-POLL] task exiting (cancelled)")
         }
 
+        #if COLUMBA_RUNTIME_PYTHON
+        // Local Network coordination (Option C): probe the Local Network
+        // permission (triggering the prompt if undetermined) and arm the
+        // carrier re-adopt. Python backend only - the Model B node owns its
+        // own sockets in the NE and never uses this path.
+        startLocalNetworkProbe()
+        #endif
+
         #if DEBUG
         // Test-only deep-link observers (the `lxma://test-*` surface used by the
         // interop / smoke harnesses). The matching `onOpenURL` trigger in
@@ -2499,6 +2552,14 @@ public final class AppServices {
                     auto.state = newState
                     auto.online = status.online
                 }
+                #if COLUMBA_RUNTIME_PYTHON
+                // The real liveness signal for the AutoInterface is the adopted
+                // count (0 = cold-start dead, RNS will never re-scan on its own).
+                // `online` alone is useless here: final_init() sets it True even
+                // with zero adopted interfaces. Drive Local Network health + the
+                // carrier re-adopt from it.
+                updateLocalNetworkHealth(adoptedCount: status.adoptedCount)
+                #endif
             case .ble:
                 if let ble = self.bleInterface, ble.state != newState {
                     DiagLog.log("[RNS] iface \(status.sectionName) -> \(newState) (BLE, rx=\(status.rxBytes) tx=\(status.txBytes))")
@@ -2818,6 +2879,11 @@ public final class AppServices {
             DiagLog.log("[RNS-HOT] add \(section) error: \(error)")
         }
         await seedSwiftStub(for: entity)
+        #if COLUMBA_RUNTIME_PYTHON
+        if entity.type == .autoInterface {
+            noteAutoInterfaceAvailability(changed: false)
+        }
+        #endif
     }
 
     /// Hot-remove one interface from the running Python stack and tear down its
@@ -2832,6 +2898,11 @@ public final class AppServices {
             DiagLog.log("[RNS-HOT] remove \(section) error: \(error)")
         }
         await teardownSwiftStub(for: entity)
+        #if COLUMBA_RUNTIME_PYTHON
+        if entity.type == .autoInterface {
+            noteAutoInterfaceAvailability(changed: true)
+        }
+        #endif
     }
 
     /// Create the Swift-side status mirror for a freshly hot-added interface so
@@ -3898,6 +3969,134 @@ public final class AppServices {
         logger.info("AutoInterface stopped")
     }
 
+    #if COLUMBA_RUNTIME_PYTHON
+    // MARK: - Local Network coordination (Option C)
+
+    /// Run the Local Network permission probe for this backend start and keep
+    /// `localNetworkState` current. Started from `startPythonBackend()`, reset
+    /// (so a backend restart re-probes) and cancelled on shutdown.
+    ///
+    /// The probe triggers the system prompt (if undetermined) via a declared
+    /// Bonjour browse + publish. We run it at most once per backend start: a
+    /// prior grant makes it redundant, and a prior denial re-shows nothing
+    /// (the Open-Settings action is the recovery).
+    func startLocalNetworkProbe() {
+        guard !BackendPreference.modelB else { return }
+        localNetworkProbeTask?.cancel()
+        localNetworkProbeRan = false
+        autoReadoptInFlight = false
+        lastReadoptAttempt = .distantPast
+        autoAdoptedCount = -1
+
+        let hasAuto = InterfaceRepository().getEnabledInterfaces().contains { $0.type == .autoInterface }
+        guard hasAuto else {
+            localNetworkState = .notConfigured
+            return
+        }
+        localNetworkState = .noCarrier
+
+        localNetworkProbeTask = Task { @MainActor [weak self] in
+            // Give the backend a beat so its first status snapshot has landed
+            // (the probe result is combined with the adopted count below).
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
+            guard let self, !Task.isCancelled, !self.localNetworkProbeRan else { return }
+            let result = await LocalNetworkProbe().probe()
+            self.localNetworkProbeRan = true
+            DiagLog.log("[LN] probe result: \(result.rawValue) (adopted=\(self.autoAdoptedCount))")
+            switch result {
+            case .denied:
+                self.localNetworkState = .denied
+            case .granted, .unknown:
+                // Granted (or undetermined - fail-open): the adopted count is
+                // the live signal; the poll hook refines it each snapshot.
+                self.localNetworkState = (self.autoAdoptedCount > 0) ? .healthy : .noCarrier
+            }
+        }
+    }
+
+    /// Update Local Network health from a fresh status snapshot and arm the
+    /// carrier re-adopt when the AutoInterface has adopted zero interfaces.
+    /// Called from the status poll (every snapshot).
+    func updateLocalNetworkHealth(adoptedCount: Int?) {
+        guard let adopted = adoptedCount else { return }
+        if adopted != autoAdoptedCount {
+            DiagLog.log("[LN] auto adopted_count: \(autoAdoptedCount) -> \(adopted)")
+        }
+        autoAdoptedCount = adopted
+        if localNetworkState == .denied || localNetworkState == .notConfigured {
+            return // denial is sticky; nothing to re-adopt with no interface
+        }
+        localNetworkState = (adopted > 0) ? .healthy : .noCarrier
+        if adopted == 0 {
+            scheduleAutoReadopt()
+        }
+    }
+
+    /// Re-adopt an AutoInterface that adopted zero system interfaces.
+    ///
+    /// SAFE ONLY when `adopted_count == 0`: that instance holds no discovery
+    /// sockets (they are created per adopted interface in the constructor), so
+    /// the hot-remove + hot-add cannot leak any. Upstream `AutoInterface
+    /// .detach()` does not release sockets, so re-adopting a LIVE interface
+    /// (one or more adopted) would leak the multicast sockets and split
+    /// incoming announcements between the dead and new instances - the same
+    /// reason `restartPythonBackend` refuses to run with an AutoInterface. A
+    /// live interface never needs re-adopting anyway: its `peer_jobs` loop
+    /// tracks address changes on the interfaces it already holds.
+    ///
+    /// The hot-remove + hot-add re-runs the AutoInterface constructor
+    /// (`_synthesize_interface` -> fresh `AutoInterface(...)`), which re-scans
+    /// `list_interfaces()` - now with the link up - and re-adopts en0.
+    private func scheduleAutoReadopt() {
+        guard !autoReadoptInFlight else { return }
+        let now = Date()
+        guard now.timeIntervalSince(lastReadoptAttempt) >= reAdoptCooldown else { return }
+        lastReadoptAttempt = now
+        autoReadoptInFlight = true
+        Task { @MainActor [weak self] in
+            defer { self?.autoReadoptInFlight = false }
+            guard let self, !BackendPreference.modelB, let backend = self.backend else { return }
+            // Re-read fresh state (user may have disabled the interface in the
+            // meantime - a MainActor read sees the repository's current value).
+            guard let entity = InterfaceRepository().getEnabledInterfaces().first(where: { $0.type == .autoInterface }) else {
+                self.localNetworkState = .notConfigured
+                return
+            }
+            DiagLog.log("[LN] re-adopting AutoInterface (adopted=0, retry after \(Int(self.reAdoptCooldown))s cooldown)")
+            // Exact same path as a user-driven interface change (the "changed"
+            // branch of applyInterfaceChanges): remove, then re-add (re-synthesize).
+            await self.hotRemoveInterface(entity, backend: backend)
+            await self.hotAddInterface(entity, backend: backend)
+        }
+    }
+
+    /// Tear down the probe on shutdown / backend teardown.
+    func stopLocalNetworkProbe() {
+        localNetworkProbeTask?.cancel()
+        localNetworkProbeTask = nil
+        localNetworkState = nil
+        autoAdoptedCount = -1
+    }
+
+    /// Called when the AutoInterface is hot-added or hot-removed by the user
+    /// (the UI's Apply path), so Local Network state tracks the interface
+    /// rather than going stale.
+    func noteAutoInterfaceAvailability(changed: Bool) {
+        guard !BackendPreference.modelB else { return }
+        if changed {
+            localNetworkState = .notConfigured
+            autoAdoptedCount = -1
+        } else {
+            // Auto interface enabled. If this backend start never probed (the
+            // interface was added after launch), run the probe now so the
+            // prompt is raised and denial is surfaced.
+            if !localNetworkProbeRan {
+                startLocalNetworkProbe()
+            }
+        }
+    }
+    #endif
+
     #if canImport(CoreBluetooth)
     /// Start the BLE interface for Bluetooth peer-to-peer networking.
     ///
@@ -4542,6 +4741,9 @@ public final class AppServices {
         pythonEventTask = nil
         pythonStatusPollTask?.cancel()
         pythonStatusPollTask = nil
+        #if COLUMBA_RUNTIME_PYTHON
+        stopLocalNetworkProbe()
+        #endif
         // Remove the test-deeplink NotificationCenter observers registered in
         // startPythonBackend(); without this they'd accumulate across restart
         // cycles and fire each handler once per past start.

--- a/Sources/ColumbaApp/Services/LocalNetworkProbe.swift
+++ b/Sources/ColumbaApp/Services/LocalNetworkProbe.swift
@@ -1,0 +1,208 @@
+//
+//  LocalNetworkProbe.swift
+//  ColumbaApp
+//
+//  Triggers the iOS Local Network permission prompt (if it has not been shown
+//  yet) and reports the outcome, so a denied / never-prompted state is visible
+//  instead of silently dead.
+//
+//  Background: Columba's Auto Discovery interface talks over raw IPv6 link-local
+//  multicast from the embedded Python (RNS). iOS 14+ gates local-network access
+//  behind a one-shot permission, but the system only raises the prompt when the
+//  app actually performs a local-network operation through a path the OS can
+//  intercept. A raw-socket multicast join can fail to trigger the prompt at all
+//  (the "0 interfaces, never prompted, silently dead" dead-end). There is also
+//  no public API to *read* the current Local Network authorization state.
+//
+//  This probe uses the composite technique that reliably (a) raises the prompt
+//  and (b) determines the answer:
+//    1. Start an `NWBrowser` for a declared Bonjour service type. Browsing is
+//       the OS-recognized local-network operation that makes the system show the
+//       prompt when the permission is still undetermined.
+//    2. Concurrently publish an `NSNetService` of the same type. Its
+//       `netServiceDidPublish` delegate callback fires only when access is
+//       granted, giving us a positive grant signal (the browser reaching `.ready`
+//       alone is not a reliable grant confirmation on every iOS version).
+//    3. If the user denies, the `NWBrowser` transitions to `.waiting(error)` -
+//       that is our denial signal.
+//
+//  The service type MUST be listed in `Info.plist` `NSBonjourServices`, or the
+//  browser silently fails to trigger the prompt. See `LocalNetworkProbe
+//  .probeServiceType` and the matching plist entry.
+//
+//  The probe is discovery-only: it publishes a single static, ephemeral service
+//  name carrying no user data, stopped as soon as the outcome is known. It does
+//  NOT require the multicast entitlement (that is a separate, still-off concern
+//  for RNS's raw sockets).
+//
+
+import Foundation
+import Network
+
+/// The outcome of a Local Network permission probe.
+public enum LocalNetworkPermission: String, Equatable, Sendable {
+    /// Access is granted (previously allowed, or the user just allowed it).
+    case granted
+    /// Access is denied (the user denied the prompt, or a prior decision denied it).
+    case denied
+    /// No definitive signal within the probe window. Callers should fail-open
+    /// (attempt the local operation anyway) rather than assume denial.
+    case unknown
+}
+
+/// Coarse Local Network health for the Auto Discovery interface, surfaced in
+/// the Manage Interfaces UI. Derived from the permission outcome and the
+/// AutoInterface's live adopted-interface count.
+public enum LocalNetworkHealthState: Equatable, Sendable {
+    /// Local Network access is granted AND the AutoInterface has adopted at
+    /// least one system interface - discovery is healthy.
+    case healthy
+    /// Access is granted but the AutoInterface adopted zero interfaces (the
+    /// cold-start-before-link-local case). Carrier re-adopt is armed; the UI
+    /// shows a transient "reconnecting" note rather than a hard error.
+    case noCarrier
+    /// The user denied Local Network access (or it was denied earlier). The
+    /// UI shows a warning with an Open Settings action. This is the state that
+    /// was previously invisible - the interface silently failed to bind.
+    case denied
+    /// No AutoInterface is enabled, so Local Network state is not applicable.
+    case notConfigured
+}
+
+/// Triggers the Local Network permission prompt and reports the result.
+///
+/// Usage: `let result = await LocalNetworkProbe().probe()`. Each call is
+/// self-contained and short-lived (a few seconds at most); the browser and
+/// service are torn down before the continuation resumes. Idempotent - re-
+/// probing after the prompt has already been answered simply re-confirms the
+/// current state without showing the prompt again.
+///
+/// Thread safety: every state mutation and callback (NWBrowser state handler
+/// on `.main`, NSNetService delegate on the main run loop, dispatch work items
+/// on main) runs on the main queue, so the instance is serialized without a
+/// lock and safe to hand across executors. Hence `@unchecked Sendable`.
+public final class LocalNetworkProbe: NSObject, NSNetServiceDelegate, @unchecked Sendable {
+
+    /// Bonjour service type used to trigger + confirm Local Network access.
+    /// Declared in `Info.plist` `NSBonjourServices`. Distinct from the real
+    /// `_reticulum._tcp` protocol type so the probe never advertises a service
+    /// that a real peer could mistake for a Reticulum endpoint.
+    public static let probeServiceType = "_columba-lnp._tcp"
+    public static let probeDomain = "local."
+    private static let probeName = "columba-lnp-probe"
+
+    private var browser: NWBrowser?
+    private var netService: NSNetService?
+    private var continuation: CheckedContinuation<LocalNetworkPermission, Never>?
+    private var timeoutItem: DispatchWorkItem?
+    private var readyGraceItem: DispatchWorkItem?
+    private var resolved = false
+
+    public override init() {
+        super.init()
+    }
+
+    /// Trigger the prompt (if undetermined) and report the outcome.
+    ///
+    /// - Parameter timeout: Fail-open window. If neither a grant nor a denial
+    ///   signal arrives within this long, returns `.unknown` (callers attempt
+    ///   the operation anyway). Defaults to 10s, which comfortably covers the
+    ///   time a user takes to answer the system prompt.
+    public func probe(timeout: TimeInterval = 10) async -> LocalNetworkPermission {
+        await withCheckedContinuation { (cont: CheckedContinuation<LocalNetworkPermission, Never>) in
+            self.continuation = cont
+            self.resolved = false
+            // All state mutation + callback handling runs on the main queue
+            // (NWBrowser state handler on `.main`; NSNetService delegate on the
+            // main run loop; work items on main), so `self` is serialized
+            // without an actor.
+            DispatchQueue.main.async {
+                self.begin(timeout: timeout)
+            }
+        }
+    }
+
+    // MARK: - Probe lifecycle (main queue)
+
+    private func begin(timeout: TimeInterval) {
+        // 1. Trigger: browsing a declared type is the operation that makes the
+        //    OS raise the Local Network prompt when the permission is
+        //    undetermined.
+        let params = NWParameters()
+        params.includePeerToPeer = true
+        let browser = NWBrowser(for: .bonjour(Self.probeServiceType, Self.probeDomain), using: params)
+        browser.stateUpdateHandler = { [weak self] state in
+            DispatchQueue.main.async {
+                guard let self else { return }
+                switch state {
+                case .waiting(let error):
+                    // .waiting WITHOUT an error means the system prompt is
+                    // still on screen (or not yet raised) - keep waiting.
+                    // .waiting WITH an error is a (prior) denial: the browse
+                    // cannot proceed.
+                    if error != nil {
+                        self.finish(.denied)
+                    }
+                case .ready:
+                    // The prompt was answered "Allow" (or already granted). The
+                    // publish callback is the authoritative grant confirmation;
+                    // give it a short grace, then trust the browser if the
+                    // callback is slow.
+                    self.finish(.granted, afterGrace: 1.5)
+                case .failed, .cancelled, .shuttingDown, .setup:
+                    break
+                }
+            }
+        }
+        browser.start(queue: .main)
+        self.browser = browser
+
+        // 2. Confirmation: publish fires `netServiceDidPublish` only when access
+        //    is actually granted.
+        let service = NSNetService(domain: Self.probeDomain, type: Self.probeServiceType, name: Self.probeName)
+        service.delegate = self
+        self.netService = service
+        service.publish()
+
+        // 3. Fail-open timeout.
+        let item = DispatchWorkItem { [weak self] in self?.finish(.unknown) }
+        self.timeoutItem = item
+        DispatchQueue.main.asyncAfter(deadline: .now() + timeout, execute: item)
+    }
+
+    private func finish(_ result: LocalNetworkPermission, afterGrace: TimeInterval? = nil) {
+        guard !resolved else { return }
+        if let grace = afterGrace {
+            // Defer the grant a short window so an imminent `netServiceDidPublish`
+            // (or a `.waiting(error)` denial) can land first.
+            let item = DispatchWorkItem { [weak self] in self?.finish(.granted) }
+            self.readyGraceItem = item
+            DispatchQueue.main.asyncAfter(deadline: .now() + grace, execute: item)
+            return
+        }
+        resolved = true
+        timeoutItem?.cancel()
+        timeoutItem = nil
+        readyGraceItem?.cancel()
+        readyGraceItem = nil
+        browser?.cancel()
+        browser = nil
+        netService?.stop()
+        netService = nil
+        let cont = continuation
+        continuation = nil
+        cont?.resume(returning: result)
+    }
+
+    // MARK: - NSNetServiceDelegate (main run loop)
+
+    public func netServiceDidPublish(_ netService: NSNetService) {
+        DispatchQueue.main.async { [weak self] in
+            self?.finish(.granted)
+        }
+    }
+
+    // `didNotPublish` is not a definitive denial (it can be a transient bind
+    // hiccup); the browser state and the timeout are the authoritative signals,
+    // so we intentionally do not resolve from it.
+}

--- a/Sources/ColumbaApp/Services/LocalNetworkProbe.swift
+++ b/Sources/ColumbaApp/Services/LocalNetworkProbe.swift
@@ -131,9 +131,9 @@ public final class LocalNetworkProbe: NSObject, NetServiceDelegate, @unchecked S
         let params = NWParameters()
         params.includePeerToPeer = true
         let browser = NWBrowser(for: .bonjour(type: Self.probeServiceType, domain: Self.probeDomain), using: params)
-        browser.stateUpdateHandler = { [weak self] state in
+        browser.stateUpdateHandler = { [weak self] (state: NWBrowser.State) in
             DispatchQueue.main.async {
-                guard let self else { return }
+                guard let probe = self else { return }
                 switch state {
                 case .waiting(let error):
                     // .waiting WITHOUT an error means the system prompt is
@@ -141,14 +141,14 @@ public final class LocalNetworkProbe: NSObject, NetServiceDelegate, @unchecked S
                     // .waiting WITH an error is a (prior) denial: the browse
                     // cannot proceed.
                     if error != nil {
-                        self.finish(.denied)
+                        probe.finish(.denied)
                     }
                 case .ready:
                     // The prompt was answered "Allow" (or already granted). The
                     // publish callback is the authoritative grant confirmation;
                     // give it a short grace, then trust the browser if the
                     // callback is slow.
-                    self.finish(.granted, afterGrace: 1.5)
+                    probe.finish(.granted, afterGrace: 1.5)
                 case .failed, .cancelled, .shuttingDown, .setup:
                     break
                 }

--- a/Sources/ColumbaApp/Services/LocalNetworkProbe.swift
+++ b/Sources/ColumbaApp/Services/LocalNetworkProbe.swift
@@ -131,27 +131,10 @@ public final class LocalNetworkProbe: NSObject, NetServiceDelegate, @unchecked S
         let params = NWParameters()
         params.includePeerToPeer = true
         let browser = NWBrowser(for: .bonjour(type: Self.probeServiceType, domain: Self.probeDomain), using: params)
-        browser.stateUpdateHandler = { [weak self] (state: NWBrowser.State) in
+        browser.stateUpdateHandler = { [weak self] state in
             DispatchQueue.main.async {
-                guard let probe = self else { return }
-                switch state {
-                case .waiting(let error):
-                    // .waiting WITHOUT an error means the system prompt is
-                    // still on screen (or not yet raised) - keep waiting.
-                    // .waiting WITH an error is a (prior) denial: the browse
-                    // cannot proceed.
-                    if error != nil {
-                        probe.finish(.denied)
-                    }
-                case .ready:
-                    // The prompt was answered "Allow" (or already granted). The
-                    // publish callback is the authoritative grant confirmation;
-                    // give it a short grace, then trust the browser if the
-                    // callback is slow.
-                    probe.finish(.granted, afterGrace: 1.5)
-                case .failed, .cancelled, .shuttingDown, .setup:
-                    break
-                }
+                guard let self else { return }
+                self.handleBrowserState(state)
             }
         }
         browser.start(queue: .main)
@@ -168,6 +151,28 @@ public final class LocalNetworkProbe: NSObject, NetServiceDelegate, @unchecked S
         let item = DispatchWorkItem { [weak self] in self?.finish(.unknown) }
         self.timeoutItem = item
         DispatchQueue.main.asyncAfter(deadline: .now() + timeout, execute: item)
+    }
+
+    // MARK: - Browser state (main queue)
+
+    /// Interpret an NWBrowser state transition for the probe.
+    private func handleBrowserState(_ state: NWBrowser.State) {
+        switch state {
+        case .waiting(let error):
+            // .waiting WITHOUT an error means the system prompt is still on
+            // screen (or not yet raised) - keep waiting. .waiting WITH an
+            // error is a (prior) denial: the browse cannot proceed.
+            if error != nil {
+                self.finish(.denied)
+            }
+        case .ready:
+            // The prompt was answered "Allow" (or already granted). The
+            // publish callback is the authoritative grant confirmation; give
+            // it a short grace, then trust the browser if it is slow.
+            self.finish(.granted, afterGrace: 1.5)
+        case .failed, .cancelled, .shuttingDown, .setup:
+            break
+        }
     }
 
     private func finish(_ result: LocalNetworkPermission, afterGrace: TimeInterval? = nil) {

--- a/Sources/ColumbaApp/Services/LocalNetworkProbe.swift
+++ b/Sources/ColumbaApp/Services/LocalNetworkProbe.swift
@@ -81,7 +81,7 @@ public enum LocalNetworkHealthState: Equatable, Sendable {
 /// on `.main`, NSNetService delegate on the main run loop, dispatch work items
 /// on main) runs on the main queue, so the instance is serialized without a
 /// lock and safe to hand across executors. Hence `@unchecked Sendable`.
-public final class LocalNetworkProbe: NSObject, NSNetServiceDelegate, @unchecked Sendable {
+public final class LocalNetworkProbe: NSObject, NetServiceDelegate, @unchecked Sendable {
 
     /// Bonjour service type used to trigger + confirm Local Network access.
     /// Declared in `Info.plist` `NSBonjourServices`. Distinct from the real
@@ -92,7 +92,7 @@ public final class LocalNetworkProbe: NSObject, NSNetServiceDelegate, @unchecked
     private static let probeName = "columba-lnp-probe"
 
     private var browser: NWBrowser?
-    private var netService: NSNetService?
+    private var netService: NetService?
     private var continuation: CheckedContinuation<LocalNetworkPermission, Never>?
     private var timeoutItem: DispatchWorkItem?
     private var readyGraceItem: DispatchWorkItem?
@@ -159,7 +159,7 @@ public final class LocalNetworkProbe: NSObject, NSNetServiceDelegate, @unchecked
 
         // 2. Confirmation: publish fires `netServiceDidPublish` only when access
         //    is actually granted.
-        let service = NSNetService(domain: Self.probeDomain, type: Self.probeServiceType, name: Self.probeName)
+        let service = NetService(domain: Self.probeDomain, type: Self.probeServiceType, name: Self.probeName)
         service.delegate = self
         self.netService = service
         service.publish()
@@ -194,9 +194,9 @@ public final class LocalNetworkProbe: NSObject, NSNetServiceDelegate, @unchecked
         cont?.resume(returning: result)
     }
 
-    // MARK: - NSNetServiceDelegate (main run loop)
+    // MARK: - NetServiceDelegate (main run loop)
 
-    public func netServiceDidPublish(_ netService: NSNetService) {
+    public func netServiceDidPublish(_ netService: NetService) {
         DispatchQueue.main.async { [weak self] in
             self?.finish(.granted)
         }

--- a/Sources/ColumbaApp/Services/LocalNetworkProbe.swift
+++ b/Sources/ColumbaApp/Services/LocalNetworkProbe.swift
@@ -170,7 +170,7 @@ public final class LocalNetworkProbe: NSObject, NetServiceDelegate, @unchecked S
             // publish callback is the authoritative grant confirmation; give
             // it a short grace, then trust the browser if it is slow.
             self.finish(.granted, afterGrace: 1.5)
-        case .failed, .cancelled, .shuttingDown, .setup:
+        case .failed, .cancelled, .setup:
             break
         }
     }

--- a/Sources/ColumbaApp/Services/LocalNetworkProbe.swift
+++ b/Sources/ColumbaApp/Services/LocalNetworkProbe.swift
@@ -130,7 +130,7 @@ public final class LocalNetworkProbe: NSObject, NetServiceDelegate, @unchecked S
         //    undetermined.
         let params = NWParameters()
         params.includePeerToPeer = true
-        let browser = NWBrowser(for: .bonjour(Self.probeServiceType, Self.probeDomain), using: params)
+        let browser = NWBrowser(for: .bonjour(type: Self.probeServiceType, domain: Self.probeDomain), using: params)
         browser.stateUpdateHandler = { [weak self] state in
             DispatchQueue.main.async {
                 guard let self else { return }

--- a/Sources/ColumbaApp/ViewModels/InterfaceManagementViewModel.swift
+++ b/Sources/ColumbaApp/ViewModels/InterfaceManagementViewModel.swift
@@ -54,6 +54,14 @@ public final class InterfaceManagementViewModel: TCPClientWizardSaveSink {
     /// Current success message (auto-dismissing)
     public var successMessage: String?
 
+    /// Local Network permission + carrier health for the Auto Discovery
+    /// interface (Python backend only; the Model B node owns its sockets in
+    /// the NE and has no such state). nil = not applicable or not yet
+    /// evaluated. Drives the compact warning banner on Manage Interfaces.
+    #if COLUMBA_RUNTIME_PYTHON
+    public var localNetworkState: LocalNetworkHealthState?
+    #endif
+
     /// Whether there are pending changes to apply
     public var hasPendingChanges: Bool = false
 
@@ -688,6 +696,13 @@ public final class InterfaceManagementViewModel: TCPClientWizardSaveSink {
                             self.interfaceStatus[autoEntity.id] = .disconnected
                         }
                     }
+
+                    // Mirror Local Network health (permission + carrier) so the
+                    // warning banner appears / clears reactively. Python
+                    // backend only.
+                    #if COLUMBA_RUNTIME_PYTHON
+                    self.localNetworkState = self.appServices.localNetworkState
+                    #endif
 
                     // Track BLE interface status
                     if let bleEntity = enabledIfs.first(where: { $0.type == .ble }) {

--- a/Sources/ColumbaApp/Views/Settings/InterfaceManagementScreen.swift
+++ b/Sources/ColumbaApp/Views/Settings/InterfaceManagementScreen.swift
@@ -8,6 +8,9 @@
 
 import SwiftUI
 import RNSAPI
+#if canImport(UIKit)
+import UIKit
+#endif
 
 /// Main screen for managing network interfaces.
 ///
@@ -59,6 +62,17 @@ struct InterfaceManagementScreen: View {
                 VStack(spacing: 16) {
                     // Summary Card
                     summaryCard
+
+                    // Local Network warning (Auto Discovery). Only shown while
+                    // the state is actionable (denied or awaiting a carrier);
+                    // it auto-clears when discovery becomes healthy. Python
+                    // backend only.
+                    #if COLUMBA_RUNTIME_PYTHON
+                    if let state = viewModel.localNetworkState,
+                       state == .denied || state == .noCarrier {
+                        localNetworkWarningCard(state)
+                    }
+                    #endif
 
                     // Interface Discovery entry card — always visible,
                     // tappable into the discovered-interfaces screen.
@@ -207,6 +221,62 @@ struct InterfaceManagementScreen: View {
         .background(Theme.backgroundSecondary)
         .clipShape(RoundedRectangle(cornerRadius: Theme.cornerRadiusLarge))
     }
+
+    // MARK: - Local Network Warning
+
+    /// Compact warning for the Auto Discovery (Local Network) state. Shown
+    /// only while actionable (denied, or awaiting a carrier), non-dismissible,
+    /// tappable straight into app Settings (denied case), and it auto-clears
+    /// the moment discovery becomes healthy. Carries no PII.
+    #if COLUMBA_RUNTIME_PYTHON
+    @ViewBuilder
+    private func localNetworkWarningCard(_ state: LocalNetworkHealthState) -> some View {
+        let denied = (state == .denied)
+        let tint: Color = denied ? Theme.warning : Theme.textSecondary
+        let icon = denied ? "exclamationmark.triangle.fill" : "wifi.exclamationmark"
+        let title = String(localized: denied ? "Local Network access is off" : "Waiting for a network connection")
+        let detail = String(localized: denied
+            ? "Columba can't find nearby peers until Local Network access is allowed. This setting can be changed in iOS Settings."
+            : "Auto Discovery is ready and will connect as soon as a Wi-Fi or cellular connection is available.")
+        Button {
+            if denied {
+                if let url = URL(string: UIApplication.openSettingsURLString) {
+                    UIApplication.shared.open(url)
+                }
+            }
+        } label: {
+            HStack(spacing: 12) {
+                Image(systemName: icon)
+                    .font(.body)
+                    .foregroundStyle(tint)
+                    .frame(width: 28)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(Theme.textPrimary)
+                    Text(detail)
+                        .font(.caption)
+                        .foregroundStyle(Theme.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                Spacer(minLength: 8)
+                if denied {
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundStyle(Theme.textSecondary)
+                }
+            }
+            .padding(14)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(tint.opacity(0.12))
+            .clipShape(RoundedRectangle(cornerRadius: Theme.cornerRadiusMedium))
+        }
+        .buttonStyle(.plain)
+        .disabled(!denied)
+        .accessibilityIdentifier(denied ? "local_network_denied_warning" : "local_network_no_carrier_warning")
+        .accessibilityHint(denied ? "Opens app settings to enable Local Network access" : "")
+    }
+    #endif
 
     // MARK: - Discovery Entry Card
 

--- a/Sources/PythonBridge/PythonBridge.swift
+++ b/Sources/PythonBridge/PythonBridge.swift
@@ -649,9 +649,16 @@ public final class PythonBridge: @unchecked Sendable {
             public let rxBytes: Int
             public let txBytes: Int
             /// True when RNS spawned this interface from a discovery announce
-            /// (the `autoconnect_hash` marker set by `Discovery.autoconnect`).
+            /// (`autoconnect_hash` marker set by `Discovery.autoconnect`).
             /// The status poll renders these with a "via discovery" badge.
             public let isAutoconnect: Bool
+            /// Number of system interfaces the AutoInterface adopted at
+            /// construction (nil for non-Auto interfaces). A cold start before
+            /// link-local IPv6 is ready can adopt 0 - and RNS never re-scans,
+            /// so 0 stays 0 until the interface is re-created. The carrier
+            /// re-adopt coordinator uses this (not `online`, which is True
+            /// either way) to detect the dead interface.
+            public let adoptedCount: Int?
 
             enum CodingKeys: String, CodingKey {
                 case sectionName = "section_name"
@@ -660,6 +667,7 @@ public final class PythonBridge: @unchecked Sendable {
                 case rxBytes = "rx_bytes"
                 case txBytes = "tx_bytes"
                 case isAutoconnect = "is_autoconnect"
+                case adoptedCount = "adopted_count"
             }
 
             public init(from decoder: Decoder) throws {
@@ -670,6 +678,7 @@ public final class PythonBridge: @unchecked Sendable {
                 self.rxBytes = (try? c.decode(Int.self, forKey: .rxBytes)) ?? 0
                 self.txBytes = (try? c.decode(Int.self, forKey: .txBytes)) ?? 0
                 self.isAutoconnect = (try? c.decode(Bool.self, forKey: .isAutoconnect)) ?? false
+                self.adoptedCount = (try? c.decode(Int?.self, forKey: .adoptedCount)) ?? nil
             }
         }
 

--- a/Sources/RNSAPI/Protocols/RnsBackend.swift
+++ b/Sources/RNSAPI/Protocols/RnsBackend.swift
@@ -171,11 +171,18 @@ public struct StatusSnapshot: Decodable, Sendable {
         /// (the `autoconnect_hash` marker). The status poll renders these
         /// with a "via discovery" badge.
         public let isAutoconnect: Bool?
+        /// Number of system interfaces the AutoInterface adopted at
+        /// construction (Python backend only; nil elsewhere or for non-Auto
+        /// interfaces). A cold start before link-local IPv6 is ready can
+        /// adopt 0 and RNS never re-scans, so 0 stays 0 until the interface
+        /// is re-created. The carrier re-adopt coordinator keys off this
+        /// (not `online`, which is True either way).
+        public let adoptedCount: Int?
 
         public init(sectionName: String, name: String, online: Bool, rxBytes: Int, txBytes: Int,
                     typeRaw: String? = nil, isBLEPeer: Bool? = nil, isAutoPeer: Bool? = nil,
                     peerAddress: String? = nil, lastError: String? = nil,
-                    isAutoconnect: Bool? = nil) {
+                    isAutoconnect: Bool? = nil, adoptedCount: Int? = nil) {
             self.sectionName = sectionName
             self.name = name
             self.online = online
@@ -187,6 +194,7 @@ public struct StatusSnapshot: Decodable, Sendable {
             self.peerAddress = peerAddress
             self.lastError = lastError
             self.isAutoconnect = isAutoconnect
+            self.adoptedCount = adoptedCount
         }
 
         enum CodingKeys: String, CodingKey {
@@ -200,6 +208,7 @@ public struct StatusSnapshot: Decodable, Sendable {
             case peerAddress = "peer_address"
             case lastError = "last_error"
             case isAutoconnect = "is_autoconnect"
+            case adoptedCount = "adopted_count"
         }
 
         public init(from decoder: Decoder) throws {
@@ -215,6 +224,7 @@ public struct StatusSnapshot: Decodable, Sendable {
             self.peerAddress = try? c.decode(String.self, forKey: .peerAddress)
             self.lastError = try? c.decode(String.self, forKey: .lastError)
             self.isAutoconnect = try? c.decode(Bool.self, forKey: .isAutoconnect)
+            self.adoptedCount = (try? c.decode(Int?.self, forKey: .adoptedCount)) ?? nil
         }
     }
 

--- a/Sources/RNSBackendPy/PythonRNSBackend.swift
+++ b/Sources/RNSBackendPy/PythonRNSBackend.swift
@@ -501,7 +501,8 @@ public final class PythonRNSBackend: RnsBackend, @unchecked Sendable {
                 StatusSnapshot.InterfaceStatus(
                     sectionName: $0.sectionName, name: $0.name, online: $0.online,
                     rxBytes: $0.rxBytes, txBytes: $0.txBytes,
-                    isAutoconnect: $0.isAutoconnect
+                    isAutoconnect: $0.isAutoconnect,
+                    adoptedCount: $0.adoptedCount
                 )
             },
             destinationTableSize: s.destinationTableSize,

--- a/app/rns_bridge.py
+++ b/app/rns_bridge.py
@@ -2124,6 +2124,14 @@ def status() -> dict[str, Any]:
                 # their friendly name didn't start with AutoInterfacePeer /
                 # BLEPeer, so the user couldn't tell which interfaces were
                 # auto-connected from discovery (issue #193 follow-up).
+                # AutoInterface: `online` is True even when ZERO system
+                # interfaces were adopted at construction (a cold start before
+                # link-local IPv6 is ready) and it stays that way forever -
+                # RNS never re-scans. `adopted_count` is the real liveness
+                # signal: 0 means the interface has no sockets and cannot
+                # discover peers until it is re-created. Non-Auto interfaces
+                # report None (Swift treats that as "no re-adopt signal").
+                adopted = getattr(iface, "adopted_interfaces", None)
                 iface_info.append({
                     "section_name": section_name,
                     "name": str(iface),
@@ -2132,6 +2140,7 @@ def status() -> dict[str, Any]:
                     "rx_bytes": getattr(iface, "rxb", 0),
                     "tx_bytes": getattr(iface, "txb", 0),
                     "is_autoconnect": bool(getattr(iface, "autoconnect_hash", None)),
+                    "adopted_count": (len(adopted) if isinstance(adopted, dict) else None),
                 })
             out["interfaces"] = iface_info
         except Exception as e:


### PR DESCRIPTION
## Problem

Auto Discovery (RNS AutoInterface: raw IPv6 link-local multicast, discovery-only) has two silent dead ends on iOS:

1. **Prompt never fires.** iOS gates local-network access behind a one-shot permission, but the prompt is behavior-triggered and a raw-socket multicast join can fail to raise it at all. The user never sees a prompt, and a denial never re-prompts - the interface is silently dead with no visible cause.
2. **0 interfaces adopted at cold start, never retried.** RNS `AutoInterface` scans system interfaces exactly once, in its constructor. If the app cold-starts before link-local IPv6 is ready, it logs `could not autoconfigure`, sets `receives=False`, and never re-scans: `peer_jobs()` only rebinds already-adopted interfaces, and the `carrier_changed` flag is set but consumed nowhere upstream. Dead until app relaunch.

Note `online` is useless as a liveness signal here: `final_init()` sets it `True` even with zero adopted interfaces.

## Fix (Option C - no Apple dependency, multicast entitlement stays OFF)

- **`LocalNetworkProbe`** (new): `NWBrowser` browse + `NetService` publish of a dedicated declared Bonjour type (`_columba-lnp._tcp`). Browsing is the OS-recognized local-network operation that reliably raises the prompt when undetermined; the publish callback confirms a grant; `.waiting(error)` reports a denial. One probe per backend start, fail-open on timeout. Finally exercises the already-declared `NSBonjourServices` key (was dead).
- **Carrier re-adopt**: Python `status()` now reports per-interface `adopted_count` (nil for non-Auto). The Swift coordinator re-adopts on the first 0-adopted sighting via the existing hot-remove + hot-add path (`_synthesize_interface` re-runs the adoption loop), with a 30s cooldown and an in-flight guard.
  - **Safety**: re-adopt is scoped strictly to `adopted_count == 0`. That instance owns no discovery sockets (they are created per adopted interface in the constructor), so nothing leaks. Re-adopting a *live* interface would leak its multicast sockets on detach (upstream `detach()` only sets `online=False`) - the same reason `restartPythonBackend` refuses with an AutoInterface. A live interface never needs it: its `peer_jobs` loop already tracks address changes.
- **UI**: compact, non-dismissible warning on Manage Interfaces - denied: tappable Open Settings; no-carrier: informational. Auto-clears when discovery becomes healthy. All new state is `COLUMBA_RUNTIME_PYTHON`-gated; Model B (NE-owned sockets) is untouched.

## Verification

- `adopted_count` semantics smoke-tested (0 / None / 1) against the real status() code path.
- Full Xcode build **SUCCEEDED** on Mac mini: `Columba` (Python flavor) and `Columba-ModelB` both green.
- Built bundle verified: `_columba-lnp._tcp` in Info.plist `NSBonjourServices` + binary string literal; `adopted_count` in bundled `app/rns_bridge.py`; zero symlinks in bundle.
- Static contract suite: 374 tests, 1 failure **pre-existing on origin/main** (`test_lxst_voice_call_routing` resolver regex - verified identical failure on a detached origin/main control worktree; untouched by this diff).
- xcstrings kept in original 2-space format; only the 4 new keys added.

## Known limits (honest scope)

- The probe makes the prompt reliable and the denial visible; it does NOT make raw multicast work if iOS 26 enforces the multicast entitlement (that request is separately pending).
- Local-network privacy is not enforced in the simulator; prompt/denial behavior must be judged on a physical device.